### PR TITLE
Use only Sphinx 2.1 (some sphinxcontrib-trio features moved there).

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,7 +1,6 @@
 # Python dependencies to build the documentation
-Sphinx>=2.0
+Sphinx>=2.1
 sphinx-rtd-theme
 cairosvg
 breathe
-sphinxcontrib-trio
 sphinx-issues

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -40,7 +40,6 @@ extensions = [
     'sphinx.ext.intersphinx',
     'cairosvgconverter',
     'breathe',
-    'sphinxcontrib_trio',
     'sphinx_issues',
     ]
 


### PR DESCRIPTION
This prevents us from needing a newer sphinxcontrib-trio (because of https://github.com/python-trio/sphinxcontrib-trio/issues/23) for no real advantage compared to pure Sphinx.