### PR TITLE
Keep traceback for unhandled exceptions in Python 2

### DIFF
--- a/cocotb/outcomes.py
+++ b/cocotb/outcomes.py
@@ -6,6 +6,8 @@ or `asyncio.Future`, but without being tied to a particular task model.
 """
 import abc
 
+from cocotb.utils import reraise
+
 # https://stackoverflow.com/a/38668373
 # Backport of abc.ABC, compatible with Python 2 and 3
 abc_ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
@@ -44,14 +46,14 @@ class Value(Outcome):
 
 
 class Error(Outcome):
-    def __init__(self, error):
-        self.error = error
+    def __init__(self, *exc_info):
+        self.exc_info = exc_info
 
     def send(self, gen):
-        return gen.throw(self.error)
+        return gen.throw(*self.exc_info)
 
     def get(self):
-        raise self.error
+        reraise(*self.exc_info)
 
     def __repr__(self):
-        return "Error({!r})".format(self.error)
+        return "Error({!r})".format(self.exc_info[1])

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -565,7 +565,8 @@ class First(_AggregateWaitable):
                 try:
                     ret = outcomes.Value((yield t))
                 except BaseException as exc:
-                    ret = outcomes.Error(exc)
+                    exc_info = sys.exc_info()
+                    ret = outcomes.Error(*exc_info)
 
                 completed.append(ret)
                 e.set()

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -424,6 +424,28 @@ else:
         exec("""exec _code_ in _globs_, _locs_""")
 
 
+# This is essentially six.reraise
+if sys.version_info.major == 3:
+    # this has to not be a syntax error in py2
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+else:
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
 # this is six.with_metaclass, with a clearer docstring
 def with_metaclass(meta, *bases):
     """This provides:

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -890,6 +890,36 @@ def test_exceptions(dut):
     else:
         raise TestFailure("Exception was not raised")
 
+
+@cocotb.test(expect_error=True)
+def test_nested_exc_traceback(dut):
+    """
+    Test that when an exception is passed up through coroutines
+    the same exception object is raised in the test, and that the
+    full traceback is shown.
+    """
+    the_exception = ValueError("Original exception")
+
+    @cocotb.coroutine
+    def raise_exc():
+        yield Timer(10)
+        raise the_exception
+
+    @cocotb.coroutine
+    def passthrough():
+        yield Timer(10)
+        yield raise_exc()
+
+    try:
+        yield passthrough()
+    except ValueError as e:
+        assert e is the_exception
+        # raise the exception to display traceback
+        raise
+    else:
+        raise TestFailure("Exception didn't reach top level test")
+
+
 @cocotb.test()
 def test_stack_overflow(dut):
     """

--- a/tests/test_cases/test_cocotb/test_cocotb_35.py
+++ b/tests/test_cases/test_cocotb/test_cocotb_35.py
@@ -34,6 +34,8 @@ class SomeException(Exception):
     """ Custom exception to test for that can't be thrown by internals """
     pass
 
+exc_info = (SomeException, SomeException(), None)
+
 
 # just to be sure...
 @cocotb.test(expect_fail=True)
@@ -52,7 +54,7 @@ def test_annotated_async_from_coro(dut):
     assert v == 1
 
     try:
-        yield produce.async_annotated(Error(SomeException))
+        yield produce.async_annotated(Error(*exc_info))
     except SomeException:
         pass
     else:
@@ -66,7 +68,7 @@ async def test_annotated_async_from_async(dut):
     assert v == 1
 
     try:
-        await produce.async_annotated(Error(SomeException))
+        await produce.async_annotated(Error(*exc_info))
     except SomeException:
         pass
     else:
@@ -74,13 +76,13 @@ async def test_annotated_async_from_async(dut):
 
 
 @cocotb.test()
-async def test_annotated_async_from_async(dut):
+async def test_async_from_async(dut):
     """ Test that async coroutines are able to call raw async functions """
     v = await produce.async_(Value(1))
     assert v == 1
 
     try:
-        await produce.async_(Error(SomeException))
+        await produce.async_(Error(*exc_info))
     except SomeException:
         pass
     else:
@@ -94,7 +96,7 @@ async def test_coro_from_async(dut):
     assert v == 1
 
     try:
-        await produce.coro(Error(SomeException))
+        await produce.coro(Error(*exc_info))
     except SomeException:
         pass
     else:


### PR DESCRIPTION
In Python 2, we don't get implicit exception chaining ala the
__context__ attribute of exceptions from Python 3.

When exceptions are raised in coroutines, if the exception is not
handled as it propagates up through the coroutine stack, keep
the traceback information as we go so that the eventual
call to raise_error() can print out the full traceback to where
the exception was raised.

Also added printing of traceback when a forked coroutine raises an
exception and nothing was waiting on a Join.