### PR TITLE
Consistent randomisation of X values

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -35,6 +35,9 @@ import random
 import warnings
 
 resolve_x_to = os.getenv('COCOTB_RESOLVE_X', "VALUE_ERROR")
+rand_gen = random.Random()
+rand_gen.seed(os.getenv('RANDOM_SEED', random.getrandbits(32)))
+consistent_val = rand_gen.getrandbits(32)
 
 def resolve(string):
     for char in BinaryValue._resolve_to_0:
@@ -51,6 +54,8 @@ def resolve(string):
         elif resolve_x_to == "RANDOM":
             bits = "{0:b}".format(random.getrandbits(1))
             string = string.replace(char, bits)
+        elif resolve_x_to == "CONSISTENT_RANDOM":
+            string = string.replace(char, '1' if (hash(string)*consistent_val) & 0x80000000 else '0')
     return string
 
 


### PR DESCRIPTION
`COCOTB_RESOLVE_X=RANDOM` is useful in general to catch edge cases, but can cause issues, for instance `r == r` failing when `r` contains an `x`. I think it would be useful to have a "consistent random" mode, where the `x` values are filled in based on a hash of the non-X values and `RANDOM_SEED`, so that values resolve in a consistent manner and behave more sensibly.

- Added a new `COCOTB_RESOLVE_X` mode (`RANDOM`)
- Use optional environmental variable `RANDOM_SEED` to choose seed for how to evaluate 0s and 1s throughout the test

Some things that may need changing:
- Is there a place where `COCOTB_RESOLVE_X` is documented, probably want to add this option to the docs
- Is `RANDOM_SEED` the best name for this setting, it may sound too global
    - Is there actually a globalised seed for cocotb already?
    - Does cocotb print out its seeds at the end of a test so that test cases can be re-run?