### PR TITLE
 Reduce tracebacks to not contain noise from the `outcome` module

### DIFF
--- a/cocotb/outcomes.py
+++ b/cocotb/outcomes.py
@@ -5,9 +5,11 @@ An outcome is similar to the builtin `concurrent.futures.Future`
 or `asyncio.Future`, but without being tied to a particular task model.
 """
 import abc
+import copy
 import sys
 
 from cocotb import _py_compat
+from cocotb.utils import remove_traceback_frames
 
 
 def capture(fn, *args, **kwargs):
@@ -58,6 +60,11 @@ if sys.version_info.major >= 3:
         def get(self):
             raise self.error
 
+        # Once we drop Python 2, this can be inlined at the caller, it's here
+        # just for convenience writing code that works on both versions
+        def without_frames(self, frame_names):
+            return Error(remove_traceback_frames(self.error, frame_names))
+
 else:
     # Python 2 needs extra work to preserve tracebacks
     class Error(_ErrorBase):
@@ -76,9 +83,20 @@ else:
         def send(self, gen):
             return gen.throw(self.error_type, self.error, self.error_tb)
 
-        _py_compat.exec_("""def get(self):
+        def without_frames(self, frame_names):
+            ret = copy.copy(self)
+            ret.error_tb = remove_traceback_frames(ret.error_tb, frame_names)
+            return ret
+
+        # We need a wrapper function to ensure the traceback is the same
+        # depth as on Python 3 - `raise type, val, tb` is not included in the
+        # stack trace in Python 2.
+        _py_compat.exec_("""def _get(self):
             try:
                 raise self.error_type, self.error, self.error_tb
             finally:
                 del self
         """)
+
+        def get(self):
+            return self._get()


### PR DESCRIPTION
Since the outcome module is plumbing to pass exceptions around, the user probably does not want to see it.
<details>

<summary> Outdated content </summary>

Doesn't help on python 2 (although we could make it work with gh-899)

Tested by changing test_cocotb.py to print all errors. The diff from the output logs (after removing pointers and line numbers) is:

```diff
--- output_old.txt	2019-08-26 23:21:58.613923300 -0700
+++ output_new.txt	2019-08-26 23:21:55.391809000 -0700

@@ -177,30 +177,12 @@
                                                                                                                      Description: Test doing invalid sim operation
     69.41ns ERROR    cocotb.regression                         regression.py:xxx  in handle_result                   Test Failed: test_cached_write_in_readonly (result was Exception)
                                                                                                                      Traceback (most recent call last):
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/regression.py", line xx, in handle_result
-                                                                                                                         test._outcome.get()
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in get
-                                                                                                                         raise self.error
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line xx, in _advance
-                                                                                                                         return outcome.send(self._coro)
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in send
-                                                                                                                         return gen.throw(self.error)
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/tests/test_cases/test_cocotb/test_cocotb.py", line xx, in test_cached_write_in_readonly
                                                                                                                          yield [Join(coro), Timer(10000)]
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line xx, in _advance
-                                                                                                                         return outcome.send(self._coro)
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in send
-                                                                                                                         return gen.send(self.value)
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/triggers.py", line xx, in _wait
-                                                                                                                         raise ReturnValue(ret.get())
+                                                                                                                         result = ret.get()
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in get
                                                                                                                          raise self.error
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/triggers.py", line xx, in _wait_callback
-                                                                                                                         ret = outcomes.Value((yield trigger))
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line xx, in _advance
-                                                                                                                         return outcome.send(self._coro)
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in send
-                                                                                                                         return gen.send(self.value)
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/tests/test_cases/test_cocotb/test_cocotb.py", line xx, in do_test_cached_write_in_readonly
                                                                                                                          dut.clk <= 0
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/handle.py", line xx, in __le__
@@ -255,20 +237,8 @@
   2581.85ns WARNING  cocotb.clk                               test_cocotb.py:xxx  in clock_gen                       Clock generator finished!
   2581.95ns ERROR    cocotb.regression                         regression.py:xxx  in handle_result                   Test Failed: test_coroutine_syntax_error (result was NameError)
                                                                                                                      Traceback (most recent call last):
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/regression.py", line xx, in handle_result
-                                                                                                                         test._outcome.get()
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in get
-                                                                                                                         raise self.error
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line xx, in _advance
-                                                                                                                         return outcome.send(self._coro)
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in send
-                                                                                                                         return gen.throw(self.error)
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/tests/test_cases/test_cocotb/test_cocotb.py", line xx, in test_coroutine_syntax_error
                                                                                                                          yield syntax_error()
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line xx, in _advance
-                                                                                                                         return outcome.send(self._coro)
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in send
-                                                                                                                         return gen.send(self.value)
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/tests/test_cases/test_cocotb/test_cocotb.py", line xx, in syntax_error
                                                                                                                          fail
                                                                                                                      NameError: name 'fail' is not defined
@@ -316,22 +286,9 @@
   2589.13ns INFO     .._fork_syntax_error.0xXXXXXXXXXXXX       decorators.py:xxx  in _advance                        Starting test: "test_fork_syntax_error"
                                                                                                                      Description: Syntax error in a coroutine that we fork
   2590.13ns WARNING  cocotb.clk                               test_cocotb.py:xxx  in clock_gen                       Clock generator finished!
+  2590.23ns ERROR    ..utine.syntax_error.0xXXXXXXXXXXXX        scheduler.py:xxx  in unschedule                      Exception raised by forked coroutine
   2590.23ns ERROR    cocotb.regression                         regression.py:xxx  in handle_result                   Test Failed: test_fork_syntax_error (result was NameError)
                                                                                                                      Traceback (most recent call last):
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/regression.py", line xx, in handle_result
-                                                                                                                         test._outcome.get()
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in get
-                                                                                                                         raise self.error
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/scheduler.py", line xx, in unschedule
-                                                                                                                         coro.retval
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line xx, in retval
-                                                                                                                         return self._outcome.get()
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in get
-                                                                                                                         raise self.error
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line xx, in _advance
-                                                                                                                         return outcome.send(self._coro)
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in send
-                                                                                                                         return gen.send(self.value)
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/tests/test_cases/test_cocotb/test_cocotb.py", line xx, in syntax_error
                                                                                                                          fail
                                                                                                                      NameError: name 'fail' is not defined
@@ -424,14 +381,6 @@
   2604.96ns WARNING  cocotb.clk                               test_cocotb.py:xxx  in clock_gen                       Clock generator finished!
   2604.97ns ERROR    cocotb.regression                         regression.py:xxx  in handle_result                   Test Failed: test_syntax_error (result was NameError)
                                                                                                                      Traceback (most recent call last):
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/regression.py", line xx, in handle_result
-                                                                                                                         test._outcome.get()
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in get
-                                                                                                                         raise self.error
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line xx, in _advance
-                                                                                                                         return outcome.send(self._coro)
-                                                                                                                       File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line xx, in send
-                                                                                                                         return gen.send(self.value)
                                                                                                                        File "/mnt/c/Users/wiese/Repos/cocotb/tests/test_cases/test_cocotb/test_cocotb.py", line xx, in test_syntax_error
                                                                                                                          fail
                                                                                                                      NameError: name 'fail' is not defined
```

</details>