### PR TITLE
Questa: start simulation from PWD, not PWD/sim_build

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -89,10 +89,10 @@ $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_SIM_DEPS) $
 	@echo "onerror {" >> $@
 	@echo "	quit -f -code 1" >> $@
 	@echo "}" >> $@
-	@echo "if [file exists $(RTL_LIBRARY)] {vdel -lib $(RTL_LIBRARY) -all}" >> $@
-	@echo "vlib $(RTL_LIBRARY)" >> $@
+	@echo "if [file exists $(SIM_BUILD)/$(RTL_LIBRARY)] {vdel -lib $(SIM_BUILD)/$(RTL_LIBRARY) -all}" >> $@
+	@echo "vlib $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
 	@echo "vmap -c" >> $@
-	@echo "vmap $(RTL_LIBRARY) $(RTL_LIBRARY)" >> $@
+	@echo "vmap $(RTL_LIBRARY) $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)
 	@echo "vcom -work $(RTL_LIBRARY) $(VCOM_ARGS) $(VHDL_SOURCES)" >> $@
 endif
@@ -102,7 +102,7 @@ endif
 ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@
 endif
-	@echo "vsim $(VSIM_ARGS) $(EXTRA_ARGS) $(TOPLEVEL)" >> $@
+	@echo "vsim $(VSIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/$(TOPLEVEL)" >> $@
 ifeq ($(WAVES),1)
 	@echo "log -recursive /*" >> $@
 endif
@@ -146,9 +146,9 @@ endif
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(INT_LIBS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
-	set -o pipefail; cd $(SIM_BUILD) && $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 \
+	set -o pipefail; $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 \
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) \
-	$(CMD) $(PLUSARGS) -do runsim.do 2>&1 | tee sim.log
+	$(CMD) $(PLUSARGS) -do $(SIM_BUILD)/runsim.do 2>&1 | tee $(SIM_BUILD)/sim.log
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -58,10 +58,12 @@ and
 .. make:var:: VERILOG_SOURCES
 
       A list of the Verilog source files to include.
+      Paths can be absolute or relative; if relative, they are interpreted as relative to the Makefile's location.
 
 .. make:var:: VHDL_SOURCES
 
       A list of the VHDL source files to include.
+      Paths can be absolute or relative; if relative, they are interpreted as relative to the Makefile's location.
 
 .. make:var:: VHDL_SOURCES_<lib>
 

--- a/documentation/source/newsfragments/1063.change.rst
+++ b/documentation/source/newsfragments/1063.change.rst
@@ -1,0 +1,1 @@
+Questa now interprets relative paths to source files as relative to the Makefile, the same behavior used by other simulators.


### PR DESCRIPTION
The Icarus and Cadence (ius) simulator targets run the simulation relative to ```${PWD}```; i.e. the location of the Makefile. The Questa one, though, seems to run everything out of the ```${PWD}/sim_build``` directory.

This commit changes the questa Makefile to run from ```${PWD}```, while keeping the "work" library and the run script in sim_build, for better compatibility with the other simulators.

In particular, I just tried to port a project from Cadence to Questa and found that, because my Makefile didn't explicitly refer to ```${PWD}``` but instead just provided source paths relative to the current working directory, the simulation would not start. Hence this change.

Hopefully this does not break anything: it would be great if people with more mature Questa projects could test!

I should say: it's possible that this isn't desired behavior. In which case, maybe the other simulators should be changed instead for consistency? (This all also may be immaterial if the makefile approach to cocotb is replaced with the purer-Python cocotb-test approach, but assuming we keep some kind of compatibility layer with the Makefiles, it would probably still be good to fix this).