### PR TITLE
Force event.set() to append the transaction

### DIFF
--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -158,7 +158,7 @@ class Monitor(object):
             self._recvQ.append(transaction)
 
         if self._event is not None:
-            self._event.set()
+            self._event.set(data=transaction)
 
         # If anyone was waiting then let them know
         if self._wait_event is not None:


### PR DESCRIPTION
 - when calling Monitor::_recv(self,trxn), the trxn was not pushed into
   self._event when the Event.set method was called.