### PR TITLE
Add documentation for Trigger members, and mark the prime method as abstract

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -31,6 +31,7 @@ import os
 import weakref
 import sys
 import textwrap
+import abc
 
 if "COCOTB_SIM" in os.environ:
     import simulator
@@ -51,9 +52,9 @@ import cocotb
 class TriggerException(Exception):
     pass
 
-class Trigger(object):
+class Trigger(with_metaclass(abc.ABCMeta)):
     """Base class to derive from."""
-    
+
     def __init__(self):
         self.signal = None
         self.primed = False
@@ -62,17 +63,37 @@ class Trigger(object):
     def log(self):
         return SimLog("cocotb.%s" % (self.__class__.__name__), id(self))
 
-    def prime(self, *args):
-        """FIXME: document"""
+    @abc.abstractmethod
+    def prime(self, callback):
+        """Set a callback to be invoked when the trigger fires.
+
+        The callback will be invoked with a single argumement, `self`.
+
+        Subclasses must override this, but should end by calling the base class
+        method.
+
+        Do not call this directly within coroutines, it is intended to be used
+        only by the scheduler.
+        """
         self.primed = True
 
     def unprime(self):
-        """Remove any pending callbacks if necessary."""
+        """Remove the callback, and perform cleanup if necessary.
+
+        After being unprimed, a Trigger may be reprimed again in future.
+        Calling `unprime` multiple times is allowed, subsequent calls should be
+        a no-op.
+
+        Subclasses may override this, but should end by calling the base class
+        method.
+
+        Do not call this directly within coroutines, it is intended to be used
+        only by the scheduler.
+        """
         self.primed = False
 
     def __del__(self):
-        """Ensure if a trigger drops out of scope we remove any pending
-        callbacks."""
+        # Ensure if a trigger drops out of scope we remove any pending callbacks
         self.unprime()
 
     def __str__(self):
@@ -80,6 +101,11 @@ class Trigger(object):
 
     @property
     def _outcome(self):
+        """The result that `yield this_trigger` produces in a coroutine.
+
+        The default is to produce the trigger itself, which is done for
+        ease of use with :class:`~cocotb.triggers.First`.
+        """
         return outcomes.Value(self)
 
     # Once 2.7 is dropped, this can be run unconditionally
@@ -93,12 +119,9 @@ class Trigger(object):
 
 class PythonTrigger(Trigger):
     """Python triggers don't use GPI at all.
-        For example notification of coroutine completion etc.
 
-        TODO:
-            Still need to implement unprime.
-        """
-    pass
+    For example notification of coroutine completion etc.
+    """
 
 
 class GPITrigger(Trigger):
@@ -145,17 +168,23 @@ class Timer(GPITrigger):
                                                            callback, self)
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
-        Trigger.prime(self)
+        GPITrigger.prime(self, callback)
 
     def __str__(self):
         return self.__class__.__name__ + "(%1.2fps)" % get_time_from_sim_steps(self.sim_steps,units='ps')
 
 
-class ReadOnly(with_metaclass(ParametrizedSingleton, GPITrigger)):
+# This is needed to make our custom metaclass work with abc.ABCMeta used in the
+# `Trigger` base class.
+class _ParameterizedSingletonAndABC(ParametrizedSingleton, abc.ABCMeta):
+    pass
+
+
+class ReadOnly(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Execution will resume when the readonly portion of the sim cycles is
     reached.
     """
-    
+
     @classmethod
     def __singleton_key__(cls):
         return None
@@ -164,22 +193,21 @@ class ReadOnly(with_metaclass(ParametrizedSingleton, GPITrigger)):
         GPITrigger.__init__(self)
 
     def prime(self, callback):
-        """FIXME: document"""
         if self.cbhdl == 0:
             self.cbhdl = simulator.register_readonly_callback(callback, self)
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
-        Trigger.prime(self)
+        GPITrigger.prime(self, callback)
 
     def __str__(self):
         return self.__class__.__name__ + "(readonly)"
 
 
