### PR TITLE
Disabled warnings at time 0 for test_iteration_vhdl

### DIFF
--- a/tests/test_cases/test_iteration_vhdl/Makefile
+++ b/tests/test_cases/test_iteration_vhdl/Makefile
@@ -27,3 +27,11 @@
 
 include ../../designs/viterbi_decoder_axi4s/Makefile
 MODULE = test_iteration
+
+ifeq ($(SIM),$(filter $(SIM), ius xcelium))
+    SIM_ARGS += -notimezeroasrtmsg
+endif
+
+ifeq ($(SIM),$(filter $(SIM), ghdl))
+    SIM_ARGS += --ieee-asserts=disable-at-0
+endif


### PR DESCRIPTION
Follow up for #1078.

I can only test the GHDL path, just guessing with IUS/Xcelium :P