### PR TITLE
Add flag to compile as VHDL93 for IUS/Xcelium for some designs

### DIFF
--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -36,6 +36,10 @@ VERILOG_SOURCES =   $(SRC_BASE)/verilog/baud_gen.v \
 VERILOG_SOURCES += $(SRC_BASE)/top/verilog_toplevel.sv
 TOPLEVEL = verilog_toplevel
 
+ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+    SIM_ARGS += -v93
+endif
+
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim
 

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -28,11 +28,15 @@ VHDL_SOURCES = $(COCOTB)/tests/designs/vhdl_configurations/dut.vhd
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/vhdl_configurations/testbench.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-   	VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/testbench.vhd
+    VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/testbench.vhd
 else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/configurations.vhd
+
+ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+    SIM_ARGS += -v93
+endif
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -63,7 +63,11 @@ VHDL_SOURCES = $(SRC_BASE)/packages/pkg_helper.vhd \
 	       $(SRC_BASE)/src/ram_ctrl.vhd \
 	       $(SRC_BASE)/src/reorder.vhd \
 	       $(SRC_BASE)/src/recursion.vhd \
-	       $(SRC_BASE)/src/dec_viterbi.vhd \
+	       $(SRC_BASE)/src/dec_viterbi.vhd
+
+ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+    SIM_ARGS += -v93
+endif
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim


### PR DESCRIPTION
Explicitly set ``-v93`` when compiling under Cadence IUS/Xcelium for the designs that are VHDL 93.
This switch is set by default for IUS in ``Makefile.ius`` (and probably should stay that way for backward compatibility reasons,) but this is not the case for the newer ``Makefile.xcelium`` because it is at least confusing when a design needs e.g. the VHDL 2008 switch set.
This results in ``-v93`` being specified twice for IUS but the simulator does not care.