### PR TITLE
Better Windows support

### DIFF
--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -34,6 +34,7 @@
 #include "embed.h"
 #include "../compat/python3_compat.h"
 #include "locale.h"
+#include <unistd.h>
 
 #if defined(_WIN32)
 #include <windows.h>

--- a/cocotb/share/makefiles/Makefile.pylib.Darwin
+++ b/cocotb/share/makefiles/Makefile.pylib.Darwin
@@ -53,3 +53,5 @@ PYLIBS:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; from di
 
 PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())')
 PYTHON_DYN_LIB:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')
+
+LIB_LOAD = LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)

--- a/cocotb/share/makefiles/Makefile.pylib.Linux
+++ b/cocotb/share/makefiles/Makefile.pylib.Linux
@@ -53,3 +53,5 @@ PYLIBS:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; from di
 
 PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())')
 PYTHON_DYN_LIB:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')
+
+LIB_LOAD = LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)

--- a/cocotb/share/makefiles/Makefile.pylib.Msys
+++ b/cocotb/share/makefiles/Makefile.pylib.Msys
@@ -29,17 +29,9 @@
 
 # All common python related rules
 
-# if not explicitly set, auto-detect python dir from system path
-ifeq ($(PYTHON_DIR),)
-	PYTHON_DIR ?= $(shell dirname $(shell which python))
-endif
+PYTHON_BIN?=python.exe
 
-# make sure python dir was set properly
-ifeq ($(PYTHON_DIR),)
-	$(error "Path to Python directory must be included in system path or defined in PYTHON_DIR environment variable")
-endif
-
-PYTHON_BIN?=$(PYTHON_DIR)/python.exe
+PYTHON_DIR := $(shell dirname $(shell which $(PYTHON_BIN)))
 
 # We might work with other Python versions
 LOCAL_PYTHON_VERSION?=$(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_version() )')
@@ -54,5 +46,31 @@ empty :=
 PYTHON_VERSION=$(subst $(period),$(empty),$(LOCAL_PYTHON_VERSION))
 PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_inc() )')
 
