### PR TITLE
Fix crashes due to uninitialised or NULL variables

### DIFF
--- a/lib/embed/gpi_embed.c
+++ b/lib/embed/gpi_embed.c
@@ -239,16 +239,18 @@ void embed_sim_event(gpi_event_t level, const char *msg)
     FENTER
     /* Indicate to the upper layer a sim event occoured */
 
-    PyGILState_STATE gstate;
-    gstate = PyGILState_Ensure();
+    if (pEventFn) {
+        PyGILState_STATE gstate;
+        gstate = PyGILState_Ensure();
 
-    PyObject *fArgs = PyTuple_New(2);
-    PyTuple_SetItem(fArgs, 0, PyInt_FromLong(level));
-    PyTuple_SetItem(fArgs, 1, PyString_FromString(msg));
-    PyObject *pValue = PyObject_Call(pEventFn, fArgs, NULL);
+        PyObject *fArgs = PyTuple_New(2);
+        PyTuple_SetItem(fArgs, 0, PyInt_FromLong(level));
+        PyTuple_SetItem(fArgs, 1, PyString_FromString(msg));
+        PyObject *pValue = PyObject_Call(pEventFn, fArgs, NULL);
 
-    Py_DECREF(fArgs);
-    PyGILState_Release(gstate);
+        Py_DECREF(fArgs);
+        PyGILState_Release(gstate);
+    }
 
     FEXIT
 }


### PR DESCRIPTION
Saw a couple of crashes under Valgrind when I hadn't set PYTHON_PATH correctly.
