### PR TITLE
 [RFC][WIP] Fix failing ghdl test

### DIFF
--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -35,7 +35,7 @@ clean::
 
 else
 
-TOPLEVEL = dec_viterbi
+TOPLEVEL = decoder_viterbi
 
 ifeq ($(OS),Msys)
 WPWD=$(shell sh -c 'pwd -W')
@@ -46,6 +46,8 @@ endif
 COCOTB?=$(WPWD)/../../..
 
 SRC_BASE = $(COCOTB)/tests/designs/viterbi_decoder_axi4s
+
+GHDL_ARGS += --ieee=synopsys
 
 RTL_LIBRARY = dec_viterbi
 
@@ -63,7 +65,7 @@ VHDL_SOURCES = $(SRC_BASE)/packages/pkg_helper.vhd \
 	       $(SRC_BASE)/src/ram_ctrl.vhd \
 	       $(SRC_BASE)/src/reorder.vhd \
 	       $(SRC_BASE)/src/recursion.vhd \
-	       $(SRC_BASE)/src/dec_viterbi.vhd \
+	       $(SRC_BASE)/src/decoder_viterbi.vhd \
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim

--- a/tests/designs/viterbi_decoder_axi4s/src/decoder_viterbi.vhd
+++ b/tests/designs/viterbi_decoder_axi4s/src/decoder_viterbi.vhd
@@ -26,7 +26,7 @@ use dec_viterbi.pkg_components.all;
 use dec_viterbi.pkg_trellis.all;
 
 
-entity dec_viterbi is
+entity decoder_viterbi is
 	port(
 
 	--
@@ -70,10 +70,10 @@ entity dec_viterbi is
 	s_axis_ctrl_tlast  : in std_logic;
 	s_axis_ctrl_tready : out std_logic
 );
-end entity dec_viterbi;
+end entity decoder_viterbi;
 
 
-architecture rtl of dec_viterbi is
+architecture rtl of decoder_viterbi is
 
 	alias clk is aclk;
 	signal rst : std_logic;
@@ -397,3 +397,4 @@ begin
 	end process pr_reorder_tready;
 
 end architecture rtl;
+


### PR DESCRIPTION
While trying to fix the ghdl issues with dec_viterbi, another error popped up, this time apparently with VPI. Somehow, [here](https://github.com/potentialventures/cocotb/blob/master/tests/test_cases/test_vhdl_access/test_vhdl_access.py#L63) cocotb fails to get the element 0. Tracking down the issue, it seems that the problem comes from [here](https://github.com/potentialventures/cocotb/blob/master/cocotb/handle.py#L346), as the returned `new_handle` is `0`.

Unfortunately, I'm not yet able to track it down by myself, any suggestion? This seems to be quite important, as it is currently impossible to reference any instance generated with the "`for ... generate`" construct.

Thanks.