-PYLIBS = -lPython$(PYTHON_VERSION)
-PYTHON_DYN_LIB = Python$(PYTHON_VERSION).dll
+# Convert `libpython.so` to `python`
+SYSCONFIG_LDLIBRARY = $(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; print( sysconfig.get_config_var("LDLIBRARY") )')
+ifeq ($(SYSCONFIG_LDLIBRARY),None)
+    PYLIBS := -lPython$(PYTHON_VERSION)
+else
+    PYLIBS:=$(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; import os; print("-l"+os.path.splitext(sysconfig.get_config_var("LDLIBRARY"))[0][3:])')
+endif
+
+# Some simulators accept only paths in form of "c:/../.."
+ifneq ($(VERILOG_SOURCES),)
+    VERILOG_SOURCES := $(shell cygpath -m $(VERILOG_SOURCES))
+endif
+ifneq ($(VHDL_SOURCES),)
+    VHDL_SOURCES := $(shell cygpath -m $(VHDL_SOURCES))
+endif
+
+PWD ?= $(shell pwd)
+
+# sys.path in form "/c/../:/c/.."
+PYTHON_SYS_PATH := $(shell $(PYTHON_BIN) -c "import sys, os; print(':'.join(['/'+dir.replace('\\\ ',' ').replace(os.sep,'/').replace(':','') for dir in sys.path]))")
+# escape "() " with "\"
+PYTHONPATH_ESCAPE := $(shell echo "$(PYTHON_SYS_PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
+PYTHONPATH := $(PYTHONPATH_ESCAPE)
+
+PYTHONHOME:=$(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; print( sysconfig.get_config_var("prefix") )')
+# escape "() " with "\"
+PATH_ESCAPE := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
+LIB_LOAD := PATH=$(LIB_DIR):$(PATH_ESCAPE) PYTHONHOME=$(PYTHONHOME)

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -45,7 +45,7 @@ endif
 ifeq (, $(CMD))
     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	ALDEC_BIN_DIR := $(shell dirname $(CMD))
+    ALDEC_BIN_DIR := $(shell dirname $(CMD))
     export ALDEC_BIN_DIR
 endif
 
@@ -144,36 +144,14 @@ ifeq ($(COVERAGE),1)
 endif
 endif
 
-ifeq ($(OS),Msys)
-
-# Windows allows the situation where the libstc++ used at link time as
-# specified by -L can be different to the one that is used at runtime which
-# comes from the first libstdc++ that it finds in the path. As such
-# we use the mingw lib used at build time and put this at the start of the path
-# before running
-
-MINGW_BIN_DIR = $(shell dirname $(shell which gcc))
-
-EXTRA_LIBS := -laldecpli
-EXTRA_LIBDIRS := -L$(ALDEC_BIN_DIR)
-OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
-LIB_LOAD = PATH=$(MINGW_BIN_DIR):$(OLD_PATH):$(LIB_DIR)
-NEW_PYTHONPATH := $(shell echo "$(PYTHONPATH)" | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):\//\/\1\//g' -e 's/;/:/g')
-else
 EXTRA_LIBS = -laldecpli
-ifeq ($(ARCH),i686)
-EXTRA_LIBDIRS = -L$(ALDEC_BIN_DIR)/Linux
-else
-EXTRA_LIBDIRS = -L$(ALDEC_BIN_DIR)/Linux64
-endif
-LIB_LOAD := LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)
-NEW_PYTHONPATH := $(PYTHONPATH)
-endif
+EXTRA_LIBDIRS := -L$(ALDEC_BIN_DIR)
+
 
 # Note it's the redirection of the output rather than the 'do' command
 # that turns on batch mode (i.e. exit on completion/error)
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(COCOTB_LIBS) $(COCOTB_VHPI_LIB) $(COCOTB_VPI_LIB) $(CUSTOM_SIM_DEPS)
-	set -o pipefail; cd $(SIM_BUILD) && PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
+	set -o pipefail; cd $(SIM_BUILD) && PYTHONPATH=$(LIB_DIR):$(PWD):$(PYTHONPATH) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 $(CMD) -do runsim.tcl | tee sim.log
 
 clean::

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -56,33 +56,23 @@ BUILD_VPI=1
 
 COMPILE_ARGS += -g2012 # Default to latest SystemVerilog standard
 
+ifeq ($(OS),Msys)
+    EXTRA_LIBS := -lvpi
+    EXTRA_LIBDIRS := -L$(ICARUS_BIN_DIR)/../lib
+endif
+
 # Compilation phase
 $(SIM_BUILD)/sim.vvp: $(SIM_BUILD) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS)
 	$(CMD) -o $(SIM_BUILD)/sim.vvp -D COCOTB_SIM=1 -s $(TOPLEVEL) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
-
-ifeq ($(OS),Msys)
-
-EXTRA_LIBS := -lvpi
-EXTRA_LIBDIRS := -L$(ICARUS_BIN_DIR)/../lib
-OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
-LIB_LOAD = PATH=$(OLD_PATH):$(LIB_DIR)
-NEW_PYTHONPATH:=$(shell python -c "import sys, os; print(':'.join(['/'+dir.replace(os.sep,'/').replace(':','') for dir in sys.path]))")
-PWD = $(shell pwd)
-
-else
-LIB_LOAD := LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)
-NEW_PYTHONPATH := $(PYTHONPATH)
-endif
-
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
-	PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
+	PYTHONPATH=$(LIB_DIR):$(PWD):$(PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
         $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 
 debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
-	PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
+	PYTHONPATH=$(LIB_DIR):$(PWD):$(PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
         gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -115,37 +115,17 @@ else
 endif
 
 ifeq ($(OS),Msys)
-
-# Windows allows the situation where the libstc++ used at link time as
-# specified by -L can be different to the one that is used at runtime which
-# comes from the first libstdc++ that it finds in the path. As such
-# we use the mingw lib used at build time and put this at the start of the path
-# before running
-
-MINGW_BIN_DIR = $(shell dirname $(shell which gcc))
-
-EXTRA_LIBS := -lmtipli
-EXTRA_LIBDIRS := -L$(MODELSIM_BIN_DIR)
-OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
-
-LIB_LOAD := PATH=$(MINGW_BIN_DIR):$(OLD_PATH):$(LIB_DIR)
-NEW_PYTHONPATH := $(shell echo "$(PYTHONPATH)" | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):\//\/\1\//g' -e 's/;/:/g')
-else
-LIB_LOAD = LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)
-NEW_PYTHONPATH := $(PYTHONPATH)
+    EXTRA_LIBS := -lmtipli
+    EXTRA_LIBDIRS := -L$(MODELSIM_BIN_DIR)
 endif
 
 INT_LIBS := $(COCOTB_VPI_LIB) $(COCOTB_FLI_LIB)
-
-ifneq ($(ARCH),i686)
-CMD += -64
-endif
 
 # Depending on the version of modelsim the interfaces that it supports can change
 # Append or remove values to INT_LIBS depenending on your license
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(INT_LIBS)
 	set -o pipefail; cd $(SIM_BUILD) && $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 \
-	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) \
+	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) PYTHONPATH=$(LIB_DIR):$(PWD):$(PYTHONPATH) \
 	$(CMD) $(PLUSARGS) -do runsim.do 2>&1 | tee sim.log
 # Potential fix for buffered stdout, YMMV
 # STDOUT=$(SIM_BUILD)/sim.log stdbuf --output=0 $(CMD) -do runsim.do 2>&1 && stdbuf --output=0 --input=0 tail -f sim.log && exit $${PIPESTATUS[0]}

