### PR TITLE
Align makefiles for examples/ with those for tests/.

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -27,10 +27,13 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-
 EXAMPLES := adder/tests \
-	    endian_swapper/tests \
             axi_lite_slave/tests \
+            dff/tests \
+            endian_swapper/tests \
+            mean/tests \
+            mixed_language/tests \
+            ping_tun_tap/tests
 
 .PHONY: $(EXAMPLES)
 
@@ -38,8 +41,17 @@ EXAMPLES := adder/tests \
 all: $(EXAMPLES)
 
 $(EXAMPLES):
+ifeq ($(TRAVIS),true)
+	@echo "travis_fold:start:$@"
+endif
 	@cd $@ && $(MAKE)
+ifeq ($(TRAVIS),true)
+	@echo "travis_fold:end:$@"
+endif
 
 .PHONY: clean
 clean:
 	$(foreach TEST, $(EXAMPLES), $(MAKE) -C $(TEST) clean;)
+
+regression:
+	$(foreach TEST, $(EXAMPLES), $(MAKE) -C $(TEST) regression;)

--- a/examples/dff/tests/Makefile
+++ b/examples/dff/tests/Makefile
@@ -15,13 +15,17 @@ else
   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
-TOPLEVEL=dff
-MODULE=$(TOPLEVEL)_cocotb
+TOPLEVEL = dff
+MODULE := $(TOPLEVEL)_cocotb
 
 CUSTOM_SIM_DEPS=$(CWD)/Makefile
 
 ifeq ($(SIM),questa)
-SIM_ARGS=-t 1ps
+    SIM_ARGS=-t 1ps
+endif
+
+ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+    SIM_ARGS += -v93
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.inc

--- a/examples/endian_swapper/tests/Makefile
+++ b/examples/endian_swapper/tests/Makefile
@@ -47,6 +47,9 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES = $(WPWD)/../hdl/endian_swapper.vhdl
     TOPLEVEL = endian_swapper_vhdl
+    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+        SIM_ARGS += -v93
+    endif
 else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -30,6 +30,10 @@ VERILOG_SOURCES = $(WPWD)/../hdl/mean_sv.sv
 
 MODULE := test_mean
 
+ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+   SIM_ARGS += -v93
+endif
+
 include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -29,5 +29,9 @@ endif
 
 MODULE=test_mixed_language
 
+ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+   SIM_ARGS += -v93
+endif
+
 include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim


### PR DESCRIPTION
List all examples in higher-level makefile; add target ``regression`` to it.
Add Travis fold markers in case we want to run examples in CI at some point.
Add option for VHDL93 for Cadence simulators in the single example's makefiles.