### PR TITLE
Issue #820: Clean-up FLI to remove code that was causing stack traces

### DIFF
--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -124,7 +124,7 @@ int FliSimPhaseCbHdl::arm_callback(void)
 }
 
 FliSignalCbHdl::FliSignalCbHdl(GpiImplInterface *impl,
-                               FliSignalObjHdl *sig_hdl,
+                               FliValueObjHdl *sig_hdl,
                                unsigned int edge) : GpiCbHdl(impl),
                                                     FliProcessCbHdl(impl),
                                                     GpiValueCbHdl(impl, sig_hdl, edge)

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -40,6 +40,9 @@ static FliProcessCbHdl *sim_finish_cb;
 static FliImpl         *fli_table;
 } //extern "C"
 
+/** local helper functions */
+namespace {
+
 bool fli_is_logic(mtiTypeIdT type)
 {
     mtiInt32T numEnums = mti_TickLength(type);
@@ -127,6 +130,7 @@ bool fli_is_const(void *hdl)
                                 || _type == accAliasGeneric);
 }
 
+} //namespace
 
 void FliImpl::sim_end(void)
 {

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -40,7 +40,7 @@ void handle_fli_callback(void *data);
 }
 
 class FliImpl;
-class FliSignalObjHdl;
+class FliValueObjHdl;
 
 // Callback handles
 
@@ -66,7 +66,7 @@ class FliSignalCbHdl : public FliProcessCbHdl, public GpiValueCbHdl {
 
 public:
     FliSignalCbHdl(GpiImplInterface *impl,
-                   FliSignalObjHdl *sig_hdl,
+                   FliValueObjHdl *sig_hdl,
                    unsigned int edge);
 
     virtual ~FliSignalCbHdl() { }
@@ -150,103 +150,86 @@ private:
     uint64_t m_time_ps;
 };
 
