### PR TITLE
Fix Py_SetProgramName() for Windows virtualenv.

### DIFF
--- a/cocotb/share/makefiles/Makefile.pylib.Msys
+++ b/cocotb/share/makefiles/Makefile.pylib.Msys
@@ -44,7 +44,10 @@ PYTHON_BIN?=$(PYTHON_DIR)/python.exe
 # We might work with other Python versions
 LOCAL_PYTHON_VERSION?=$(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_version() )')
 PYTHON_DYNLIBDIR:=$(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; print( sysconfig.get_config_var("DESTSHARED") )')
-PYTHON_LIBDIR=$(PYTHON_DIR)/libs
+PYTHON_LIBDIR:=$(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; print( sysconfig.get_config_var("LIBDIR") )')
+ifeq ($(PYTHON_LIBDIR),None)
+    PYTHON_LIBDIR=$(PYTHON_DIR)/libs
+endif
 
 period := .
 empty :=


### PR DESCRIPTION
On Windows, the Python interpreter for virtual environments
is located in the Scripts subfolder.
Also moved the venv_path char array to static memory as outlined
in the Python docs.

Is this the best way to check for Windows?
I could change to `#if defined(WIN32) || defined(WIN64)`