### PR TITLE
Questa: use ifndef VLOG_ARGS to fix #1057

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -47,9 +47,7 @@ RTL_LIBRARY ?= work
 
 TOPLEVEL := "$(RTL_LIBRARY).$(TOPLEVEL)"
 
-ifdef VLOG_ARGS
-VLOG_ARGS = $(VLOG_ARGS)
-else
+ifndef VLOG_ARGS
 VLOG_ARGS = -timescale 1ns/100ps -mfcu +acc=rmb
 endif
 ifdef VERILOG_INCLUDE_DIRS


### PR DESCRIPTION
The Questa makefile had a block of code which checked:

```
ifdef VLOG_ARGS
VLOG_ARGS = $(VLOG_ARGS)
else
...
```

There's no reason for this to be written like this; if VLOG_ARGS is defined, then it doesn't need to be assigned to itself, as it's already defined. A cleaner version of this is to use ```ifndef```:

```
ifndef VLOG_ARGS
...
```

Note that this can actually cause problems if e.g. a makefile invoking cocotb has used the ```export``` directive to allow variables to be passed down recursively. Since it doesn't do anything as written, and only potentially leads to problems... I think this should just be rewritten to use an ifndef. This will fix #1057.