### PR TITLE
Support GPI_IMPL=vhpi for SIM=ius

### DIFF
--- a/makefiles/simulators/Makefile.ius
+++ b/makefiles/simulators/Makefile.ius
@@ -30,6 +30,7 @@
 # Common Makefile for Cadence Incisive
 
 EXTRA_ARGS += -64bit
+EXTRA_ARGS += -nclibdirname $(SIM_BUILD)
 
 ifeq ($(GUI),1)
     EXTRA_ARGS += -gui
@@ -45,10 +46,9 @@ endif
 
 ifeq ($(GPI_IMPL),vhpi)
     GPI_ARGS = -loadvhpi $(LIB_DIR)/libgpi:vhpi_startup_routines_bootstrap
-    EXTRA_ARGS += -work $(SIM_BUILD)
-    EXTRA_ARGS += -cdslib cds.lib
+    #EXTRA_ARGS += -cdslib cds.lib
     EXTRA_ARGS += -v93
-    EXTRA_ARGS += -top work.$(TOPLEVEL)
+    EXTRA_ARGS += -top worklib.$(TOPLEVEL)
     HDL_SOURCES = $(VHDL_SOURCES)
 endif
 


### PR DESCRIPTION
Here is some initial support for using GPI_IMPL=vhpi with Cadence IUS (errors left over will be filed as an issue).
It also adds support for GUI=1 and sets the work library directory name to $(SIM_BUILD) so that it cleans correctly.
