### PR TITLE
Update source repo name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ deploy:
   provider: pypi
   user: themperek
   password:
-    secure: "Olc0PdhY/0b8zYrgsPCUrfusPJgYLRBpAux/c5M6j4OzKyZN3fjjpPw+Yrs6o8RxBPa4uqN/niKo8MmgxLQeq3vAy+3nNo3YukL9Q/AYrbJ+JvHfe+2Be73LaujbNvuS9+A7NX3GOT40bB1eo/kOT/kjgzAJvlFhVnXq8h5a9Gc="
+    secure: "MLCDTXDYX7TKtPDXxUz7hIibXAIHGkz297yVQ7inLToCX/bKAkjdy/uwQZ4W7goRUFKJ6XliqBU8l/tihqPXCPtRaIU4hdLF9LZjR02Z16Ik3vDHBQcX/htfm32WAkFIVdbzBldD0N1NJIPYc83GnwLtgFM2u1fuCffiu2VqkTY="
   on:
     tags: true
-    repo: potentialventures/cocotb
+    repo: cocotb/cocotb
   distributions: sdist

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
   * [Raise a bug / request an enhancement](https://github.com/cocotb/cocotb/issues/new) (Requires a GitHub account)
   * [Join the mailing list](https://lists.librecores.org/listinfo/cocotb)
   * [Join the Gitter chat room](https://gitter.im/cocotb)
-* Get in contact: [E-mail us](mailto:cocotb@potentialventures.com)
-* Follow us on twitter: [@PVCocotb](https://twitter.com/PVCocotb)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 * Read the [documentation](http://cocotb.readthedocs.org)
 * Get involved:
-  * [Raise a bug / request an enhancement](https://github.com/potentialventures/cocotb/issues/new) (Requires a GitHub account)
+  * [Raise a bug / request an enhancement](https://github.com/cocotb/cocotb/issues/new) (Requires a GitHub account)
   * [Join the mailing list](https://lists.librecores.org/listinfo/cocotb)
   * [Join the Gitter chat room](https://gitter.im/cocotb)
 * Get in contact: [E-mail us](mailto:cocotb@potentialventures.com)
@@ -21,7 +21,7 @@ Cocotb can be installed by running `pip install cocotb`.
     sudo yum install -y iverilog python-devel gtkwave
     
     # Checkout git repositories
-    git clone https://github.com/potentialventures/cocotb.git
+    git clone https://github.com/cocotb/cocotb.git
     
     # Install cocotb
     pip install ./cocotb

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -47,7 +47,7 @@ extensions = [
 intersphinx_mapping = {'https://docs.python.org/3': None}
 
 # Github repo
-issues_github_path = "potentialventures/cocotb"
+issues_github_path = "cocotb/cocotb"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/documentation/source/introduction.rst
+++ b/documentation/source/introduction.rst
@@ -7,7 +7,7 @@ What is cocotb?
 
 **cocotb** is a *COroutine* based *COsimulation* *TestBench* environment for verifying VHDL/Verilog RTL using `Python <https://www.python.org>`_.
 
-cocotb is completely free, open source (under the `BSD License <https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_(%22BSD_License_2.0%22,_%22Revised_BSD_License%22,_%22New_BSD_License%22,_or_%22Modified_BSD_License%22)>`_) and hosted on `GitHub <https://github.com/potentialventures/cocotb>`_.
+cocotb is completely free, open source (under the `BSD License <https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_(%22BSD_License_2.0%22,_%22Revised_BSD_License%22,_%22New_BSD_License%22,_or_%22Modified_BSD_License%22)>`_) and hosted on `GitHub <https://github.com/cocotb/cocotb>`_.
 
 cocotb requires a simulator to simulate the RTL. Simulators that have been tested and known to work with cocotb:
 
@@ -78,8 +78,8 @@ Contributors
 cocotb was developed by `Potential Ventures <https://potential.ventures>`_ with the support of
 `Solarflare Communications Ltd <https://www.solarflare.com/>`_
 and contributions from Gordon McGregor and Finn Grimwood
-(see `contributers <https://github.com/potentialventures/cocotb/graphs/contributors>`_ for the full list of contributions).
+(see `contributers <https://github.com/cocotb/cocotb/graphs/contributors>`_ for the full list of contributions).
 
 We also have a list of talks and papers, libraries and examples at our wiki page
-`Further Resources <https://github.com/potentialventures/cocotb/wiki/Further-Resources>`_.
+`Further Resources <https://github.com/cocotb/cocotb/wiki/Further-Resources>`_.
 Feel free to add links to cocotb-related content that we are still missing!

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -163,7 +163,7 @@ For development version:
 
 .. code-block:: bash
 
-    $> git clone https://github.com/potentialventures/cocotb
+    $> git clone https://github.com/cocotb/cocotb
     $> pip install -e ./cocotb
 
 Running an example
@@ -171,7 +171,7 @@ Running an example
 
 .. code-block:: bash
 
-    $> git clone https://github.com/potentialventures/cocotb
+    $> git clone https://github.com/cocotb/cocotb
     $> cd cocotb/examples/endian_swapper/tests
     $> make
 

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -2,7 +2,7 @@
 Release Notes
 #############
 
-All releases are available from the `GitHub Releases Page <https://github.com/potentialventures/cocotb/releases>`_.
+All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
 cocotb 1.2
 ==========

--- a/documentation/source/roadmap.rst
+++ b/documentation/source/roadmap.rst
@@ -5,6 +5,6 @@ Roadmap
 cocotb is in active development.
 
 We use GitHub issues to track our pending tasks.
-Take a look at the `open Feature List <https://github.com/potentialventures/cocotb/issues?q=is%3Aissue+is%3Aopen+label%3Atype%3Afeature>`_ to see the work that's lined up.
+Take a look at the `open Feature List <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+is%3Aopen+label%3Atype%3Afeature>`_ to see the work that's lined up.
 
-If you have a GitHub account you can also `raise an enhancement request <https://github.com/potentialventures/cocotb/issues/new>`_ to suggest new features.
+If you have a GitHub account you can also `raise an enhancement request <https://github.com/cocotb/cocotb/issues/new>`_ to suggest new features.


### PR DESCRIPTION
In preparation for a 1.2 release (planned on Wednesday) we need to fix the repository URL in various places in the documentation and in the travis configuration.