### PR TITLE
Add target 'regression' to the 'all tests' Makefile.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,3 +46,6 @@ endif
 
 clean:
 	$(foreach TEST, $(REGRESSIONS), $(MAKE) -C test_cases/$(TEST) clean;)
+
+regression:
+	$(foreach TEST, $(REGRESSIONS), $(MAKE) -C test_cases/$(TEST) regression;)


### PR DESCRIPTION
I'm gradually working through all tests in my local, non-Travis setting and was missing the ``regression`` target there.