### PR TITLE
Move backports to their own file, to more clearly separate them from utilities

### DIFF
--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -28,6 +28,7 @@ Backports and compatibility shims for newer python features.
 These are for internal use - users should use a third party library like `six`
 if they want to use these shims in their own code
 """
+import abc
 import sys
 
 # This is six.integer_types
@@ -131,3 +132,8 @@ class nullcontext(object):
 
     def __exit__(self, *excinfo):
         pass
+
+
+# https://stackoverflow.com/a/38668373
+# Backport of abc.ABC, compatible with Python 2 and 3
+abc_ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})

--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -1,0 +1,133 @@
+# Copyright (c) cocotb contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the copyright holder nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+Backports and compatibility shims for newer python features.
+
+These are for internal use - users should use a third party library like `six`
+if they want to use these shims in their own code
+"""
+import sys
+
+# This is six.integer_types
+if sys.version_info.major >= 3:
+    integer_types = (int,)
+else:
+    integer_types = (int, long)  # noqa
+
+
+# This is essentially six.exec_
+if sys.version_info.major == 3:
+    # this has to not be a syntax error in py2
+    import builtins
+    exec_ = getattr(builtins, 'exec')
+else:
+    # this has to not be a syntax error in py3
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+
+# this is six.with_metaclass, with a clearer docstring
+def with_metaclass(meta, *bases):
+    """This provides:
+
+    .. code-block:: python
+
+        class Foo(with_metaclass(Meta, Base1, Base2)): pass
+
+    which is a unifying syntax for:
+
+    .. code-block:: python
+
+        # Python 3
+        class Foo(Base1, Base2, metaclass=Meta): pass
+
+        # Python 2
+        class Foo(Base1, Base2):
+            __metaclass__ = Meta
+    """
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+# this is six.raise_from
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+    """)
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+    """)
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+# backport of Python 3.7's contextlib.nullcontext
+class nullcontext(object):
+    """Context manager that does no additional processing.
+    Used as a stand-in for a normal context manager, when a particular
+    block of code is only sometimes used with a normal context manager:
+
+    cm = optional_cm if condition else nullcontext()
+    with cm:
+        # Perform operation, using optional_cm if condition is True
+    """
+
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+
+    def __enter__(self):
+        return self.enter_result
+
+    def __exit__(self, *excinfo):
+        pass

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -28,7 +28,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
-from cocotb.utils import integer_types
+from cocotb import _py_compat
 
 import os
 import random
