### PR TITLE
Fix for BinaryValue type

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -29,6 +29,7 @@
 
 from __future__ import print_function
 from cocotb.utils import integer_types
+from cocotb.log import SimLog
 
 import os
 import random
@@ -37,6 +38,10 @@ import warnings
 resolve_x_to = os.getenv('COCOTB_RESOLVE_X', "VALUE_ERROR")
 
 def resolve(string):
+    """Resolve a multi-state binary string to a 2 state binary string
+
+    Resolve other states (e.g. X from VHDL std_logic/Verilog logic) to 0 or 1
+    """
     for char in BinaryValue._resolve_to_0:
         string = string.replace(char, "0")
     for char in BinaryValue._resolve_to_1:
@@ -91,6 +96,7 @@ class BinaryValue(object):
     '*'
 
     """
+    # Accepted characters and resolution
     _resolve_to_0     = "-lL"  # noqa
     _resolve_to_1     = "hH"  # noqa
     _resolve_to_error = "xXzZuUwW"  # Resolve to a ValueError() since these usually mean something is wrong
@@ -98,22 +104,34 @@ class BinaryValue(object):
 
     def __init__(self, value=None, n_bits=None, bigEndian=True,
                  binaryRepresentation=BinaryRepresentation.UNSIGNED,
-                 bits=None):
+                 bits=None, ascending_range=False):
         """Args:
             value (str or int or long, optional): Value to assign to the bus.
             n_bits (int, optional): Number of bits to use for the underlying
                 binary representation.
-            bigEndian (bool, optional): Interpret the binary as big-endian
-                when converting to/from a string buffer.
+            bigEndian (bool, optional): Interpret the binary string as
+                big-endian when converting to/from a byte string buffer.
+                AKA byte-ordering
             binaryRepresentation (BinaryRepresentation): The representation
                 of the binary value
                 (one of :any:`UNSIGNED`, :any:`SIGNED_MAGNITUDE`, :any:`TWOS_COMPLEMENT`).
                 Defaults to unsigned representation.
+            ascending_range (bool, optional): Interpret the binary string bit-order
+                as having an ascending range (big-endian bits).
             bits (int, optional): Deprecated: Compatibility wrapper for :attr:`n_bits`.
         """
+        # The underlying vector:
+        # - Mirrors the representation in HW
+        # - This is a Python string of bits
+        # - Note that because it is a string, if acending_range is false, indexing (of strings) no
+        #   longer provides the expected result (0th index is still the start of the string)
         self._str = ""
+
         self.big_endian = bigEndian
         self.binaryRepresentation = binaryRepresentation
+        self.ascending_range = ascending_range
+
+        self._log = SimLog("cocotb.binary.%s" % self.__class__.__name__)
 
         # bits is the deprecated name for n_bits, allow its use for
         # backward-compat reasons.
@@ -127,17 +145,23 @@ class BinaryValue(object):
 
         self._n_bits = n_bits
 
-        self._convert_to = {
-                            BinaryRepresentation.UNSIGNED         : self._convert_to_unsigned   ,
-                            BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_to_signed_mag ,
-                            BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_to_twos_comp  ,
-                            }
+        # Convert integer to string buffer
+        self._convert_to = {BinaryRepresentation.UNSIGNED         : self._convert_to_unsigned,
+                            BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_to_signed_mag,
+                            BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_to_twos_comp,
+                           }
 
-        self._convert_from = {
-                            BinaryRepresentation.UNSIGNED         : self._convert_from_unsigned   ,
-                            BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_from_signed_mag ,
-                            BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_from_twos_comp  ,
-                            }
+        # Convert to integer from string buffer
+        self._convert_from = {BinaryRepresentation.UNSIGNED         : self._convert_from_unsigned,
+                              BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_from_signed_mag,
+                              BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_from_twos_comp,
+                             }
+
+        # Extend/truncate string buffer
+        self._adjust = {BinaryRepresentation.UNSIGNED         : self._adjust_unsigned,
+                        BinaryRepresentation.SIGNED_MAGNITUDE : self._adjust_signed_mag,
+                        BinaryRepresentation.TWOS_COMPLEMENT  : self._adjust_twos_comp,
+                       }
 
         if value is not None:
             self.assign(value)
@@ -161,141 +185,169 @@ class BinaryValue(object):
                 self.binstr = value
             except ValueError:
                 self.buff = value
+        else:
+            raise TypeError("assign requires a str or int or long, "
+                            "got type '{}'".format(type(value)))
 
     def _convert_to_unsigned(self, x):
+        """Convert an unsigned integer to a unsigned binary string"""
         x = bin(x)
         if x[0] == '-':
             raise ValueError('Attempt to assigned negative number to unsigned '
                              'BinaryValue')
-        return self._adjust_unsigned(x[2:])
+        x = x[2:] # Remove '0b' prefix
+        if self.ascending_range:
+            x = x[::-1]
+        return self._adjust_unsigned(x)
 
     def _convert_to_signed_mag(self, x):
-        x = bin(x)
+        """Convert a signed integer to a signed magnitude binary string"""
+        x = bin(x) # Little-endian bit-order
         if x[0] == '-':
-            binstr = self._adjust_signed_mag('1' + x[3:])
+            x = '1' + x[3:] # Attach negative sign
         else:
-            binstr = self._adjust_signed_mag('0' + x[2:])
-        if self.big_endian:
-            binstr = binstr[::-1]
-        return binstr
+            x = '0' + x[2:0] # Attach positive sign
+        if self.ascending_range:
+            x = x[::-1] # Convert x to big-endian bit-order
+        return self._adjust_signed_mag(x)
 
     def _convert_to_twos_comp(self, x):
-        if x < 0:
+        """Convert a signed integer to a twos complement signed binary string"""
+        if x < 0: # Convert to integer representing unsigned twos complement value
             binstr = bin(2 ** (_clog2(abs(x)) + 1) + x)[2:]
-            binstr = self._adjust_twos_comp(binstr)
         else:
-            binstr = self._adjust_twos_comp('0' + bin(x)[2:])
-        if self.big_endian:
+            binstr = '0' + bin(x)[2:]
+        # binstr is little-endian bit-order
+        if self.ascending_range:
             binstr = binstr[::-1]
-        return binstr
+        return self._adjust_twos_comp(binstr)
 
     def _convert_from_unsigned(self, x):
+        """Convert an unsigned binary string to an integer"""
+        if self.ascending_range:
+            x = x[::-1] # Python interprets binary strings as little-endian bit-order
         return int(resolve(x), 2)
 
     def _convert_from_signed_mag(self, x):
-        rv = int(resolve(self._str[1:]), 2)
-        if self._str[0] == '1':
-            rv = rv * -1
-        return rv
+        """Convert a signed magnitude binary string to an integer"""
+        if self.ascending_range:
+            x = x[::-1] # Python interprets binary strings as little-endian bit-order
+        magnitude = int(resolve(x[1:]), 2)
+        if x[0] == '1': # Handle sign bit
+            return 0 - magnitude
+        return magnitude
 
     def _convert_from_twos_comp(self, x):
-        if x[0] == '1':
-            binstr = x[1:]
-            binstr = self._invert(binstr)
-            rv = int(binstr, 2) + 1
-            if x[0] == '1':
-                rv = rv * -1
-        else:
-            rv = int(resolve(x), 2)
-        return rv
+        """Convert a signed twos complement binary string to an integer"""
+        if self.ascending_range:
+            x = x[::-1] # Python interprets binary strings as little-endian bit-order
+        if x[0] == '1': # Negative value
+            # Conversion = invert and add 1
+            binstr = self._invert(x[1:]) # Remove sign and invert
+            return 0 - (int(binstr, 2) + 1)
+        return int(resolve(x), 2)
 
     def _invert(self, x):
-        inverted = ''
+        """Invert the bits of a bit string"""
+        inverted = []
         for bit in x:
             if bit == '0':
-                inverted = inverted + '1'
+                inverted.append('1')
             elif bit == '1':
-                inverted = inverted + '0'
+                inverted.append('0')
             else:
-                inverted = inverted + bit
-        return inverted
+                inverted.append(bit)
+        return "".join(inverted)
 
-    def _adjust_unsigned(self, x):
-        if self._n_bits is None:
-            return x
-        l = len(x)
-        if l <= self._n_bits:
-            if self.big_endian:
-                rv = x + '0' * (self._n_bits - l)
-            else:
-                rv = '0' * (self._n_bits - l) + x
-        elif l > self._n_bits:
-            print("WARNING: truncating value to match requested number of bits "
-                  "(%d -> %d)" % (l, self._n_bits))
-            if self.big_endian:
-                rv = x[l - self._n_bits:]
-            else:
-                rv = x[:l - self._n_bits]
-        return rv
+    def _adjust_unsigned(self, x, n_bits=None):
+        """Extend/truncate an unsigned binary string to n_bits length
 
-    def _adjust_signed_mag(self, x):
-        """Pad/truncate the bit string to the correct length."""
-        if self._n_bits is None:
+        If truncation is required, occurs on least significant bits
+        Args:
+            x (str): Unsigned binary string
+            n_bits (int, optional): Size override
+        """
+        if n_bits is None:
+            n_bits = self._n_bits
+        if n_bits is None:
             return x
-        l = len(x)
-        if l <= self._n_bits:
-            if self.big_endian:
-                rv = x[:-1] + '0' * (self._n_bits - 1 - l)
-                rv = rv + x[-1]
-            else:
-                rv = '0' * (self._n_bits - 1 - l) + x[1:]
-                rv = x[0] + rv
-        elif l > self._n_bits:
-            print("WARNING: truncating value to match requested number of bits "
-                  "(%d -> %d)" % (l, self._n_bits))
-            if self.big_endian:
-                rv = x[l - self._n_bits:]
-            else:
-                rv = x[:-(l - self._n_bits)]
-        else:
-            rv = x
-        return rv
+        length = len(x)
+        if length <= n_bits: # Extension with 0s (unsigned)
+            if self.ascending_range:
+                return x + '0' * (n_bits - length)
+            return '0' * (n_bits - length) + x
+        else: # Truncation (l > n_bits)
+            self._log.warning("Truncating value to match requested number of bits (%d -> %d)",
+                              length, n_bits)
+            # Truncate MSBs (standard verilog behaviour)
+            if self.ascending_range:
+                return x[:n_bits - length]
+            return x[length - n_bits:]
 
-    def _adjust_twos_comp(self, x):
-        if self._n_bits is None:
+    def _adjust_signed_mag(self, x, n_bits=None):
+        """Extend/truncate a signed magnitude bit string to n_bits length
+
+        Args:
+            x (str): Unsigned binary string
+            n_bits (int, optional): Size override
+        """
+        if n_bits is None:
+            n_bits = self._n_bits
+        if n_bits is None:
             return x
-        l = len(x)
-        if l <= self._n_bits:
-            if self.big_endian:
-                rv = x + x[-1] * (self._n_bits - l)
-            else:
-                rv = x[0] * (self._n_bits - l) + x
-        elif l > self._n_bits:
-            print("WARNING: truncating value to match requested number of bits "
-                  "(%d -> %d)" % (l, self._n_bits))
-            if self.big_endian:
-                rv = x[l - self._n_bits:]
-            else:
-                rv = x[:-(l - self._n_bits)]
-        else:
-            rv = x
-        return rv
+        length = len(x)
+        if length <= n_bits:
+            if self.ascending_range:
+                # (x without sign) + (padding 0s) + (sign)
+                return x[:-1] + '0' * (n_bits - 1 - length) + x[-1]
+            # (sign) + (padding 0s) + (x without sign)
+            return x[0] + '0' * (n_bits - 1 - length) + x[1:]
+        else: # Truncation (l > n_bits)
+            self._log.warning("Truncating value to match requested number of bits (%d -> %d)",
+                              length, n_bits)
+            # Truncate MSBs (standard verilog behaviour)
+            # NOTE: Lose sign data
+            if self.ascending_range:
+                return x[:n_bits - length]
+            return x[length - n_bits:]
+
+    def _adjust_twos_comp(self, x, n_bits=None):
+        """Extend/truncate a twos complement bit string to n_bits length
+
+        Args:
+            x (str): Unsigned binary string
+            n_bits (int, optional): Size override
+        """
+        if n_bits is None:
+            n_bits = self._n_bits
+        if n_bits is None:
+            return x
+        length = len(x)
+        if length <= n_bits: # Sign extension
+            if self.ascending_range:
+                return x + x[-1] * (n_bits - length)
+            return x[0] * (n_bits - length) + x
+        else: # Truncation (l > self._n_bits)
+            self._log.warning("Truncating value to match requested number of bits (%d -> %d)",
+                              length, n_bits)
+            if self.ascending_range:
+                return x[:n_bits - length]
+            return x[length - n_bits:]
 
     def get_value(self):
         """Return the integer representation of the underlying vector."""
         return self._convert_from[self.binaryRepresentation](self._str)
 
     def get_value_signed(self):
-        """Return the signed integer representation of the underlying vector."""
-        ival = int(resolve(self._str), 2)
-        bits = len(self._str)
-        signbit = (1 << (bits - 1))
-        if (ival & signbit) == 0:
-            return ival
-        else:
-            return -1 * (1 + (int(~ival) & (signbit - 1)))
+        """Return the signed integer representation of the underlying vector. **deprecated**"""
+        if self.binaryRepresentation == BinaryRepresentation.UNSIGNED:
+            raise ValueError("Attempt to convert unsigned value to signed")
+        elif self.binaryRepresentation not in [BinaryRepresentation.SIGNED_MAGNITUDE, BinaryRepresentation.TWOS_COMPLEMENT]:
+            raise TypeError("Unrecognised binary representation")
+        return self.get_value()
 
     def set_value(self, integer):
+        """Set the integer value"""
         self._str = self._convert_to[self.binaryRepresentation](integer)
 
     @property
@@ -303,95 +355,123 @@ class BinaryValue(object):
         """Does the value contain any ``X``'s?  Inquiring minds want to know."""
         return not any(char in self._str for char in BinaryValue._resolve_to_error)
 