--- a/tests/test_cases/issue_253/Makefile
+++ b/tests/test_cases/issue_253/Makefile
@@ -44,19 +44,19 @@ $(COCOTB_RESULTS_FILE):
 	@echo "Skipping"
 
 notset_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
-	PYTHONPATH=$(LIB_DIR):$(COCOTB_PY_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
+	PYTHONPATH=$(LIB_DIR):$(COCOTB_PY_DIR):$(PWD):$(PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
 	COCOTB_SIM=1 TESTCASE=issue_253_notset TOPLEVEL= \
 	vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 	mkdir -p $@_result && mv results.xml $@_result/
 
 empty_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
-	PYTHONPATH=$(LIB_DIR):$(COCOTB_PY_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
+	PYTHONPATH=$(LIB_DIR):$(COCOTB_PY_DIR):$(PWD):$(PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
 	COCOTB_SIM=1 TESTCASE=issue_253_empty TOPLEVEL="" \
 	vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 	mkdir -p $@_result && mv results.xml $@_result/
 
 no_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
-	PYTHONPATH=$(LIB_DIR):$(COCOTB_PY_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
+	PYTHONPATH=$(LIB_DIR):$(COCOTB_PY_DIR):$(PWD):$(PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
 	COCOTB_SIM=1 TESTCASE=issue_253_none \
 	vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 	mkdir -p $@_result && mv results.xml $@_result/


### PR DESCRIPTION
Resolves: #1064 #428 #498 #436 #354 

## Usage:
- (For Aldec) Do not install C++ compiler together with Riviera or remove/rename `mingw` directory from the install directory
- Install [Miniconda](https://conda.io/en/latest/miniconda.html)  (according to your simulation version 32/64bit)
- Start `Anaconda Prompt` 
-  Install msys `conda install -c msys2 m2-base m2-make libpython m2w64-toolchain` 
- Set proper `%path%` to the binary of the simulator

For msys2 install [msys2](https://www.msys2.org). Install `pacman -S --needed base-devel mingw-w64-i686-python3-pip` or `pacman -S --needed mingw-w64-x86_64-toolchain mingw-w64-x86_64-python3-pip`

## Test matrix on Windows 10 (64):

|            | icarus 10.1,64 | questa 10.7,64 | questa 10.7,32 | Rivera 2019.04,64 | Rivera 2019.04,32 | Modelsim 10.1b,32 |
|------------|----------------|----------------|----------------|-------------------|-------------------|-------------------|
| conda(3.7) | ok             | ok             | ok             | ok               | ok                | ok                |
| conda(2.7) | ok             | ok             | ok             | ok               | ok                | ok                |
| msys(3.7)   | ok             | ok             | ok             | ok               | ok                | ok                |

If this is acceptable will update documentation.

PS. Thanks to [Aldec](https://www.aldec.com/) for providing the license.