@@ -154,7 +154,7 @@ class BinaryValue(object):
         Args:
             value (str or int or long): The value to assign.
         """
-        if isinstance(value, integer_types):
+        if isinstance(value, _py_compat.integer_types):
             self.value = value
         elif isinstance(value, str):
             try:
@@ -640,11 +640,11 @@ class BinaryValue(object):
 
     def __setitem__(self, key, val):
         """BinaryValue uses Verilog/VHDL style slices as opposed to Python style."""
-        if not isinstance(val, str) and not isinstance(val, integer_types):
+        if not isinstance(val, str) and not isinstance(val, _py_compat.integer_types):
             raise TypeError('BinaryValue slices only accept string or integer values')
 
         # convert integer to string
-        if isinstance(val, integer_types):
+        if isinstance(val, _py_compat.integer_types):
             if isinstance(key, slice):
                 num_slice_bits = abs(key.start - key.stop) + 1
             else:

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -38,8 +38,9 @@ import os
 import cocotb
 from cocotb.log import SimLog
 from cocotb.result import ReturnValue, raise_error
-from cocotb.utils import get_sim_time, with_metaclass, exec_, lazy_property
+from cocotb.utils import get_sim_time, lazy_property
 from cocotb import outcomes
+from cocotb import _py_compat
 
 # Sadly the Python standard logging module is very slow so it's better not to
 # make any calls by testing a boolean flag first
@@ -196,7 +197,7 @@ class RunningCoroutine(object):
 
     # Once 2.7 is dropped, this can be run unconditionally
     if sys.version_info >= (3, 3):
-        exec_(textwrap.dedent("""
+        _py_compat.exec_(textwrap.dedent("""
         def __await__(self):
             # It's tempting to use `return (yield from self._coro)` here,
             # which bypasses the scheduler. Unfortunately, this means that
@@ -399,7 +400,7 @@ class _decorator_helper(type):
 
 
 @public
-class hook(with_metaclass(_decorator_helper, coroutine)):
+class hook(_py_compat.with_metaclass(_decorator_helper, coroutine)):
     """Decorator to mark a function as a hook for cocotb.
 
     Used as ``@cocotb.hook()``.
@@ -419,7 +420,7 @@ class hook(with_metaclass(_decorator_helper, coroutine)):
 
 
 @public
-class test(with_metaclass(_decorator_helper, coroutine)):
+class test(_py_compat.with_metaclass(_decorator_helper, coroutine)):
     """Decorator to mark a function as a test.
 
     All tests are coroutines.  The test decorator provides

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -43,7 +43,7 @@ import cocotb
 from cocotb.binary import BinaryValue
 from cocotb.log import SimLog
 from cocotb.result import TestError
-from cocotb.utils import integer_types
+from cocotb import _py_compat
 
 # Only issue a warning for each deprecated attribute access
 _deprecation_warned = {}
@@ -584,13 +584,13 @@ class ModifiableObject(NonConstantObject):
             TypeError: If target is not wide enough or has an unsupported type
                  for value assignment.
         """
-        if isinstance(value, integer_types) and value < 0x7fffffff and len(self) <= 32:
+        if isinstance(value, _py_compat.integer_types) and value < 0x7fffffff and len(self) <= 32:
             simulator.set_signal_val_long(self._handle, value)
             return
 
         if isinstance(value, ctypes.Structure):
             value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
-        elif isinstance(value, integer_types):
+        elif isinstance(value, _py_compat.integer_types):
             value = BinaryValue(value=value, n_bits=len(self), bigEndian=False)
         elif isinstance(value, dict):
             # We're given a dictionary with a list of values and a bit size...
@@ -679,7 +679,7 @@ class EnumObject(ModifiableObject):
         """
         if isinstance(value, BinaryValue):
             value = int(value)
-        elif not isinstance(value, integer_types):
+        elif not isinstance(value, _py_compat.integer_types):
             self._log.critical("Unsupported type for integer value assignment: %s (%s)", type(value), repr(value))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
@@ -707,7 +707,7 @@ class IntegerObject(ModifiableObject):
         """
         if isinstance(value, BinaryValue):
             value = int(value)
-        elif not isinstance(value, integer_types):
+        elif not isinstance(value, _py_compat.integer_types):
             self._log.critical("Unsupported type for integer value assignment: %s (%s)", type(value), repr(value))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 

--- a/cocotb/outcomes.py
+++ b/cocotb/outcomes.py
@@ -6,9 +6,7 @@ or `asyncio.Future`, but without being tied to a particular task model.
 """
 import abc
 
-# https://stackoverflow.com/a/38668373
-# Backport of abc.ABC, compatible with Python 2 and 3
-abc_ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
+from cocotb import _py_compat
 
 
 def capture(fn, *args, **kwargs):
@@ -19,7 +17,7 @@ def capture(fn, *args, **kwargs):
         return Error(e)
 
 
-class Outcome(abc_ABC):
+class Outcome(_py_compat.abc_ABC):
     @abc.abstractmethod
     def send(self, gen):
         """ Send or throw this outcome into a generator """

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -54,8 +54,9 @@ import cocotb
 import cocotb.ANSI as ANSI
 from cocotb.log import SimLog
 from cocotb.result import TestError, TestFailure, TestSuccess, SimFailure
-from cocotb.utils import get_sim_time, raise_from
+from cocotb.utils import get_sim_time
 from cocotb.xunit_reporter import XUnitReporter
+from cocotb import _py_compat
 
 
 def _my_import(name):
@@ -146,7 +147,7 @@ class RegressionManager(object):
                     except AttributeError:
                         self.log.error("Requested test %s wasn't found in module %s", test, module_name)
                         err = AttributeError("Test %s doesn't exist in %s" % (test, module_name))
-                        raise_from(err, None)  # discard nested traceback
+                        _py_compat.raise_from(err, None)  # discard nested traceback
 
                     if not hasattr(_test, "im_test"):
                         self.log.error("Requested %s from module %s isn't a cocotb.test decorated coroutine", test, module_name)

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -63,7 +63,7 @@ from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly,
                              NextTimeStep, ReadWrite, Event, Join, NullTrigger)
 from cocotb.log import SimLog
 from cocotb.result import TestComplete
-from cocotb.utils import nullcontext
+from cocotb import _py_compat
 
 # On python 3.7 onwards, `dict` is guaranteed to preserve insertion order.
 # Since `OrderedDict` is a little slower that `dict`, we prefer the latter
@@ -303,7 +303,7 @@ class Scheduler(object):
             ps.dump_stats("test_profile.pstat")
             ctx = profiling_context()
         else:
-            ctx = nullcontext()
+            ctx = _py_compat.nullcontext()
 
         with ctx:
             self._mode = Scheduler._MODE_NORMAL
@@ -367,7 +367,7 @@ class Scheduler(object):
         if _profiling:
             ctx = profiling_context()
         else:
-            ctx = nullcontext()
+            ctx = _py_compat.nullcontext()
 
         with ctx:
             # When a trigger fires it is unprimed internally

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -40,18 +40,19 @@ else:
 from cocotb.log import SimLog
 from cocotb.result import raise_error, ReturnValue
 from cocotb.utils import (
-    get_sim_steps, get_time_from_sim_steps, with_metaclass,
-    ParametrizedSingleton, exec_, lazy_property
+    get_sim_steps, get_time_from_sim_steps, ParametrizedSingleton,
+    lazy_property,
 )
 from cocotb import decorators
 from cocotb import outcomes
+from cocotb import _py_compat
 import cocotb
 
 
 class TriggerException(Exception):
     pass
 
-class Trigger(with_metaclass(abc.ABCMeta)):
+class Trigger(_py_compat.with_metaclass(abc.ABCMeta)):
     """Base class to derive from."""
 
     # __dict__ is needed here for the `.log` lazy_property below to work.
@@ -119,7 +120,7 @@ class Trigger(with_metaclass(abc.ABCMeta)):
 
     # Once 2.7 is dropped, this can be run unconditionally
     if sys.version_info >= (3, 3):
-        exec_(textwrap.dedent("""
+        _py_compat.exec_(textwrap.dedent("""
         def __await__(self):
             # hand the trigger back to the scheduler trampoline
             return (yield self)
@@ -187,7 +188,7 @@ class _ParameterizedSingletonAndABC(ParametrizedSingleton, abc.ABCMeta):
     pass
 
 
-class ReadOnly(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
+class ReadOnly(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Fires when the current simulation timestep moves to the readonly phase.
 
     The :any:`ReadOnly` phase is entered when the current timestep no longer has any further delta steps.
@@ -215,7 +216,7 @@ class ReadOnly(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
         return self.__class__.__name__ + "(readonly)"
 
 
-class ReadWrite(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
+class ReadWrite(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Fires when the readwrite portion of the sim cycles is reached."""
     __slots__ = ()
 
@@ -239,7 +240,7 @@ class ReadWrite(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
         return self.__class__.__name__ + "(readwritesync)"
 
 
-class NextTimeStep(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
+class NextTimeStep(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Fires when the next time step is started."""
     __slots__ = ()
 
@@ -261,7 +262,7 @@ class NextTimeStep(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
         return self.__class__.__name__ + "(nexttimestep)"
 
 
-class _EdgeBase(with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
+class _EdgeBase(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, GPITrigger)):
     """Internal base class that fires on a given edge of a signal."""
     __slots__ = ('signal',)
 
@@ -491,7 +492,7 @@ class NullTrigger(Trigger):
         return self.__class__.__name__ + "(%s)" % self.name
 
 
-class Join(with_metaclass(_ParameterizedSingletonAndABC, PythonTrigger)):
+class Join(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, PythonTrigger)):
     r"""Fires when a :func:`fork`\ ed coroutine completes
 
     The result of blocking on the trigger can be used to get the coroutine

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -46,6 +46,7 @@ from cocotb.result import ReturnValue, TestFailure, TestError, TestSuccess
 from cocotb.utils import get_sim_time
 
 from cocotb.binary import BinaryValue
+from cocotb import _py_compat
 
 # Tests relating to providing meaningful errors if we forget to use the
 # yield keyword correctly to turn a function into a coroutine
@@ -875,7 +876,7 @@ def test_tests_are_tests(dut):
 if sys.version_info[:2] >= (3, 3):
     # this would be a syntax error in older python, so we do the whole
     # thing inside exec
-    cocotb.utils.exec_(textwrap.dedent('''
+    _py_compat.exec_(textwrap.dedent('''
     @cocotb.test()
     def test_coroutine_return(dut):
         """ Test that the Python 3.3 syntax for returning from generators works """


### PR DESCRIPTION
By starting this new module name with a `_`, we indicate that users are not supposed to be touching these pieces, and they will be removed without notice (when cocotb increases its minimum python version).