### PR TITLE
Move the trigger documentation into the class docstrings

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -153,10 +153,7 @@ class GPITrigger(Trigger):
 
 
 class Timer(GPITrigger):
-    """Execution will resume when the specified time period expires.
-
-    Consumes simulation time.
-    """
+    """Fires after the specified simulation time period has elapsed."""
     def __init__(self, time_ps, units=None):
         GPITrigger.__init__(self)
         self.sim_steps = get_sim_steps(time_ps, units)
@@ -181,8 +178,12 @@ class _ParameterizedSingletonAndABC(ParametrizedSingleton, abc.ABCMeta):
 
 
 class ReadOnly(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
-    """Execution will resume when the readonly portion of the sim cycles is
-    reached.
+    """Fires when the current simulation timestep moves to the readonly phase.
+
+    The :any:`ReadOnly` phase is entered when the current timestep no longer has any further delta steps.
+    This should be a point where all the signal values are stable as there are no more RTL events scheduled for the timestep.
+    The simulator should not allow scheduling of more events in this timestep.
+    Useful for monitors which need to wait for all processes to execute (both RTL and cocotb) to ensure sampled signal values are final.
     """
     __slots__ = ()
 
@@ -205,9 +206,7 @@ class ReadOnly(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
 
 
 class ReadWrite(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
-    """Execution will resume when the readwrite portion of the sim cycles is
-    reached.
-    """
+    """Fires when the readwrite portion of the sim cycles is reached."""
     __slots__ = ()
 
     @classmethod
@@ -231,7 +230,7 @@ class ReadWrite(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
 
 
 class NextTimeStep(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
-    """Execution will resume when the next time step is started."""
+    """Fires when the next time step is started."""
     __slots__ = ()
 
     @classmethod
@@ -253,7 +252,7 @@ class NextTimeStep(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
 
 
 class _EdgeBase(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
-    """Execution will resume when an edge occurs on the provided signal."""
+    """Internal base class that fires on a given edge of a signal."""
     __slots__ = ('signal',)
 
     @classmethod
@@ -285,19 +284,19 @@ class _EdgeBase(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
 
 
 class RisingEdge(_EdgeBase):
-    """Triggers on the rising edge of the provided signal."""
+    """Fires on the rising edge of *signal*, on a transition from ``0`` to ``1``."""
     __slots__ = ()
     _edge_type = 1
 
 
 class FallingEdge(_EdgeBase):
-    """Triggers on the falling edge of the provided signal."""
+    """Fires on the falling edge of *signal*, on a transition from ``1`` to ``0``."""
     __slots__ = ()
     _edge_type = 2
 
 
 class Edge(_EdgeBase):
-    """Triggers on either edge of the provided signal."""
+    """Fires on any value change of *signal*."""
     __slots__ = ()
     _edge_type = 3
 
@@ -325,7 +324,11 @@ class _Event(PythonTrigger):
 
 
 class Event(object):
-    """Event to permit synchronisation between two coroutines."""
+    """Event to permit synchronisation between two coroutines.
+
+    Yielding :meth:`wait()` from one coroutine will block the coroutine until
+    :meth:`set()` is called somewhere else.
+    """
 
     def __init__(self, name=""):
         self._pending = []
@@ -337,7 +340,7 @@ class Event(object):
         self._pending.append(trigger)
 
     def set(self, data=None):
-        """Wake up any coroutines blocked on this event."""
+        """Wake up all coroutines blocked on this event."""
         self.fired = True
         self.data = data
 
@@ -349,12 +352,12 @@ class Event(object):
             trigger()
 
     def wait(self):
-        """This can be yielded to block this coroutine
-        until another wakes it.
+        """Get a trigger which fires when another coroutine sets the event.
 
-        If the event has already been fired, this returns ``NullTrigger``.
+        If the event has already been set, the trigger will fire immediately.
+
         To reset the event (and enable the use of ``wait`` again),
-        :meth:`~cocotb.triggers.Event.clear` should be called.
+        :meth:`clear` should be called.
         """
         if self.fired:
             return NullTrigger(name="{}.wait()".format(str(self)))
@@ -394,13 +397,22 @@ class _Lock(PythonTrigger):
 
 
 class Lock(object):
-    """Lock primitive (not re-entrant)."""
+    """Lock primitive (not re-entrant).
+
+    This should be used as::
+
+        yield lock.acquire()
+        try:
+            # do some stuff
+        finally:
+            lock.release()
+    """
 
     def __init__(self, name=""):
         self._pending_unprimed = []
         self._pending_primed = []
         self.name = name
-        self.locked = False
+        self.locked = False  #: True if the lock is held
 
     def _prime_trigger(self, trigger, callback):
         self._pending_unprimed.remove(trigger)
@@ -412,7 +424,7 @@ class Lock(object):
             self._pending_primed.append(trigger)
 
     def acquire(self):
-        """This can be yielded to block until the lock is acquired."""
+        """ Produce a trigger which fires when the lock is acquired. """
         trig = _Lock(self)
         self._pending_unprimed.append(trig)
         return trig
@@ -446,8 +458,9 @@ class Lock(object):
 
 
 class NullTrigger(Trigger):
-    """
-    A trigger that fires instantly, primarily for internal scheduler use.
+    """Fires immediately.
+
+    Primarily for internal scheduler use.
     """
     def __init__(self, name="", outcome=None):
         super(NullTrigger, self).__init__()
@@ -469,7 +482,37 @@ class NullTrigger(Trigger):
 
 
 class Join(with_metaclass(_ParameterizedSingletonAndABC, PythonTrigger)):
-    """Join a coroutine, firing when it exits."""
+    r"""Fires when a :func:`fork`\ ed coroutine completes
+
+    The result of blocking on the trigger can be used to get the coroutine
+    result::
+
+        @cocotb.coroutine()
+        def coro_inner():
+            yield Timer(1)
+            raise ReturnValue("Hello world")
+
+        task = cocotb.fork(coro_inner())
+        result = yield Join(task)
+        assert result == "Hello world"
+
+    Or using the syntax in Python 3.5 onwards:
+
+    .. code-block:: python3
+
+        @cocotb.coroutine()
+        async def coro_inner():
+            await Timer(1)
+            return "Hello world"
+
+        task = cocotb.fork(coro_inner())
+        result = await Join(task)
+        assert result == "Hello world"
+
+    If the coroutine threw an exception, the :keyword:`await` or :keyword:`yield`
+    will re-raise it.
+
+    """
     __slots__ = ('_coroutine',)
 
     @classmethod
@@ -488,7 +531,19 @@ class Join(with_metaclass(_ParameterizedSingletonAndABC, PythonTrigger)):
     def retval(self):
         """The return value of the joined coroutine.
 
-        If the coroutine threw an exception, this attribute will re-raise it.
+        .. note::
+            Typically there is no need to use this attribute - the
+            following code samples are equivalent::
+
+                forked = cocotb.fork(mycoro())
+                j = Join(forked)
+                yield j
+                result = j.retval
+
+            ::
+
+                forked = cocotb.fork(mycoro())
+                result = yield Join(forked)
         """
         return self._coroutine.retval
 
@@ -532,8 +587,8 @@ class _AggregateWaitable(Waitable):
     """
     __slots__ = ('triggers',)
 
-    def __init__(self, *args):
-        self.triggers = tuple(args)
+    def __init__(self, *triggers):
+        self.triggers = tuple(triggers)
 
         # Do some basic type-checking up front, rather than waiting until we
         # yield them.
@@ -560,7 +615,7 @@ def _wait_callback(trigger, callback):
 
 class Combine(_AggregateWaitable):
     """
-    Waits until all the passed triggers have fired.
+    Fires when all of *triggers* have fired.
 
     Like most triggers, this simply returns itself.
     """
@@ -589,9 +644,13 @@ class Combine(_AggregateWaitable):
 
 class First(_AggregateWaitable):
     """
-    Wait for the first of multiple triggers.
+    Fires when the first trigger in *triggers* fires.
 
     Returns the result of the trigger that fired.
+
+    As a shorthand, ``t = yield [a, b]`` can be used instead of
+    ``t = yield First(a, b)``. Note that this shorthand is not available when
+    using :keyword:`await`.
 
     .. note::
         The event loop is single threaded, so while events may be simultaneous
@@ -634,9 +693,13 @@ class First(_AggregateWaitable):
 
 class ClockCycles(Waitable):
     """
-    Execution will resume after *num_cycles* rising edges or *num_cycles* falling edges.
+    Fires after *num_cycles* transitions of *signal* from ``0`` to ``1``.
     """
     def __init__(self, signal, num_cycles, rising=True):
+        """
+        :param rising: If true, the default, count rising edges. Otherwise,
+            count falling edges
+        """
         self.signal = signal
         self.num_cycles = num_cycles
         if rising is True:

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -181,8 +181,8 @@ class ReadOnly(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Fires when the current simulation timestep moves to the readonly phase.
 
     The :any:`ReadOnly` phase is entered when the current timestep no longer has any further delta steps.
-    This should be a point where all the signal values are stable as there are no more RTL events scheduled for the timestep.
-    The simulator should not allow scheduling of more events in this timestep.
+    This will be a point where all the signal values are stable as there are no more RTL events scheduled for the timestep.
+    The simulator will not allow scheduling of more events in this timestep.
     Useful for monitors which need to wait for all processes to execute (both RTL and cocotb) to ensure sampled signal values are final.
     """
     __slots__ = ()

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -305,3 +305,5 @@ breathe_domain_by_extension = {
     "h" : "cpp",
 }
 breathe_show_define_initializer = True
+
+autoclass_content = "both"

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -50,52 +50,18 @@ Interacting with the Simulator
 
 .. autoclass:: cocotb.clock.Clock
 
-
 Triggers
 --------
+See :ref:`simulator-triggers` for a list of subclasses. Below are the internal
+classes used within ``cocotb``.
 
-Triggers are used to indicate when the scheduler should resume coroutine execution.
-Typically a coroutine will :keyword:`yield` a trigger or a list of triggers.
+.. currentmodule:: cocotb.triggers
 
-.. autoclass:: cocotb.triggers.Trigger
-
-Simulation Timing
-~~~~~~~~~~~~~~~~~
-
-.. autoclass:: cocotb.triggers.Timer
-
-.. autoclass:: cocotb.triggers.ReadOnly
-
-.. autoclass:: cocotb.triggers.NextTimeStep
-
-.. autoclass:: cocotb.triggers.ClockCycles
-
-Signal related
-~~~~~~~~~~~~~~
-
-.. autoclass:: cocotb.triggers.Edge
-
-.. autoclass:: cocotb.triggers.RisingEdge
-
-.. autoclass:: cocotb.triggers.FallingEdge
-
-
-Python Triggers
-~~~~~~~~~~~~~~~
-
-.. autoclass:: cocotb.triggers.Combine
+.. autoclass:: Trigger
     :members:
     :member-order: bysource
 
-.. autoclass:: cocotb.triggers.Event
-    :members:
-    :member-order: bysource
-
-.. autoclass:: cocotb.triggers.Lock
-    :members:
-    :member-order: bysource
-
-.. autoclass:: cocotb.triggers.Join
+.. autoclass:: GPITrigger
     :members:
     :member-order: bysource
 

--- a/documentation/source/triggers.rst
+++ b/documentation/source/triggers.rst
@@ -2,47 +2,76 @@ Triggers
 ========
 
 Triggers are used to indicate when the cocotb scheduler should resume coroutine execution.
-Typically a coroutine will :keyword:`yield` a trigger or a list of triggers,
-while it is waiting for them to complete.
+To use a trigger, a coroutine should :keyword:`await` or :keyword:`yield` it.
+This will cause execution of the current coroutine to pause.
+When the trigger fires, execution of the paused coroutine will resume::
 
-Simulation Timing
------------------
+    @cocotb.coroutine
+    def coro():
+        print("Some time before the edge")
+        yield RisingEdge(clk)
+        print("Immediately after the edge")
 
-:class:`Timer(time) <.Timer()>`
-    Registers a timed callback with the simulator to continue execution of the coroutine
-    after a specified simulation time period has elapsed.
+Or using the syntax in Python 3.5 onwards:
+
+.. code-block:: python3
+
+    @cocotb.coroutine
+    async def coro():
+        print("Some time before the edge")
+        await RisingEdge(clk)
+        print("Immediately after the edge")
+
+.. _simulator-triggers:
+
+Simulator Triggers
+------------------
+
+Signals
+~~~~~~~
+
+.. autoclass:: cocotb.triggers.Edge
+
+.. autoclass:: cocotb.triggers.RisingEdge
+
+.. autoclass:: cocotb.triggers.FallingEdge
+
+.. autoclass:: cocotb.triggers.ClockCycles
 
 
-:class:`.ReadOnly()`
-    Registers a callback which will continue execution of the coroutine when the current simulation timestep moves to the :any:`ReadOnly` phase of the RTL simulator.
-    The :any:`ReadOnly` phase is entered when the current timestep no longer has any further delta steps.
-    This should be a point where all the signal values are stable as there are no more RTL events scheduled for the timestep.
-    The simulator should not allow scheduling of more events in this timestep.
-    Useful for monitors which need to wait for all processes to execute (both RTL and cocotb) to ensure sampled signal values are final.
+Timing
+~~~~~~
 
+.. autoclass:: cocotb.triggers.Timer
 
-Signal related
---------------
+.. autoclass:: cocotb.triggers.ReadOnly
 
-:class:`Edge(signal) <.Edge()>`
-    Registers a callback that will continue execution of the coroutine on any value change of *signal*.
+.. autoclass:: cocotb.triggers.ReadWrite
 
-:class:`RisingEdge(signal) <.RisingEdge()>`
-    Registers a callback that will continue execution of the coroutine on a transition from ``0`` to ``1`` of *signal*.
-
-:class:`FallingEdge(signal) <.FallingEdge()>`
-    Registers a callback that will continue execution of the coroutine on a transition from ``1`` to ``0`` of *signal*.
-
-:class:`ClockCycles(signal, num_cycles) <.ClockCycles>`
-    Registers a callback that will continue execution of the coroutine when *num_cycles* transitions from ``0`` to ``1`` have occured on *signal*.
+.. autoclass:: cocotb.triggers.NextTimeStep
 
 
 Python Triggers
 ---------------
 
-:class:`.Event()`
-    Can be used to synchronise between coroutines.
-    Yielding :meth:`.Event.wait()` will block the coroutine until :meth:`.Event.set()` is called somewhere else.
+.. autoclass:: cocotb.triggers.Combine
 
-:class:`Join(coroutine_2) <.Join()>`
-    Will block the coroutine until *coroutine_2* has completed.
+.. autoclass:: cocotb.triggers.First
+
+.. autoclass:: cocotb.triggers.Join
+    :members: retval
+
+
+Synchronization
+~~~~~~~~~~~~~~~
+
+These are not :class:`Trigger`\ s themselves, but contain methods that can be used as triggers.
+These are used to synchronize coroutines with each other.
+
+.. autoclass:: cocotb.triggers.Event
+    :members:
+    :member-order: bysource
+
+.. autoclass:: cocotb.triggers.Lock
+    :members:
+    :member-order: bysource


### PR DESCRIPTION
Rather than having two different descriptions of the same feature (the source and the rst), this merges the two into the source, and then uses autodoc to pull it back out into the RST.

Since sphinx does not link well if the same class is described in two places, this changes the library reference to link to the triggers page.

Some other general trigger doc changes:
* More trigger examples
* Use of the word "Fire" for concise trigger descriptions
* Some more `async` examples
* Adds some missing classes to the documentation