### PR TITLE
Add vpi Net type support

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -786,6 +786,7 @@ def SimHandle(handle, path=None):
         simulator.MODULE:      HierarchyObject,
         simulator.STRUCTURE:   HierarchyObject,
         simulator.REG:         ModifiableObject,
+        simulator.NET:         ModifiableObject,
         simulator.NETARRAY:    NonHierarchyIndexableObject,
         simulator.REAL:        RealObject,
         simulator.INTEGER:     IntegerObject,

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -231,7 +231,7 @@ int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
             m_indexable   = false; // Don't want to iterate over indices
             m_range_left  = 0;
             m_range_right = m_num_elems-1;
-        } else if (GpiObjHdl::get_type() == GPI_REGISTER) {
+        } else if (GpiObjHdl::get_type() == GPI_REGISTER || GpiObjHdl::get_type() == GPI_NET) {
             vpiHandle hdl = GpiObjHdl::get_handle<vpiHandle>();
 
             m_indexable   = vpi_get(vpiVector, hdl);

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -77,6 +77,8 @@ gpi_objtype_t to_gpi_objtype(int32_t vpitype)
     switch (vpitype) {
         case vpiNet:
         case vpiNetBit:
+            return GPI_NET;
+
         case vpiReg:
         case vpiRegBit:
         case vpiMemoryWord:
@@ -308,7 +310,7 @@ GpiObjHdl* VpiImpl::native_check_create(int32_t index, GpiObjHdl *parent)
         writable.push_back('\0');
 
         new_hdl = vpi_handle_by_name(&writable[0], NULL);
-    } else if (obj_type == GPI_REGISTER || obj_type == GPI_ARRAY || obj_type == GPI_STRING) {
+    } else if (obj_type == GPI_REGISTER || obj_type == GPI_NET || obj_type == GPI_ARRAY || obj_type == GPI_STRING) {
         new_hdl = vpi_handle_by_index(vpi_hdl, index);
 
         /* vpi_handle_by_index() doesn't work for all simulators when dealing with a two-dimensional array.
@@ -379,7 +381,7 @@ GpiObjHdl* VpiImpl::native_check_create(int32_t index, GpiObjHdl *parent)
             }
         }
     } else {
-        LOG_ERROR("VPI: Parent of type %s must be of type GPI_GENARRAY, GPI_REGISTER, GPI_ARRAY, or GPI_STRING to have an index.", parent->get_type_str());
+        LOG_ERROR("VPI: Parent of type %s must be of type GPI_GENARRAY, GPI_REGISTER, GPI_NET, GPI_ARRAY, or GPI_STRING to have an index.", parent->get_type_str());
         return NULL;
     }
 

--- a/documentation/source/newsfragments/1107.feature.rst
+++ b/documentation/source/newsfragments/1107.feature.rst
@@ -1,0 +1,1 @@
+Add support for distinguishing between NET (vpiNet) and REG (vpiReg) type when using vpi interface.

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -117,4 +117,10 @@ always @(posedge clk) begin
     register_array[0] <= 0;
 end
 
+//For testing type assigned to logic
+logic logic_a, logic_b, logic_c;
+assign logic_a = stream_in_valid;
+always@* logic_b = stream_in_valid;
+always@(posedge clk) logic_c <= stream_in_valid;
+
 endmodule

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -443,3 +443,33 @@ def custom_type(dut):
     if expected_top != count:
         raise TestFailure("Expected %d found %d for cosLut" % (expected_top, count))
 
+@cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"])
+def type_check_verilog(dut):
+    """
+    Test if types are recognized
+    """
+
+    tlog = logging.getLogger("cocotb.test")
+
+    yield Timer(1)
+
+    test_handles = [
+        (dut.stream_in_ready, "GPI_REGISTER"),
+        (dut.register_array, "GPI_ARRAY"),
+        (dut.NUM_OF_MODULES, "GPI_PARAMETER"),
+        (dut.temp, "GPI_REGISTER"),
+        (dut.and_output, "GPI_NET"),
+        (dut.stream_in_data, "GPI_NET"),
+        (dut.logic_b, "GPI_REGISTER"),
+        (dut.logic_c, "GPI_REGISTER"),
+    ]
+
+    if cocotb.SIM_NAME.lower().startswith(("icarus")):
+        test_handles.append((dut.logic_a, "GPI_NET")) # https://github.com/steveicarus/iverilog/issues/312
+    else:
+        test_handles.append((dut.logic_a, "GPI_REGISTER"))
+
+    for handle in test_handles:
+        tlog.info("Handle %s" %  (handle[0]._fullname,))
+        if handle[0]._type != handle[1]:
+            raise TestFailure("Expected %s found %s for %s" % (handle[1], handle[0]._type, handle[0]._fullname))


### PR DESCRIPTION
One can distinguish between `NET` and `REG `when using vpi. 

Used for error injection.