-class ReadWrite(with_metaclass(ParametrizedSingleton, GPITrigger)):
+class ReadWrite(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Execution will resume when the readwrite portion of the sim cycles is
     reached.
     """
-    
+
     @classmethod
     def __singleton_key__(cls):
         return None
@@ -188,22 +216,21 @@ class ReadWrite(with_metaclass(ParametrizedSingleton, GPITrigger)):
         GPITrigger.__init__(self)
 
     def prime(self, callback):
-        """FIXME: document"""
         if self.cbhdl == 0:
             # import pdb
             # pdb.set_trace()
             self.cbhdl = simulator.register_rwsynch_callback(callback, self)
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
-        Trigger.prime(self)
+        GPITrigger.prime(self, callback)
 
     def __str__(self):
         return self.__class__.__name__ + "(readwritesync)"
 
 
-class NextTimeStep(with_metaclass(ParametrizedSingleton, GPITrigger)):
+class NextTimeStep(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Execution will resume when the next time step is started."""
-    
+
     @classmethod
     def __singleton_key__(cls):
         return None
@@ -216,15 +243,15 @@ class NextTimeStep(with_metaclass(ParametrizedSingleton, GPITrigger)):
             self.cbhdl = simulator.register_nextstep_callback(callback, self)
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
-        Trigger.prime(self)
+        GPITrigger.prime(self, callback)
 
     def __str__(self):
         return self.__class__.__name__ + "(nexttimestep)"
 
 
-class _EdgeBase(with_metaclass(ParametrizedSingleton, GPITrigger)):
+class _EdgeBase(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Execution will resume when an edge occurs on the provided signal."""
-    
+
     @classmethod
     @property
     def _edge_type(self):
@@ -247,7 +274,7 @@ class _EdgeBase(with_metaclass(ParametrizedSingleton, GPITrigger)):
             )
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
-        super(_EdgeBase, self).prime()
+        super(_EdgeBase, self).prime(callback)
 
     def __str__(self):
         return self.__class__.__name__ + "(%s)" % self.signal._name
@@ -287,7 +314,7 @@ class _Event(PythonTrigger):
     def prime(self, callback):
         self._callback = callback
         self.parent._prime_trigger(self, callback)
-        Trigger.prime(self)
+        Trigger.prime(self, callback)
 
     def __call__(self):
         self._callback(self)
@@ -356,7 +383,7 @@ class _Lock(PythonTrigger):
     def prime(self, callback):
         self._callback = callback
         self.parent._prime_trigger(self, callback)
-        Trigger.prime(self)
+        Trigger.prime(self, callback)
 
     def __call__(self):
         self._callback(self)
@@ -437,9 +464,9 @@ class NullTrigger(Trigger):
         return self.__class__.__name__ + "(%s)" % self.name
 
 
-class Join(with_metaclass(ParametrizedSingleton, PythonTrigger)):
+class Join(with_metaclass(_ParameterizedSingletonAndABC, PythonTrigger)):
     """Join a coroutine, firing when it exits."""
-    
+
     @classmethod
     def __singleton_key__(cls, coroutine):
         return coroutine
@@ -455,11 +482,13 @@ class Join(with_metaclass(ParametrizedSingleton, PythonTrigger)):
 
     @property
     def retval(self):
-        """FIXME: document"""
+        """The return value of the joined coroutine.
+
+        If the coroutine threw an exception, this attribute will re-raise it.
+        """
         return self._coroutine.retval
 
     def prime(self, callback):
-        """FIXME: document"""
         if self._coroutine._finished:
             callback(self)
         else:


### PR DESCRIPTION
Unfortunately in order to use `abc.ABCMeta` with the `ParameterizedSingleton` metaclass, we have to create a new metaclass derived from both classes, else python gives a metaclass conflict. This only costs a couple lines thankfully.

Relates to gh-811