### PR TITLE
Use units argument for Timer and Clock in examples.

### DIFF
--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -14,8 +14,8 @@ when it occurs.  For example:
 
     @cocotb.coroutine
     def wait_10ns():
-        cocotb.log.info("About to wait for 10ns")
-        yield Timer(10000)
+        cocotb.log.info("About to wait for 10 ns")
+        yield Timer(10, units='ns')
         cocotb.log.info("Simulation time has advanced by 10 ns")
 
 Coroutines may also yield other coroutines:
@@ -59,7 +59,7 @@ execution should resume if *any* of them fires:
     @cocotb.coroutine
     def packet_with_timeout(monitor, timeout):
         """Wait for a packet but time out if nothing arrives"""
-        yield [Timer(timeout), RisingEdge(dut.ready)]
+        yield [Timer(timeout, units='ns'), RisingEdge(dut.ready)]
 
 
 The trigger that caused execution to resume is passed back to the coroutine,
@@ -70,7 +70,7 @@ allowing them to distinguish which trigger fired:
     @cocotb.coroutine
     def packet_with_timeout(monitor, timeout):
         """Wait for a packet but time out if nothing arrives"""
-        tout_trigger = Timer(timeout)
+        tout_trigger = Timer(timeout, units='ns')
         result = yield [tout_trigger, RisingEdge(dut.ready)]
         if result is tout_trigger:
             raise TestFailure("Timed out waiting for packet")
@@ -86,14 +86,14 @@ the forked code.
         """While reset is active, toggle signals"""
         tb = uart_tb(dut)
         # "Clock" is a built in class for toggling a clock signal
-        cocotb.fork(Clock(dut.clk, 1000).start())
+        cocotb.fork(Clock(dut.clk, 1, units='ns').start())
         # reset_dut is a function -
         # part of the user-generated "uart_tb" class
-        cocotb.fork(tb.reset_dut(dut.rstn, 20000))
+        cocotb.fork(tb.reset_dut(dut.rstn, 20))
 
-        yield Timer(10000)
+        yield Timer(10, units='ns')
         print("Reset is still active: %d" % dut.rstn)
-        yield Timer(15000)
+        yield Timer(15, units='ns')
         print("Reset has gone inactive: %d" % dut.rstn)
 
 
@@ -102,8 +102,8 @@ Coroutines can be joined to end parallel operation within a function.
 .. code-block:: python3
 
     @cocotb.test()
-    def test_count_edge_cycles(dut, period=1000, clocks=6):
-        cocotb.fork(Clock(dut.clk, period).start())
+    def test_count_edge_cycles(dut, period=1, clocks=6):
+        cocotb.fork(Clock(dut.clk, period, units='ns').start())
         yield RisingEdge(dut.clk)
 
         timer = Timer(period + 10)
@@ -133,10 +133,10 @@ they'd naturally end.
 
         clk_gen = cocotb.fork(clk_1mhz.start())
         start_time_ns = get_sim_time(units='ns')
-        yield Timer(1)
+        yield Timer(1, units='ns')
         yield RisingEdge(dut.clk)
         edge_time_ns = get_sim_time(units='ns')
-        # NOTE: isclose is a python 3.5+ feature
+        # NOTE: isclose is a Python 3.5+ feature
         if not isclose(edge_time_ns, start_time_ns + 1000.0):
             raise TestFailure("Expected a period of 1 us")
 
@@ -144,10 +144,10 @@ they'd naturally end.
 
         clk_gen = cocotb.fork(clk_250mhz.start())
         start_time_ns = get_sim_time(units='ns')
-        yield Timer(1)
+        yield Timer(1, units='ns')
         yield RisingEdge(dut.clk)
         edge_time_ns = get_sim_time(units='ns')
-        # NOTE: isclose is a python 3.5+ feature
+        # NOTE: isclose is a Python 3.5+ feature
         if not isclose(edge_time_ns, start_time_ns + 4.0):
             raise TestFailure("Expected a period of 4 ns")
 
@@ -164,7 +164,7 @@ syntax. For example:
     @cocotb.coroutine
     async def wait_10ns():
         cocotb.log.info("About to wait for 10 ns")
