### PR TITLE
Generalize cosim Makefile for endian_swapper example

### DIFF
--- a/examples/endian_swapper/cosim/Makefile
+++ b/examples/endian_swapper/cosim/Makefile
@@ -1,17 +1,21 @@
+PYTHON_INCDIR ?= /usr/include/python2.7
+PYTHON_LIBDIR ?= /usr/lib64
+SWIG ?= swig
 
+.PHONY: all
 all: io_module.so _hal.so
 
 io_module.o: io.c io_module.h io.h
-	gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -I/usr/include/python2.7 -c $< -o $@
+	gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -I$(PYTHON_INCDIR) -c $< -o $@
 
 io_module.so: io_module.o
-	gcc -pthread -shared -Wl,-z,relro $< -L/usr/lib64 -lpython2.7 -o $@
+	gcc -pthread -shared -Wl,-z,relro $< -L$(PYTHON_LIBDIR) -lpython2.7 -o $@
 
-_hal.so : ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so
-	gcc -g -ldl -shared -fPIC -I$(shell pwd) -I/usr/include/python2.7 -I../hal ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so -o $@
+_hal.so: ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so
+	gcc -g -ldl -shared -fPIC -I$(shell pwd) -I$(PYTHON_INCDIR) -I../hal ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so -o $@
 
 endian_swapper_hal_wrap.c: ../hal/endian_swapper_hal.h
-	swig -python -outcurrentdir ../hal/endian_swapper_hal.h
+	$(SWIG) -python -outcurrentdir ../hal/endian_swapper_hal.h
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Define and use PYTHON_INCDIR, PYTHON_INCDIR and SWIG as variables so that they can be overwritten externally.