-
-// Object Handles
-class FliObj {
+class FliValueObjIntf {
 public:
-    FliObj(int acc_type,
-           int acc_full_type) :
-               m_acc_type(acc_type),
-               m_acc_full_type(acc_full_type) { }
-
-    virtual ~FliObj() { }
-
-    int get_acc_type(void) { return m_acc_type; }
-    int get_acc_full_type(void) { return m_acc_full_type; }
-
-
-protected:
-    int m_acc_type;
-    int m_acc_full_type;
+    virtual mtiTypeIdT mti_get_type(void) = 0;
+    virtual mtiInt32T  mti_get_value(void) = 0;
+    virtual void *     mti_get_array_value(void *buffer) = 0;
+    virtual void *     mti_get_value_indirect(void *buffer) = 0;
+    virtual void       mti_set_value(mtiLongT value) = 0;
 };
 
-class FliObjHdl : public GpiObjHdl, public FliObj {
+class FliSignalObjIntf : public FliValueObjIntf {
 public:
-    FliObjHdl(GpiImplInterface *impl,
-              void *hdl,
-              gpi_objtype_t objtype,
-              int acc_type,
-              int acc_full_type) :
-                  GpiObjHdl(impl, hdl, objtype, false),
-                  FliObj(acc_type, acc_full_type) { }
+    FliSignalObjIntf(mtiSignalIdT hdl) : m_hdl(hdl) { }
 
-    FliObjHdl(GpiImplInterface *impl,
-              void *hdl,
-              gpi_objtype_t objtype,
-              int acc_type,
-              int acc_full_type,
-              bool is_const) :
-                  GpiObjHdl(impl, hdl, objtype, is_const),
-                  FliObj(acc_type, acc_full_type) { }
+    virtual ~FliSignalObjIntf() { }
+
+    mtiTypeIdT mti_get_type(void);
+    mtiInt32T  mti_get_value(void);
+    void *     mti_get_array_value(void *buffer);
+    void *     mti_get_value_indirect(void *buffer);
+    void       mti_set_value(mtiLongT value);
+
+private:
+    mtiSignalIdT m_hdl;
+};
+
+class FliVariableObjIntf : public FliValueObjIntf {
+public:
+    FliVariableObjIntf(mtiVariableIdT hdl) : m_hdl(hdl) { }
+
+    virtual ~FliVariableObjIntf() { }
+
+    mtiTypeIdT mti_get_type(void);
+    mtiInt32T  mti_get_value(void);
+    void *     mti_get_array_value(void *buffer);
+    void *     mti_get_value_indirect(void *buffer);
+    void       mti_set_value(mtiLongT value);
+
+private:
+    mtiVariableIdT m_hdl;
+};
+
+class FliArrayObjHdl : public GpiObjHdl {
+public:
+    FliArrayObjHdl(GpiImplInterface *impl, mtiSignalIdT hdl);
+    FliArrayObjHdl(GpiImplInterface *impl, mtiVariableIdT hdl, bool is_const);
+    virtual ~FliArrayObjHdl();
+    virtual int initialise(std::string &name, std::string &fq_name);
+
+protected:
+    FliValueObjIntf *m_fli_intf;
+};
+
+class FliRecordObjHdl : public GpiObjHdl {
+public:
+    FliRecordObjHdl(GpiImplInterface *impl, mtiSignalIdT hdl);
+    FliRecordObjHdl(GpiImplInterface *impl, mtiVariableIdT hdl, bool is_const);
+    virtual ~FliRecordObjHdl();
+    virtual int initialise(std::string &name, std::string &fq_name);
+
+protected:
+    FliValueObjIntf *m_fli_intf;
+};
+
+// Object Handles
+class FliObjHdl : public GpiObjHdl {
+public:
+    FliObjHdl(GpiImplInterface *impl, mtiRegionIdT hdl, gpi_objtype_t objtype) :
+                  GpiObjHdl(impl, hdl, objtype, false) { }
 
     virtual ~FliObjHdl() { }
 
     virtual int initialise(std::string &name, std::string &fq_name);
 };
 
-class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
+class FliValueObjHdl : public GpiSignalObjHdl {
 public:
-    FliSignalObjHdl(GpiImplInterface *impl,
-                    void *hdl,
-                    gpi_objtype_t objtype,
-                    bool is_const,
-                    int acc_type,
-                    int acc_full_type,
-                    bool is_var) :
-                        GpiSignalObjHdl(impl, hdl, objtype, is_const),
-                        FliObj(acc_type, acc_full_type),
-                        m_is_var(is_var),
-                        m_rising_cb(impl, this, GPI_RISING),
-                        m_falling_cb(impl, this, GPI_FALLING),
-                        m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }
+    FliValueObjHdl(GpiImplInterface *impl, mtiSignalIdT hdl, gpi_objtype_t objtype);
+    FliValueObjHdl(GpiImplInterface *impl, mtiVariableIdT hdl, gpi_objtype_t objtype, bool is_const);
 
-    virtual ~FliSignalObjHdl() { }
-
-    virtual GpiCbHdl *value_change_cb(unsigned int edge);
-    virtual int initialise(std::string &name, std::string &fq_name);
-
-    bool is_var(void) { return m_is_var; }
-
-protected:
-    bool               m_is_var;
-    FliSignalCbHdl     m_rising_cb;
-    FliSignalCbHdl     m_falling_cb;
-    FliSignalCbHdl     m_either_cb;
-};
-
-class FliValueObjHdl : public FliSignalObjHdl {
-public:
-    FliValueObjHdl(GpiImplInterface *impl,
-                   void *hdl,
-                   gpi_objtype_t objtype,
-                   bool is_const,
-                   int acc_type,
-                   int acc_full_type,
-                   bool is_var,
-                   mtiTypeIdT valType,
-                   mtiTypeKindT typeKind) :
-                       FliSignalObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type, is_var),
-                       m_fli_type(typeKind),
-                       m_val_type(valType),
-                       m_val_buff(NULL),
-                       m_sub_hdls(NULL) { }
-
-    virtual ~FliValueObjHdl() {
-        if (m_val_buff != NULL)
-            free(m_val_buff);
-        if (m_sub_hdls != NULL)
-            mti_VsimFree(m_sub_hdls);
-    }
+    virtual ~FliValueObjHdl();
 
     virtual const char* get_signal_value_binstr(void);
     virtual const char* get_signal_value_str(void);
@@ -257,32 +240,25 @@ public:
     virtual int set_signal_value(const double value);
     virtual int set_signal_value(std::string &value);
 
-    virtual void *get_sub_hdl(int index);
-
+    virtual GpiCbHdl *value_change_cb(unsigned int edge);
     virtual int initialise(std::string &name, std::string &fq_name);
 
-    mtiTypeKindT get_fli_typekind(void) { return m_fli_type; }
-    mtiTypeIdT   get_fli_typeid(void) { return m_val_type; }
-
 protected:
-    mtiTypeKindT       m_fli_type;
-    mtiTypeIdT         m_val_type;
-    char              *m_val_buff;
-    void             **m_sub_hdls;
+    FliValueObjIntf *m_fli_intf;
+    FliSignalCbHdl  *m_rising_cb;
+    FliSignalCbHdl  *m_falling_cb;
+    FliSignalCbHdl  *m_either_cb;
 };
 
 class FliEnumObjHdl : public FliValueObjHdl {
 public:
-    FliEnumObjHdl(GpiImplInterface *impl,
-                  void *hdl,
-                  gpi_objtype_t objtype,
-                  bool is_const,
-                  int acc_type,
-                  int acc_full_type,
-                  bool is_var,
-                  mtiTypeIdT valType,
-                  mtiTypeKindT typeKind) :
-                      FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type, is_var, valType, typeKind),
+    FliEnumObjHdl(GpiImplInterface *impl, mtiSignalIdT hdl) :
+                      FliValueObjHdl(impl, hdl, GPI_ENUM),
+                      m_value_enum(NULL),
+                      m_num_enum(0) { }
+
+    FliEnumObjHdl(GpiImplInterface *impl, mtiVariableIdT hdl, bool is_const) :
+                      FliValueObjHdl(impl, hdl, GPI_ENUM, is_const),
                       m_value_enum(NULL),
                       m_num_enum(0) { }
 
