### PR TITLE
Docs: Require at least GCC 4.8.1

### DIFF
--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -12,7 +12,7 @@ Cocotb has the following requirements:
 
 * Python 2.7, Python 3.5+ (recommended)
 * Python-dev packages
-* GCC and associated development packages
+* GCC 4.8.1+ and associated development packages
 * GNU Make
 * A Verilog or VHDL simulator, depending on your RTL source code
 


### PR DESCRIPTION
GCC 4.8.1 is the first version to fully support C++11, and is available
in RHEL7, SLES12SP3, and Ubuntu 16.04 LTS (where GCC is at 5.3.1).

On RHEL6, users already need to add a SCL to get a supported Python
version. They can do the same to get a supported GCC version.

This change allows us to use C++11 in our C++ code.

Fixes #1087