### PR TITLE
Removed SIM_ARGS from test_iteration_vhdl

### DIFF
--- a/tests/test_cases/test_iteration_vhdl/Makefile
+++ b/tests/test_cases/test_iteration_vhdl/Makefile
@@ -27,4 +27,3 @@
 
 include ../../designs/viterbi_decoder_axi4s/Makefile
 MODULE = test_iteration
-SIM_ARGS ?= --ieee-asserts=disable-at-0


### PR DESCRIPTION
for #1073.

The total warning look like this:
```
../../src/ieee/numeric_std-body.v93:2098:7:@0ms:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
../../src/ieee/numeric_std-body.v93:2098:7:@0ms:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
../../src/ieee/numeric_std-body.v93:2098:7:@0ms:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
../../src/ieee/numeric_std-body.v93:2098:7:@0ms:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
../../src/ieee/numeric_std-body.v93:1710:7:@0ms:(assertion warning): NUMERIC_STD."=": metavalue detected, returning FALSE
../../src/ieee/numeric_std-body.v93:1710:7:@0ms:(assertion warning): NUMERIC_STD."=": metavalue detected, returning FALSE
```
I'm happy to just remove SIM_ARGS if it's all the same.  It's not required and I can't see other examples of sim specific args.