@@ -302,32 +278,28 @@ private:
 
 class FliLogicObjHdl : public FliValueObjHdl {
 public:
-    FliLogicObjHdl(GpiImplInterface *impl,
-                   void *hdl,
-                   gpi_objtype_t objtype,
-                   bool is_const,
-                   int acc_type,
-                   int acc_full_type,
-                   bool is_var, 
-                   mtiTypeIdT valType,
-                   mtiTypeKindT typeKind) :
-                       FliValueObjHdl(impl,
-                                      hdl,
-                                      objtype,
-                                      is_const,
-                                      acc_type,
-                                      acc_full_type,
-                                      is_var,
-                                      valType,
-                                      typeKind),
+    FliLogicObjHdl(GpiImplInterface *impl, mtiSignalIdT hdl) :
+                       FliValueObjHdl(impl, hdl, GPI_REGISTER),
+                       m_val_buff(NULL),
+                       m_mti_buff(NULL),
+                       m_value_enum(NULL),
+                       m_num_enum(0),
+                       m_enum_map() { }
+
+    FliLogicObjHdl(GpiImplInterface *impl, mtiVariableIdT hdl, bool is_const) :
+                       FliValueObjHdl(impl, hdl, GPI_REGISTER, is_const),
+                       m_val_buff(NULL),
                        m_mti_buff(NULL),
                        m_value_enum(NULL),
                        m_num_enum(0),
                        m_enum_map() { }
 
     virtual ~FliLogicObjHdl() {
+        if (m_val_buff != NULL)
+            delete [] m_val_buff;
+
         if (m_mti_buff != NULL)
-            free(m_mti_buff);
+            delete [] m_mti_buff;
     }
 
     const char* get_signal_value_binstr(void);
@@ -337,8 +309,8 @@ public:
 
     int initialise(std::string &name, std::string &fq_name);
 
-
 private:
+    char                      *m_val_buff;
     char                      *m_mti_buff;
     char                     **m_value_enum;    // Do Not Free
     mtiInt32T                  m_num_enum;
@@ -347,18 +319,18 @@ private:
 
 class FliIntObjHdl : public FliValueObjHdl {
 public:
-    FliIntObjHdl(GpiImplInterface *impl,
-                 void *hdl,
-                 gpi_objtype_t objtype,
-                 bool is_const,
-                 int acc_type,
-                 int acc_full_type,
-                 bool is_var,
-                 mtiTypeIdT valType,
-                 mtiTypeKindT typeKind) :
-                     FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type, is_var, valType, typeKind) { }
+    FliIntObjHdl(GpiImplInterface *impl, mtiSignalIdT hdl) :
+                       FliValueObjHdl(impl, hdl, GPI_INTEGER),
+                       m_val_buff(NULL) { }
 
-    virtual ~FliIntObjHdl() { }
+    FliIntObjHdl(GpiImplInterface *impl, mtiVariableIdT hdl, bool is_const) :
+                       FliValueObjHdl(impl, hdl, GPI_INTEGER, is_const),
+                       m_val_buff(NULL) { }
+
+    virtual ~FliIntObjHdl() {
+        if (m_val_buff != NULL)
+            delete [] m_val_buff;
+    }
 
     const char* get_signal_value_binstr(void);
     long get_signal_value_long(void);
@@ -366,64 +338,51 @@ public:
     int set_signal_value(const long value);
 
     int initialise(std::string &name, std::string &fq_name);
+
+private:
+    char *m_val_buff;
 };
 
 class FliRealObjHdl : public FliValueObjHdl {
 public:
-    FliRealObjHdl(GpiImplInterface *impl,
-                  void *hdl,
-                  gpi_objtype_t objtype,
-                  bool is_const,
-                  int acc_type,
-                  int acc_full_type,
-                  bool is_var,
-                  mtiTypeIdT valType,
-                  mtiTypeKindT typeKind) :
-                      FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type, is_var, valType, typeKind),
-                      m_mti_buff(NULL) { }
+    FliRealObjHdl(GpiImplInterface *impl, mtiSignalIdT hdl) :
+                      FliValueObjHdl(impl, hdl, GPI_REAL) { }
 