+    def _get_bytes(self):
+        """Get the value as a list of resolved bytes
+
+        The value is resolved and grouped into bytes.
+        This returns a big-endian byte-order list of bytes.
+        """
+        length = len(self._str)
+        if length % 8 != 0:
+            length = ((length // 8) + 1) * 8 # Round up to nearest byte
+        bits = self._adjust[self.binaryRepresentation](resolve(self._str), length)
+        byte_list = (int(bits[i:i+8], 2) for i in range(0, len(bits), 8))
+        if self.big_endian:
+            return list(byte_list)
+        return list(byte_list)[::-1]
+
+    def get_buff(self):
+        """Attribute :attr:`buff` represents the value as a resolved byte string buffer.
+
+        >>> "0100000100101111".buff == "\x41\x2F"
+        True
+
+        Buffer has the same bit order endian-ness as the binary value
+        Returns a big-endian byte-order bytestring
+        """
+        return "".join(chr(byte) for byte in self._get_bytes())
+
+    def get_hex_buff(self):
+        """Get the value as a resolved hex string buffer
+
+        >>> "0100000100101111".buff == "412F"
+        True
+
+        Buffer has the same bit order endian-ness as the binary value
+        Returns a big-endian byte-order hex string
+        """
+        return "".join(hex(byte)[2:0] for byte in self._get_bytes()).upper()
+
+    def set_buff(self, buff):
+        """Set the value using a byte string
+
+        Takes a big-endian byte-order bit string.
+        Buffer assumed to have the same bit order endian-ness as the binary value
+        """
+        converted_buffer = "".join("{:08b}".format(ord(char)) for char in buff)
+        if not self.big_endian:
+            converted_buffer = list(converted_buffer)[::-1]
+        self._str = self._adjust[self.binaryRepresentation](converted_buffer)
+
+    def get_binstr(self):
+        """Attribute :attr:`binstr` is the unresolved binary representation stored
+        as a string of ``1`` and ``0``."""
+        return self._str
+
+    def set_binstr(self, string):
+        """Set the internal binary string"""
+        for char in string:
+            if char not in BinaryValue._permitted_chars:
+                raise ValueError("Attempting to assign character %s to a %s" %
+                                 (char, self.__class__.__name__))
+        self._str = self._adjust[self.binaryRepresentation](string)
+
     value = property(get_value, set_value, None,
                      "Integer access to the value. **deprecated**")
     integer = property(get_value, set_value, None,
                        "The integer representation of the underlying vector.")
     signed_integer = property(get_value_signed, set_value, None,
-                              "The signed integer representation of the underlying vector.")
-
-    def get_buff(self):
-        """Attribute :attr:`buff` represents the value as a binary string buffer.
-
-        >>> "0100000100101111".buff == "\x41\x2F"
-        True
-        """
-        bits = resolve(self._str)
-
-        if len(bits) % 8:
-            bits = "0" * (8 - len(bits) % 8) + bits
-
-        buff = ""
-        while bits:
-            byte = bits[:8]
-            bits = bits[8:]
-            val = int(byte, 2)
-            if self.big_endian:
-                buff += chr(val)
-            else:
-                buff = chr(val) + buff
-        return buff
-
-    def get_hex_buff(self):
-        bstr = self.get_buff()
-        hstr = '%0*X' % ((len(bstr) + 3) // 4, int(bstr, 2))
-        return hstr
-
-    def set_buff(self, buff):
-        self._str = ""
-        for char in buff:
-            if self.big_endian:
-                self._str += "{0:08b}".format(ord(char))
-            else:
-                self._str = "{0:08b}".format(ord(char)) + self._str
-        self._adjust()
-
-    def _adjust(self):
-        """Pad/truncate the bit string to the correct length."""
-        if self._n_bits is None:
-            return
-        l = len(self._str)
-        if l < self._n_bits:
-            if self.big_endian:
-                self._str = self._str + "0" * (self._n_bits - l)
-            else:
-                self._str = "0" * (self._n_bits - l) + self._str
-        elif l > self._n_bits:
-            print("WARNING: truncating value to match requested number of bits "
-                  "(%d -> %d)" % (l, self._n_bits))
-            self._str = self._str[l - self._n_bits:]
-
+                              "The signed integer representation of the underlying vector. **deprecated**")
     buff = property(get_buff, set_buff, None,
                     "Access to the value as a buffer.")
-
-    def get_binstr(self):
-        """Attribute :attr:`binstr` is the binary representation stored as
-        a string of ``1`` and ``0``."""
-        return self._str
-
-    def set_binstr(self, string):
-        for char in string:
-            if char not in BinaryValue._permitted_chars:
-                raise ValueError("Attempting to assign character %s to a %s" %
-                                 (char, self.__class__.__name__))
-        self._str = string
-        self._adjust()
-
     binstr = property(get_binstr, set_binstr, None,
                       "Access to the binary string.")
 
+    @property
+    def big_endian(self):
+        """Whether the byte order is big endian (bool)
+
+        Changes how binary string is interpreted when converting to/from a string buffer
+        """
+        return self._big_endian
+
+    @big_endian.setter
+    def big_endian(self, value):
+        if isinstance(value, bool):
+            self._big_endian = value
+        else:
+            raise TypeError("big_endian is a boolean")
+
+    @property
+    def ascending_range(self):
+        """Whether the bit order is big endian (bool)
+
+        Changes how the binary string is interpreted when converting between integers
+        """
+        return self._ascending_range
+
+    @ascending_range.setter
+    def ascending_range(self, value):
+        if isinstance(value, bool):
+            self._ascending_range = value
+        else:
+            raise TypeError("ascending_range is a boolean")
+
+    @property
+    def n_bits(self):
+        """Number of bits of the binary value"""
+        return self._get_n_bits()
+
     def _get_n_bits(self):
-        """The number of bits of the binary value."""
+        """The number of bits of the binary value
+
+        Returns: int or None if unsized
+        """
         return self._n_bits
 
-    n_bits = property(_get_n_bits, None, None,
-                      "Access to the number of bits of the binary value.")
-
     def hex(self):
-        try:
-            return hex(self.get_value())
-        except Exception:
-            return hex(int(self.binstr, 2))
+        """Get the value as a Python formatted hex string"""
+        return self.__hex__()
 
     def __le__(self, other):
         self.assign(other)
@@ -418,26 +498,28 @@ class BinaryValue(object):
         True
 
         """
-        for char in self._str:
-            if char == "1":
-                return True
-        return False
+        return any(char == "1" for char in self._str)
 
     def __eq__(self, other):
+        """Two values are equal if they represent the same value
+
+        NOTE: Can be different strings, so long as binary
+              representation type is different
+        """
         if isinstance(other, BinaryValue):
-            other = other.value
-        return self.value == other
+            other = other.integer
+        return self.integer == other
 
     def __ne__(self, other):
         if isinstance(other, BinaryValue):
-            other = other.value
-        return self.value != other
+            other = other.integer
+        return self.integer != other
 
     def __cmp__(self, other):
         """Comparison against other values"""
         if isinstance(other, BinaryValue):
-            other = other.value
-        return self.value.__cmp__(other)
+            other = other.integer
+        return self.integer.__cmp__(other)
 
     def __int__(self):
         return self.integer
@@ -502,10 +584,10 @@ class BinaryValue(object):
         return other % self.integer
 
     def __pow__(self, other, modulo=None):
-        return pow(self.integer, other)
+        return pow(self.integer, other, modulo)
 
-    def __ipow__(self, other):
-        self.integer = pow(self.integer, other)
+    def __ipow__(self, other, modulo=None):
+        self.integer = pow(self.integer, other, modulo)
         return self
 
     def __rpow__(self, other):
@@ -596,112 +678,132 @@ class BinaryValue(object):
         return self.integer
 
     def __len__(self):
-        return len(self.binstr)
+        return self._n_bits or len(self.binstr)
+
+    def _check_index(self, index):
+        """Validate the index used when slicing/indexing BinaryValue"""
+        length = self.__len__()
+        if not isinstance(index, integer_types):
+            raise TypeError("BinaryValue only accepts integer indices")
+        if index < 0:
+            raise IndexError("BinaryValue does not support negative indices")
+        if index > length - 1:
+            raise IndexError("BinaryValue index {:d} is out of range"
+                             "(length {:d})".format(index, length))
+
+    def _handle_slice(self, slice_object):
+        """Handles Python slice, formatting it to how BinaryValue can use this
+
+        See __getitem__/__setitem__
+        Note: This converts the slice indices from BinaryValue Verilog/VHDL format
+              to Python format
+
+        Returns: (slice) Formatted slice
+        """
+        if slice_object.step is not None:
+            raise IndexError("BinaryValue does not support a stepping index")
+
+        max_index = self.__len__() - 1
+
+        if slice_object.start is None:
+            slice_object.start = 0 if self.ascending_range else max_index
+        if slice_object.stop is None:
+            slice_object.stop = max_index if self.ascending_range else 0
+
+        self._check_index(slice_object.start)
+        self._check_index(slice_object.stop)
+
+        if self.ascending_range:
+            if slice_object.start > slice_object.stop:
+                raise IndexError("Big-endian (ascending range) indices "
+                                 "must be specified low to high")
+            return slice_object
+        if slice_object.start < slice_object.stop:
+            raise IndexError("Little-endian (descending range) indices "
+                             "must be specified high to low")
+        # Python lists are always big-endian bit-order, must convert indices
+        length = self.__len__()
+        high = length - slice_object.stop
+        low = length - 1 - slice_object.start
+        return slice(low, high)
+
+    def _handle_index(self, key):
+        """Handle index passed to __getitem__/__setitem__"""
+        if isinstance(key, slice):
+            return self._handle_slice(key)
+        self._check_index(key)
+        if not self.ascending_range:
+            # Convert indices to big-endian bit-order
+            return self.__len__() - 1 - key
+        return key
 
     def __getitem__(self, key):
-        """BinaryValue uses Verilog/VHDL style slices as opposed to Python
-        style"""
+        """BinaryValue uses Verilog/VHDL style slices as opposed to Python style
+
+        Step is not supported
+        Negative indices are not supported
+        Indices are inclusive e.g. [0:3] returns length 4 string
+        Indices must be the correct order for bit-order endian-ness of value
+
+        WARNING: When getting a slice, this value is shifted to the 0th index
+        """
+        key = self._handle_index(key)
+
         if isinstance(key, slice):
-            first, second = key.start, key.stop
-            if self.big_endian:
-                if first < 0 or second < 0:
-                    raise IndexError('BinaryValue does not support negative '
-                                     'indices')
-                if second > self._n_bits - 1:
-                    raise IndexError('High index greater than number of bits.')
-                if first > second:
-                    raise IndexError('Big Endian indices must be specified '
-                                     'low to high')
-                _binstr = self.binstr[first:(second + 1)]
-            else:
-                if first < 0 or second < 0:
-                    raise IndexError('BinaryValue does not support negative '
-                                     'indices')
-                if first > self._n_bits - 1:
-                    raise IndexError('High index greater than number of bits.')
-                if second > first:
-                    raise IndexError('Litte Endian indices must be specified '
-                                     'high to low')
-                high = self._n_bits - second
-                low = self._n_bits - 1 - first
-                _binstr = self.binstr[low:high]
+            binstr = self.binstr[key.start:key.stop]
         else:
-            index = key
-            if index > self._n_bits - 1:
-                raise IndexError('Index greater than number of bits.')
-            if self.big_endian:
-                _binstr = self.binstr[index]
-            else:
-                _binstr = self.binstr[self._n_bits-1-index]
-        rv = BinaryValue(bits=len(_binstr), bigEndian=self.big_endian,
-                         binaryRepresentation=self.binaryRepresentation)
-        rv.set_binstr(_binstr)
-        return rv
+            binstr = self.binstr[key]
+        return BinaryValue(bits=len(binstr),
+                           bigEndian=self.big_endian,
+                           ascending_range=self.ascending_range,
+                           binaryRepresentation=self.binaryRepresentation,
+                           value=binstr)
 
     def __setitem__(self, key, val):
-        """BinaryValue uses Verilog/VHDL style slices as opposed to Python style."""
-        if not isinstance(val, str) and not isinstance(val, integer_types):
-            raise TypeError('BinaryValue slices only accept string or integer values')
+        """BinaryValue uses Verilog/VHDL style slices as opposed to Python style
 
-        # convert integer to string
-        if isinstance(val, integer_types):
-            if isinstance(key, slice):
-                num_slice_bits = abs(key.start - key.stop) + 1
-            else:
-                num_slice_bits = 1
-            if val < 0:
-                raise ValueError('Integer must be positive')
-            if val >= 2**num_slice_bits:
-                raise ValueError('Integer is too large for the specified slice '
-                                 'length')
-            val = "{:0{width}b}".format(val, width=num_slice_bits)
+        Step is not supported
+        Negative indices are not supported
+        Indices are inclusive e.g. [0:3] returns length 4 string
+        Indices must be the correct order for bit-order endian-ness of value
+        """
+        key = self._handle_index(key)
 
         if isinstance(key, slice):
-            first, second = key.start, key.stop
-
-            if self.big_endian:
-                if first < 0 or second < 0:
-                    raise IndexError('BinaryValue does not support negative '
-                                     'indices')
-                if second > self._n_bits - 1:
-                    raise IndexError('High index greater than number of bits.')
-                if first > second:
-                    raise IndexError('Big Endian indices must be specified '
-                                     'low to high')
-                if len(val) > (second + 1 - first):
-                    raise ValueError('String length must be equal to slice '
-                                     'length')
-                slice_1 = self.binstr[:first]
-                slice_2 = self.binstr[second + 1:]
-                self.binstr = slice_1 + val + slice_2
-            else:
-                if first < 0 or second < 0:
-                    raise IndexError('BinaryValue does not support negative '
-                                     'indices')
-                if first > self._n_bits - 1:
-                    raise IndexError('High index greater than number of bits.')
-                if second > first:
-                    raise IndexError('Litte Endian indices must be specified '
-                                     'high to low')
-                high = self._n_bits - second
-                low = self._n_bits - 1 - first
-                if len(val) > (high - low):
-                    raise ValueError('String length must be equal to slice '
-                                     'length')
-                slice_1 = self.binstr[:low]
-                slice_2 = self.binstr[high:]
-                self.binstr = slice_1 + val + slice_2
+            num_slice_bits = abs(key.start - key.stop)
         else:
-            if len(val) != 1:
+            num_slice_bits = 1
+
+        if isinstance(val, str): # We want value as a bit string
+            if len(val) != num_slice_bits:
                 raise ValueError('String length must be equal to slice '
                                  'length')
-            index = key
-            if index > self._n_bits - 1:
-                raise IndexError('Index greater than number of bits.')
-            if self.big_endian:
-                self.binstr = self.binstr[:index] + val + self.binstr[index + 1:]
-            else:
-                self.binstr = self.binstr[0:self._n_bits-index-1] + val + self.binstr[self._n_bits-index:self._n_bits]
+        elif isinstance(val, integer_types):
+            if val < 0:
+                raise ValueError('Integer must be positive') # Don't know representation of slice
+            if val >= pow(2, num_slice_bits):
+                raise ValueError('Integer is too large for the specified slice '
+                                 'length')
+            # If passing an integer, it is a Python int IE little-endian bit-order
+            val = "{:0{width}b}".format(val, width=num_slice_bits)
+        elif isinstance(val, BinaryValue):
+            val = val.binstr
+            if len(val) > num_slice_bits:
+                raise ValueError("Input BinaryValue is too large for the "
+                                 "specified slice length")
+        else:
+            raise TypeError("BinaryValue slices only accept string, integer, or BinaryValue types")
+
+        if isinstance(key, slice):
+            # Endian-ness has already been handled by the index converter
+            low = key.start
+            high = key.stop
+        else:
+            # Convert to Python slice
+            low = key
+            high = key + 1
+
+        self.binstr = self.binstr[:low] + val + self.binstr[high:]
 
 if __name__ == "__main__":
     import doctest

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -148,20 +148,17 @@ class BinaryValue(object):
         # Convert integer to string buffer
         self._convert_to = {BinaryRepresentation.UNSIGNED         : self._convert_to_unsigned,
                             BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_to_signed_mag,
-                            BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_to_twos_comp,
-                           }
+                            BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_to_twos_comp}
 
         # Convert to integer from string buffer
         self._convert_from = {BinaryRepresentation.UNSIGNED         : self._convert_from_unsigned,
                               BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_from_signed_mag,
-                              BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_from_twos_comp,
-                             }
+                              BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_from_twos_comp}
 
         # Extend/truncate string buffer
         self._adjust = {BinaryRepresentation.UNSIGNED         : self._adjust_unsigned,
                         BinaryRepresentation.SIGNED_MAGNITUDE : self._adjust_signed_mag,
-                        BinaryRepresentation.TWOS_COMPLEMENT  : self._adjust_twos_comp,
-                       }
+                        BinaryRepresentation.TWOS_COMPLEMENT  : self._adjust_twos_comp}
 
         if value is not None:
             self.assign(value)
@@ -195,25 +192,25 @@ class BinaryValue(object):
         if x[0] == '-':
             raise ValueError('Attempt to assigned negative number to unsigned '
                              'BinaryValue')
-        x = x[2:] # Remove '0b' prefix
+        x = x[2:]  # Remove '0b' prefix
         if self.ascending_range:
             x = x[::-1]
         return self._adjust_unsigned(x)
 
     def _convert_to_signed_mag(self, x):
         """Convert a signed integer to a signed magnitude binary string"""
-        x = bin(x) # Little-endian bit-order
+        x = bin(x)  # Little-endian bit-order
         if x[0] == '-':
-            x = '1' + x[3:] # Attach negative sign
+            x = '1' + x[3:]  # Attach negative sign
         else:
-            x = '0' + x[2:0] # Attach positive sign
+            x = '0' + x[2:0]  # Attach positive sign
         if self.ascending_range:
-            x = x[::-1] # Convert x to big-endian bit-order
+            x = x[::-1]  # Convert x to big-endian bit-order
         return self._adjust_signed_mag(x)
 
     def _convert_to_twos_comp(self, x):
         """Convert a signed integer to a twos complement signed binary string"""
-        if x < 0: # Convert to integer representing unsigned twos complement value
+        if x < 0:  # Convert to integer representing unsigned twos complement value
             binstr = bin(2 ** (_clog2(abs(x)) + 1) + x)[2:]
         else:
             binstr = '0' + bin(x)[2:]
@@ -225,25 +222,25 @@ class BinaryValue(object):
     def _convert_from_unsigned(self, x):
         """Convert an unsigned binary string to an integer"""
         if self.ascending_range:
-            x = x[::-1] # Python interprets binary strings as little-endian bit-order
+            x = x[::-1]  # Python interprets binary strings as little-endian bit-order
         return int(resolve(x), 2)
 
     def _convert_from_signed_mag(self, x):
         """Convert a signed magnitude binary string to an integer"""
         if self.ascending_range:
-            x = x[::-1] # Python interprets binary strings as little-endian bit-order
+            x = x[::-1]  # Python interprets binary strings as little-endian bit-order
         magnitude = int(resolve(x[1:]), 2)
-        if x[0] == '1': # Handle sign bit
+        if x[0] == '1':  # Handle sign bit
             return 0 - magnitude
         return magnitude
 
     def _convert_from_twos_comp(self, x):
         """Convert a signed twos complement binary string to an integer"""
         if self.ascending_range:
-            x = x[::-1] # Python interprets binary strings as little-endian bit-order
-        if x[0] == '1': # Negative value
+            x = x[::-1]  # Python interprets binary strings as little-endian bit-order
+        if x[0] == '1':  # Negative value
             # Conversion = invert and add 1
-            binstr = self._invert(x[1:]) # Remove sign and invert
+            binstr = self._invert(x[1:])  # Remove sign and invert
             return 0 - (int(binstr, 2) + 1)
         return int(resolve(x), 2)
 
@@ -272,11 +269,11 @@ class BinaryValue(object):
         if n_bits is None:
             return x
         length = len(x)
-        if length <= n_bits: # Extension with 0s (unsigned)
+        if length <= n_bits:  # Extension with 0s (unsigned)
             if self.ascending_range:
                 return x + '0' * (n_bits - length)
             return '0' * (n_bits - length) + x
-        else: # Truncation (l > n_bits)
+        else:  # Truncation (l > n_bits)
             self._log.warning("Truncating value to match requested number of bits (%d -> %d)",
                               length, n_bits)
             # Truncate MSBs (standard verilog behaviour)
@@ -302,7 +299,7 @@ class BinaryValue(object):
                 return x[:-1] + '0' * (n_bits - 1 - length) + x[-1]
             # (sign) + (padding 0s) + (x without sign)
             return x[0] + '0' * (n_bits - 1 - length) + x[1:]
-        else: # Truncation (l > n_bits)
+        else:  # Truncation (l > n_bits)
             self._log.warning("Truncating value to match requested number of bits (%d -> %d)",
                               length, n_bits)
             # Truncate MSBs (standard verilog behaviour)
@@ -323,11 +320,11 @@ class BinaryValue(object):
         if n_bits is None:
             return x
         length = len(x)
-        if length <= n_bits: # Sign extension
+        if length <= n_bits:  # Sign extension
             if self.ascending_range:
                 return x + x[-1] * (n_bits - length)
             return x[0] * (n_bits - length) + x
-        else: # Truncation (l > self._n_bits)
+        else:  # Truncation (l > self._n_bits)
             self._log.warning("Truncating value to match requested number of bits (%d -> %d)",
                               length, n_bits)
             if self.ascending_range:
@@ -363,7 +360,7 @@ class BinaryValue(object):
         """
         length = len(self._str)
         if length % 8 != 0:
-            length = ((length // 8) + 1) * 8 # Round up to nearest byte
+            length = ((length // 8) + 1) * 8  # Round up to nearest byte
         bits = self._adjust[self.binaryRepresentation](resolve(self._str), length)
         byte_list = (int(bits[i:i+8], 2) for i in range(0, len(bits), 8))
         if self.big_endian:
@@ -774,13 +771,13 @@ class BinaryValue(object):
         else:
             num_slice_bits = 1
 
-        if isinstance(val, str): # We want value as a bit string
+        if isinstance(val, str):  # We want value as a bit string
             if len(val) != num_slice_bits:
                 raise ValueError('String length must be equal to slice '
                                  'length')
         elif isinstance(val, integer_types):
             if val < 0:
-                raise ValueError('Integer must be positive') # Don't know representation of slice
+                raise ValueError('Integer must be positive')  # Don't know representation of slice
             if val >= pow(2, num_slice_bits):
                 raise ValueError('Integer is too large for the specified slice '
                                  'length')

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -509,7 +509,8 @@ class AvalonST(ValidatedBusDriver):
     _signals = ["valid", "data"]
     _optional_signals = ["ready"]
 
-    _default_config = {"firstSymbolInHighOrderBits" : True}
+    _default_config = {"firstSymbolInHighOrderBits" : True,
+                       "dataBitsPerSymbol": 8}
 
     def __init__(self, *args, **kwargs):
         config = kwargs.pop('config', {})
@@ -520,6 +521,9 @@ class AvalonST(ValidatedBusDriver):
         for configoption, value in config.items():
             self.config[configoption] = value
             self.log.debug("Setting config option %s to %s", configoption, str(value))
+
+        if self.config["dataBitsPerSymbol"] != 8:
+            raise AttributeError("AvalonST driver doesn't support support dataBitsPerSymbol != 8")
 
         word = BinaryValue(n_bits=len(self.bus.data), bigEndian=self.config["firstSymbolInHighOrderBits"],
                            value="x" * len(self.bus.data))
@@ -552,7 +556,7 @@ class AvalonST(ValidatedBusDriver):
         # Avoid spurious object creation by recycling
         clkedge = RisingEdge(self.clock)
 
-        word = BinaryValue(n_bits=len(self.bus.data), bigEndian=False)
+        word = BinaryValue(n_bits=len(self.bus.data), bigEndian=self.config["firstSymbolInHighOrderBits"])
 
         # Drive some defaults since we don't know what state we're in
         self.bus.valid <= 0
@@ -619,6 +623,9 @@ class AvalonSTPkts(ValidatedBusDriver):
             self.log.debug("Setting config option %s to %s",
                            configoption, str(value))
 
+        if self.config["dataBitsPerSymbol"] != 8:
+            raise AttributeError("AvalonSTPkts driver doesn't support support dataBitsPerSymbol != 8")
+
         num_data_symbols = (len(self.bus.data) /
                             self.config["dataBitsPerSymbol"])
         if (num_data_symbols > 1 and not hasattr(self.bus, 'empty')):
@@ -632,7 +639,7 @@ class AvalonSTPkts(ValidatedBusDriver):
         word = BinaryValue(n_bits=len(self.bus.data),
                            bigEndian=self.config["firstSymbolInHighOrderBits"])
 
-        single = BinaryValue(n_bits=1, bigEndian=False)
+        single = BinaryValue(n_bits=1, bigEndian=self.config["firstSymbolInHighOrderBits"])
 
         word.binstr   = "x" * len(self.bus.data)
         single.binstr = "x"

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -453,7 +453,7 @@ class ConstantObject(NonHierarchyObject):
             self._value = simulator.get_signal_val_str(self._handle)
         else:
             val = simulator.get_signal_val_binstr(self._handle)
-            self._value = BinaryValue(n_bits=len(val))
+            self._value = BinaryValue(n_bits=len(val), ascendingRange=False)
             try:
                 self._value.binstr = val
             except Exception:
@@ -615,7 +615,7 @@ class ModifiableObject(NonConstantObject):
 
     def _getvalue(self):
         binstr = simulator.get_signal_val_binstr(self._handle)
-        result = BinaryValue(binstr, len(binstr))
+        result = BinaryValue(binstr, len(binstr), ascendingRange=False)
         return result
 
     def _setcachedvalue(self, value):

--- a/cocotb/monitors/avalon.py
+++ b/cocotb/monitors/avalon.py
@@ -51,7 +51,8 @@ class AvalonST(BusMonitor):
     _signals = ["valid", "data"]
     _optional_signals = ["ready"]
 
-    _default_config = {"firstSymbolInHighOrderBits": True}
+    _default_config = {"dataBitsPerSymbol": 8,
+                       "firstSymbolInHighOrderBits": True}
 
     def __init__(self, *args, **kwargs):
         config = kwargs.pop('config', {})
@@ -62,6 +63,9 @@ class AvalonST(BusMonitor):
         for configoption, value in config.items():
             self.config[configoption] = value
             self.log.debug("Setting config option %s to %s", configoption, str(value))
+
+        if self.config["dataBitsPerSymbol"] != 8:
+            raise AttributeError("AvalonST driver doesn't support support dataBitsPerSymbol != 8")
 
     @coroutine
     def _monitor_recv(self):
@@ -114,6 +118,9 @@ class AvalonSTPkts(BusMonitor):
             self.config[configoption] = value
             self.log.debug("Setting config option %s to %s",
                            configoption, str(value))
+
+        if self.config["dataBitsPerSymbol"] != 8:
+            raise AttributeError("AvalonST driver doesn't support support dataBitsPerSymbol != 8")
 
         num_data_symbols = (len(self.bus.data) /
                             self.config["dataBitsPerSymbol"])

--- a/tests/designs/logic_verilog_module/Makefile
+++ b/tests/designs/logic_verilog_module/Makefile
@@ -1,0 +1,26 @@
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
+TOPLEVEL := logic_testbench
+
+ifeq ($(OS),Msys)
+WPWD=$(shell sh -c 'pwd -W')
+else
+WPWD=$(shell pwd)
+endif
+
+COCOTB?=$(WPWD)/../../..
+
+VERILOG_SOURCES = $(COCOTB)/tests/designs/logic_verilog_module/logic_testbench.v
+
+include $(COCOTB)/makefiles/Makefile.inc
+include $(COCOTB)/makefiles/Makefile.sim
+
+endif

--- a/tests/designs/logic_verilog_module/logic_testbench.v
+++ b/tests/designs/logic_verilog_module/logic_testbench.v
@@ -1,0 +1,98 @@
+`timescale 1 ps / 1 ps
+
+module logic_testbench (
+    input clk,
+    input reset
+);
+
+// Normal counters
+reg [15:0] unsigned_counter_little;
+reg signed [16:0] signed_counter_little;
+reg [0:15] unsigned_counter_big;
+reg signed [0:16] signed_counter_big;
+
+always @ (posedge clk or negedge reset) begin
+    if (~reset) begin
+        unsigned_counter_little <= 0;
+        signed_counter_little <= 0;
+        unsigned_counter_big <= 0;
+        signed_counter_big <= 0;
+    end else begin
+        unsigned_counter_little <= unsigned_counter_little + 1;
+        signed_counter_little <= signed_counter_little + 1;
+        unsigned_counter_big <= unsigned_counter_big + 1;
+        signed_counter_big <= signed_counter_big + 1;
+    end
+end
+
+// Overflowing counters
+reg [2:0] unsigned_overflow_counter_little;
+reg signed [3:0] signed_overflow_counter_little;
+reg [0:2] unsigned_overflow_counter_big;
+reg signed [0:3] signed_overflow_counter_big;
+
+always @ (posedge clk or negedge reset) begin
+    if (~reset) begin
+        unsigned_overflow_counter_little <= 0;
+        signed_overflow_counter_little <= 0;
+        unsigned_overflow_counter_big <= 0;
+        signed_overflow_counter_big <= 0;
+    end else begin
+        unsigned_overflow_counter_little <= unsigned_overflow_counter_little + 1;
+        signed_overflow_counter_little <= signed_overflow_counter_little + 1;
+        unsigned_overflow_counter_big <= unsigned_overflow_counter_big + 1;
+        signed_overflow_counter_big <= signed_overflow_counter_big + 1;
+    end
+end
+
+// Truncation
+wire [8:0] truncate_unsigned_little;
+wire signed [9:0] truncate_signed_little;
+wire [0:8] truncate_unsigned_big;
+wire signed [0:9] truncate_signed_big;
+
+assign truncate_unsigned_little = unsigned_counter_little;
+assign truncate_signed_little = signed_counter_little;
+assign truncate_unsigned_big = unsigned_counter_big;
+assign truncate_signed_big = signed_counter_big;
+
+// Extension
+wire [8:0] extend_unsigned_little;
+wire signed [9:0] extend_signed_little;
+wire [0:8] extend_unsigned_big;
+wire signed [0:9] extend_signed_big;
+
+assign extend_unsigned_little = unsigned_overflow_counter_little;
+assign extend_signed_little = signed_overflow_counter_little;
+assign extend_unsigned_big = unsigned_overflow_counter_big;
+assign extend_signed_big = signed_overflow_counter_big;
+
+// Endian-ness swap
+wire [0:15] unsigned_counter_little_to_big;
+wire signed [0:16] signed_counter_little_to_big;
+wire [15:0] unsigned_counter_big_to_little;
+wire signed [16:0] signed_counter_big_to_little;
+
+assign unsigned_counter_little_to_big = unsigned_counter_little;
+assign signed_counter_little_to_big = signed_counter_little;
+assign unsigned_counter_big_to_little = unsigned_counter_big;
+assign signed_counter_big_to_little = signed_counter_big;
+
+// Use of $signed
+wire [7:0] unsigned_assigned_dollar_signed_little;
+wire signed [8:0] signed_assigned_dollar_signed_little;
+wire [0:7] unsigned_assigned_dollar_signed_big;
+wire signed [0:8] signed_assigned_dollar_signed_big;
+
+assign unsigned_assigned_dollar_signed_little = $signed(-57);
+assign signed_assigned_dollar_signed_little = $signed(-57);
+assign unsigned_assigned_dollar_signed_big = $signed(-57);
+assign signed_assigned_dollar_signed_big = $signed(-57);
+
+// Waves
+initial begin
+    $dumpfile("waveform.vcd");
+    $dumpvars(0, logic_testbench);
+end
+
+endmodule

--- a/tests/designs/logic_vhdl_module/Makefile
+++ b/tests/designs/logic_vhdl_module/Makefile
@@ -1,0 +1,26 @@
+TOPLEVEL_LANG ?= vhdl
+
+ifneq ($(TOPLEVEL_LANG),vhdl)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being vhdl"
+clean::
+
+else
+
+TOPLEVEL := logic_testbench
+
+ifeq ($(OS),Msys)
+WPWD=$(shell sh -c 'pwd -W')
+else
+WPWD=$(shell pwd)
+endif
+
+COCOTB?=$(WPWD)/../../..
+
+VHDL_SOURCES = $(COCOTB)/tests/designs/logic_vhdl_module/logic_testbench.vhd
+
+include $(COCOTB)/makefiles/Makefile.inc
+include $(COCOTB)/makefiles/Makefile.sim
+
+endif

--- a/tests/designs/logic_vhdl_module/logic_testbench.vhd
+++ b/tests/designs/logic_vhdl_module/logic_testbench.vhd
@@ -1,0 +1,108 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity logic_testbench is
+    port (
+        clk     : in std_logic;
+        reset   : in std_logic
+    );
+end entity logic_testbench;
+
+architecture rtl of logic_testbench is
+    -- Normal counters
+    signal unsigned_counter_little : unsigned(15 downto 0);
+    signal signed_counter_little : signed(16 downto 0);
+    signal unsigned_counter_big : unsigned(0 to 15);
+    signal signed_counter_big : signed(0 to 16);
+    -- Overflowing counters
+    signal unsigned_overflow_counter_little : unsigned(2 downto 0);
+    signal signed_overflow_counter_little : signed(3 downto 0);
+    signal unsigned_overflow_counter_big : unsigned(0 to 2);
+    signal signed_overflow_counter_big : signed(0 to 3);
+    -- Truncation
+    signal truncate_unsigned_little : unsigned(8 downto 0);
+    signal truncate_signed_little : signed(9 downto 0);
+    signal truncate_unsigned_big : unsigned(0 to 8);
+    signal truncate_signed_big : signed(0 to 9);
+    -- Extension
+    signal extend_unsigned_little : unsigned(8 downto 0);
+    signal extend_signed_little : signed(8 downto 0);
+    signal extend_unsigned_big : unsigned(0 to 8);
+    signal extend_signed_big : signed(0 to 8);
+    -- Endian-ness swap
+    signal unsigned_counter_little_to_big : unsigned(0 to 15);
+    signal signed_counter_little_to_big : signed(0 to 16);
+    signal unsigned_counter_big_to_little : unsigned(15 downto 0);
+    signal signed_counter_big_to_little : signed(16 downto 0);
+    -- Assign integer
+    signal unsigned_assigned_signed_little : unsigned(7 downto 0);
+    signal signed_assigned_signed_little : signed(8 downto 0);
+    signal unsigned_assigned_signed_big : unsigned(0 to 7);
+    signal signed_assigned_signed_big : signed(0 to 8);
+begin
+    normal_count : process (clk, reset)
+    begin
+        if (reset = '0') then
+            unsigned_counter_little <= (others => '0');
+            signed_counter_little <= (others => '0');
+            unsigned_counter_big <= (others => '0');
+            signed_counter_big <= (others => '0');
+        elsif (clk'event and clk = '1') then
+            unsigned_counter_little <= unsigned_counter_little + 1;
+            signed_counter_little <= signed_counter_little + 1;
+            unsigned_counter_big <= unsigned_counter_big + 1;
+            signed_counter_big <= signed_counter_big + 1;
+        end if;
+    end process;
+
+    overflow_count : process (clk, reset)
+    begin
+        if (reset = '0') then
+            unsigned_overflow_counter_little <= (others => '0');
+            signed_overflow_counter_little <= (others => '0');
+            unsigned_overflow_counter_big <= (others => '0');
+            signed_overflow_counter_big <= (others => '0');
+        elsif (clk'event and clk = '1') then
+            unsigned_overflow_counter_little <= unsigned_overflow_counter_little + 1;
+            signed_overflow_counter_little <= signed_overflow_counter_little + 1;
+            unsigned_overflow_counter_big <= unsigned_overflow_counter_big + 1;
+            signed_overflow_counter_big <= signed_overflow_counter_big + 1;
+        end if;
+    end process;
+
+    -- Truncation
+    -- Have to be specified on what you what to truncate, so can always truncate correctly
+    truncate_unsigned_little <= unsigned_counter_little(truncate_unsigned_little'range);
+    truncate_signed_little <= signed_counter_little(truncate_signed_little'range);
+    truncate_unsigned_big <= unsigned_counter_big(truncate_unsigned_big'range);
+    truncate_signed_big <= signed_counter_big(truncate_signed_big'range);
+
+    -- Extension
+    extension : process (unsigned_overflow_counter_little,
+                         signed_overflow_counter_little,
+                         unsigned_overflow_counter_big,
+                         signed_overflow_counter_big)
+    begin
+        -- Have to explicitly say how you're extending in VHDL
+        extend_unsigned_little <= resize(unsigned_overflow_counter_little, extend_unsigned_little'length);
+        extend_signed_little <= resize(signed_overflow_counter_little, extend_signed_little'length);
+        -- The 'resize' function explicitly says it extends to the left
+        -- Going to treat this like the verilog case where you could assume (incorrectly) it extend the MS-end
+        extend_unsigned_big <= resize(unsigned_overflow_counter_big, extend_unsigned_big'length);
+        extend_signed_big <= resize(signed_overflow_counter_big, extend_signed_big'length);
+    end process;
+
+    -- Endian-ness swap
+    unsigned_counter_little_to_big <= unsigned_counter_little;
+    signed_counter_little_to_big <= signed_counter_little;
+    unsigned_counter_big_to_little <= unsigned_counter_big;
+    signed_counter_big_to_little <= signed_counter_big;
+
+    -- Assign an integer
+    -- VHDL is great and doesn't let us assign a signed value to an unsigned vector
+    --unsigned_assigned_signed_little <= to_unsigned(-57, 8);
+    signed_assigned_signed_little <= to_signed(-57, 9);
+    --unsigned_assigned_signed_big <= to_unsigned(-57, 8);
+    signed_assigned_signed_big <= to_signed(-57, 9);
+end rtl;

--- a/tests/test_cases/issue_608/Makefile
+++ b/tests/test_cases/issue_608/Makefile
@@ -1,0 +1,4 @@
+
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_608

--- a/tests/test_cases/issue_608/issue_608.py
+++ b/tests/test_cases/issue_608/issue_608.py
@@ -1,40 +1,43 @@
-import cocotb
-from cocotb.binary import BinaryValue, BinaryRepresentation
-from cocotb.triggers import Timer
-import logging
+"""Test case for BinaryValue behaviour documented in issue #608
 
+https://github.com/potentialventures/cocotb/issues/608
+"""
+import logging
 import random
+
+import cocotb
+from cocotb.binary import BinaryValue
+from cocotb.triggers import Timer
 
 @cocotb.test()
 def issue_608(dut):
-    """ BinaryValues test """
-    
+    """BinaryValues test"""
+
     tlog = logging.getLogger("cocotb.test")
     yield Timer(10)
 
-    def test_bin(value, bitW, bigEndian = True):
-        tlog.info("Testing value \"%d\" using %d bits in %s ..." % 
-          (value, bitW, "big endian" if bigEndian else "little endian")
-        )
-        v = BinaryValue(value, bitW, bigEndian)
-        tlog.info("Binary representation: %s" % v.binstr)
-        assert (v == value)
+    def test_bin(value, bitW, bigEndian=True):
+        """Test for a single binary value"""
+        tlog.info("Testing value \"%d\" using %d bits in %s ...",
+                  value, bitW,
+                  "big endian" if bigEndian else "little endian")
+        bin_value = BinaryValue(value, bitW, bigEndian)
+        tlog.info("Binary representation: %s", bin_value.binstr)
+        assert bin_value == value
 
-    test_bin(3,3)
-    test_bin(4,4)
-    test_bin(4,3)
-    test_bin(5,5)
-    test_bin(11,4) #something assymetric
-    test_bin(3,3, False)
-    test_bin(4,4, False)
-    test_bin(4,3, False)
-    test_bin(5,5, False)
-    test_bin(11,4, False)
+    test_bin(3, 3)
+    test_bin(4, 4)
+    test_bin(4, 3)
+    test_bin(5, 5)
+    test_bin(11, 4)  # something asymmetric
+    test_bin(3, 3, False)
+    test_bin(4, 4, False)
+    test_bin(4, 3, False)
+    test_bin(5, 5, False)
+    test_bin(11, 4, False)
 
     for _ in range(100):
-        bw = random.randint(1,16)
-        value = random.randint(0,2**bw-1)
+        bit_width = random.randint(1, 16)
+        value = random.randint(0, 2 ** bit_width - 1)
         endian = random.choice([True, False])
-        test_bin(value,bw,endian)
-    
-    
+        test_bin(value, bit_width, endian)

--- a/tests/test_cases/issue_608/issue_608.py
+++ b/tests/test_cases/issue_608/issue_608.py
@@ -1,0 +1,40 @@
+import cocotb
+from cocotb.binary import BinaryValue, BinaryRepresentation
+from cocotb.triggers import Timer
+import logging
+
+import random
+
+@cocotb.test()
+def issue_608(dut):
+    """ BinaryValues test """
+    
+    tlog = logging.getLogger("cocotb.test")
+    yield Timer(10)
+
+    def test_bin(value, bitW, bigEndian = True):
+        tlog.info("Testing value \"%d\" using %d bits in %s ..." % 
+          (value, bitW, "big endian" if bigEndian else "little endian")
+        )
+        v = BinaryValue(value, bitW, bigEndian)
+        tlog.info("Binary representation: %s" % v.binstr)
+        assert (v == value)
+
+    test_bin(3,3)
+    test_bin(4,4)
+    test_bin(4,3)
+    test_bin(5,5)
+    test_bin(11,4) #something assymetric
+    test_bin(3,3, False)
+    test_bin(4,4, False)
+    test_bin(4,3, False)
+    test_bin(5,5, False)
+    test_bin(11,4, False)
+
+    for _ in range(100):
+        bw = random.randint(1,16)
+        value = random.randint(0,2**bw-1)
+        endian = random.choice([True, False])
+        test_bin(value,bw,endian)
+    
+    

--- a/tests/test_cases/test_binary/Makefile
+++ b/tests/test_cases/test_binary/Makefile
@@ -1,0 +1,5 @@
+MODULE = test_binary
+
+all:
+	$(MAKE) -C vhdl MODULE=$(MODULE)
+	$(MAKE) -C verilog MODULE=$(MODULE)

--- a/tests/test_cases/test_binary/test_binary.py
+++ b/tests/test_cases/test_binary/test_binary.py
@@ -1,0 +1,457 @@
+"""Tests for the BinaryValue type and its interaction with hardware
+
+BinaryValue is a shim of the data stored in the simulation.
+When calling .value on a signal in the DUT, it reads a binary string from the simulation
+(through VPI/whichever interface is available) and places it into a BinaryValue.
+
+These tests show the interaction between BinaryValue and the hardware, and the distinctions between
+Verilog/VHDL data and Python.
+"""
+
+#TODO: Signed magnitude tests
+
+import os
+
+import cocotb
+from cocotb.triggers import RisingEdge, ReadOnly
+from cocotb.clock import Clock
+from cocotb.result import TestError, TestSuccess
+from cocotb.binary import BinaryValue, BinaryRepresentation
+
+TEST_VHDL = os.getenv("TOPLEVEL_LANG").upper() == "VHDL"
+TEST_VERILOG = os.getenv("TOPLEVEL_LANG").upper() == "VERILOG"
+if not (TEST_VHDL ^ TEST_VERILOG):
+    raise TestError("TOPLEVEL_LANG must be vhdl or verilog")
+
+class BinaryTestbench:
+    def __init__(self, dut):
+        self.dut = dut
+        self.log = dut._log
+
+        self.clkedge = RisingEdge(self.dut.clk)
+
+    @cocotb.coroutine
+    def initialise(self):
+        cocotb.fork(Clock(self.dut.clk, 1.0, units='ns').start())
+
+        self.dut.reset <= 0
+        for _ in range(2):
+            yield self.clkedge
+        self.dut.reset <= 1
+        yield self.clkedge
+
+def integer_endian_swap(value):
+    """Swap the endian-ness of a positive integer"""
+    new_value = 0
+    while value > 0:
+        new_value = (new_value << 1) + (value & 0x1)
+        value >>= 1
+    return new_value
+
+@cocotb.test()
+def test_signed_counting(dut):
+    """Test behaviour of a normal counter"""
+    tb = BinaryTestbench(dut)
+    yield tb.initialise()
+
+    def compare_count(expected_value, actual_value, sign_type, big_endian, desc):
+        """Compare the signal with the expected count value"""
+        actual_value.big_endian = big_endian
+        actual_value.sign_type = sign_type
+
+        # Shouldn't overflow so don't need to worry about the sign_type
+        if not big_endian:
+            if actual_value != expected_value:
+                raise TestError("Values ({}) do not match. "
+                                "Expected: {}; Actual: {}".format(desc,
+                                                                  expected_value,
+                                                                  actual_value.integer))
+        else:
+            expected_str = bin(expected_value)[2:].zfill(actual_value.n_bits)
+            if actual_value.binstr != expected_str:
+                raise TestError("Values ({}) do not match. "
+                                "Expected: {}; Actual: {}".format(desc,
+                                                                  expected_str,
+                                                                  actual_value.binstr))
+
+    count = 1
+    for _ in range(128):
+        yield tb.clkedge
+        compare_count(count,
+                      dut.unsigned_counter_little.value,
+                      BinaryRepresentation.UNSIGNED, False,
+                      "unsigned little-endian")
+        compare_count(count,
+                      dut.signed_counter_little.value,
+                      BinaryRepresentation.TWOS_COMPLEMENT, False,
+                      "signed little-endian")
+        compare_count(count,
+                      dut.unsigned_counter_big.value,
+                      BinaryRepresentation.UNSIGNED, True,
+                      "unsigned big-endian")
+        compare_count(count,
+                      dut.signed_counter_big.value,
+                      BinaryRepresentation.TWOS_COMPLEMENT, True,
+                      "signed big-endian")
+        count += 1
+
+
+@cocotb.test()
+def test_signed_overflow(dut):
+    """Test behaviour of an overflowing counter"""
+    tb = BinaryTestbench(dut)
+    yield tb.initialise()
+
+    count_unsigned = BinaryValue(value=1, n_bits=3, bigEndian=False,
+                                 binaryRepresentation=BinaryRepresentation.UNSIGNED)
+    count_signed = BinaryValue(value=1, n_bits=4, bigEndian=False,
+                               binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
+
+    def compare_count(expected_value, actual_value, sign_type, big_endian, desc):
+        """Compare the signal with the expected binary count value"""
+        actual_value.big_endian = big_endian
+        actual_value.binaryRepresentation = sign_type
+
+        if not big_endian:
+            if actual_value != expected_value:
+                raise TestError("Values ({}) do not match. "
+                                "Expected: {}; Actual: {}".format(desc,
+                                                                  expected_value.integer,
+                                                                  actual_value.integer))
+        else:
+            if actual_value.binstr != expected_value.binstr:
+                raise TestError("Values ({}) do not match. "
+                                "Expected: {}; Actual: {}".format(desc,
+                                                                  expected_value.binstr,
+                                                                  actual_value.binstr))
+
+    for _ in range(128):
+        yield tb.clkedge
+        compare_count(count_unsigned,
+                      dut.unsigned_overflow_counter_little.value,
+                      BinaryRepresentation.UNSIGNED, False,
+                      "unsigned little-endian")
+        compare_count(count_signed,
+                      dut.signed_overflow_counter_little.value,
+                      BinaryRepresentation.TWOS_COMPLEMENT, False,
+                      "signed little-endian")
+        compare_count(count_unsigned,
+                      dut.unsigned_overflow_counter_big.value,
+                      BinaryRepresentation.UNSIGNED, True,
+                      "unsigned big-endian")
+        compare_count(count_signed,
+                      dut.signed_overflow_counter_big.value,
+                      BinaryRepresentation.TWOS_COMPLEMENT, True,
+                      "signed big-endian")
+        count_unsigned += 1
+        count_signed += 1
+
+@cocotb.test(skip=TEST_VHDL)
+def test_verilog_truncation(dut):
+    """Test behaviour of truncation in Verilog.
+
+    This is using the implicit truncation in Verilog, that a user is likely
+    to use, assuming it will correctly truncate the value
+
+    However Verilog always truncates the left-most bits
+    """
+    tb = BinaryTestbench(dut)
+    yield tb.initialise()
+
+    def compare_truncated(long_value, short_value, sign_type, big_endian, desc):
+        """Compare two equal values, one a truncation of the other"""
+        short_value.big_endian = big_endian
+        short_value.binaryRepresentation = sign_type
+        short_length = short_value.n_bits
+
+        truncate_value = BinaryValue(value=long_value.binstr, binaryRepresentation=sign_type,
+                                     bigEndian=False, n_bits=short_length)
+        truncate_value.big_endian = big_endian
+
+        if short_value.integer != truncate_value.integer:
+            raise TestError("Values ({}) do not match as expected. "
+                            "Original value: {}; Truncated value: {}".format(desc,
+                                                                             long_value.binstr,
+                                                                             short_value.binstr))
+
+    for _ in range(128):
+        yield tb.clkedge
+        compare_truncated(dut.unsigned_counter_little.value,
+                          dut.truncate_unsigned_little.value,
+                          BinaryRepresentation.UNSIGNED, False,
+                          "unsigned little-endian")
+        compare_truncated(dut.signed_counter_little.value,
+                          dut.truncate_signed_little.value,
+                          BinaryRepresentation.TWOS_COMPLEMENT, False,
+                          "signed little-endian")
+        compare_truncated(dut.unsigned_counter_big.value,
+                          dut.truncate_unsigned_big.value,
+                          BinaryRepresentation.UNSIGNED, True,
+                          "unsigned big-endian")
+        compare_truncated(dut.signed_counter_big.value,
+                          dut.truncate_signed_big.value,
+                          BinaryRepresentation.TWOS_COMPLEMENT, True,
+                          "signed big-endian")
+
+@cocotb.test(skip=TEST_VERILOG)
+def test_vhdl_truncation(dut):
+    """Test behaviour of truncation in VHDL.
+
+    In VHDL, you cannot implicitly truncate, you must specify which bits you want.
+    In the big endian case this means you can cut off the MSBs, which is what one
+    would typically do in a truncation.
+    """
+    tb = BinaryTestbench(dut)
+    yield tb.initialise()
+
+    def create_mask(size):
+        """Create a mask of 'size' bits"""
+        mask = 0
+        for _ in range(size):
+            mask <<= 1
+            mask |= 1
+        return mask
+
+    def compare_truncated(long_value, short_value, sign_type, big_endian, desc):
+        """Compare two equal values, one a truncation of the other"""
+        long_value.big_endian = big_endian
+        short_value.big_endian = big_endian
+        long_value.binaryRepresentation = sign_type
+        short_value.binaryRepresentation = sign_type
+        short_length = short_value.n_bits
+
+        if sign_type == BinaryRepresentation.UNSIGNED:
+            if short_value.integer != (long_value.integer & create_mask(short_length)):
+                raise TestError("Values ({}) do not match as expected. "
+                                "Original value: {}; Truncated value: {}".format(desc,
+                                                                                 long_value.binstr,
+                                                                                 short_value.binstr))
+        elif sign_type == BinaryRepresentation.TWOS_COMPLEMENT:
+            dut._log.info(long_value.integer)
+            truncated_value = BinaryValue(value=long_value.integer, binaryRepresentation=sign_type,
+                                          bigEndian=big_endian, n_bits=short_length)
+            dut._log.info("{} {} {} {}".format(truncated_value.integer, truncated_value.binstr, truncated_value.n_bits, truncated_value.big_endian))
+            if short_value.integer != truncated_value.integer:
+                raise TestError("Values ({}) do not match as expected. "
+                                "Original value: {}; Truncated value: {}".format(desc,
+                                                                                 long_value.binstr,
+                                                                                 truncated_value.binstr))
+        else:
+            raise TestError("Unrecognised sign type: {}".format(sign_type))
+
+    for _ in range(128):
+        yield tb.clkedge
+        compare_truncated(dut.unsigned_counter_little.value,
+                          dut.truncate_unsigned_little.value,
+                          BinaryRepresentation.UNSIGNED, False,
+                          "unsigned little-endian")
+        compare_truncated(dut.signed_counter_little.value,
+                          dut.truncate_signed_little.value,
+                          BinaryRepresentation.TWOS_COMPLEMENT, False,
+                          "signed little-endian")
+        compare_truncated(dut.unsigned_counter_big.value,
+                          dut.truncate_unsigned_big.value,
+                          BinaryRepresentation.UNSIGNED, True,
+                          "unsigned big-endian")
+        compare_truncated(dut.signed_counter_big.value,
+                          dut.truncate_signed_big.value,
+                          BinaryRepresentation.TWOS_COMPLEMENT, True,
+                          "signed big-endian")
+
+@cocotb.test()
+def test_extension(dut):
+    """Test behaviour of sign extension"""
+    tb = BinaryTestbench(dut)
+    yield tb.initialise()
+
+    def compare_extended(short_value, long_value, sign_type, big_endian, desc):
+        """Compare two equal values, one an extension of the other"""
+        short_value.big_endian = big_endian
+        long_value.big_endian = big_endian
+        short_value.binaryRepresentation = sign_type
+        long_value.binaryRepresentation = sign_type
+        short_length = short_value.n_bits
+        long_length = long_value.n_bits
+
+        # Verilog/VHDL have no concept of big/little endian-ness
+        # Only care about left/right-most value
+        if not big_endian:
+            if short_value != long_value:
+                raise TestError("Values ({}) do not match".format(desc))
+        else:
+            if sign_type == BinaryRepresentation.UNSIGNED:
+                if long_value != short_value.integer * pow(2, long_value.n_bits - short_value.n_bits):
+                    raise TestError("Values ({}) do not have expected equivalence".format(desc))
+            # We're going to ignore the other cases (sign extension on the "wrong" side)
+
+        if sign_type == BinaryRepresentation.UNSIGNED:
+            short_to_long = '0' * (long_length - short_length) + short_value.binstr
+        elif sign_type == BinaryRepresentation.TWOS_COMPLEMENT:
+            short_to_long = short_value.binstr[0] * (long_length - short_length) + short_value.binstr
+        else:
+            raise TestError("Unsupported sign type: {}".format(sign_type))
+
+        if short_to_long != long_value.binstr:
+            raise TestError("Values ({}) do not match binstrings. "
+                            "Expected: {}; Actual: {}".format(desc,
+                                                              short_to_long,
+                                                              long_value.binstr))
+
+    for _ in range(128):
+        yield tb.clkedge
+        compare_extended(dut.unsigned_overflow_counter_little.value,
+                         dut.extend_unsigned_little.value,
+                         BinaryRepresentation.UNSIGNED,
+                         False, "unsigned little-endian")
+        compare_extended(dut.signed_overflow_counter_little.value,
+                         dut.extend_signed_little.value,
+                         BinaryRepresentation.TWOS_COMPLEMENT,
+                         False, "signed little-endian")
+        compare_extended(dut.unsigned_overflow_counter_big.value,
+                         dut.extend_unsigned_big.value,
+                         BinaryRepresentation.UNSIGNED,
+                         True, "unsigned big-endian")
+        compare_extended(dut.signed_overflow_counter_big.value,
+                         dut.extend_signed_big.value,
+                         BinaryRepresentation.TWOS_COMPLEMENT,
+                         True, "signed big-endian")
+
+@cocotb.test()
+def test_endianness_swap(dut):
+    """Test behaviour of an endian-ness swap
+
+    Assigning big-endian value to little-endian value and vice-versa
+    """
+    tb = BinaryTestbench(dut)
+    yield tb.initialise()
+
+    def compare_flipped_value(big_endian_value, little_endian_value, binary_repr, desc):
+        """Compare two equal values (in verilog) with different endian-ness"""
+        big_endian_value.big_endian = True
+        big_endian_value.binaryRepresentation = binary_repr
+        little_endian_value.big_endian = False
+        little_endian_value.binaryRepresentation = binary_repr
+
+        if big_endian_value.binstr != little_endian_value.binstr:
+            raise TestError("Value ({}) not matching binary strings: "
+                            "bigEndian: {}; littleEndian: {}".format(desc,
+                                                                     big_endian_value.binstr,
+                                                                     little_endian_value.binstr))
+        if big_endian_value.integer == integer_endian_swap(little_endian_value.integer): # Should never reach negative little-endian number
+            raise TestError("Value ({}) should not match (flipped) integers: "
+                            "bigEndian: {}; littleEndian: {}".format(desc,
+                                                                     big_endian_value.integer,
+                                                                     little_endian_value.integer))
+
+    for _ in range(128):
+        yield tb.clkedge
+        compare_flipped_value(dut.unsigned_counter_little_to_big.value,
+                              dut.unsigned_counter_little.value,
+                              BinaryRepresentation.UNSIGNED,
+                              "unsigned little to big")
+        compare_flipped_value(dut.signed_counter_little_to_big.value,
+                              dut.signed_counter_little.value,
+                              BinaryRepresentation.TWOS_COMPLEMENT,
+                              "signed little to big")
+        compare_flipped_value(dut.unsigned_counter_big_to_little.value,
+                              dut.unsigned_counter_big.value,
+                              BinaryRepresentation.UNSIGNED,
+                              "unsigned big to little")
+        compare_flipped_value(dut.signed_counter_big_to_little.value,
+                              dut.signed_counter_big.value,
+                              BinaryRepresentation.TWOS_COMPLEMENT,
+                              "signed big to little")
+
+@cocotb.test(skip=TEST_VHDL)
+def test_signed_function(dut):
+    """Test the behaviour of the $signed Verilog function
+
+    This forces the wire to act as signed, even if not declared as such
+    Signed in Verilog is twos complement
+    """
+    tb = BinaryTestbench(dut)
+    yield tb.initialise()
+
+    # Expected values
+    EXPECTED_SIGNED_VALUE = -57
+    EXPECTED_UNSIGNED_VALUE = 199 # 11000111
+    EXPECTED_STRING = "111000111"
+
+    unsigned_little_end_signal = dut.unsigned_assigned_dollar_signed_little.value
+    if unsigned_little_end_signal.binstr != EXPECTED_STRING[1:]: # Signal is only 8 bits
+        raise TestError("Didn't get expected value: $signed(-57) == 11000111 (in unsigned little-endian wire)")
+    unsigned_little_end_signal.big_endian = False
+    unsigned_little_end_signal.binaryRepresentation = BinaryRepresentation.UNSIGNED
+    if unsigned_little_end_signal.integer != EXPECTED_UNSIGNED_VALUE:
+        tb.log.error("Expected value: %d; Actual value: %d",
+                     EXPECTED_UNSIGNED_VALUE, unsigned_little_end_signal.integer)
+        raise TestError("Didn't get expected integer value (in unsigned little-end wire)")
+
+    unsigned_big_end_signal = dut.unsigned_assigned_dollar_signed_big.value
+    if unsigned_big_end_signal.binstr != EXPECTED_STRING[1:]: # Signal is only 8 bits
+        raise TestError("Didn't get expected value: $signed(-57) == 11000111 (in unsigned big-endian wire)")
+    unsigned_big_end_signal.big_endian = True
+    unsigned_big_end_signal.binaryRepresentation = BinaryRepresentation.UNSIGNED
+    if unsigned_big_end_signal.integer != int(EXPECTED_STRING[1:][::-1], 2):
+        tb.log.error("Expected value: %d; Actual value: %d",
+                     int(EXPECTED_STRING[1:][::-1], 2), unsigned_big_end_signal.integer)
+        raise TestError("Didn't get expected integer value (in unsigned big-end wire)")
+
+    signed_little_end_signal = dut.signed_assigned_dollar_signed_little.value
+    if signed_little_end_signal.binstr != EXPECTED_STRING:
+        raise TestError("Didn't get expected value: $signed(-57) == 111000111 (in signed little-endian wire)")
+    signed_little_end_signal.big_endian = False
+    signed_little_end_signal.binaryRepresentation = BinaryRepresentation.TWOS_COMPLEMENT
+    if signed_little_end_signal.integer != EXPECTED_SIGNED_VALUE:
+        tb.log.error("Expected value: %d; Actual value: %d",
+                     EXPECTED_SIGNED_VALUE, signed_little_end_signal.integer)
+        raise TestError("Didn't get expected integer value (in signed little-end wire)")
+
+    signed_big_end_signal = dut.signed_assigned_dollar_signed_big.value
+    if signed_big_end_signal.binstr != EXPECTED_STRING:
+        raise TestError("Didn't get expected value: $signed(-57) == 111000111 (in signed big-endian wire)")
+    signed_big_end_signal.big_endian = False
+    signed_big_end_signal.binaryRepresentation = BinaryRepresentation.TWOS_COMPLEMENT
+    if signed_big_end_signal.integer != EXPECTED_SIGNED_VALUE: # -57 is the same value reversed when 9 bits
+        tb.log.error("Expected value: %d; Actual value: %d",
+                     EXPECTED_SIGNED_VALUE, signed_big_end_signal.integer)
+        raise TestError("Didn't get expected integer value (in signed big-end wire)")
+
+    raise TestSuccess("Test complete")
+
+@cocotb.test(skip=TEST_VERILOG)
+def test_to_signed_function(dut):
+    """Test the behaviour of the to_signed VHDL function
+
+    From numeric_std package.
+    """
+    # The behaviour here is strictly defined by the VHDL LRM
+    # No implicit conversions to worry about
+    tb = BinaryTestbench(dut)
+    yield tb.initialise()
+
+    # Expected values
+    EXPECTED_STRING = "111000111"
+    EXPECTED_VALUE = -57
+
+    little_end_signal = dut.signed_assigned_signed_little.value
+    if little_end_signal.binstr != EXPECTED_STRING:
+        raise TestError("Didn't get expected value: to_signed(-57, 9) == 111000111 (for little-endian signal)")
+    little_end_signal.big_endian = False
+    little_end_signal.binaryRepresentation = BinaryRepresentation.TWOS_COMPLEMENT
+    if little_end_signal != EXPECTED_VALUE:
+        tb.log.error("Expected value: %d; Actual value: %d",
+                     EXPECTED_VALUE, little_end_signal.integer)
+        raise TestError("Didn't get expected integer value (for little-endian signal)")
+
+    big_end_signal = dut.signed_assigned_signed_big.value
+    if big_end_signal.binstr != EXPECTED_STRING:
+        raise TestError("Didn't get expected value: to_signed(-57, 9) == 111000111 (for big-endian signal)")
+    big_end_signal.big_endian = True
+    big_end_signal.binaryRepresentation = BinaryRepresentation.TWOS_COMPLEMENT
+    if big_end_signal.integer != EXPECTED_VALUE: # Fun: -57 is the same backwards when 9 bits
+        tb.log.error("Expected value: %d; Actual value: %d",
+                     EXPECTED_VALUE, big_end_signal.integer)
+        raise TestError("Didn't get expected integer value (in big-endian signal)")
+
+    raise TestSuccess("Test complete")

--- a/tests/test_cases/test_binary/test_binary.py
+++ b/tests/test_cases/test_binary/test_binary.py
@@ -102,9 +102,9 @@ def test_signed_overflow(dut):
     tb = BinaryTestbench(dut)
     yield tb.initialise()
 
-    count_unsigned = BinaryValue(value=1, n_bits=3, ascending_range=False,
+    count_unsigned = BinaryValue(value=1, n_bits=3, ascendingRange=False,
                                  binaryRepresentation=BinaryRepresentation.UNSIGNED)
-    count_signed = BinaryValue(value=1, n_bits=4, ascending_range=False,
+    count_signed = BinaryValue(value=1, n_bits=4, ascendingRange=False,
                                binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
 
     def compare_count(expected_value, actual_value, sign_type, big_endian, desc):
@@ -165,7 +165,7 @@ def test_verilog_truncation(dut):
         short_length = short_value.n_bits
 
         truncate_value = BinaryValue(value=long_value.binstr, binaryRepresentation=sign_type,
-                                     ascending_range=False, n_bits=short_length)
+                                     ascendingRange=False, n_bits=short_length)
         truncate_value.ascending_range = big_endian
 
         if short_value.integer != truncate_value.integer:
@@ -228,7 +228,7 @@ def test_vhdl_truncation(dut):
                                                                                  short_value.binstr))
         elif sign_type == BinaryRepresentation.TWOS_COMPLEMENT:
             truncated_value = BinaryValue(value=long_value.integer, binaryRepresentation=sign_type,
-                                          ascending_range=big_endian, n_bits=short_length)
+                                          ascendingRange=big_endian, n_bits=short_length)
             if short_value.integer != truncated_value.integer:
                 raise TestError("Values ({}) do not match as expected. "
                                 "Original value: {}; Truncated value: {}".format(desc,

--- a/tests/test_cases/test_binary/test_binary.py
+++ b/tests/test_cases/test_binary/test_binary.py
@@ -56,7 +56,7 @@ def test_signed_counting(dut):
 
     def compare_count(expected_value, actual_value, sign_type, big_endian, desc):
         """Compare the signal with the expected count value"""
-        actual_value.big_endian = big_endian
+        actual_value.ascending_range = big_endian
         actual_value.sign_type = sign_type
 
         # Shouldn't overflow so don't need to worry about the sign_type
@@ -102,14 +102,14 @@ def test_signed_overflow(dut):
     tb = BinaryTestbench(dut)
     yield tb.initialise()
 
-    count_unsigned = BinaryValue(value=1, n_bits=3, bigEndian=False,
+    count_unsigned = BinaryValue(value=1, n_bits=3, ascending_range=False,
                                  binaryRepresentation=BinaryRepresentation.UNSIGNED)
-    count_signed = BinaryValue(value=1, n_bits=4, bigEndian=False,
+    count_signed = BinaryValue(value=1, n_bits=4, ascending_range=False,
                                binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
 
     def compare_count(expected_value, actual_value, sign_type, big_endian, desc):
         """Compare the signal with the expected binary count value"""
-        actual_value.big_endian = big_endian
+        actual_value.ascending_range = big_endian
         actual_value.binaryRepresentation = sign_type
 
         if not big_endian:
@@ -160,13 +160,13 @@ def test_verilog_truncation(dut):
 
     def compare_truncated(long_value, short_value, sign_type, big_endian, desc):
         """Compare two equal values, one a truncation of the other"""
-        short_value.big_endian = big_endian
+        short_value.ascending_range = big_endian
         short_value.binaryRepresentation = sign_type
         short_length = short_value.n_bits
 
         truncate_value = BinaryValue(value=long_value.binstr, binaryRepresentation=sign_type,
-                                     bigEndian=False, n_bits=short_length)
-        truncate_value.big_endian = big_endian
+                                     ascending_range=False, n_bits=short_length)
+        truncate_value.ascending_range = big_endian
 
         if short_value.integer != truncate_value.integer:
             raise TestError("Values ({}) do not match as expected. "
@@ -214,8 +214,8 @@ def test_vhdl_truncation(dut):
 
     def compare_truncated(long_value, short_value, sign_type, big_endian, desc):
         """Compare two equal values, one a truncation of the other"""
-        long_value.big_endian = big_endian
-        short_value.big_endian = big_endian
+        long_value.ascending_range = big_endian
+        short_value.ascending_range = big_endian
         long_value.binaryRepresentation = sign_type
         short_value.binaryRepresentation = sign_type
         short_length = short_value.n_bits
@@ -227,10 +227,8 @@ def test_vhdl_truncation(dut):
                                                                                  long_value.binstr,
                                                                                  short_value.binstr))
         elif sign_type == BinaryRepresentation.TWOS_COMPLEMENT:
-            dut._log.info(long_value.integer)
             truncated_value = BinaryValue(value=long_value.integer, binaryRepresentation=sign_type,
-                                          bigEndian=big_endian, n_bits=short_length)
-            dut._log.info("{} {} {} {}".format(truncated_value.integer, truncated_value.binstr, truncated_value.n_bits, truncated_value.big_endian))
+                                          ascending_range=big_endian, n_bits=short_length)
             if short_value.integer != truncated_value.integer:
                 raise TestError("Values ({}) do not match as expected. "
                                 "Original value: {}; Truncated value: {}".format(desc,
@@ -266,8 +264,8 @@ def test_extension(dut):
 
     def compare_extended(short_value, long_value, sign_type, big_endian, desc):
         """Compare two equal values, one an extension of the other"""
-        short_value.big_endian = big_endian
-        long_value.big_endian = big_endian
+        short_value.ascending_range = big_endian
+        long_value.ascending_range = big_endian
         short_value.binaryRepresentation = sign_type
         long_value.binaryRepresentation = sign_type
         short_length = short_value.n_bits
@@ -327,9 +325,9 @@ def test_endianness_swap(dut):
 
     def compare_flipped_value(big_endian_value, little_endian_value, binary_repr, desc):
         """Compare two equal values (in verilog) with different endian-ness"""
-        big_endian_value.big_endian = True
+        big_endian_value.ascending_range = True
         big_endian_value.binaryRepresentation = binary_repr
-        little_endian_value.big_endian = False
+        little_endian_value.ascending_range = False
         little_endian_value.binaryRepresentation = binary_repr
 
         if big_endian_value.binstr != little_endian_value.binstr:
@@ -380,7 +378,7 @@ def test_signed_function(dut):
     unsigned_little_end_signal = dut.unsigned_assigned_dollar_signed_little.value
     if unsigned_little_end_signal.binstr != EXPECTED_STRING[1:]: # Signal is only 8 bits
         raise TestError("Didn't get expected value: $signed(-57) == 11000111 (in unsigned little-endian wire)")
-    unsigned_little_end_signal.big_endian = False
+    unsigned_little_end_signal.ascending_range = False
     unsigned_little_end_signal.binaryRepresentation = BinaryRepresentation.UNSIGNED
     if unsigned_little_end_signal.integer != EXPECTED_UNSIGNED_VALUE:
         tb.log.error("Expected value: %d; Actual value: %d",
@@ -390,7 +388,7 @@ def test_signed_function(dut):
     unsigned_big_end_signal = dut.unsigned_assigned_dollar_signed_big.value
     if unsigned_big_end_signal.binstr != EXPECTED_STRING[1:]: # Signal is only 8 bits
         raise TestError("Didn't get expected value: $signed(-57) == 11000111 (in unsigned big-endian wire)")
-    unsigned_big_end_signal.big_endian = True
+    unsigned_big_end_signal.ascending_range = True
     unsigned_big_end_signal.binaryRepresentation = BinaryRepresentation.UNSIGNED
     if unsigned_big_end_signal.integer != int(EXPECTED_STRING[1:][::-1], 2):
         tb.log.error("Expected value: %d; Actual value: %d",
@@ -400,7 +398,7 @@ def test_signed_function(dut):
     signed_little_end_signal = dut.signed_assigned_dollar_signed_little.value
     if signed_little_end_signal.binstr != EXPECTED_STRING:
         raise TestError("Didn't get expected value: $signed(-57) == 111000111 (in signed little-endian wire)")
-    signed_little_end_signal.big_endian = False
+    signed_little_end_signal.ascending_range = False
     signed_little_end_signal.binaryRepresentation = BinaryRepresentation.TWOS_COMPLEMENT
     if signed_little_end_signal.integer != EXPECTED_SIGNED_VALUE:
         tb.log.error("Expected value: %d; Actual value: %d",
@@ -410,7 +408,7 @@ def test_signed_function(dut):
     signed_big_end_signal = dut.signed_assigned_dollar_signed_big.value
     if signed_big_end_signal.binstr != EXPECTED_STRING:
         raise TestError("Didn't get expected value: $signed(-57) == 111000111 (in signed big-endian wire)")
-    signed_big_end_signal.big_endian = False
+    signed_big_end_signal.ascending_range = False
     signed_big_end_signal.binaryRepresentation = BinaryRepresentation.TWOS_COMPLEMENT
     if signed_big_end_signal.integer != EXPECTED_SIGNED_VALUE: # -57 is the same value reversed when 9 bits
         tb.log.error("Expected value: %d; Actual value: %d",
@@ -437,7 +435,7 @@ def test_to_signed_function(dut):
     little_end_signal = dut.signed_assigned_signed_little.value
     if little_end_signal.binstr != EXPECTED_STRING:
         raise TestError("Didn't get expected value: to_signed(-57, 9) == 111000111 (for little-endian signal)")
-    little_end_signal.big_endian = False
+    little_end_signal.ascending_range = False
     little_end_signal.binaryRepresentation = BinaryRepresentation.TWOS_COMPLEMENT
     if little_end_signal != EXPECTED_VALUE:
         tb.log.error("Expected value: %d; Actual value: %d",
@@ -447,7 +445,7 @@ def test_to_signed_function(dut):
     big_end_signal = dut.signed_assigned_signed_big.value
     if big_end_signal.binstr != EXPECTED_STRING:
         raise TestError("Didn't get expected value: to_signed(-57, 9) == 111000111 (for big-endian signal)")
-    big_end_signal.big_endian = True
+    big_end_signal.ascending_range = True
     big_end_signal.binaryRepresentation = BinaryRepresentation.TWOS_COMPLEMENT
     if big_end_signal.integer != EXPECTED_VALUE: # Fun: -57 is the same backwards when 9 bits
         tb.log.error("Expected value: %d; Actual value: %d",

--- a/tests/test_cases/test_binary/verilog/Makefile
+++ b/tests/test_cases/test_binary/verilog/Makefile
@@ -1,0 +1,4 @@
+COCOTB?=$(WPWD)/../../../..
+MODULE=test_binary
+export PYTHONPATH:=$(PYTHONPATH):$(realpath $(PWD)/..)
+include ../../../designs/logic_verilog_module/Makefile

--- a/tests/test_cases/test_binary/vhdl/Makefile
+++ b/tests/test_cases/test_binary/vhdl/Makefile
@@ -1,0 +1,4 @@
+COCOTB?=$(WPWD)/../../../..
+MODULE=test_binary
+export PYTHONPATH:=$(PYTHONPATH):$(realpath $(PWD)/..)
+include ../../../designs/logic_vhdl_module/Makefile


### PR DESCRIPTION
A number of issues have noted an problem with the `BinaryValue` type, which seems to centre around the `big_endian` member variable. It is treated as both byte-order and bit-order in different places in the code, so I have attempted to clarify this in comments/function docstrings.

- When the binary value type was first added, there was no concept of endian-ness ([commit](https://github.com/Matthewar/cocotb/commit/55023b9644aaf0574579edc07e30a1166f166550#diff-77cf4987173ad37eab355c44a547ffefR56))
- The `bigEndian` argument was added to the constructor/`big_endian`member added to the class to convert to/from a bytestring IE it represents byte-ordering ([commit](https://github.com/Matthewar/cocotb/commit/761ead050745328d317250a6c20898aaa78db8cd#diff-77cf4987173ad37eab355c44a547ffefR106))
- When signed representation was added to the class, `big_endian` was used for bit ordering ([commit](https://github.com/Matthewar/cocotb/commit/030a25bdeae4d02db12becf461f33c5d4217c67f))

Big-endian doesn't seem to have been used or tested thoroughly, at least for when it represents bit ordering, which makes sense as hardware designs typically don't use a big endian bit order, and the languages don't really have the concept of bit-endianness in the same way:

- In 1364-2005 (the verilog specification) section 4.3.1: "The most significant bit specified by the _msb_ constant expression is the left-hand value in the range, and the least signficant bit specified by the _lsb_ constant expression is the right-hand value in the range".
    - Implicit extension/truncation will occur on the left side, even if an ascending range (e.g. `logic [0:3]`) is declared.
    - Implicit integer conversion will always result in the vector being treated as having a little-endian bit order
- In the 1076-2002 (VHDL revision) section 16.8.5.1 which defines the `numeric_std`package, `signed` and `unsigned` types clearly define: "The type UNSIGNED represents an unsigned binary integer with the most significant bit on the left, while the type SIGNED represents a two's-complement binary integer with the most significant bit on the left."
    - Explicit extension/truncation can occur on whichever side (left/right) you want, so for big-endian bit order signals (e.g. `signal example : std_logic_vector(0 to 9);`) you can extend/truncate on the right side if you'd prefer
    - The `RESIZE` function acts like Verilog implicit truncation/extension and always operations on the left side
    - `TO_INTEGER` function takes a little-endian bit-order vector

To solve this:
- Returned `big_endian` member to represent the byte order of the internal string
    - When calling `get_buff`/`set_buff`, it is assumed you are using a big-endian byte order value, so byteswapping will only occur if the internal value is being treated as little-endian byte order
    - Wasn't sure if this was the best way to go about this, but `bigEndian=True` has been the default behaviour for a long time, even though most verilog/vhdl signals aren't big-endian byte order (otherwise the bit indices would go `7,6,5,4,3,2,1,0,15,14,13,12,11,10,9,8`, I think?)
    - Haven't done this yet, but maybe should change `handle.py` to return `BinaryValue`s with `bigEndian=False`
- Added `ascending_range` member
    - This is the bit-ordering (`ascending_range=True` => big-endian bit order)
    - Used for conversion between integer forms and string buffer
    - Used for indexing the bit string
        - Only when you index `BinaryValue`, not when you index the result of `get_binstr`, which returns a Python string, which will always have the leftmost value at index zero
        - Don't flip the binary string outputted so it's indexable correctly, it's showing directly what is in the simulation

Also:
- Added simulations to show the behaviour of bit-endianness in Verilog/VHDL, confirm behaviour of `BinaryValue.ascending_range`
- Added check to avalon drivers/monitors to ensure `dataBitsPerSymbol` is always 8, as that means `firstSymbolInHigherOrderBits` represents the byte order, which is how it has been used previously
- Removed `other` argument from `__neg__`, which doesn't take arguments
- Made `modulo` argument for `__ipow__` method optional as defined
- __Deprecated__ `signed_integer` member/getter
    - Added in [commit](https://github.com/Matthewar/cocotb/commit/f3008e5478d6b806552b6c664f65e28ca97086ac)
    - Before signed representation/endian-ness were added
    - Integer member/setter/getter handles signed values anyway, this isn't needed and just seems to force the value to act signed using a different method to the other code
- Some formatting changes - missing docstrings, some incorrect indentation, comments, etc.