### PR TITLE
Treat `assert`s like `raise TestFailure`

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -53,7 +53,7 @@ if "COVERAGE" in os.environ:
 import cocotb
 import cocotb.ANSI as ANSI
 from cocotb.log import SimLog
-from cocotb.result import TestError, TestFailure, TestSuccess, SimFailure
+from cocotb.result import TestError, TestSuccess, SimFailure
 from cocotb.utils import get_sim_time, remove_traceback_frames
 from cocotb.xunit_reporter import XUnitReporter
 from cocotb import _py_compat
@@ -287,7 +287,7 @@ class RegressionManager(object):
                 not test.expect_error):
             self.log.info("Test Passed: %s" % test.funcname)
 
-        elif (isinstance(result, TestFailure) and
+        elif (isinstance(result, AssertionError) and
                 test.expect_fail):
             self.log.info("Test failed as expected: " + _result_was())
 

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -95,7 +95,7 @@ class TestError(TestComplete):
     pass
 
 
-class TestFailure(TestComplete):
+class TestFailure(TestComplete, AssertionError):
     """Exception showing that test was completed with severity Failure."""
     pass
 

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -1195,5 +1195,11 @@ def test_trigger_with_failing_prime(dut):
         raise TestFailure
 
 
+@cocotb.test(expect_fail=True)
+def test_assertion_is_failure(dut):
+    yield Timer(1)
+    assert False
+
+
 if sys.version_info[:2] >= (3, 5):
     from test_cocotb_35 import *


### PR DESCRIPTION
Previously, `assert` would be considered a "test error". This change makes them a "test failure".