-        await Timer(10000)
+        await Timer(10, units='ns')
         cocotb.log.info("Simulation time has advanced by 10 ns")
 
 To wait on a trigger or a nested coroutine, these use :keyword:`await` instead
@@ -184,7 +184,7 @@ Async generators
 
 In Python 3.6, a ``yield`` statement within an ``async`` function has a new
 meaning (rather than being a ``SyntaxError``) which matches the typical meaning
-of ``yield`` within regular python code. It can be used to create a special
+of ``yield`` within regular Python code. It can be used to create a special
 type of generator function that can be iterated with ``async for``:
 
 .. code-block:: python3

--- a/documentation/source/ping_tun_tap.rst
+++ b/documentation/source/ping_tun_tap.rst
@@ -95,7 +95,7 @@ and :class:`~.triggers.RisingEdge` triggers.
         dut._log.debug("Resetting DUT")
         dut.reset_n <= 0
         stream_in.bus.valid <= 0
-        yield Timer(10000)
+        yield Timer(10, units='ns')
         yield RisingEdge(dut.clk)
         dut.reset_n <= 1
         dut.stream_out_ready <= 1

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -200,9 +200,9 @@ following:
         dut._log.info("Running test!")
         for cycle in range(10):
             dut.clk = 0
-            yield Timer(1000)
+            yield Timer(1, units='ns')
             dut.clk = 1
-            yield Timer(1000)
+            yield Timer(1, units='ns')
         dut._log.info("Running test!")
 
 This will drive a square wave clock onto the ``clk`` port of the toplevel.
@@ -292,7 +292,7 @@ Parallel and sequential execution of coroutines
     @cocotb.coroutine
     def reset_dut(reset_n, duration):
         reset_n <= 0
-        yield Timer(duration)
+        yield Timer(duration, units='ns')
         reset_n <= 1
         reset_n._log.debug("Reset complete")
 
