### PR TITLE
Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 
 [![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=latest)](http://cocotb.readthedocs.org/en/latest/)
-[![Build Status](https://travis-ci.org/potentialventures/cocotb.svg?branch=master)](https://travis-ci.org/potentialventures/cocotb)
+[![Build Status](https://travis-ci.org/cocotb/cocotb.svg?branch=master)](https://travis-ci.org/cocotb/cocotb)
 [![Coverity Scan Status](https://scan.coverity.com/projects/6110/badge.svg)](https://scan.coverity.com/projects/cocotb)
 
 * Read the [documentation](http://cocotb.readthedocs.org)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=latest)](http://cocotb.readthedocs.org/en/latest/)
 [![Build Status](https://travis-ci.org/cocotb/cocotb.svg?branch=master)](https://travis-ci.org/cocotb/cocotb)
-[![Coverity Scan Status](https://scan.coverity.com/projects/6110/badge.svg)](https://scan.coverity.com/projects/cocotb)
 
 * Read the [documentation](http://cocotb.readthedocs.org)
 * Get involved:


### PR DESCRIPTION
After our repository move we need to update the Travis badge in the README. Remove the coverity badge, since we didn't run this for ages.