-    virtual ~FliRealObjHdl() {
-        if (m_mti_buff != NULL)
-            free(m_mti_buff);
-    }
+    FliRealObjHdl(GpiImplInterface *impl, mtiVariableIdT hdl, bool is_const) :
+                      FliValueObjHdl(impl, hdl, GPI_REAL, is_const) { }
+
+    virtual ~FliRealObjHdl() { }
 
     double get_signal_value_real(void);
 
     int set_signal_value(const double value);
 
     int initialise(std::string &name, std::string &fq_name);
-
-private:
-    double *m_mti_buff;
 };
 
 class FliStringObjHdl : public FliValueObjHdl {
 public:
-    FliStringObjHdl(GpiImplInterface *impl,
-                  void *hdl,
-                  gpi_objtype_t objtype,
-                  bool is_const,
-                  int acc_type,
-                  int acc_full_type,
-                  bool is_var,
-                  mtiTypeIdT valType,
-                  mtiTypeKindT typeKind) :
-                      FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type, is_var, valType, typeKind),
-                      m_mti_buff(NULL) { }
+    FliStringObjHdl(GpiImplInterface *impl, mtiSignalIdT hdl) :
+                        FliValueObjHdl(impl, hdl, GPI_STRING),
+                        m_val_buff(NULL) { }
+
+    FliStringObjHdl(GpiImplInterface *impl, mtiVariableIdT hdl, bool is_const) :
+                        FliValueObjHdl(impl, hdl, GPI_STRING, is_const),
+                        m_val_buff(NULL) { }
 
     virtual ~FliStringObjHdl() {
-        if (m_mti_buff != NULL)
-            free(m_mti_buff);
+        if (m_val_buff != NULL)
+            delete [] m_val_buff;
     }
 
