### PR TITLE
Fix Python 3.8 deprecation/syntax warnings

### DIFF
--- a/bin/combine_results.py
+++ b/bin/combine_results.py
@@ -52,7 +52,7 @@ def main():
     for fname in find_all("results.xml", args.directory):
         if args.debug : print("Reading file %s" % fname)
         tree = ET.parse(fname)
-        for ts in tree.getiterator("testsuite"):
+        for ts in tree.iter("testsuite"):
             if args.debug : print("Ts name : %s, package : %s" % ( ts.get('name'), ts.get('package')))
             use_element = None
             for existing in result:

--- a/tests/test_cases/test_closedown/test_closedown.py
+++ b/tests/test_cases/test_closedown/test_closedown.py
@@ -41,7 +41,7 @@ from cocotb.clock import Clock
 def test_read(dut):
     global test_count
     dut._log.info("Inside test_read")
-    while test_count is not 5:
+    while test_count != 5:
         yield RisingEdge(dut.clk)
         test_count += 1
 

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -321,7 +321,7 @@ def test_anternal_clock(dut):
     function"""
     clk_gen = cocotb.fork(Clock(dut.clk, 100).start())
     count = 0
-    while count is not 100:
+    while count != 100:
         yield RisingEdge(dut.clk)
         count += 1
     clk_gen.kill()
@@ -422,7 +422,7 @@ def test_afterdelay_in_readonly_valid(dut):
 @cocotb.coroutine
 def clock_one(dut):
     count = 0
-    while count is not 50:
+    while count != 50:
         yield RisingEdge(dut.clk)
         yield Timer(1000)
         count += 1
@@ -431,7 +431,7 @@ def clock_one(dut):
 @cocotb.coroutine
 def clock_two(dut):
     count = 0
-    while count is not 50:
+    while count != 50:
         yield RisingEdge(dut.clk)
         yield Timer(10000)
         count += 1
@@ -570,32 +570,32 @@ def test_either_edge(dut):
     yield Timer(1)
     dut.clk <= 1
     yield Edge(dut.clk)
-    if dut.clk.value.integer is not 1:
+    if dut.clk.value.integer != 1:
         raise TestError("Value should be 0")
     yield Timer(10)
     dut.clk <= 0
     yield Edge(dut.clk)
-    if dut.clk.value.integer is not 0:
+    if dut.clk.value.integer != 0:
         raise TestError("Value should be 0")
     yield Timer(10)
     dut.clk <= 1
     yield Edge(dut.clk)
-    if dut.clk.value.integer is not 1:
+    if dut.clk.value.integer != 1:
         raise TestError("Value should be 0")
     yield Timer(10)
     dut.clk <= 0
     yield Edge(dut.clk)
-    if dut.clk.value.integer is not 0:
+    if dut.clk.value.integer != 0:
         raise TestError("Value should be 0")
     yield Timer(10)
     dut.clk <= 1
     yield Edge(dut.clk)
-    if dut.clk.value.integer is not 1:
+    if dut.clk.value.integer != 1:
         raise TestError("Value should be 0")
     yield Timer(10)
     dut.clk <= 0
     yield Edge(dut.clk)
-    if dut.clk.value.integer is not 0:
+    if dut.clk.value.integer != 0:
         raise TestError("Value should be 0")
 
 

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -175,7 +175,7 @@ def access_integer(dut):
         raise TestFailure("Access into an integer should be invalid")
 
     length = len(test_int)
-    if length is not 1:
+    if length != 1:
         raise TestFailure("Length should be 1 not %d" % length)
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["verilog"])
@@ -352,7 +352,7 @@ def access_boolean(dut):
         raise TestFailure("Access into an integer should be invalid")
 
     length = len(boolean)
-    if length is not 1:
+    if length != 1:
         raise TestFailure("Length should be 1 not %d" % length)
 
     tlog.info("Value of %s is %d" % (boolean, boolean))

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -54,7 +54,7 @@ def decorated_test_read(dut, signal):
     global test_count
     dut._log.info("Inside decorated_test_read")
     test_count = 0
-    while test_count is not 5:
+    while test_count != 5:
         yield RisingEdge(dut.clk)
         test_count += 1
 
@@ -64,7 +64,7 @@ def decorated_test_read(dut, signal):
 def test_read(dut, signal):
     global test_count
     dut._log.info("Inside test_read")
-    while test_count is not 5:
+    while test_count != 5:
         yield RisingEdge(dut.clk)
         test_count += 1
 
@@ -115,7 +115,7 @@ def test_callable(dut):
     clk_gen = cocotb.fork(Clock(dut.clk, 100).start())
     yield Timer(100000)
     clk_gen.kill()
-    if test_count is not 5:
+    if test_count != 5:
         print("Count was %d" % test_count)
         raise TestFailure
 
@@ -137,7 +137,7 @@ def test_callable_fail(dut):
     clk_gen = cocotb.fork(Clock(dut.clk, 100).start())
     yield Timer(100000)
     clk_gen.kill()
-    if test_count is not 5:
+    if test_count != 5:
         raise TestFailure
 
 


### PR DESCRIPTION
A number of places in the tests trigger the following new warning in Python 3.8:

> SyntaxWarning: "is not" with a literal. Did you mean "!="?

See here for discussion of this change: https://bugs.python.org/issue34850

This commit resolves this by changing all instances of "is not" with a literal to use "!=".

There is also an additional compatibility-related change; the combine_results.py script uses a deprecated "getiterator" method in the xml.etree.elementtree package. This method has been deprecated in favor of the "iter" method since Python 2.7, so it should be safe to switch.

(These problems were all discovered while I was working on [packaging cocotb in Fedora](https://bugzilla.redhat.com/show_bug.cgi?id=1747574)).