### PR TITLE
Remove all remaining callers of `raise_error`.

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -37,7 +37,7 @@ import os
 
 import cocotb
 from cocotb.log import SimLog
-from cocotb.result import ReturnValue, raise_error
+from cocotb.result import ReturnValue
 from cocotb.utils import get_sim_time, lazy_property
 from cocotb import outcomes
 from cocotb import _py_compat
@@ -420,12 +420,6 @@ class hook(_py_compat.with_metaclass(_decorator_helper, coroutine)):
         super(hook, self).__init__(f)
         self.im_hook = True
         self.name = self._func.__name__
-
-    def __call__(self, *args, **kwargs):
-        try:
-            return RunningCoroutine(self._func(*args, **kwargs), self)
-        except Exception as e:
-            raise raise_error(self, "Hook raised exception:")
 
 
 @public

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -53,7 +53,7 @@ if "COVERAGE" in os.environ:
 import cocotb
 import cocotb.ANSI as ANSI
 from cocotb.log import SimLog
-from cocotb.result import TestError, TestSuccess, SimFailure
+from cocotb.result import TestSuccess, SimFailure
 from cocotb.utils import get_sim_time, remove_traceback_frames
 from cocotb.xunit_reporter import XUnitReporter
 from cocotb import _py_compat
@@ -197,8 +197,8 @@ class RegressionManager(object):
                 if hasattr(thing, "im_hook"):
                     try:
                         test = thing(self._dut)
-                    except TestError:
-                        self.log.warning("Failed to initialize hook %s" % thing.name)
+                    except Exception:
+                        self.log.warning("Failed to initialize hook %s" % thing.name, exc_info=True)
                     else:
                         cocotb.scheduler.add(test)
 

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -36,6 +36,10 @@ from io import StringIO, BytesIO
 def raise_error(obj, msg):
     """Creates a :exc:`TestError` exception and raises it after printing a traceback.
 
+    Note that since cocotb will print a traceback for you when an exception is
+    caught, you are unlikely to need this - use ``raise TestError(msg)``
+    instead.
+
     Args:
         obj: Object with a log method.
         msg (str): The log message.
@@ -58,6 +62,8 @@ def raise_error(obj, msg):
 def create_error(obj, msg):
     """Like :func:`raise_error`, but return the exception rather than raise it, 
     simply to avoid too many levels of nested `try/except` blocks.
+
+    Prefer using ``TestError(msg)`` directly instead of this function.
 
     Args:
         obj: Object with a log method.

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -28,6 +28,7 @@
 # TODO: Could use cStringIO?
 import traceback
 import sys
+import warnings
 # from StringIO import StringIO
 from io import StringIO, BytesIO
 
@@ -36,14 +37,22 @@ from io import StringIO, BytesIO
 def raise_error(obj, msg):
     """Creates a :exc:`TestError` exception and raises it after printing a traceback.
 
-    Note that since cocotb will print a traceback for you when an exception is
-    caught, you are unlikely to need this - use ``raise TestError(msg)``
-    instead.
+    .. deprecated:: 1.3
+        Use ``raise TestError(msg)`` instead of this function. A stacktrace will
+        be printed by cocotb automatically if the exception is unhandled.
 
     Args:
         obj: Object with a log method.
         msg (str): The log message.
     """
+    warnings.warn(
+        "``raise_error`` is deprecated - use ``raise TestError(msg)`` (or any "
+        "other exception type) instead",
+        DeprecationWarning, stacklevel=2)
+    _raise_error(obj, msg)
+
+
+def _raise_error(obj, msg):
     exc_info = sys.exc_info()
     # Python 2.6 cannot use named access
     if sys.version_info[0] >= 3:
@@ -63,14 +72,20 @@ def create_error(obj, msg):
     """Like :func:`raise_error`, but return the exception rather than raise it, 
     simply to avoid too many levels of nested `try/except` blocks.
 
-    Prefer using ``TestError(msg)`` directly instead of this function.
+    .. deprecated:: 1.3
+        Use ``TestError(msg)`` directly instead of this function.
 
     Args:
         obj: Object with a log method.
         msg (str): The log message.
     """
+    warnings.warn(
+        "``create_error`` is deprecated - use ``TestError(msg)`` (or any other "
+        "exception type) instead",
+        DeprecationWarning, stacklevel=2)
     try:
-        raise_error(obj, msg)
+        # use the private version to avoid multiple warnings
+        _raise_error(obj, msg)
     except TestError as error:
         return error
     return TestError("Creating error traceback failed")

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -38,7 +38,7 @@ else:
     simulator = None
 
 from cocotb.log import SimLog
-from cocotb.result import raise_error, ReturnValue
+from cocotb.result import ReturnValue
 from cocotb.utils import (
     get_sim_steps, get_time_from_sim_steps, ParametrizedSingleton,
     lazy_property,
@@ -175,7 +175,7 @@ class Timer(GPITrigger):
             self.cbhdl = simulator.register_timed_callback(self.sim_steps,
                                                            callback, self)
             if self.cbhdl == 0:
-                raise_error(self, "Unable set up %s Trigger" % (str(self)))
+                raise TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger.prime(self, callback)
 
     def __str__(self):
@@ -209,7 +209,7 @@ class ReadOnly(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, GPITrigg
         if self.cbhdl == 0:
             self.cbhdl = simulator.register_readonly_callback(callback, self)
             if self.cbhdl == 0:
-                raise_error(self, "Unable set up %s Trigger" % (str(self)))
+                raise TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger.prime(self, callback)
 
     def __str__(self):
@@ -233,7 +233,7 @@ class ReadWrite(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, GPITrig
             # pdb.set_trace()
             self.cbhdl = simulator.register_rwsynch_callback(callback, self)
             if self.cbhdl == 0:
-                raise_error(self, "Unable set up %s Trigger" % (str(self)))
+                raise TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger.prime(self, callback)
 
     def __str__(self):
@@ -255,7 +255,7 @@ class NextTimeStep(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, GPIT
         if self.cbhdl == 0:
             self.cbhdl = simulator.register_nextstep_callback(callback, self)
             if self.cbhdl == 0:
-                raise_error(self, "Unable set up %s Trigger" % (str(self)))
+                raise TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger.prime(self, callback)
 
     def __str__(self):
@@ -287,7 +287,7 @@ class _EdgeBase(_py_compat.with_metaclass(_ParameterizedSingletonAndABC, GPITrig
                 self.signal._handle, callback, type(self)._edge_type, self
             )
             if self.cbhdl == 0:
-                raise_error(self, "Unable set up %s Trigger" % (str(self)))
+                raise TriggerException("Unable set up %s Trigger" % (str(self)))
         super(_EdgeBase, self).prime(callback)
 
     def __str__(self):
@@ -443,7 +443,7 @@ class Lock(object):
     def release(self):
         """Release the lock."""
         if not self.locked:
-            raise_error(self, "Attempt to release an unacquired Lock %s" %
+            raise TriggerException("Attempt to release an unacquired Lock %s" %
                         (str(self)))
 
         self.locked = False


### PR DESCRIPTION
This seemed to exist only because tracebacks were not otherwise being printed.

Now that they are, there is little reason to keep this function around.  Summarizing the changes:
* Hooks behave exactly as before, silencing all exceptions and logging tracebacks. Now that the `__call__` method does not need to catch any exceptions, it can be removed entirely in favor of using the method from the base class.
* Failing triggers throw `TriggerException` rather than `TestError`. Since the exception already existed, it seemed appropriate to throw.