### PR TITLE
Don't register VPI systemtf functions for Verilator

### DIFF
--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -592,6 +592,7 @@ static void register_final_callback(void)
     sim_finish_cb->arm_callback();
 }
 
+#ifndef VERILATOR
 // Called at compile time to validate the arguments to the system functions
 // we redefine (info, warning, error, fatal).
 //
@@ -686,10 +687,13 @@ static void register_system_functions(void)
     vpi_register_systf( &tfData );
 
 }
+#endif
 
 void (*vlog_startup_routines[])(void) = {
     register_embed,
+#ifndef VERILATOR
     register_system_functions,
+#endif
     register_initial_callback,
     register_final_callback,
     0


### PR DESCRIPTION
Hi,

this does not necessarily need to be merged before the Verilator part is done, but I want to put it to discussion. Surprisingly, the most contentious point is that Verilator does not have vpi_register_systf. Adding it would be a massive task, for the fact that it is just for display-style printfs. So, I am wondering if people would accept this patch. The VERILATOR define is already generated by cocotb itself and the actual Verilator infrastructure would then use DPI and overload display, info, ...

Looking forward to your feedback.

Thanks,
Stefan