### PR TITLE
Renamed dec_viterbi_ent to avoid collision with library.

### DIFF
--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -35,7 +35,7 @@ clean::
 
 else
 
-TOPLEVEL = dec_viterbi
+TOPLEVEL = dec_viterbi_ent
 
 ifeq ($(OS),Msys)
 WPWD=$(shell sh -c 'pwd -W')

--- a/tests/designs/viterbi_decoder_axi4s/src/dec_viterbi.vhd
+++ b/tests/designs/viterbi_decoder_axi4s/src/dec_viterbi.vhd
@@ -26,7 +26,7 @@ use dec_viterbi.pkg_components.all;
 use dec_viterbi.pkg_trellis.all;
 
 
-entity dec_viterbi is
+entity dec_viterbi_ent is
 	port(
 
 	--
@@ -70,10 +70,10 @@ entity dec_viterbi is
 	s_axis_ctrl_tlast  : in std_logic;
 	s_axis_ctrl_tready : out std_logic
 );
-end entity dec_viterbi;
+end entity dec_viterbi_ent;
 
 
-architecture rtl of dec_viterbi is
+architecture rtl of dec_viterbi_ent is
 
 	alias clk is aclk;
 	signal rst : std_logic;

--- a/tests/designs/viterbi_decoder_axi4s/src/generic_sp_ram.vhd
+++ b/tests/designs/viterbi_decoder_axi4s/src/generic_sp_ram.vhd
@@ -13,7 +13,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
-use ieee.std_logic_unsigned.all;
 
 library dec_viterbi;
 use dec_viterbi.pkg_helper.all;
@@ -80,9 +79,9 @@ begin
 	if rising_edge(clk) then
 		if en = '1' then
 			if wen =  '1' then
-				sp_ram(conv_integer(a)) <= d;
+				sp_ram(to_integer(unsigned(a))) <= d;
 			else
-				q <= sp_ram(conv_integer(a));
+				q <= sp_ram(to_integer(unsigned(a)));
 			end if;
 		end if;
 	end if;

--- a/tests/test_cases/test_iteration_vhdl/Makefile
+++ b/tests/test_cases/test_iteration_vhdl/Makefile
@@ -27,3 +27,4 @@
 
 include ../../designs/viterbi_decoder_axi4s/Makefile
 MODULE = test_iteration
+SIM_ARGS ?= --ieee-asserts=disable-at-0


### PR DESCRIPTION
Also converting std_logic_vector to integer with std_numeric, removed
std_logic_unsigned in one instance.