@@ -308,7 +308,7 @@ Parallel and sequential execution of coroutines
         # Call reset_dut in parallel with this coroutine
         reset_thread = cocotb.fork(reset_dut(reset_n, 500)
 
-        yield Timer(250)
+        yield Timer(250, units='ns')
         dut._log.debug("During reset (reset_n = %s)" % reset_n.value)
 
         # Wait for the other thread to complete

--- a/examples/adder/tests/test_adder.py
+++ b/examples/adder/tests/test_adder.py
@@ -9,14 +9,14 @@ import random
 @cocotb.test()
 def adder_basic_test(dut):
     """Test for 5 + 10"""
-    yield Timer(2)
+    yield Timer(2, units='ns')
     A = 5
     B = 10
 
     dut.A = A
     dut.B = B
 
-    yield Timer(2)
+    yield Timer(2, units='ns')
 
     if int(dut.X) != adder_model(A, B):
         raise TestFailure(
@@ -28,7 +28,7 @@ def adder_basic_test(dut):
 @cocotb.test()
 def adder_randomised_test(dut):
     """Test for adding 2 random numbers multiple times"""
-    yield Timer(2)
+    yield Timer(2, units='ns')
 
     for i in range(10):
         A = random.randint(0, 15)
@@ -37,7 +37,7 @@ def adder_randomised_test(dut):
         dut.A = A
         dut.B = B
 
-        yield Timer(2)
+        yield Timer(2, units='ns')
 
         if int(dut.X) != adder_model(A, B):
             raise TestFailure(

--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -11,13 +11,13 @@ from cocotb.triggers import Timer
 from cocotb.drivers.amba import AXI4LiteMaster
 from cocotb.drivers.amba import AXIProtocolError
 
-CLK_PERIOD = 10
+CLK_PERIOD_NS = 10
 
 MODULE_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "hdl")
 MODULE_PATH = os.path.abspath(MODULE_PATH)
 
 def setup_dut(dut):
-    cocotb.fork(Clock(dut.clk, CLK_PERIOD).start())
+    cocotb.fork(Clock(dut.clk, CLK_PERIOD_NS, units='ns').start())
 
 # Write to address 0 and verify that value got through
 @cocotb.test(skip = False)
@@ -36,14 +36,14 @@ def write_address_0(dut):
     dut.test_id <= 0
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
     ADDRESS = 0x00
     DATA = 0xAB
 
     yield axim.write(ADDRESS, DATA)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
 
     value = dut.dut.r_temp_0
     if value != DATA:
@@ -71,17 +71,17 @@ def read_address_1(dut):
     dut.test_id <= 1
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
-    yield Timer(CLK_PERIOD)
+    yield Timer(CLK_PERIOD_NS, units='ns')
     ADDRESS = 0x01
     DATA = 0xCD
 
     dut.dut.r_temp_1 <= DATA
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
 
     value = yield axim.read(ADDRESS)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
 
     if value != DATA:
         # Fail
@@ -108,7 +108,7 @@ def write_and_read(dut):
     dut.test_id <= 2
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
     ADDRESS = 0x00
@@ -116,11 +116,11 @@ def write_and_read(dut):
 
     # Write to the register
     yield axim.write(ADDRESS, DATA)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
 
     # Read back the value
     value = yield axim.read(ADDRESS)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
 
     value = dut.dut.r_temp_0
     if value != DATA:
@@ -146,7 +146,7 @@ def write_fail(dut):
     dut.test_id <= 3
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
     ADDRESS = 0x02
@@ -154,7 +154,7 @@ def write_fail(dut):
 
     try:
         yield axim.write(ADDRESS, DATA)
-        yield Timer(CLK_PERIOD * 10)
+        yield Timer(CLK_PERIOD_NS * 10, units='ns')
     except AXIProtocolError as e:
         print("Exception: %s" % str(e))
         dut._log.info("Bus successfully raised an error")
@@ -178,7 +178,7 @@ def read_fail(dut):
     dut.test_id <= 4
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD * 10)
+    yield Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
     ADDRESS = 0x02
@@ -186,7 +186,7 @@ def read_fail(dut):
 
     try:
         yield axim.read(ADDRESS, DATA)
-        yield Timer(CLK_PERIOD * 10)
+        yield Timer(CLK_PERIOD_NS * 10, units='ns')
     except AXIProtocolError as e:
         print("Exception: %s" % str(e))
         dut._log.info("Bus Successfully Raised an Error")

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -101,11 +101,11 @@ class EndianSwapperTB(object):
         self.pkts_sent += 1
 
     @cocotb.coroutine
-    def reset(self, duration=10000):
+    def reset(self, duration=10):
         self.dut._log.debug("Resetting DUT")
         self.dut.reset_n <= 0
         self.stream_in.bus.valid <= 0
-        yield Timer(duration)
+        yield Timer(duration, units='ns')
         yield RisingEdge(self.dut.clk)
         self.dut.reset_n <= 1
         self.dut._log.debug("Out of reset")
@@ -115,7 +115,7 @@ class EndianSwapperTB(object):
 def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None,
              backpressure_inserter=None):
 
-    cocotb.fork(Clock(dut.clk, 5000).start())
+    cocotb.fork(Clock(dut.clk, 5, units='ns').start())
     tb = EndianSwapperTB(dut)
 
     yield tb.reset()
@@ -182,7 +182,7 @@ def wavedrom_test(dut):
     """
     Generate a JSON wavedrom diagram of a trace and save it to wavedrom.json
     """
-    cocotb.fork(Clock(dut.clk,5000).start())
+    cocotb.fork(Clock(dut.clk, 5, units='ns').start())
     yield RisingEdge(dut.clk)
     tb = EndianSwapperTB(dut)
     yield tb.reset()

--- a/examples/endian_swapper/tests/test_endian_swapper_hal.py
+++ b/examples/endian_swapper/tests/test_endian_swapper_hal.py
@@ -37,11 +37,11 @@ import io_module
 
 
 @cocotb.coroutine
-def reset(dut, duration=10000):
+def reset(dut, duration=10):
     dut._log.debug("Resetting DUT")
     dut.reset_n = 0
     dut.stream_in_valid = 0
-    yield Timer(duration)
+    yield Timer(duration, units='ns')
     yield RisingEdge(dut.clk)
     dut.reset_n = 1
     dut._log.debug("Out of reset")
