### PR TITLE
Avoid rounding errors in simulation times when using rational numbers

### DIFF
--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -33,6 +33,8 @@ import sys
 import textwrap
 import traceback
 import warnings
+from fractions import Fraction
+from decimal import Decimal
 
 """
 A set of tests that demonstrate cocotb functionality
@@ -313,6 +315,19 @@ def test_timer_with_units(dut):
 
     if get_sim_time(units='fs') != time_fs+1000000000.0:
         raise TestFailure("Expected a delay of 1 us")
+
+@cocotb.test()
+def test_timer_with_rational_units(dut):
+    """ Test that rounding errors are not introduced in exact values """
+    # now with fractions
+    time_fs = get_sim_time(units='fs')
+    yield Timer(Fraction(1, int(1e9)), units='sec')
+    assert get_sim_time(units='fs') == time_fs + 1000000.0, "Expected a delay of 1 ns"
+
+    # now with decimals
+    time_fs = get_sim_time(units='fs')
+    yield Timer(Decimal('1e-9'), units='sec')
+    assert get_sim_time(units='fs') == time_fs + 1000000.0, "Expected a delay of 1 ns"
 
 
 @cocotb.test(expect_fail=False)


### PR DESCRIPTION
Previously the rounding errors inherent in floats containing negative powers of 10 would cause exact rational numbers to be incorrectly rejected.

Both tests in this patch would fail before this change.

This prevents rounding in `Timer(...)`, and overflow in `get_sim_time` if the units are smaller than the simulation timestep. Precision is still lost in `get_sim_time(unit='s')` - fixing this would require choosing `Fraction` or `Decimal` as a return type, which would break existing code.