### PR TITLE
Clean makefiles, fix C/C++ warnings, support Clang

### DIFF
--- a/cocotb/share/include/cocotb_utils.h
+++ b/cocotb/share/include/cocotb_utils.h
@@ -45,6 +45,8 @@ extern int is_python_context;
 void to_python(void);
 void to_simulator(void);
 
+#define COCOTB_UNUSED(x) ((void)x)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -221,7 +221,7 @@ void *gpi_get_callback_data(gpi_sim_hdl gpi_hdl);
 
 // Print out what implementations are registered. Python needs to be loaded for this,
 // Returns the number of libs
-int gpi_print_registered_impl(void);
+size_t gpi_print_registered_impl(void);
 
 #define GPI_RET(_code) \
     if (_code == 1) \

--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -73,7 +73,7 @@ void set_log_filter(void *filter);
 void clear_log_filter(void);
 void set_log_level(enum gpi_log_levels new_level);
 
-void gpi_log(const char *name, long level, const char *pathname, const char *funcname, long lineno, const char *msg, ...);
+void gpi_log(const char *name, enum gpi_log_levels level, const char *pathname, const char *funcname, long lineno, const char *msg, ...);
 
 EXTERN_C_END
 

--- a/cocotb/share/lib/compat/python3_compat.h
+++ b/cocotb/share/lib/compat/python3_compat.h
@@ -1,6 +1,8 @@
 #ifndef _PYTHON3_COMPAT_H
 #define _PYTHON3_COMPAT_H
 
+#include <cocotb_utils.h>  // COCOTB_UNUSED
+
 struct module_state {
     PyObject *error;
 };
