### PR TITLE
Replace (void) with () in cpp files

### DIFF
--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -36,7 +36,7 @@
  * NB need a way to determine if should leave it sensitised, hmmm...
  *
  */
-int FliProcessCbHdl::cleanup_callback(void)
+int FliProcessCbHdl::cleanup_callback()
 {
     if (m_sensitised) {
         mti_Desensitize(m_proc_hdl);
@@ -53,7 +53,7 @@ FliTimedCbHdl::FliTimedCbHdl(GpiImplInterface *impl,
     m_proc_hdl = mti_CreateProcessWithPriority(NULL, handle_fli_callback, (void *)this, MTI_PROC_IMMEDIATE);
 }
 
-int FliTimedCbHdl::arm_callback(void)
+int FliTimedCbHdl::arm_callback()
 {
     #if defined(__LP64__) || defined(_WIN64)
         mti_ScheduleWakeup64(m_proc_hdl, m_time_ps);
@@ -67,7 +67,7 @@ int FliTimedCbHdl::arm_callback(void)
     return 0;
 }
 
-int FliTimedCbHdl::cleanup_callback(void)
+int FliTimedCbHdl::cleanup_callback()
 {
     switch (get_call_state()) {
     case GPI_PRIMED:
@@ -93,7 +93,7 @@ int FliTimedCbHdl::cleanup_callback(void)
     return 0;
 }
 
-int FliSignalCbHdl::arm_callback(void)
+int FliSignalCbHdl::arm_callback()
 {
     if (NULL == m_proc_hdl) {
         LOG_DEBUG("Creating a new process to sensitise to signal %s", mti_GetSignalName(m_sig_hdl));
@@ -108,7 +108,7 @@ int FliSignalCbHdl::arm_callback(void)
     return 0;
 }
 
-int FliSimPhaseCbHdl::arm_callback(void)
+int FliSimPhaseCbHdl::arm_callback()
 {
     if (NULL == m_proc_hdl) {
         LOG_DEBUG("Creating a new process to sensitise with priority %d", m_priority);
@@ -132,7 +132,7 @@ FliSignalCbHdl::FliSignalCbHdl(GpiImplInterface *impl,
     m_sig_hdl = m_signal->get_handle<mtiSignalIdT>();
 }
 
-int FliStartupCbHdl::arm_callback(void)
+int FliStartupCbHdl::arm_callback()
 {
     mti_AddLoadDoneCB(handle_fli_callback,(void *)this);
     set_call_state(GPI_PRIMED);
@@ -140,7 +140,7 @@ int FliStartupCbHdl::arm_callback(void)
     return 0;
 }
 
-int FliStartupCbHdl::run_callback(void)
+int FliStartupCbHdl::run_callback()
 {
     gpi_sim_info_t sim_info;
 
@@ -178,7 +178,7 @@ int FliStartupCbHdl::run_callback(void)
     return 0;
 }
 
-int FliShutdownCbHdl::arm_callback(void)
+int FliShutdownCbHdl::arm_callback()
 {
     mti_AddQuitCB(handle_fli_callback,(void *)this);
     set_call_state(GPI_PRIMED);
@@ -186,7 +186,7 @@ int FliShutdownCbHdl::arm_callback(void)
     return 0;
 }
 
-int FliShutdownCbHdl::run_callback(void)
+int FliShutdownCbHdl::run_callback()
 {
     gpi_embed_end();
 

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -40,7 +40,7 @@ static FliProcessCbHdl *sim_finish_cb;
 static FliImpl         *fli_table;
 }
 
-void FliImpl::sim_end(void)
+void FliImpl::sim_end()
 {
     if (GPI_DELETE != sim_finish_cb->get_call_state()) {
         sim_finish_cb->set_call_state(GPI_DELETE);
@@ -503,7 +503,7 @@ GpiCbHdl *FliImpl::register_timed_callback(uint64_t time_ps)
 }
 
 
-GpiCbHdl *FliImpl::register_readonly_callback(void)
+GpiCbHdl *FliImpl::register_readonly_callback()
 {
     if (m_readonly_cbhdl.arm_callback()) {
         return NULL;
@@ -511,7 +511,7 @@ GpiCbHdl *FliImpl::register_readonly_callback(void)
     return &m_readonly_cbhdl;
 }
 
-GpiCbHdl *FliImpl::register_readwrite_callback(void)
+GpiCbHdl *FliImpl::register_readwrite_callback()
 {
     if (m_readwrite_cbhdl.arm_callback()) {
         return NULL;
@@ -519,7 +519,7 @@ GpiCbHdl *FliImpl::register_readwrite_callback(void)
     return &m_readwrite_cbhdl;
 }
 
-GpiCbHdl *FliImpl::register_nexttime_callback(void)
+GpiCbHdl *FliImpl::register_nexttime_callback()
 {
     if (m_nexttime_cbhdl.arm_callback()) {
         return NULL;
@@ -1008,7 +1008,7 @@ void handle_fli_callback(void *data)
     }
 };
 
-static void register_initial_callback(void)
+static void register_initial_callback()
 {
     FENTER
     sim_init_cb = new FliStartupCbHdl(fli_table);
@@ -1016,7 +1016,7 @@ static void register_initial_callback(void)
     FEXIT
 }
 
-static void register_final_callback(void)
+static void register_final_callback()
 {
     FENTER
     sim_finish_cb = new FliShutdownCbHdl(fli_table);
@@ -1024,7 +1024,7 @@ static void register_final_callback(void)
     FEXIT
 }
 
-static void register_embed(void)
+static void register_embed()
 {
     fli_table = new FliImpl("FLI");
     gpi_register_impl(fli_table);
@@ -1032,7 +1032,7 @@ static void register_embed(void)
 }
 
 
-void cocotb_init(void)
+void cocotb_init()
 {
     LOG_INFO("cocotb_init called\n");
     register_embed();

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -35,7 +35,7 @@
 #include <map>
 
 extern "C" {
-void cocotb_init(void);
+void cocotb_init();
 void handle_fli_callback(void *data);
 }
 
@@ -53,8 +53,8 @@ public:
                                               m_sensitised(false) { }
     virtual ~FliProcessCbHdl() { }
 
-    virtual int arm_callback(void) = 0;
-    virtual int cleanup_callback(void);
+    virtual int arm_callback() = 0;
+    virtual int cleanup_callback();
 
 protected:
     mtiProcessIdT       m_proc_hdl;
@@ -70,8 +70,8 @@ public:
                    unsigned int edge);
 
     virtual ~FliSignalCbHdl() { }
-    int arm_callback(void);
-    int cleanup_callback(void) {
+    int arm_callback();
+    int cleanup_callback() {
         return FliProcessCbHdl::cleanup_callback();
     }
 
@@ -88,7 +88,7 @@ public:
                                                                              m_priority(priority) { }
     virtual ~FliSimPhaseCbHdl() { }
 
-    int arm_callback(void);
+    int arm_callback();
 
 protected:
     mtiProcessPriorityT         m_priority;
@@ -122,8 +122,8 @@ public:
                                               FliProcessCbHdl(impl) { }
     virtual ~FliStartupCbHdl() { }
 
-    int arm_callback(void);
-    int run_callback(void);
+    int arm_callback();
+    int run_callback();
 };
 
 class FliShutdownCbHdl : public FliProcessCbHdl {
@@ -132,8 +132,8 @@ public:
                                                FliProcessCbHdl(impl) { }
     virtual ~FliShutdownCbHdl() { }
 
-    int arm_callback(void);
-    int run_callback(void);
+    int arm_callback();
+    int run_callback();
 };
 
 class FliTimedCbHdl : public FliProcessCbHdl {
@@ -141,11 +141,11 @@ public:
     FliTimedCbHdl(GpiImplInterface *impl, uint64_t time_ps);
     virtual ~FliTimedCbHdl() { }
 
-    int arm_callback(void);
+    int arm_callback();
     void reset_time(uint64_t new_time) {
         m_time_ps = new_time;
     }
-    int cleanup_callback(void);
+    int cleanup_callback();
 private:
     uint64_t m_time_ps;
 };
@@ -161,8 +161,8 @@ public:
 
     virtual ~FliObj() { }
 
-    int get_acc_type(void) { return m_acc_type; }
-    int get_acc_full_type(void) { return m_acc_full_type; }
+    int get_acc_type() { return m_acc_type; }
+    int get_acc_full_type() { return m_acc_full_type; }
 
 
 protected:
@@ -215,7 +215,7 @@ public:
     virtual GpiCbHdl *value_change_cb(unsigned int edge);
     virtual int initialise(std::string &name, std::string &fq_name);
 
-    bool is_var(void) { return m_is_var; }
+    bool is_var() { return m_is_var; }
 
 protected:
     bool               m_is_var;
@@ -248,10 +248,10 @@ public:
             mti_VsimFree(m_sub_hdls);
     }
 
-    virtual const char* get_signal_value_binstr(void);
-    virtual const char* get_signal_value_str(void);
-    virtual double get_signal_value_real(void);
-    virtual long get_signal_value_long(void);
+    virtual const char* get_signal_value_binstr();
+    virtual const char* get_signal_value_str();
+    virtual double get_signal_value_real();
+    virtual long get_signal_value_long();
 
     virtual int set_signal_value(const long value);
     virtual int set_signal_value(const double value);
@@ -261,8 +261,8 @@ public:
 
     virtual int initialise(std::string &name, std::string &fq_name);
 
-    mtiTypeKindT get_fli_typekind(void) { return m_fli_type; }
-    mtiTypeIdT   get_fli_typeid(void) { return m_val_type; }
+    mtiTypeKindT get_fli_typekind() { return m_fli_type; }
+    mtiTypeIdT   get_fli_typeid() { return m_val_type; }
 
 protected:
     mtiTypeKindT       m_fli_type;
@@ -288,8 +288,8 @@ public:
 
     virtual ~FliEnumObjHdl() { }
 
-    const char* get_signal_value_str(void);
-    long get_signal_value_long(void);
+    const char* get_signal_value_str();
+    long get_signal_value_long();
 
     int set_signal_value(const long value);
 
@@ -330,7 +330,7 @@ public:
             free(m_mti_buff);
     }
 
-    const char* get_signal_value_binstr(void);
+    const char* get_signal_value_binstr();
 
     int set_signal_value(const long value);
     int set_signal_value(std::string &value);
@@ -360,8 +360,8 @@ public:
 
     virtual ~FliIntObjHdl() { }
 
-    const char* get_signal_value_binstr(void);
-    long get_signal_value_long(void);
+    const char* get_signal_value_binstr();
+    long get_signal_value_long();
 
     int set_signal_value(const long value);
 
@@ -387,7 +387,7 @@ public:
             free(m_mti_buff);
     }
 
-    double get_signal_value_real(void);
+    double get_signal_value_real();
 
     int set_signal_value(const double value);
 
@@ -416,7 +416,7 @@ public:
             free(m_mti_buff);
     }
 
-    const char* get_signal_value_str(void);
+    const char* get_signal_value_str();
 
     int set_signal_value(std::string &value);
 
@@ -480,7 +480,7 @@ public:
                                        m_readwrite_cbhdl(this) { }
 
      /* Sim related */
-    void sim_end(void);
+    void sim_end();
     void get_sim_time(uint32_t *high, uint32_t *low);
     void get_sim_precision(int32_t *precision);
 
@@ -493,9 +493,9 @@ public:
 
     /* Callback related, these may (will) return the same handle*/
     GpiCbHdl *register_timed_callback(uint64_t time_ps);
-    GpiCbHdl *register_readonly_callback(void);
-    GpiCbHdl *register_nexttime_callback(void);
-    GpiCbHdl *register_readwrite_callback(void);
+    GpiCbHdl *register_readonly_callback();
+    GpiCbHdl *register_nexttime_callback();
+    GpiCbHdl *register_readwrite_callback();
     int deregister_callback(GpiCbHdl *obj_hdl);
 
     /* Method to provide strings from operation types */

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -115,25 +115,25 @@ int FliValueObjHdl::initialise(std::string &name, std::string &fq_name)
     return FliSignalObjHdl::initialise(name, fq_name);
 }
 
-const char* FliValueObjHdl::get_signal_value_binstr(void)
+const char* FliValueObjHdl::get_signal_value_binstr()
 {
     LOG_ERROR("Getting signal/variable value as binstr not supported for %s of type %d", m_fullname.c_str(), m_type);
     return NULL;
 }
 
-const char* FliValueObjHdl::get_signal_value_str(void)
+const char* FliValueObjHdl::get_signal_value_str()
 {
     LOG_ERROR("Getting signal/variable value as str not supported for %s of type %d", m_fullname.c_str(), m_type);
     return NULL;
 }
 
-double FliValueObjHdl::get_signal_value_real(void)
+double FliValueObjHdl::get_signal_value_real()
 {
     LOG_ERROR("Getting signal/variable value as double not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }
 
-long FliValueObjHdl::get_signal_value_long(void)
+long FliValueObjHdl::get_signal_value_long()
 {
     LOG_ERROR("Getting signal/variable value as long not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
@@ -192,7 +192,7 @@ int FliEnumObjHdl::initialise(std::string &name, std::string &fq_name)
     return FliValueObjHdl::initialise(name, fq_name);
 }
 
-const char* FliEnumObjHdl::get_signal_value_str(void)
+const char* FliEnumObjHdl::get_signal_value_str()
 {
     if (m_is_var) {
         return m_value_enum[mti_GetVarValue(get_handle<mtiVariableIdT>())];
@@ -201,7 +201,7 @@ const char* FliEnumObjHdl::get_signal_value_str(void)
     }
 }
 
-long FliEnumObjHdl::get_signal_value_long(void)
+long FliEnumObjHdl::get_signal_value_long()
 {
     if (m_is_var) {
         return (long)mti_GetVarValue(get_handle<mtiVariableIdT>());
@@ -270,7 +270,7 @@ int FliLogicObjHdl::initialise(std::string &name, std::string &fq_name)
     return FliValueObjHdl::initialise(name, fq_name);
 }
 
-const char* FliLogicObjHdl::get_signal_value_binstr(void)
+const char* FliLogicObjHdl::get_signal_value_binstr()
 {
     switch (m_fli_type) {
         case MTI_TYPE_ENUM:
@@ -382,7 +382,7 @@ int FliIntObjHdl::initialise(std::string &name, std::string &fq_name)
     return FliValueObjHdl::initialise(name, fq_name);
 }
 
-const char* FliIntObjHdl::get_signal_value_binstr(void)
+const char* FliIntObjHdl::get_signal_value_binstr()
 {
     mtiInt32T val;
 
@@ -399,7 +399,7 @@ const char* FliIntObjHdl::get_signal_value_binstr(void)
     return m_val_buff;
 }
 
-long FliIntObjHdl::get_signal_value_long(void)
+long FliIntObjHdl::get_signal_value_long()
 {
     mtiInt32T value;
 
@@ -437,7 +437,7 @@ int FliRealObjHdl::initialise(std::string &name, std::string &fq_name)
     return FliValueObjHdl::initialise(name, fq_name);
 }
 
-double FliRealObjHdl::get_signal_value_real(void)
+double FliRealObjHdl::get_signal_value_real()
 {
     if (m_is_var) {
         mti_GetVarValueIndirect(get_handle<mtiVariableIdT>(), m_mti_buff);
@@ -486,7 +486,7 @@ int FliStringObjHdl::initialise(std::string &name, std::string &fq_name)
     return FliValueObjHdl::initialise(name, fq_name);
 }
 
-const char* FliStringObjHdl::get_signal_value_str(void)
+const char* FliStringObjHdl::get_signal_value_str()
 {
     if (m_is_var) {
         mti_GetArrayVarValue(get_handle<mtiVariableIdT>(), m_mti_buff);

--- a/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -28,22 +28,22 @@
 
 #include "gpi_priv.h"
 
-const char * GpiObjHdl::get_name_str(void)
+const char * GpiObjHdl::get_name_str()
 {
     return m_name.c_str();
 }
 
-const char * GpiObjHdl::get_fullname_str(void)
+const char * GpiObjHdl::get_fullname_str()
 {
     return m_fullname.c_str();
 }
 
-const std::string & GpiObjHdl::get_fullname(void)
+const std::string & GpiObjHdl::get_fullname()
 {
     return m_fullname;
 }
 
-const char * GpiObjHdl::get_type_str(void)
+const char * GpiObjHdl::get_type_str()
 {
 #define CASE_OPTION(_X) \
     case _X: \
@@ -73,7 +73,7 @@ const char * GpiObjHdl::get_type_str(void)
     return ret;
 }
 
-const std::string & GpiObjHdl::get_name(void)
+const std::string & GpiObjHdl::get_name()
 {
     return m_name;
 }
@@ -121,7 +121,7 @@ int GpiObjHdl::initialise(std::string &name, std::string &fq_name)
     return 0;
 }
 
-int GpiCbHdl::run_callback(void)
+int GpiCbHdl::run_callback()
 {
     LOG_DEBUG("Generic run_callback");
     this->gpi_function(m_cb_data);
@@ -129,13 +129,13 @@ int GpiCbHdl::run_callback(void)
     return 0;
 }
 
-int GpiCbHdl::cleanup_callback(void)
+int GpiCbHdl::cleanup_callback()
 {
     LOG_WARN("Generic cleanup_handler");
     return 0;
 }
 
-int GpiCbHdl::arm_callback(void)
+int GpiCbHdl::arm_callback()
 {
     LOG_WARN("Generic arm_callback");
     return 0;
@@ -151,7 +151,7 @@ int GpiCbHdl::set_user_data(int (*gpi_function)(const void*), const void *data)
     return 0;
 }
 
-const void * GpiCbHdl::get_user_data(void)
+const void * GpiCbHdl::get_user_data()
 {
     return m_cb_data;
 }
@@ -161,12 +161,12 @@ void GpiCbHdl::set_call_state(gpi_cb_state_e new_state)
     m_state = new_state;
 }
 
-gpi_cb_state_e GpiCbHdl::get_call_state(void)
+gpi_cb_state_e GpiCbHdl::get_call_state()
 {
     return m_state;
 }
 
-GpiCbHdl::~GpiCbHdl(void)
+GpiCbHdl::~GpiCbHdl()
 {
 
 }
@@ -184,7 +184,7 @@ GpiValueCbHdl::GpiValueCbHdl(GpiImplInterface *impl,
         required_value = "0";
 }
 
-int GpiValueCbHdl::run_callback(void)
+int GpiValueCbHdl::run_callback()
 {
     std::string current_value;
     bool pass = false;

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -61,7 +61,7 @@ public:
         }
     }
 
-    uint64_t handle_count(void) {
+    uint64_t handle_count() {
         return handle_map.size();
     }
 
@@ -81,7 +81,7 @@ static GpiHandleStore unique_handles;
 #endif
 
 
-int gpi_print_registered_impl(void)
+int gpi_print_registered_impl()
 {
     vector<GpiImplInterface*>::iterator iter;
     for (iter = registered_impls.begin();
@@ -115,13 +115,13 @@ void gpi_embed_init(gpi_sim_info_t *info)
         gpi_embed_end();
 }
 
-void gpi_embed_end(void)
+void gpi_embed_end()
 
 {
     embed_sim_event(SIM_FAIL, "Simulator shutdown prematurely");
 }
 
-void gpi_sim_end(void)
+void gpi_sim_end()
 {
     registered_impls[0]->sim_end();
 }
@@ -161,7 +161,7 @@ static void gpi_load_libs(std::vector<std::string> to_load)
     }
 }
 
-void gpi_load_extra_libs(void)
+void gpi_load_extra_libs()
 {
     static bool loading = false;
 
@@ -613,10 +613,10 @@ void gpi_deregister_callback(gpi_sim_hdl hdl)
     cb_hdl->m_impl->deregister_callback(cb_hdl);
 }
 
-const char* GpiImplInterface::get_name_c(void) {
+const char* GpiImplInterface::get_name_c() {
     return m_name.c_str();
 }
 
-const string& GpiImplInterface::get_name_s(void) {
+const string& GpiImplInterface::get_name_s() {
     return m_name;
 }

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -68,7 +68,7 @@ public:
     virtual int initialise(std::string &name);                   // Post constructor init
 
 
-    template<typename T> T get_handle(void) const {
+    template<typename T> T get_handle() const {
         return static_cast<T>(m_obj_hdl);
     }
 
@@ -120,21 +120,21 @@ public:
                                                                           m_const(is_const) { }
     virtual ~GpiObjHdl() { }
 
-    virtual const char* get_name_str(void);
-    virtual const char* get_fullname_str(void);
-    virtual const char* get_type_str(void);
-    gpi_objtype_t get_type(void) { return m_type; };
-    bool get_const(void) { return m_const; };
-    int get_num_elems(void) {
+    virtual const char* get_name_str();
+    virtual const char* get_fullname_str();
+    virtual const char* get_type_str();
+    gpi_objtype_t get_type() { return m_type; };
+    bool get_const() { return m_const; };
+    int get_num_elems() {
         LOG_DEBUG("%s has %d elements", m_name.c_str(), m_num_elems);
         return m_num_elems;
     }
-    int get_range_left(void) { return m_range_left; }
-    int get_range_right(void) { return m_range_right; }
-    int get_indexable(void) { return m_indexable; }
+    int get_range_left() { return m_range_left; }
+    int get_range_right() { return m_range_right; }
+    int get_indexable() { return m_indexable; }
 
-    const std::string & get_name(void);
-    const std::string & get_fullname(void);
+    const std::string & get_name();
+    const std::string & get_fullname();
 
     virtual const char* get_definition_name() { return m_definition_name.c_str(); };
     virtual const char* get_definition_file() { return m_definition_file.c_str(); };
@@ -169,10 +169,10 @@ public:
                                                          m_length(0) { }
     virtual ~GpiSignalObjHdl() { }
     // Provide public access to the implementation (composition vs inheritance)
-    virtual const char* get_signal_value_binstr(void) = 0;
-    virtual const char* get_signal_value_str(void) = 0;
-    virtual double get_signal_value_real(void) = 0;
-    virtual long get_signal_value_long(void) = 0;
+    virtual const char* get_signal_value_binstr() = 0;
+    virtual const char* get_signal_value_str() = 0;
+    virtual double get_signal_value_real() = 0;
+    virtual long get_signal_value_long() = 0;
 
     int m_length;
 
@@ -196,16 +196,16 @@ public:
                                        m_cb_data(NULL),
                                        m_state(GPI_FREE) { }
     // Pure virtual functions for derived classes
-    virtual int arm_callback(void) = 0;         // Register with simulator
-    virtual int run_callback(void);         // Entry point from simulator
-    virtual int cleanup_callback(void) = 0;     // Cleanup the callback, arm can be called after
+    virtual int arm_callback() = 0;         // Register with simulator
+    virtual int run_callback();         // Entry point from simulator
+    virtual int cleanup_callback() = 0;     // Cleanup the callback, arm can be called after
 
     // Set the data to be used for run callback, separate to arm_callback so data can be re-used
     int set_user_data(int (*gpi_function)(const void*), const void *data);
-    const void *get_user_data(void);
+    const void *get_user_data();
 
     void set_call_state(gpi_cb_state_e new_state);
-    gpi_cb_state_e get_call_state(void);
+    gpi_cb_state_e get_call_state();
 
     virtual ~GpiCbHdl();
 
@@ -219,8 +219,8 @@ class GpiValueCbHdl : public virtual GpiCbHdl {
 public:
     GpiValueCbHdl(GpiImplInterface *impl, GpiSignalObjHdl *signal, int edge);
     virtual ~GpiValueCbHdl() { }
-    virtual int run_callback(void);
-    virtual int cleanup_callback(void) = 0;
+    virtual int run_callback();
+    virtual int cleanup_callback() = 0;
 
 protected:
     std::string required_value;
@@ -234,7 +234,7 @@ public:
     GpiClockHdl(const char *clk) { }
     ~GpiClockHdl() { }
     int start_clock(const int period_ps) { return 0; } ; /* Do things with the GpiSignalObjHdl */
-    int stop_clock(void) { return 0; }
+    int stop_clock() { return 0; }
 };
 
 class GpiIterator : public GpiHdl {
@@ -257,7 +257,7 @@ public:
         return GpiIterator::END;
     }
 
-    GpiObjHdl *get_parent(void) {
+    GpiObjHdl *get_parent() {
         return m_parent;
     }
 
@@ -303,12 +303,12 @@ template <class Ti, class Tm> std::vector<Tm> * GpiIteratorMapping<Ti, Tm>::get_
 class GpiImplInterface {
 public:
     GpiImplInterface(const std::string& name) : m_name(name) { }
-    const char *get_name_c(void);
-    const std::string& get_name_s(void);
+    const char *get_name_c();
+    const std::string& get_name_s();
     virtual ~GpiImplInterface() { }
 
     /* Sim related */
-    virtual void sim_end(void) = 0;
+    virtual void sim_end() = 0;
     virtual void get_sim_time(uint32_t *high, uint32_t *low) = 0;
     virtual void get_sim_precision(int32_t *precision) = 0;
 
@@ -321,9 +321,9 @@ public:
 
     /* Callback related, these may (will) return the same handle */
     virtual GpiCbHdl *register_timed_callback(uint64_t time_ps) = 0;
-    virtual GpiCbHdl *register_readonly_callback(void) = 0;
-    virtual GpiCbHdl *register_nexttime_callback(void) = 0;
-    virtual GpiCbHdl *register_readwrite_callback(void) = 0;
+    virtual GpiCbHdl *register_readonly_callback() = 0;
+    virtual GpiCbHdl *register_nexttime_callback() = 0;
+    virtual GpiCbHdl *register_readwrite_callback() = 0;
     virtual int deregister_callback(GpiCbHdl *obj_hdl) = 0;
 
     /* Method to provide strings from operation types */
@@ -337,16 +337,16 @@ private:
 int gpi_register_impl(GpiImplInterface *func_tbl);
 
 void gpi_embed_init(gpi_sim_info_t *info);
-void gpi_embed_end(void);
+void gpi_embed_end();
 void gpi_embed_event(gpi_event_t level, const char *msg);
-void gpi_load_extra_libs(void);
+void gpi_load_extra_libs();
 
-typedef const void (*layer_entry_func)(void);
+typedef const void (*layer_entry_func)();
 
 /* Use this macro in an implementation layer to define an enty point */
 #define GPI_ENTRY_POINT(NAME, func) \
     extern "C" { \
-        const void NAME##_entry_point(void)  \
+        const void NAME##_entry_point()  \
         { \
             func(); \
         } \

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -357,7 +357,7 @@ VhpiCbHdl::VhpiCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl)
     vhpi_time.low = 0;
 }
 
-int VhpiCbHdl::cleanup_callback(void)
+int VhpiCbHdl::cleanup_callback()
 {
     /* For non timer callbacks we disable rather than remove */
     int ret = 0;
@@ -376,7 +376,7 @@ int VhpiCbHdl::cleanup_callback(void)
     return 0;
 }
 
-int VhpiCbHdl::arm_callback(void)
+int VhpiCbHdl::arm_callback()
 {
     int ret = 0;
     vhpiStateT cbState;
@@ -650,7 +650,7 @@ int VhpiSignalObjHdl::set_signal_value(std::string &value)
     return 0;
 }
 
-const char* VhpiSignalObjHdl::get_signal_value_binstr(void)
+const char* VhpiSignalObjHdl::get_signal_value_binstr()
 {
     switch (m_value.format) {
         case vhpiRealVal:
@@ -673,7 +673,7 @@ const char* VhpiSignalObjHdl::get_signal_value_binstr(void)
     }
 }
 
-const char* VhpiSignalObjHdl::get_signal_value_str(void)
+const char* VhpiSignalObjHdl::get_signal_value_str()
 {
     switch (m_value.format) {
         case vhpiStrVal: {
@@ -695,7 +695,7 @@ const char* VhpiSignalObjHdl::get_signal_value_str(void)
     return m_value.value.str;
 }
 
-double VhpiSignalObjHdl::get_signal_value_real(void)
+double VhpiSignalObjHdl::get_signal_value_real()
 {
     m_value.format = vhpiRealVal;
     m_value.numElems = 1;
@@ -708,7 +708,7 @@ double VhpiSignalObjHdl::get_signal_value_real(void)
     return m_value.value.real;
 }
 
-long VhpiSignalObjHdl::get_signal_value_long(void)
+long VhpiSignalObjHdl::get_signal_value_long()
 {
     vhpiValueT value;
     value.format = vhpiIntVal;
@@ -808,7 +808,7 @@ VhpiShutdownCbHdl::VhpiShutdownCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
     cb_data.reason = vhpiCbEndOfSimulation;
 }
 
-int VhpiShutdownCbHdl::run_callback(void) {
+int VhpiShutdownCbHdl::run_callback() {
     set_call_state(GPI_DELETE);
     gpi_embed_end();
     return 0;
@@ -824,7 +824,7 @@ VhpiTimedCbHdl::VhpiTimedCbHdl(GpiImplInterface *impl, uint64_t time_ps) : GpiCb
     cb_data.time = &vhpi_time;
 }
 
-int VhpiTimedCbHdl::cleanup_callback(void)
+int VhpiTimedCbHdl::cleanup_callback()
 {
     if (m_state == GPI_FREE)
         return 1;

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -851,7 +851,7 @@ GpiCbHdl *VhpiImpl::register_timed_callback(uint64_t time_ps)
     return hdl;
 }
 
-GpiCbHdl *VhpiImpl::register_readwrite_callback(void)
+GpiCbHdl *VhpiImpl::register_readwrite_callback()
 {
     if (m_read_write.arm_callback())
         return NULL;
@@ -859,7 +859,7 @@ GpiCbHdl *VhpiImpl::register_readwrite_callback(void)
     return &m_read_write;
 }
 
-GpiCbHdl *VhpiImpl::register_readonly_callback(void)
+GpiCbHdl *VhpiImpl::register_readonly_callback()
 {
     if (m_read_only.arm_callback())
         return NULL;
@@ -867,7 +867,7 @@ GpiCbHdl *VhpiImpl::register_readonly_callback(void)
     return &m_read_only;
 }
 
-GpiCbHdl *VhpiImpl::register_nexttime_callback(void)
+GpiCbHdl *VhpiImpl::register_nexttime_callback()
 {
     if (m_next_phase.arm_callback())
         return NULL;
@@ -881,7 +881,7 @@ int VhpiImpl::deregister_callback(GpiCbHdl *gpi_hdl)
     return 0;
 }
 
-void VhpiImpl::sim_end(void)
+void VhpiImpl::sim_end()
 {
     sim_finish_cb->set_call_state(GPI_DELETE);
     vhpi_control(vhpiFinish);
@@ -918,7 +918,7 @@ void handle_vhpi_callback(const vhpiCbDataT *cb_data)
     return;
 };
 
-static void register_initial_callback(void)
+static void register_initial_callback()
 {
     FENTER
     sim_init_cb = new VhpiStartupCbHdl(vhpi_table);
@@ -926,7 +926,7 @@ static void register_initial_callback(void)
     FEXIT
 }
 
-static void register_final_callback(void)
+static void register_final_callback()
 {
     FENTER
     sim_finish_cb = new VhpiShutdownCbHdl(vhpi_table);
@@ -934,7 +934,7 @@ static void register_final_callback(void)
     FEXIT
 }
 
-static void register_embed(void)
+static void register_embed()
 {
     vhpi_table = new VhpiImpl("VHPI");
     gpi_register_impl(vhpi_table);
@@ -942,7 +942,7 @@ static void register_embed(void)
 }
 
 // pre-defined VHPI registration table
-void (*vhpi_startup_routines[])(void) = {
+void (*vhpi_startup_routines[])() = {
     register_embed,
     register_initial_callback,
     register_final_callback,
@@ -950,8 +950,8 @@ void (*vhpi_startup_routines[])(void) = {
 };
 
 // For non-VPI compliant applications that cannot find vlog_startup_routines
-void vhpi_startup_routines_bootstrap(void) {
-    void (*routine)(void);
+void vhpi_startup_routines_bootstrap() {
+    void (*routine)();
     int i;
     routine = vhpi_startup_routines[0];
     for (i = 0, routine = vhpi_startup_routines[i];

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -87,8 +87,8 @@ public:
     VhpiCbHdl(GpiImplInterface *impl); 
     virtual ~VhpiCbHdl() { }
 
-    virtual int arm_callback(void);
-    virtual int cleanup_callback(void);
+    virtual int arm_callback();
+    virtual int cleanup_callback();
 
 protected:
     vhpiCbDataT cb_data;
@@ -101,7 +101,7 @@ class VhpiValueCbHdl : public VhpiCbHdl, public GpiValueCbHdl {
 public:
     VhpiValueCbHdl(GpiImplInterface *impl, VhpiSignalObjHdl *sig, int edge);
     virtual ~VhpiValueCbHdl() { }
-    int cleanup_callback(void) {
+    int cleanup_callback() {
         return VhpiCbHdl::cleanup_callback();
     }
 private:
@@ -133,8 +133,8 @@ public:
 class VhpiStartupCbHdl : public VhpiCbHdl {
 public:
     VhpiStartupCbHdl(GpiImplInterface *impl);
-    int run_callback(void);
-    int cleanup_callback(void) {
+    int run_callback();
+    int cleanup_callback() {
         /* Too many sims get upset with this so we override to do nothing */
         return 0;
     }
@@ -144,8 +144,8 @@ public:
 class VhpiShutdownCbHdl : public VhpiCbHdl {
 public:
     VhpiShutdownCbHdl(GpiImplInterface *impl);
-    int run_callback(void);
-    int cleanup_callback(void) {
+    int run_callback();
+    int cleanup_callback() {
         /* Too many sims get upset with this so we override to do nothing */
         return 0;
     }
@@ -189,10 +189,10 @@ public:
                                       m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }
     virtual ~VhpiSignalObjHdl();
 
-    virtual const char* get_signal_value_binstr(void);
-    virtual const char* get_signal_value_str(void);
-    virtual double get_signal_value_real(void);
-    virtual long get_signal_value_long(void);
+    virtual const char* get_signal_value_binstr();
+    virtual const char* get_signal_value_str();
+    virtual double get_signal_value_real();
+    virtual long get_signal_value_long();
 
 
     virtual int set_signal_value(const long value);
@@ -251,7 +251,7 @@ public:
                                         m_read_only(this) { }
 
      /* Sim related */
-    void sim_end(void);
+    void sim_end();
     void get_sim_time(uint32_t *high, uint32_t *low);
     void get_sim_precision(int32_t *precision);
 
@@ -261,9 +261,9 @@ public:
 
     /* Callback related, these may (will) return the same handle*/
     GpiCbHdl *register_timed_callback(uint64_t time_ps);
-    GpiCbHdl *register_readonly_callback(void);
-    GpiCbHdl *register_nexttime_callback(void);
-    GpiCbHdl *register_readwrite_callback(void);
+    GpiCbHdl *register_readonly_callback();
+    GpiCbHdl *register_nexttime_callback();
+    GpiCbHdl *register_readwrite_callback();
     int deregister_callback(GpiCbHdl *obj_hdl);
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
     GpiObjHdl* native_check_create(int32_t index, GpiObjHdl *parent);

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -50,7 +50,7 @@ VpiCbHdl::VpiCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl)
 /* If the user data already has a callback handle then deregister
  * before getting the new one
  */
-int VpiCbHdl::arm_callback(void) {
+int VpiCbHdl::arm_callback() {
 
     if (m_state == GPI_PRIMED) {
         fprintf(stderr,
@@ -84,7 +84,7 @@ int VpiCbHdl::arm_callback(void) {
     return 0;
 }
 
-int VpiCbHdl::cleanup_callback(void)
+int VpiCbHdl::cleanup_callback()
 {
     if (m_state == GPI_FREE)
         return 0;
@@ -279,7 +279,7 @@ int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
-const char* VpiSignalObjHdl::get_signal_value_binstr(void)
+const char* VpiSignalObjHdl::get_signal_value_binstr()
 {
     FENTER
     s_vpi_value value_s = {vpiBinStrVal};
@@ -290,7 +290,7 @@ const char* VpiSignalObjHdl::get_signal_value_binstr(void)
     return value_s.value.str;
 }
 
-const char* VpiSignalObjHdl::get_signal_value_str(void)
+const char* VpiSignalObjHdl::get_signal_value_str()
 {
     s_vpi_value value_s = {vpiStringVal};
 
@@ -300,7 +300,7 @@ const char* VpiSignalObjHdl::get_signal_value_str(void)
     return value_s.value.str;
 }
 
-double VpiSignalObjHdl::get_signal_value_real(void)
+double VpiSignalObjHdl::get_signal_value_real()
 {
     FENTER
     s_vpi_value value_s = {vpiRealVal};
@@ -311,7 +311,7 @@ double VpiSignalObjHdl::get_signal_value_real(void)
     return value_s.value.real;
 }
 
-long VpiSignalObjHdl::get_signal_value_long(void)
+long VpiSignalObjHdl::get_signal_value_long()
 {
     FENTER
     s_vpi_value value_s = {vpiIntVal};
@@ -419,7 +419,7 @@ VpiValueCbHdl::VpiValueCbHdl(GpiImplInterface *impl,
     cb_data.obj = m_signal->get_handle<vpiHandle>();
 }
 
-int VpiValueCbHdl::cleanup_callback(void)
+int VpiValueCbHdl::cleanup_callback()
 {
     if (m_state == GPI_FREE)
         return 0;
@@ -448,7 +448,7 @@ VpiStartupCbHdl::VpiStartupCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
 #endif
 }
 
-int VpiStartupCbHdl::run_callback(void) {
+int VpiStartupCbHdl::run_callback() {
     s_vpi_vlog_info info;
     gpi_sim_info_t sim_info;
 
@@ -470,7 +470,7 @@ VpiShutdownCbHdl::VpiShutdownCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
     cb_data.reason = cbEndOfSimulation;
 }
 
-int VpiShutdownCbHdl::run_callback(void) {
+int VpiShutdownCbHdl::run_callback() {
     gpi_embed_end();
     return 0;
 }
@@ -485,7 +485,7 @@ VpiTimedCbHdl::VpiTimedCbHdl(GpiImplInterface *impl, uint64_t time_ps) : GpiCbHd
     cb_data.reason = cbAfterDelay;
 }
 
-int VpiTimedCbHdl::cleanup_callback(void)
+int VpiTimedCbHdl::cleanup_callback()
 {
     switch (m_state) {
     case GPI_PRIMED:

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -491,7 +491,7 @@ GpiCbHdl *VpiImpl::register_timed_callback(uint64_t time_ps)
     return hdl;
 }
 
-GpiCbHdl *VpiImpl::register_readwrite_callback(void)
+GpiCbHdl *VpiImpl::register_readwrite_callback()
 {
     if (m_read_write.arm_callback())
         return NULL;
@@ -499,7 +499,7 @@ GpiCbHdl *VpiImpl::register_readwrite_callback(void)
     return &m_read_write;
 }
 
-GpiCbHdl *VpiImpl::register_readonly_callback(void)
+GpiCbHdl *VpiImpl::register_readonly_callback()
 {
     if (m_read_only.arm_callback())
         return NULL;
@@ -507,7 +507,7 @@ GpiCbHdl *VpiImpl::register_readonly_callback(void)
     return &m_read_only;
 }
 
-GpiCbHdl *VpiImpl::register_nexttime_callback(void)
+GpiCbHdl *VpiImpl::register_nexttime_callback()
 {
     if (m_next_phase.arm_callback())
         return NULL;
@@ -523,7 +523,7 @@ int VpiImpl::deregister_callback(GpiCbHdl *gpi_hdl)
 
 // If the Python world wants things to shut down then unregister
 // the callback for end of sim
-void VpiImpl::sim_end(void)
+void VpiImpl::sim_end()
 {
     /* Some sims do not seem to be able to deregister the end of sim callback
      * so we need to make sure we have tracked this and not call the handler
@@ -572,7 +572,7 @@ int32_t handle_vpi_callback(p_cb_data cb_data)
 };
 
 
-static void register_embed(void)
+static void register_embed()
 {
     vpi_table = new VpiImpl("VPI");
     gpi_register_impl(vpi_table);
@@ -580,13 +580,13 @@ static void register_embed(void)
 }
 
 
-static void register_initial_callback(void)
+static void register_initial_callback()
 {
     sim_init_cb = new VpiStartupCbHdl(vpi_table);
     sim_init_cb->arm_callback();
 }
 
-static void register_final_callback(void)
+static void register_final_callback()
 {
     sim_finish_cb = new VpiShutdownCbHdl(vpi_table);
     sim_finish_cb->arm_callback();
@@ -661,7 +661,7 @@ static int system_function_overload(char *userdata)
     return 0;
 }
 
-static void register_system_functions(void)
+static void register_system_functions()
 {
     s_vpi_systf_data tfData = { vpiSysTask, vpiSysTask };
 
@@ -687,7 +687,7 @@ static void register_system_functions(void)
 
 }
 
-void (*vlog_startup_routines[])(void) = {
+void (*vlog_startup_routines[])() = {
     register_embed,
     register_system_functions,
     register_initial_callback,
@@ -697,8 +697,8 @@ void (*vlog_startup_routines[])(void) = {
 
 
 // For non-VPI compliant applications that cannot find vlog_startup_routines symbol
-void vlog_startup_routines_bootstrap(void) {
-    void (*routine)(void);
+void vlog_startup_routines_bootstrap() {
+    void (*routine)();
     int i;
     routine = vlog_startup_routines[0];
     for (i = 0, routine = vlog_startup_routines[i];

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -86,8 +86,8 @@ public:
     VpiCbHdl(GpiImplInterface *impl);
     virtual ~VpiCbHdl() { }
 
-    virtual int arm_callback(void);
-    virtual int cleanup_callback(void);
+    virtual int arm_callback();
+    virtual int cleanup_callback();
 
 protected:
     s_cb_data cb_data;
@@ -100,7 +100,7 @@ class VpiValueCbHdl : public VpiCbHdl, public GpiValueCbHdl {
 public:
     VpiValueCbHdl(GpiImplInterface *impl, VpiSignalObjHdl *sig, int edge);
     virtual ~VpiValueCbHdl() { }
-    int cleanup_callback(void);
+    int cleanup_callback();
 private:
     s_vpi_value m_vpi_value;
 };
@@ -133,8 +133,8 @@ public:
 class VpiStartupCbHdl : public VpiCbHdl {
 public:
     VpiStartupCbHdl(GpiImplInterface *impl);
-    int run_callback(void);
-    int cleanup_callback(void) {
+    int run_callback();
+    int cleanup_callback() {
         /* Too many sims get upset with this so we override to do nothing */
         return 0;
     }
@@ -144,8 +144,8 @@ public:
 class VpiShutdownCbHdl : public VpiCbHdl {
 public:
     VpiShutdownCbHdl(GpiImplInterface *impl);
-    int run_callback(void);
-    int cleanup_callback(void) {
+    int run_callback();
+    int cleanup_callback() {
         /* Too many sims get upset with this so we override to do nothing */
         return 0;
     }
@@ -179,10 +179,10 @@ public:
                                                              m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }
     virtual ~VpiSignalObjHdl() { }
 
-    const char* get_signal_value_binstr(void);
-    const char* get_signal_value_str(void);
-    double get_signal_value_real(void);
-    long get_signal_value_long(void);
+    const char* get_signal_value_binstr();
+    const char* get_signal_value_str();
+    double get_signal_value_real();
+    long get_signal_value_long();
 
     int set_signal_value(const long value);
     int set_signal_value(const double value);
@@ -249,7 +249,7 @@ public:
                                        m_read_only(this) { }
 
      /* Sim related */
-    void sim_end(void);
+    void sim_end();
     void get_sim_time(uint32_t *high, uint32_t *low);
     void get_sim_precision(int32_t *precision);
 
@@ -260,9 +260,9 @@ public:
 
     /* Callback related, these may (will) return the same handle*/
     GpiCbHdl *register_timed_callback(uint64_t time_ps);
-    GpiCbHdl *register_readonly_callback(void);
-    GpiCbHdl *register_nexttime_callback(void);
-    GpiCbHdl *register_readwrite_callback(void);
+    GpiCbHdl *register_readonly_callback();
+    GpiCbHdl *register_nexttime_callback();
+    GpiCbHdl *register_readwrite_callback();
     int deregister_callback(GpiCbHdl *obj_hdl);
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
     GpiObjHdl* native_check_create(int32_t index, GpiObjHdl *parent);


### PR DESCRIPTION
In C++, (void) and () mean the same thing in function prototypes.

Today, we  haev some functions declared using the former, and some using the latter.
This eliminates the (void) form which is rare in modern C++.

Note that the C files are untouched, because there there is a difference.