### PR TITLE
Fixes #922

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -41,7 +41,7 @@ import cocotb.handle
 from cocotb.scheduler import Scheduler
 from cocotb.log import SimLogFormatter, SimBaseLog, SimLog
 from cocotb.regression import RegressionManager
-from cocotb.result import TestComplete, raise_error
+from cocotb.result import TestComplete, raise_error, ReturnValue
 
 
 # Things we want in the cocotb namespace
@@ -98,11 +98,12 @@ def fork(coro):
         try:
             task = scheduler.add(coro)
             res = yield task
-            return res
         except TestComplete:
             raise
         except Exception as e:
             raise_error(task, str(e))
+        else:
+            raise ReturnValue(res)
     return scheduler.add(_monitor())
 
 # FIXME is this really required?

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -91,6 +91,7 @@ plusargs = {}
 
 # To save typing provide an alias to scheduler.add
 fork = scheduler.add
+run = scheduler.add
 
 # FIXME is this really required?
 _rlock = threading.RLock()

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -469,7 +469,7 @@ class Scheduler(object):
             except TestComplete as test_result:
                 self.log.debug("TestComplete received: {}".format(test_result.__class__.__name__))
                 self.finish_test(test_result)
-            except Exception as e:
+            except Exception:
                 pass
 
     def save_write(self, handle, value):

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -470,7 +470,7 @@ class Scheduler(object):
                 self.log.debug("TestComplete received: {}".format(test_result.__class__.__name__))
                 self.finish_test(test_result)
             except Exception as e:
-                self.finish_test(create_error(self, "Forked coroutine {} raised exception: {}".format(coro, e)))
+                pass
 
     def save_write(self, handle, value):
         if self._mode == Scheduler._MODE_READONLY:

--- a/tests/test_cases/issue_922/Makefile
+++ b/tests/test_cases/issue_922/Makefile
@@ -1,0 +1,33 @@
+###############################################################################
+# Copyright (c) 2013 Potential Ventures Ltd
+# Copyright (c) 2013 SolarFlare Communications Inc
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       SolarFlare Communications Inc nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_922

--- a/tests/test_cases/issue_922/issue_922.py
+++ b/tests/test_cases/issue_922/issue_922.py
@@ -1,0 +1,28 @@
+import cocotb
+from cocotb.triggers import Timer, NullTrigger
+
+@cocotb.coroutine
+def a_coroutine_that_fails_soon():
+    yield Timer(10, 'ns')
+    raise Exception
+
+@cocotb.coroutine
+def longer_than_soon():
+    yield Timer(100, 'ns')
+
+@cocotb.test()
+def runs(dut):
+    task = cocotb.run(a_coroutine_that_fails_soon())
+    yield longer_than_soon()
+    try:
+        yield task
+    except Exception as e:
+        pass  # we never get as far as here right now, but I think we ought to
+    else:
+        assert False
+
+@cocotb.test(expect_error=True)
+def forks(dut):
+    task = cocotb.fork(a_coroutine_that_fails_soon())
+    yield longer_than_soon()
+    assert False

--- a/tests/test_cases/issue_922/issue_922.py
+++ b/tests/test_cases/issue_922/issue_922.py
@@ -1,10 +1,12 @@
 import cocotb
 from cocotb.triggers import Timer, NullTrigger
 
+class TestException(Exception): pass
+
 @cocotb.coroutine
 def a_coroutine_that_fails_soon():
     yield Timer(10, 'ns')
-    raise Exception
+    raise TestException
 
 @cocotb.coroutine
 def longer_than_soon():
@@ -16,7 +18,7 @@ def runs(dut):
     yield longer_than_soon()
     try:
         yield task
-    except Exception as e:
+    except TestException as e:
         pass  # we never get as far as here right now, but I think we ought to
     else:
         assert False

--- a/tests/test_cases/issue_922/issue_922.py
+++ b/tests/test_cases/issue_922/issue_922.py
@@ -28,3 +28,21 @@ def forks(dut):
     task = cocotb.fork(a_coroutine_that_fails_soon())
     yield longer_than_soon()
     assert False
+
+@cocotb.test()
+def fire_and_forget_not_caught(dut):
+    task = cocotb.fire_and_forget(a_coroutine_that_fails_soon())
+    yield longer_than_soon()
+    # look at stdout, error was printed
+
+@cocotb.test()
+def fire_and_forget_caught(dut):
+    task = cocotb.fire_and_forget(a_coroutine_that_fails_soon())
+    yield longer_than_soon()
+    # look at stdout, still printing
+    try:
+        yield task
+    except TestException as e:
+        pass
+    else:
+        assert False


### PR DESCRIPTION
`fork`ed coroutines behave as they did. There is now a `cocotb.run` function that runs a coroutine in a non-blocking way (as `fork` does) that does not cause a `TestError` when catching an exception. Instead, when the user `yield`s on a `run`ed function, it will re-throw the error.

Feel free to suggest any improvements, including naming.