@@ -51,7 +51,7 @@ def reset(dut, duration=10000):
 def initial_hal_test(dut, debug=True):
     """Example of using the software HAL against cosim testbench"""
 
-    cocotb.fork(Clock(dut.clk, 5000).start())
+    cocotb.fork(Clock(dut.clk, 5, units='ns').start())
     yield reset(dut)
 
     # Create the avalon master and direct our HAL calls to that

--- a/examples/mean/tests/test_mean.py
+++ b/examples/mean/tests/test_mean.py
@@ -9,7 +9,7 @@ from cocotb.scoreboard import Scoreboard
 
 import random
 
-clock_period = 100
+CLK_PERIOD_NS = 100
 
 
 class StreamBusMonitor(BusMonitor):
@@ -29,12 +29,12 @@ class StreamBusMonitor(BusMonitor):
 
 
 @cocotb.coroutine
-def clock_gen(signal, period=10000):
+def clock_gen(signal, period=10):
     while True:
         signal <= 0
-        yield Timer(period/2)
+        yield Timer(period/2, units='ns')
         signal <= 1
-        yield Timer(period/2)
+        yield Timer(period/2, units='ns')
 
 
 @cocotb.coroutine
@@ -46,7 +46,7 @@ def value_test(dut, num):
     dut._log.info('Detected DATA_WIDTH = %d, BUS_WIDTH = %d' %
                  (data_width, bus_width))
 
-    cocotb.fork(clock_gen(dut.clk, period=clock_period))
+    cocotb.fork(clock_gen(dut.clk, period=CLK_PERIOD_NS, units='ns'))
 
     dut.rst <= 1
     for i in range(bus_width):
@@ -101,7 +101,7 @@ def mean_randomised_test(dut):
     dut._log.info('Detected DATA_WIDTH = %d, BUS_WIDTH = %d' %
                  (data_width, bus_width))
 
-    cocotb.fork(clock_gen(dut.clk, period=clock_period))
+    cocotb.fork(clock_gen(dut.clk, period=CLK_PERIOD_NS, units='ns'))
 
     dut.rst <= 1
     for i in range(bus_width):

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -6,7 +6,7 @@ from cocotb.result import TestFailure
 @cocotb.test()
 def mixed_language_test(dut):
     """Try accessing handles and setting values in a mixed language environment."""
-    yield Timer(100)
+    yield Timer(100, units='ns')
 
     verilog = dut.i_swapper_sv
     dut._log.info("Got: %s" % repr(verilog._name))
@@ -15,10 +15,10 @@ def mixed_language_test(dut):
     dut._log.info("Got: %s" % repr(vhdl._name))
 
     verilog.reset_n <= 1
-    yield Timer(100)
+    yield Timer(100, units='ns')
 
     vhdl.reset_n <= 1
-    yield Timer(100)
+    yield Timer(100, units='ns')
 
     if int(verilog.reset_n) == int(vhdl.reset_n):
         dut._log.info("Both signals read as %d" % int(vhdl.reset_n))

--- a/examples/ping_tun_tap/tests/test_icmp_reply.py
+++ b/examples/ping_tun_tap/tests/test_icmp_reply.py
@@ -85,7 +85,7 @@ def tun_tap_example_test(dut):
     must have CAP_NET_ADMIN capability.
     """
 
-    cocotb.fork(Clock(dut.clk, 5000).start())
+    cocotb.fork(Clock(dut.clk, 5, units='ns').start())
 
     stream_in = AvalonSTDriver(dut, "stream_in", dut.clk)
     stream_out = AvalonSTMonitor(dut, "stream_out", dut.clk)
@@ -98,7 +98,7 @@ def tun_tap_example_test(dut):
     dut._log.debug("Resetting DUT")
     dut.reset_n <= 0
     stream_in.bus.valid <= 0
-    yield Timer(10000)
+    yield Timer(10, units='ns')
     yield RisingEdge(dut.clk)
     dut.reset_n <= 1
     dut.stream_out_ready <= 1


### PR DESCRIPTION
Closes #1117. The tests running in CI were not touched as they are not user-facing.
It looks like sometimes the assumption was that the simulator timescale would be in picoseconds, sometimes in nanoseconds. Normalization was done to nanoseconds mostly.