@@ -14,7 +16,7 @@ struct module_state {
 #define INITERROR return NULL
 #else
 
-#define GETSTATE(m) (&_state)
+#define GETSTATE(m) (COCOTB_UNUSED(m), &_state)
 #define MODULE_ENTRY_POINT initsimulator
 #define INITERROR return
 #endif

--- a/cocotb/share/lib/embed/Makefile
+++ b/cocotb/share/lib/embed/Makefile
@@ -29,13 +29,13 @@
 
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
 
-INCLUDES	+=
-GCC_ARGS	+= -DPYTHON_SO_LIB=$(PYTHON_DYN_LIB)
-LIBS		:= $(PYLIBS) -lgpilog -lcocotbutils
-LD_PATH		:= -L$(LIB_DIR)
-SRCS		:= gpi_embed.c
+INCLUDES    +=
+C_ARGS      += -DPYTHON_SO_LIB=$(PYTHON_DYN_LIB)
+LIBS        := $(PYLIBS) -lgpilog -lcocotbutils
+LD_PATH     := -L$(LIB_DIR)
+SRCS        := gpi_embed.c
 
-LIB_NAME	:= libcocotb
+LIB_NAME    := libcocotb
 
 all: $(LIB_DIR)/$(LIB_NAME).$(LIB_EXT)
 

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -153,8 +153,10 @@ void embed_init_python(void)
        such that they can attach */
     const char *pause = getenv("COCOTB_ATTACH");
     if (pause) {
-        long sleep_time = strtol(pause, NULL, 10);
-        if (errno == ERANGE && (sleep_time == LONG_MAX || sleep_time == LONG_MIN)) {
+        unsigned long sleep_time = strtoul(pause, NULL, 10);
+        /* This should check for out-of-range parses which returns ULONG_MAX and sets errno,
+           as well as correct parses that would be sliced by the narrowing cast */
+        if (errno == ERANGE || sleep_time >= UINT_MAX) {
             LOG_ERROR("COCOTB_ATTACH only needs to be set to ~30 seconds");
             goto out;
         }
@@ -165,7 +167,7 @@ void embed_init_python(void)
         }
 
         LOG_ERROR("Waiting for %lu seconds - attach to PID %d with your debugger\n", sleep_time, getpid());
-        sleep(sleep_time);
+        sleep((unsigned int)sleep_time);
     }
 out:
     FEXIT;

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -30,6 +30,7 @@
 // Embed Python into the simulator using GPI
 
 #include <Python.h>
+#include <unistd.h>
 #include <cocotb_utils.h>
 #include "embed.h"
 #include "../compat/python3_compat.h"

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -752,8 +752,8 @@ GpiIterator::Status FliIterator::next_handle(std::string &name, GpiObjHdl **hdl,
     }
 
     char *c_name;
-    PLI_INT32 accType = 0;
-    PLI_INT32 accFullType = 0;
+    PLI_INT32 accType;
+    PLI_INT32 accFullType;
     switch (*one2many) {
         case FliIterator::OTM_CONSTANTS:
         case FliIterator::OTM_VARIABLE_SUB_ELEMENTS:
@@ -776,6 +776,9 @@ GpiIterator::Status FliIterator::next_handle(std::string &name, GpiObjHdl **hdl,
             accFullType = acc_fetch_fulltype(obj);
             break;
         default:
+            c_name = NULL;
+            accType = 0;
+            accFullType = 0;
             LOG_WARN("Unhandled OneToMany Type (%d)", *one2many);
     }
 

--- a/cocotb/share/lib/fli/Makefile
+++ b/cocotb/share/lib/fli/Makefile
@@ -29,7 +29,7 @@
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
 
 INCLUDES    += -I$(MODELSIM_BIN_DIR)/../include
-GXX_ARGS    += -DFLI_CHECKING -DUSE_CACHE
+CXX_ARGS    += -DFLI_CHECKING -DUSE_CACHE
 LIBS        := $(EXTRA_LIBS) -lgpilog -lgpi -lstdc++
 LD_PATH     := -L$(LIB_DIR) $(EXTRA_LIBDIRS)
 LIB_NAME    := libfli

--- a/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -81,7 +81,7 @@ const std::string & GpiObjHdl::get_name()
 /* Genertic base clss implementations */
 char *GpiHdl::gpi_copy_name(const char *name)
 {
-    int len;
+    size_t len;
     char *result;
     const char null[] = "NULL";
 

--- a/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -108,12 +108,6 @@ bool GpiHdl::is_this_impl(GpiImplInterface *impl)
     return impl == this->m_impl;
 }
 
-int GpiHdl::initialise(std::string &name)
-{
-    LOG_WARN("Generic initialize, doubt you should have called this");
-    return 0;
-}
-
 int GpiObjHdl::initialise(std::string &name, std::string &fq_name)
 {
     m_name = name;

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -94,7 +94,7 @@ static GpiHandleStore unique_handles;
 #endif
 
 
-int gpi_print_registered_impl()
+size_t gpi_print_registered_impl()
 {
     vector<GpiImplInterface*>::iterator iter;
     for (iter = registered_impls.begin();

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -351,8 +351,6 @@ gpi_sim_hdl gpi_get_handle_by_name(gpi_sim_hdl parent, const char *name)
 
 gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl parent, int32_t index)
 {
-    vector<GpiImplInterface*>::iterator iter;
-
     GpiObjHdl *hdl         = NULL;
     GpiObjHdl *base        = sim_to_hdl<GpiObjHdl*>(parent);
     GpiImplInterface *intf = base->m_impl;

--- a/cocotb/share/lib/gpi/Makefile
+++ b/cocotb/share/lib/gpi/Makefile
@@ -30,7 +30,7 @@
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
 
 INCLUDES    +=
-GXX_ARGS    += -DVPI_CHECKING -DLIB_EXT=$(LIB_EXT) -DSINGLETON_HANDLES
+CXX_ARGS    += -DVPI_CHECKING -DLIB_EXT=$(LIB_EXT) -DSINGLETON_HANDLES
 LIBS        := -lcocotbutils -lgpilog -lcocotb -lstdc++
 LD_PATH     := -L$(LIB_DIR)
 LIB_NAME    := libgpi

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cocotb_utils.h>  // COCOTB_UNUSED
 
 typedef enum gpi_cb_state {
     GPI_FREE = 0,
@@ -229,10 +230,10 @@ protected:
 /* We would then have */
 class GpiClockHdl {
 public:
-    GpiClockHdl(GpiObjHdl *clk) { }
-    GpiClockHdl(const char *clk) { }
+    GpiClockHdl(GpiObjHdl *clk) { COCOTB_UNUSED(clk); }
+    GpiClockHdl(const char *clk) { COCOTB_UNUSED(clk); }
     ~GpiClockHdl() { }
-    int start_clock(const int period_ps) { return 0; } ; /* Do things with the GpiSignalObjHdl */
+    int start_clock(const int period_ps) { COCOTB_UNUSED(period_ps); return 0; } ; /* Do things with the GpiSignalObjHdl */
     int stop_clock() { return 0; }
 };
 
@@ -251,6 +252,7 @@ public:
     virtual ~GpiIterator() { }
 
     virtual Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl) {
+        COCOTB_UNUSED(raw_hdl);
         name = "";
         *hdl = NULL;
         return GpiIterator::END;

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -65,7 +65,6 @@ public:
     GpiHdl(GpiImplInterface *impl) : m_impl(impl), m_obj_hdl(NULL) { }
     GpiHdl(GpiImplInterface *impl, void *hdl) : m_impl(impl), m_obj_hdl(hdl) { }
     virtual ~GpiHdl() { }
-    virtual int initialise(std::string &name);                   // Post constructor init
 
 
     template<typename T> T get_handle() const {

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -343,12 +343,12 @@ void gpi_embed_end();
 void gpi_embed_event(gpi_event_t level, const char *msg);
 void gpi_load_extra_libs();
 
-typedef const void (*layer_entry_func)();
+typedef void (*layer_entry_func)();
 
 /* Use this macro in an implementation layer to define an entry point */
 #define GPI_ENTRY_POINT(NAME, func) \
     extern "C" { \
-        const void NAME##_entry_point()  \
+        void NAME##_entry_point()  \
         { \
             func(); \
         } \

--- a/cocotb/share/lib/gpi_log/Makefile
+++ b/cocotb/share/lib/gpi_log/Makefile
@@ -30,7 +30,7 @@
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
 
 INCLUDES    +=
-GCC_ARGS    += -DFILTER
+C_ARGS      += -DFILTER
 LIBS        := $(PYLIBS)
 SRCS        := gpi_logging.c
 

--- a/cocotb/share/lib/gpi_log/gpi_logging.c
+++ b/cocotb/share/lib/gpi_log/gpi_logging.c
@@ -113,22 +113,21 @@ static char log_buff[LOG_SIZE];
  * If the Python logging mechanism is not initialised, dumps to `stderr`.
  *
  */
-void gpi_log(const char *name, long level, const char *pathname, const char *funcname, long lineno, const char *msg, ...)
+void gpi_log(const char *name, enum gpi_log_levels level, const char *pathname, const char *funcname, long lineno, const char *msg, ...)
 {
     /* We first check that the log level means this will be printed
      * before going to the expense of processing the variable
      * arguments
      */
     va_list ap;
-    int n;
 
     if (!pLogHandler) {
         if (level >= GPIInfo) {
             va_start(ap, msg);
-            n = vsnprintf(log_buff, LOG_SIZE, msg, ap);
+            int n = vsnprintf(log_buff, LOG_SIZE, msg, ap);
             va_end(ap);
 
-            if (n < 0) {
+            if (n < 0 || n >= LOG_SIZE) {
                fprintf(stderr, "Log message construction failed\n");
             }
 
@@ -136,9 +135,9 @@ void gpi_log(const char *name, long level, const char *pathname, const char *fun
             fprintf(stdout, "%-9s", log_level(level));
             fprintf(stdout, "%-35s", name);
 
-            n = strlen(pathname);
-            if (n > 20) {
-                fprintf(stdout, "..%18s:", (pathname + (n - 18)));
+            size_t pathlen = strlen(pathname);
+            if (pathlen > 20) {
+                fprintf(stdout, "..%18s:", (pathname + (pathlen - 18)));
             } else {
                 fprintf(stdout, "%20s:", pathname);
             }
@@ -188,7 +187,7 @@ void gpi_log(const char *name, long level, const char *pathname, const char *fun
 
     // Ignore truncation
     va_start(ap, msg);
-    n = vsnprintf(log_buff, LOG_SIZE, msg, ap);
+    (void)vsnprintf(log_buff, LOG_SIZE, msg, ap);
     va_end(ap);
 
     filename_arg = PyUnicode_FromString(pathname);      // New reference

--- a/cocotb/share/lib/gpi_log/gpi_logging.c
+++ b/cocotb/share/lib/gpi_log/gpi_logging.c
@@ -187,7 +187,12 @@ void gpi_log(const char *name, enum gpi_log_levels level, const char *pathname, 
 
     // Ignore truncation
     va_start(ap, msg);
-    (void)vsnprintf(log_buff, LOG_SIZE, msg, ap);
+    {
+        int n = vsnprintf(log_buff, LOG_SIZE, msg, ap);
+        if (n < 0 || n >= LOG_SIZE) {
+            fprintf(stderr, "Log message construction failed\n");
+        }
+    }
     va_end(ap);
 
     filename_arg = PyUnicode_FromString(pathname);      // New reference

--- a/cocotb/share/lib/simulator/Makefile
+++ b/cocotb/share/lib/simulator/Makefile
@@ -30,7 +30,7 @@
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
 
 INCLUDES    +=
-GCC_ARGS    +=
+C_ARGS      +=
 LIBS        := -lcocotbutils -lgpi -lgpilog $(PYLIBS)
 LD_PATH     := -L$(LIB_DIR)
 LIB_NAME    := libsim

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -399,9 +399,18 @@ static PyObject *register_timed_callback(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    // Extract the time
-    PyObject *pTime = PyTuple_GetItem(args, 0);
-    time_ps = PyLong_AsLongLong(pTime);
+    {   // Extract the time
+        PyObject *pTime = PyTuple_GetItem(args, 0);
+        long long pTime_as_longlong = PyLong_AsLongLong(pTime);
+        if (pTime_as_longlong == -1 && PyErr_Occurred()) {
+            return NULL;
+        } else if (pTime_as_longlong < 0) {
+            PyErr_SetString(PyExc_ValueError, "Timer value must be a positive integer");
+            return NULL;
+        } else {
+            time_ps = (uint64_t)pTime_as_longlong;
+        }
+    }
 
     // Extract the callback function
     function = PyTuple_GetItem(args, 1);

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -778,7 +778,8 @@ static PyObject *get_name_string(PyObject *self, PyObject *args)
 
 static PyObject *get_type(PyObject *self, PyObject *args)
 {
-    int result;
+    (void)self;
+    gpi_objtype_t result;
     gpi_sim_hdl hdl;
     PyObject *pyresult;
 
@@ -787,7 +788,7 @@ static PyObject *get_type(PyObject *self, PyObject *args)
     }
 
     result = gpi_get_object_type((gpi_sim_hdl)hdl);
-    pyresult = Py_BuildValue("i", result);
+    pyresult = Py_BuildValue("i", (int)result);
 
     return pyresult;
 }

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -40,7 +40,7 @@ static int releases = 0;
 static int sim_ending = 0;
 
 #include "simulatormodule.h"
-#include <cocotb_utils.h>
+#include <cocotb_utils.h>     // COCOTB_UNUSED
 
 typedef int (*gpi_function_t)(const void *);
 
@@ -198,6 +198,7 @@ err:
 
 static PyObject *log_msg(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     const char *name;
     const char *path;
     const char *msg;
@@ -218,6 +219,7 @@ static PyObject *log_msg(PyObject *self, PyObject *args)
 // Remaining arguments are keyword arguments to be passed to the callback
 static PyObject *register_readonly_callback(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     FENTER
 
     PyObject *fArgs;
@@ -270,6 +272,7 @@ static PyObject *register_readonly_callback(PyObject *self, PyObject *args)
 
 static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     FENTER
 
     PyObject *fArgs;
@@ -322,6 +325,7 @@ static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args)
 
 static PyObject *register_nextstep_callback(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     FENTER
 
     PyObject *fArgs;
@@ -378,6 +382,7 @@ static PyObject *register_nextstep_callback(PyObject *self, PyObject *args)
 // Remaining arguments and keyword arguments are to be passed to the callback
 static PyObject *register_timed_callback(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     FENTER
 
     PyObject *fArgs;
@@ -440,6 +445,7 @@ static PyObject *register_timed_callback(PyObject *self, PyObject *args)
 // Remaining arguments and keyword arguments are to be passed to the callback
 static PyObject *register_value_change_callback(PyObject *self, PyObject *args) //, PyObject *keywds)
 {
+    COCOTB_UNUSED(self);
     FENTER
 
     PyObject *fArgs;
@@ -508,6 +514,7 @@ static PyObject *register_value_change_callback(PyObject *self, PyObject *args) 
 
 static PyObject *iterate(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     int type;
     gpi_iterator_hdl result;
@@ -527,6 +534,7 @@ static PyObject *iterate(PyObject *self, PyObject *args)
 
 static PyObject *next(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_iterator_hdl hdl;
     gpi_sim_hdl result;
     PyObject *res;
@@ -558,6 +566,7 @@ static PyObject *next(PyObject *self, PyObject *args)
 
 static PyObject *get_signal_val_binstr(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     const char *result;
     PyObject *retstr;
@@ -574,6 +583,7 @@ static PyObject *get_signal_val_binstr(PyObject *self, PyObject *args)
 
 static PyObject *get_signal_val_str(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     const char *result;
     PyObject *retstr;
@@ -590,6 +600,7 @@ static PyObject *get_signal_val_str(PyObject *self, PyObject *args)
 
 static PyObject *get_signal_val_real(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     double result;
     PyObject *retval;
@@ -607,6 +618,7 @@ static PyObject *get_signal_val_real(PyObject *self, PyObject *args)
 
 static PyObject *get_signal_val_long(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     long result;
     PyObject *retval;
@@ -624,6 +636,7 @@ static PyObject *get_signal_val_long(PyObject *self, PyObject *args)
 
 static PyObject *set_signal_val_str(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     const char *binstr;
     PyObject *res;
@@ -640,6 +653,7 @@ static PyObject *set_signal_val_str(PyObject *self, PyObject *args)
 
 static PyObject *set_signal_val_real(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     double value;
     PyObject *res;
@@ -656,6 +670,7 @@ static PyObject *set_signal_val_real(PyObject *self, PyObject *args)
 
 static PyObject *set_signal_val_long(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     long value;
     PyObject *res;
@@ -672,6 +687,7 @@ static PyObject *set_signal_val_long(PyObject *self, PyObject *args)
 
 static PyObject *get_definition_name(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     const char* result;
     gpi_sim_hdl hdl;
     PyObject *retstr;
@@ -688,6 +704,7 @@ static PyObject *get_definition_name(PyObject *self, PyObject *args)
 
 static PyObject *get_definition_file(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     const char* result;
     gpi_sim_hdl hdl;
     PyObject *retstr;
@@ -704,6 +721,7 @@ static PyObject *get_definition_file(PyObject *self, PyObject *args)
 
 static PyObject *get_handle_by_name(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     const char *name;
     gpi_sim_hdl hdl;
     gpi_sim_hdl result;
@@ -722,6 +740,7 @@ static PyObject *get_handle_by_name(PyObject *self, PyObject *args)
 
 static PyObject *get_handle_by_index(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     int32_t index;
     gpi_sim_hdl hdl;
     gpi_sim_hdl result;
@@ -740,6 +759,7 @@ static PyObject *get_handle_by_index(PyObject *self, PyObject *args)
 
 static PyObject *get_root_handle(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     const char *name;
     gpi_sim_hdl result;
     PyObject *value;
@@ -762,6 +782,7 @@ static PyObject *get_root_handle(PyObject *self, PyObject *args)
 
 static PyObject *get_name_string(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     const char *result;
     gpi_sim_hdl hdl;
     PyObject *retstr;
@@ -778,7 +799,7 @@ static PyObject *get_name_string(PyObject *self, PyObject *args)
 
 static PyObject *get_type(PyObject *self, PyObject *args)
 {
-    (void)self;
+    COCOTB_UNUSED(self);
     gpi_objtype_t result;
     gpi_sim_hdl hdl;
     PyObject *pyresult;
@@ -795,6 +816,7 @@ static PyObject *get_type(PyObject *self, PyObject *args)
 
 static PyObject *get_const(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     int result;
     gpi_sim_hdl hdl;
     PyObject *pyresult;
@@ -811,6 +833,7 @@ static PyObject *get_const(PyObject *self, PyObject *args)
 
 static PyObject *get_type_string(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     const char *result;
     gpi_sim_hdl hdl;
     PyObject *retstr;
@@ -831,6 +854,8 @@ static PyObject *get_type_string(PyObject *self, PyObject *args)
 // log messages with the current simulation time
 static PyObject *get_sim_time(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
+    COCOTB_UNUSED(args);
     struct sim_time local_time;
 
     if (is_python_context) {
@@ -848,6 +873,8 @@ static PyObject *get_sim_time(PyObject *self, PyObject *args)
 
 static PyObject *get_precision(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
+    COCOTB_UNUSED(args);
     int32_t precision;
 
     gpi_get_sim_precision(&precision);
@@ -860,6 +887,7 @@ static PyObject *get_precision(PyObject *self, PyObject *args)
 
 static PyObject *get_num_elems(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     PyObject *retstr;
 
@@ -875,6 +903,7 @@ static PyObject *get_num_elems(PyObject *self, PyObject *args)
 
 static PyObject *get_range(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     PyObject *retstr;
 
@@ -896,6 +925,8 @@ static PyObject *get_range(PyObject *self, PyObject *args)
 
 static PyObject *stop_simulator(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
+    COCOTB_UNUSED(args);
     gpi_sim_end();
     sim_ending = 1;
     return Py_BuildValue("s", "OK!");
@@ -904,6 +935,7 @@ static PyObject *stop_simulator(PyObject *self, PyObject *args)
 
 static PyObject *deregister_callback(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     PyObject *value;
 
@@ -923,6 +955,7 @@ static PyObject *deregister_callback(PyObject *self, PyObject *args)
 
 static PyObject *log_level(PyObject *self, PyObject *args)
 {
+    COCOTB_UNUSED(self);
     enum gpi_log_levels new_level;
     PyObject *py_level;
     PyObject *value;

--- a/cocotb/share/lib/simulator/simulatormodule.h
+++ b/cocotb/share/lib/simulator/simulatormodule.h
@@ -52,7 +52,7 @@ typedef struct t_callback_data {
     gpi_sim_hdl cb_hdl;
 } s_callback_data, *p_callback_data;
 
-static PyObject *error_out(PyObject *m);
+static PyObject *error_out(PyObject *m, PyObject *args);
 static PyObject *log_msg(PyObject *self, PyObject *args);
 
 // Raise an exception on failure
@@ -125,9 +125,7 @@ static PyMethodDef SimulatorMethods[] = {
     {"get_sim_time", get_sim_time, METH_VARARGS, "Get the current simulation time as an int tuple"},
     {"get_precision", get_precision, METH_VARARGS, "Get the precision of the simulator"},
     {"deregister_callback", deregister_callback, METH_VARARGS, "De-register a callback"},
-
-    {"error_out", (PyCFunction)error_out, METH_NOARGS, NULL},
-
+    {"error_out", error_out, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/cocotb/share/lib/simulator/simulatormodule_python2.c
+++ b/cocotb/share/lib/simulator/simulatormodule_python2.c
@@ -3,8 +3,9 @@
 char error_module[] = MODULE_NAME ".Error";
 static struct module_state _state;
 
-static PyObject *error_out(PyObject *m)
+static PyObject *error_out(PyObject *m, PyObject *args)
 {
+    (void)args;
     struct module_state *st = GETSTATE(m);
     PyErr_SetString(st->error, "something bad happened");
     return NULL;

--- a/cocotb/share/lib/simulator/simulatormodule_python2.c
+++ b/cocotb/share/lib/simulator/simulatormodule_python2.c
@@ -1,11 +1,12 @@
 #include "simulatormodule.h"
+#include <cocotb_utils.h>     // COCOTB_UNUSED
 
 char error_module[] = MODULE_NAME ".Error";
 static struct module_state _state;
 
 static PyObject *error_out(PyObject *m, PyObject *args)
 {
-    (void)args;
+    COCOTB_UNUSED(args);
     struct module_state *st = GETSTATE(m);
     PyErr_SetString(st->error, "something bad happened");
     return NULL;

--- a/cocotb/share/lib/simulator/simulatormodule_python3.c
+++ b/cocotb/share/lib/simulator/simulatormodule_python3.c
@@ -1,8 +1,9 @@
 #include "simulatormodule.h"
+#include <cocotb_utils.h>     // COCOTB_UNUSED
 
 static PyObject *error_out(PyObject *m, PyObject *args)
 {
-    (void)args;
+    COCOTB_UNUSED(args);
     struct module_state *st = GETSTATE(m);
     PyErr_SetString(st->error, "something bad happened");
     return NULL;

--- a/cocotb/share/lib/simulator/simulatormodule_python3.c
+++ b/cocotb/share/lib/simulator/simulatormodule_python3.c
@@ -1,7 +1,8 @@
 #include "simulatormodule.h"
 
-static PyObject *error_out(PyObject *m)
+static PyObject *error_out(PyObject *m, PyObject *args)
 {
+    (void)args;
     struct module_state *st = GETSTATE(m);
     PyErr_SetString(st->error, "something bad happened");
     return NULL;

--- a/cocotb/share/lib/utils/Makefile
+++ b/cocotb/share/lib/utils/Makefile
@@ -29,10 +29,10 @@
 
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
 
-INCLUDES	+=
-SRCS		:= cocotb_utils.c
+INCLUDES    +=
+SRCS        := cocotb_utils.c
 
-LIB_NAME	:= libcocotbutils
+LIB_NAME    := libcocotbutils
 
 all: $(LIB_DIR)/$(LIB_NAME).$(LIB_EXT)
 

--- a/cocotb/share/lib/vhpi/Makefile
+++ b/cocotb/share/lib/vhpi/Makefile
@@ -30,7 +30,7 @@
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
 
 INCLUDES    +=
-GXX_ARGS    += -DVHPI_CHECKING
+CXX_ARGS    += -DVHPI_CHECKING
 LIBS        := $(EXTRA_LIBS) -lgpilog -lgpi -lstdc++
 LD_PATH     := $(EXTRA_LIBDIRS) -L$(LIB_DIR)
 LIB_NAME    := libcocotbvhpi

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -48,7 +48,7 @@ static inline int __check_vhpi_error(const char *file, const char *func, long li
     int err_occurred = 0;
 #if VHPI_CHECKING
     vhpiErrorInfoT info;
-    int loglevel;
+    enum gpi_log_levels loglevel;
     err_occurred = vhpi_check_error(&info);
     if (!err_occurred)
         return 0;

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -68,6 +68,9 @@ static inline int __check_vhpi_error(const char *file, const char *func, long li
         case vhpiInternal:
             loglevel = GPICritical;
             break;
+        default:
+            loglevel = GPIInfo;
+            break;
     }
 
     gpi_log("cocotb.gpi", loglevel, file, func, line,

--- a/cocotb/share/lib/vpi/Makefile
+++ b/cocotb/share/lib/vpi/Makefile
@@ -30,7 +30,7 @@
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
 
 INCLUDES    +=
-GXX_ARGS    += -DVPI_CHECKING
+CXX_ARGS    += -DVPI_CHECKING
 LIBS        := $(EXTRA_LIBS) -lgpilog -lgpi -lstdc++
 LD_PATH     := $(EXTRA_LIBDIRS) -L$(LIB_DIR)
 LIB_NAME    := libvpi
@@ -41,7 +41,7 @@ CLIBS       += $(LIB_DIR)/gpivpi.vpl
 
 #temporary hack for cvc
 ifeq ($(SIM),cvc)
-    GXX_ARGS    += -DMODELSIM
+    CXX_ARGS    += -DMODELSIM
 endif
 
 # More rules such that this may be needed depending on the requirements of

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -282,7 +282,7 @@ int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
 const char* VpiSignalObjHdl::get_signal_value_binstr()
 {
     FENTER
-    s_vpi_value value_s = {vpiBinStrVal};
+    s_vpi_value value_s = {vpiBinStrVal, {NULL}};
 
     vpi_get_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s);
     check_vpi_error();
@@ -292,7 +292,7 @@ const char* VpiSignalObjHdl::get_signal_value_binstr()
 
 const char* VpiSignalObjHdl::get_signal_value_str()
 {
-    s_vpi_value value_s = {vpiStringVal};
+    s_vpi_value value_s = {vpiStringVal, {NULL}};
 
     vpi_get_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s);
     check_vpi_error();
@@ -303,7 +303,7 @@ const char* VpiSignalObjHdl::get_signal_value_str()
 double VpiSignalObjHdl::get_signal_value_real()
 {
     FENTER
-    s_vpi_value value_s = {vpiRealVal};
+    s_vpi_value value_s = {vpiRealVal, {NULL}};
 
     vpi_get_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s);
     check_vpi_error();
@@ -314,7 +314,7 @@ double VpiSignalObjHdl::get_signal_value_real()
 long VpiSignalObjHdl::get_signal_value_long()
 {
     FENTER
-    s_vpi_value value_s = {vpiIntVal};
+    s_vpi_value value_s = {vpiIntVal, {NULL}};
 
     vpi_get_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s);
     check_vpi_error();

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -327,7 +327,7 @@ int VpiSignalObjHdl::set_signal_value(long value)
 {
     s_vpi_value value_s;
 
-    value_s.value.integer = value;
+    value_s.value.integer = (int)value;
     value_s.format = vpiIntVal;
 
     return set_signal_value(value_s);

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -666,7 +666,7 @@ static int system_function_overload(char *userdata)
 
 static void register_system_functions()
 {
-    s_vpi_systf_data tfData = { vpiSysTask, vpiSysTask };
+    s_vpi_systf_data tfData = { vpiSysTask, vpiSysTask, NULL, NULL, NULL, NULL, NULL };
 
     tfData.sizetf       = NULL;
     tfData.compiletf    = system_function_compiletf;

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -651,10 +651,12 @@ static int system_function_overload(char *userdata)
         msg = argval.value.str;
     }
 
-    gpi_log("cocotb.simulator", *userdata, vpi_get_str(vpiFile, systfref), "", (long)vpi_get(vpiLineNo, systfref), "%s", msg );
+    enum gpi_log_levels userdata_as_loglevel = (enum gpi_log_levels)*userdata;
+
+    gpi_log("cocotb.simulator", userdata_as_loglevel, vpi_get_str(vpiFile, systfref), "", (long)vpi_get(vpiLineNo, systfref), "%s", msg );
 
     // Fail the test for critical errors
-    if (GPICritical == *userdata)
+    if (GPICritical == userdata_as_loglevel)
         gpi_embed_event(SIM_TEST_FAIL, argval.value.str);
 
     return 0;

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -569,8 +569,7 @@ int32_t handle_vpi_callback(p_cb_data cb_data)
     }
 
     return rv;
-};
-
+}
 
 static void register_embed()
 {

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -26,6 +26,7 @@
 ******************************************************************************/
 
 #include "VpiImpl.h"
+#include <cocotb_utils.h>  // COCOTB_UNUSED
 
 extern "C" {
 
@@ -597,6 +598,7 @@ static void register_final_callback()
 // Expect either no arguments or a single string
 static int system_function_compiletf(char *userdata)
 {
+    COCOTB_UNUSED(userdata);
     vpiHandle systf_handle, arg_iterator, arg_handle;
     int tfarg_type;
 

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -40,7 +40,7 @@ static inline int __check_vpi_error(const char *file, const char *func, long lin
     int level=0;
 #if VPI_CHECKING
     s_vpi_error_info info;
-    int loglevel;
+    enum gpi_log_levels loglevel;
 
     memset(&info, 0, sizeof(info));
     level = vpi_chk_error(&info);

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -69,41 +69,46 @@ export LIB_DIR=$(BUILD_DIR)/libs/$(ARCH)
 export LIB_OBJ_DIR:= $(BUILD_DIR)/obj/$(ARCH)
 export INCLUDES := -I$(COCOTB_SHARE_DIR)/include -I$(PYTHON_INCLUDEDIR)
 
-LIB_EXT     := so
-PY_EXT	    := so
+LIB_EXT    := so
+PY_EXT     := so
 
-# Base GCC flags
-ifeq ($(ARCH),i686)
-GXX_ARGS    := -m32
-endif
+BASE_WARNS := -Wall -Wextra -Wconversion -Wcast-qual -Wwrite-strings -Werror
+CC_WARNS   := $(BASE_WARNS) -Wstrict-prototypes -Waggregate-return
+CXX_WARNS  := $(BASE_WARNS) -Wnon-virtual-dtor -Woverloaded-virtual
 
 ifeq ($(OS),Darwin)
-GXX_ARGS	+= -g -DDEBUG -fpic
-GCC_ARGS	:= $(GXX_ARGS)
+CXX_ARGS   := -g -DDEBUG -fpic
+C_ARGS     := $(CXX_ARGS)
 else ifeq ($(OS),Msys)
-GXX_ARGS 	+= -g -DDEBUG -shared
+CXX_ARGS   := -g -DDEBUG -shared
 ifeq ($(ARCH),x86_64)
-GXX_ARGS  += -DMS_WIN64
+CXX_ARGS   += -DMS_WIN64
 endif
-GCC_ARGS	:= $(GXX_ARGS)
-LIB_EXT		:= dll
-PY_EXT		:= pyd
+C_ARGS     := $(CXX_ARGS)
+LIB_EXT    := dll
+PY_EXT     := pyd
 else ifeq ($(OS),Linux)
-GXX_ARGS	+= -Werror -Wcast-qual -Wcast-align -Wwrite-strings \
-			-Wall -Wno-unused-parameter \
-			-fno-common -g -DDEBUG -fpic
-GCC_ARGS	:= $(GXX_ARGS) -Wstrict-prototypes -Waggregate-return
+CXX_ARGS   := -fno-common -g -DDEBUG -fpic
+C_ARGS     := $(CXX_ARGS)
 else
 $(error "Unsupported os " $(OS))
 endif
+
+ifeq ($(ARCH),i686)
+CXX_ARGS   += -m32
+C_ARGS     += -m32
+endif
+
+C_ARGS     += -std=gnu99
+CXX_ARGS   += -std=c++11
 
 ifeq ($(OS),Darwin)
 SO_LINKER_ARGS := -shared -undefined suppress -flat_namespace -L$(PYTHON_LIBDIR)
 else ifeq ($(OS),Linux)
 SO_LINKER_ARGS := -shared -Xlinker -L$(PYTHON_LIBDIR)
 else ifeq ($(OS),Msys)
-SO_LINKER_ARGS :=  -shared -Wl,-no-undefined -Wl,-enable-runtime-pseudo-reloc-v2 \
-			-Wl,--enable-auto-import -L$(PYTHON_LIBDIR)
+SO_LINKER_ARGS := -shared -Wl,-no-undefined -Wl,-enable-runtime-pseudo-reloc-v2 \
+                  -Wl,--enable-auto-import -L$(PYTHON_LIBDIR)
 else
 $(error "Unsupported os" $(OS))
 endif

--- a/cocotb/share/makefiles/Makefile.rules
+++ b/cocotb/share/makefiles/Makefile.rules
@@ -50,14 +50,18 @@ SIM_DEFINE = IUS
 endif
 
 # Add Simulator Define for compilation
-GCC_ARGS+= -D$(SIM_DEFINE)
-GXX_ARGS+= -D$(SIM_DEFINE)
+C_ARGS   += -D$(SIM_DEFINE)
+CXX_ARGS += -D$(SIM_DEFINE)
+
+# Compiler definitions
+CC  ?= cc
+CXX ?= c++
 
 $(LIB_OBJ_DIR)/%.o: %.c
-	gcc $(GCC_ARGS) -c $(INCLUDES) -o $@ $<
+	$(CC) $(C_ARGS) $(CC_WARNS) $(CFLAGS) -c $(INCLUDES) -o $@ $<
 
 $(LIB_OBJ_DIR)/%.o: %.cpp
-	g++ $(GXX_ARGS) -c $(INCLUDES) -o $@ $<
+	$(CXX) $(CXX_ARGS) $(CXX_WARNS) $(CXXFLAGS) -c $(INCLUDES) -o $@ $<
 
 $(LIB_DIR)/$(LIB_NAME).$(LIB_EXT): $($(LIB_NAME)_OBJS)
-	gcc $(GCC_ARGS) $(SO_LINKER_ARGS) -o $@ $($(LIB_NAME)_OBJS) $(ARS) $(LIBS) $(LD_PATH)
+	$(CC) $(C_ARGS) $(SO_LINKER_ARGS) $(LDFLAGS) -o $@ $($(LIB_NAME)_OBJS) $(ARS) $(LDLIBS) $(LIBS) $(LD_PATH)

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -12,7 +12,7 @@ Cocotb has the following requirements:
 
 * Python 2.7, Python 3.5+ (recommended)
 * Python-dev packages
-* GCC 4.8.1+ and associated development packages
+* GCC 4.8.1+ or Clang 3.3+ and associated development packages
 * GNU Make
 * A Verilog or VHDL simulator, depending on your RTL source code
 


### PR DESCRIPTION
Fixes #1136.
* Makefiles use `cc` and `c++` for compilation, so Clang or any other
    compiler can be used to build cocotb.
* Makefiles respect user CFLAGS, CXXFLAGS, LDFLAGS, and LDLIBS
* Increased set of warnings
* Warnings applied for all archs
* Fixed warnings in C/C++ code
* renamed GCC_ARGS and GXX_ARGS to not allude to GCC