-    const char* get_signal_value_str(void);
+    virtual const char* get_signal_value_str(void);
 
-    int set_signal_value(std::string &value);
+    virtual int set_signal_value(std::string &value);
 
-    int initialise(std::string &name, std::string &fq_name);
+    virtual int initialise(std::string &name, std::string &fq_name);
 
 private:
-    char *m_mti_buff;
+    char *m_val_buff;
 };
 
 class FliTimerCache {
@@ -502,15 +461,12 @@ public:
     const char *reason_to_string(int reason);
 
     /* Method to provide strings from operation types */
-    GpiObjHdl *create_gpi_obj_from_handle(void *hdl, std::string &name, std::string &fq_name, int accType, int accFullType);
+    GpiObjHdl *create_gpi_obj_from_handle(mtiRegionIdT   hdl, std::string &name, std::string &fq_name);
+    GpiObjHdl *create_gpi_obj_from_handle(mtiSignalIdT   hdl, std::string &name, std::string &fq_name);
+    GpiObjHdl *create_gpi_obj_from_handle(mtiVariableIdT hdl, std::string &name, std::string &fq_name);
 
 private:
-    bool isValueConst(int kind);
-    bool isValueLogic(mtiTypeIdT type);
-    bool isValueChar(mtiTypeIdT type);
-    bool isValueBoolean(mtiTypeIdT type);
-    bool isTypeValue(int type);
-    bool isTypeSignal(int type, int full_type);
+    gpi_objtype_t get_gpi_obj_type(mtiTypeIdT _typeid);
 
 public:
     FliTimerCache cache;

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -460,13 +460,14 @@ public:
     /* Method to provide strings from operation types */
     const char *reason_to_string(int reason);
 
-    /* Method to provide strings from operation types */
     GpiObjHdl *create_gpi_obj_from_handle(mtiRegionIdT   hdl, std::string &name, std::string &fq_name);
     GpiObjHdl *create_gpi_obj_from_handle(mtiSignalIdT   hdl, std::string &name, std::string &fq_name);
     GpiObjHdl *create_gpi_obj_from_handle(mtiVariableIdT hdl, std::string &name, std::string &fq_name);
 
 private:
     gpi_objtype_t get_gpi_obj_type(mtiTypeIdT _typeid);
+    gpi_objtype_t get_array_gpi_obj_type(mtiTypeIdT _typeid);
+    gpi_objtype_t get_enum_gpi_obj_type(mtiTypeIdT _typeid);
 
 public:
     FliTimerCache cache;

--- a/tests/designs/mixed_lang/Makefile
+++ b/tests/designs/mixed_lang/Makefile
@@ -1,0 +1,31 @@
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
+ifeq ($(OS),Msys)
+WPWD=$(shell sh -c 'pwd -W')
+else
+WPWD=$(shell pwd)
+endif
+
+COCOTB?=$(WPWD)/../../..
+
+SRC_BASE = $(COCOTB)/tests/designs/mixed_lang
+
+VHDL_SOURCES =      $(SRC_BASE)/counter.vhd \
+                    $(SRC_BASE)/counters.vhd
+
+VERILOG_SOURCES =   $(SRC_BASE)/mixed_lang_top.sv
+
+TOPLEVEL = mixed_lang_top
+
+include $(COCOTB)/makefiles/Makefile.inc
+include $(COCOTB)/makefiles/Makefile.sim
+
+endif

--- a/tests/designs/mixed_lang/counter.vhd
+++ b/tests/designs/mixed_lang/counter.vhd
@@ -1,0 +1,39 @@
+library ieee; use ieee.std_logic_1164.all;
+              use ieee.numeric_std.all;
+
+entity counter is
+  generic (
+    ENDVAL  : unsigned);
+  port (
+    clk     : in    std_logic;
+    rst     : in    std_logic;
+    enable  : in    std_logic;
+    done    :   out std_logic);
+end counter;
+
+architecture rtl of counter is
+  constant ZERO : unsigned(ENDVAL'range) := to_unsigned(0, ENDVAL'length);
+  signal   cnt  : unsigned(ENDVAL'range);
+begin
+  c : process(clk)
+  begin
+    if (rising_edge(clk)) then
+      if rst /= '0' then
+        cnt <= ZERO;
+      elsif ((enable = '1') and (cnt /= ENDVAL)) then
+        cnt <= cnt + 1;
+      end if;
+    end if;
+  end process c;
+
+  d : process(clk)
+  begin
+    if (rising_edge(clk)) then
+      if rst /= '0' then
+        done <= '0';
+      elsif (cnt = ENDVAL) then
+        done <= '1';
+      end if;
+    end if;
+  end process d;
+end architecture rtl;

--- a/tests/designs/mixed_lang/counters.vhd
+++ b/tests/designs/mixed_lang/counters.vhd
@@ -1,0 +1,32 @@
+library ieee; use ieee.std_logic_1164.all;
+              use ieee.numeric_std.all;
+library work;
+
+entity counters is
+  port (
+    clk     : in    std_logic;
+    rst     : in    std_logic;
+    enable  : in    std_logic;
+    done    :   out std_logic_vector(3 downto 0));
+end counters;
+
+architecture rtl of counters is
+  constant INSTALL     : boolean := TRUE;
+  constant COUNTER_LEN : natural := 8;
+begin
+  install_gen : if (INSTALL) generate
+  begin
+    cntr : for i in done'range generate
+      constant ENDVAL : unsigned(COUNTER_LEN-1 downto 0) := to_unsigned(2*(i+1), COUNTER_LEN);
+    begin
+      c_i : entity work.counter(rtl)
+        generic map (
+          ENDVAL => ENDVAL)
+        port map(
+          clk    => clk,
+          rst    => rst,
+          enable => enable,
+          done   => done(i));
+    end generate cntr;
+  end generate install_gen;
+end architecture rtl;

--- a/tests/designs/mixed_lang/mixed_lang_top.sv
+++ b/tests/designs/mixed_lang/mixed_lang_top.sv
@@ -1,0 +1,47 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2013, 2018 Potential Ventures Ltd
+// Copyright (c) 2013 SolarFlare Communications Inc
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Potential Ventures Ltd,
+//       Copyright (c) 2013 SolarFlare Communications Inc nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//-----------------------------------------------------------------------------
+
+`timescale 1 ps / 1 ps
+
+module mixed_lang_top (
+    input                                       clk,
+    input                                       rst,
+    input                                       enable,
+    output reg [3:0]                            done
+
+);
+
+
+  counters counters (
+      .clk(clk),
+      .rst(rst),
+      .enable(enable),
+      .done(done));
+
+endmodule

--- a/tests/test_cases/issue_820/Makefile
+++ b/tests/test_cases/issue_820/Makefile
@@ -1,0 +1,3 @@
+include ../../designs/mixed_lang/Makefile
+
+MODULE = issue_820

--- a/tests/test_cases/issue_820/issue_820.py
+++ b/tests/test_cases/issue_820/issue_820.py
@@ -1,0 +1,27 @@
+# A set of regression tests for open issues
+
+import cocotb
+import logging
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+from cocotb.result import TestFailure
+
+@cocotb.test()
+def issue_820(dut):
+    tlog = logging.getLogger("cocotb.test")
+
+    cocotb.fork(Clock(dut.clk, 2500).start())
+
+    dut.rst <= 1
+    dut.enable <= 0
+    yield Timer(10000)
+    dut.rst <= 0
+    yield Timer(10000)
+    dut.enable <= 1
+
+    while dut.done != 15:
+        yield RisingEdge(dut.clk)
+        tlog.info("Counter[3].cnt = %d", int(dut.counters.install_gen.cntr[3].c_i.cnt))
+
+
+    tlog.info("DONE!!!!")


### PR DESCRIPTION
Fixes #820 

This is a pretty large change to the FLI interface.  In mixed language simulations, I had seen stack traces caused by the casting to FliObj.  I reworked the interface to remove any requirement to cast to any FLI object.