### PR TITLE
Add XCELIUM to existing IUS define checks.

### DIFF
--- a/cocotb/share/include/vhpi_user.h
+++ b/cocotb/share/include/vhpi_user.h
@@ -169,7 +169,7 @@ extern "C" {
 #ifndef IUS
         size_t bufSize;  /* the size in bytes of the value buffer; this is set by the user */
 #else
-        int32_t bufSize;  /* IUS defines this as 32-bits, even when running in 64-bit mode */
+        int32_t bufSize;  /* IUS/Xcelium defines this as 32-bits, even when running in 64-bit mode */
 #endif
         int32_t numElems;
         /* different meanings depending on the format:
@@ -627,7 +627,7 @@ typedef enum
     vhpiUnitNameP               = 1317,
     vhpiSaveRestartLocationP    = 1318,
 
-    /* Cadence IUS */
+    /* Cadence IUS/Xcelium */
     vhpiFullVlogNameP = 1500,       /* Full path name (VHDL names are Verilogized) */
     vhpiFullVHDLNameP = 1501,       /* Full path name (Verilog names are vhdlized) */
     vhpiFullLSNameP = 1502,         /* Full path name (Upper case) using ':' and '.' separators */

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -47,7 +47,7 @@ VhpiSignalObjHdl::~VhpiSignalObjHdl()
 
 bool get_range(vhpiHandleT hdl, vhpiIntT dim, int *left, int *right) {
 #ifdef IUS
-    /* IUS does not appear to set the vhpiIsUnconstrainedP property.  IUS Docs say will return
+    /* IUS/Xcelium does not appear to set the vhpiIsUnconstrainedP property.  IUS Docs say will return
      * -1 if unconstrained, but with vhpiIntT being unsigned, the value returned is below.
      */
     const vhpiIntT UNCONSTRAINED = 2147483647;
@@ -108,7 +108,7 @@ bool get_range(vhpiHandleT hdl, vhpiIntT dim, int *left, int *right) {
                     if (curr_idx == dim) {
                         vhpi_release_handle(it);
 
-                        /* IUS only sets the vhpiIsUnconstrainedP incorrectly on the base type */
+                        /* IUS/Xcelium only sets the vhpiIsUnconstrainedP incorrectly on the base type */
                         if (!vhpi_get(vhpiIsUnconstrainedP, constraint)) {
                             error = false;
                             *left  = vhpi_get(vhpiLeftBoundP, constraint);

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -610,7 +610,7 @@ GpiObjHdl *VhpiImpl::native_check_create(int32_t index, GpiObjHdl *parent)
 
             if (indices.size() == num_dim) {
 #ifdef IUS
-                /* IUS does not appear to set the vhpiIsUnconstrainedP property.  IUS Docs say will return
+                /* IUS/Xcelium does not appear to set the vhpiIsUnconstrainedP property.  IUS Docs say will return
                  * -1 if unconstrained, but with vhpiIntT being unsigned, the value returned is below.
                  */
                 const vhpiIntT UNCONSTRAINED = 2147483647;
@@ -621,7 +621,7 @@ GpiObjHdl *VhpiImpl::native_check_create(int32_t index, GpiObjHdl *parent)
                 /* All necessary indices are available, need to iterate over dimension constraints to
                  * determine the index into the zero-based flattened array.
                  *
-                 * Check the constraints on the base type first. (always works for Aldec, but not unconstrained types in IUS)
+                 * Check the constraints on the base type first. (always works for Aldec, but not unconstrained types in IUS/Xcelium)
                  * If the base type fails, then try the sub-type.  (sub-type is listed as deprecated for Aldec)
                  */
                 vhpiHandleT it, constraint;
@@ -656,7 +656,7 @@ GpiObjHdl *VhpiImpl::native_check_create(int32_t index, GpiObjHdl *parent)
 
                         if (it != NULL) {
                             while ((constraint = vhpi_scan(it)) != NULL) {
-                                /* IUS only sets the vhpiIsUnconstrainedP incorrectly on the base type */
+                                /* IUS/Xcelium only sets the vhpiIsUnconstrainedP incorrectly on the base type */
                                 if (vhpi_get(vhpiIsUnconstrainedP, constraint)) {
                                     vhpi_release_handle(it);
                                     break;

--- a/cocotb/share/makefiles/Makefile.rules
+++ b/cocotb/share/makefiles/Makefile.rules
@@ -44,6 +44,11 @@ ifeq ($(SIM_DEFINE),QUESTA)
 SIM_DEFINE = MODELSIM
 endif
 
+# Use a common define for Xcelium and IUS
+ifeq ($(SIM_DEFINE),XCELIUM)
+SIM_DEFINE = IUS
+endif
+
 # Add Simulator Define for compilation
 GCC_ARGS+= -D$(SIM_DEFINE)
 GXX_ARGS+= -D$(SIM_DEFINE)


### PR DESCRIPTION
For some reason I missed to also check for the ``XCELIUM`` define when I introduced ``Makefile.xcelium``, fix that.