### PR TITLE
Use the C++11 override keyword on virtual functions, for clarity.

### DIFF
--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -51,10 +51,8 @@ public:
     FliProcessCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                               m_proc_hdl(NULL),
                                               m_sensitised(false) { }
-    virtual ~FliProcessCbHdl() { }
 
-    virtual int arm_callback() = 0;
-    virtual int cleanup_callback();
+    int cleanup_callback() override;
 
 protected:
     mtiProcessIdT       m_proc_hdl;
@@ -69,9 +67,8 @@ public:
                    FliSignalObjHdl *sig_hdl,
                    unsigned int edge);
 
-    virtual ~FliSignalCbHdl() { }
-    int arm_callback();
-    int cleanup_callback() {
+    int arm_callback() override;
+    int cleanup_callback() override {
         return FliProcessCbHdl::cleanup_callback();
     }
 
@@ -86,9 +83,8 @@ public:
     FliSimPhaseCbHdl(GpiImplInterface *impl, mtiProcessPriorityT priority) : GpiCbHdl(impl),
                                                                              FliProcessCbHdl(impl),
                                                                              m_priority(priority) { }
-    virtual ~FliSimPhaseCbHdl() { }
 
-    int arm_callback();
+    int arm_callback() override;
 
 protected:
     mtiProcessPriorityT         m_priority;
@@ -99,53 +95,47 @@ class FliReadWriteCbHdl : public FliSimPhaseCbHdl {
 public:
     FliReadWriteCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                                 FliSimPhaseCbHdl(impl, MTI_PROC_SYNCH) { }
-    virtual ~FliReadWriteCbHdl() { }
 };
 
 class FliNextPhaseCbHdl : public FliSimPhaseCbHdl {
 public:
     FliNextPhaseCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                                 FliSimPhaseCbHdl(impl, MTI_PROC_IMMEDIATE) { }
-    virtual ~FliNextPhaseCbHdl() { }
 };
 
 class FliReadOnlyCbHdl : public FliSimPhaseCbHdl {
 public:
     FliReadOnlyCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                                FliSimPhaseCbHdl(impl, MTI_PROC_POSTPONED) { }
-    virtual ~FliReadOnlyCbHdl() { }
 };
 
 class FliStartupCbHdl : public FliProcessCbHdl {
 public:
     FliStartupCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                               FliProcessCbHdl(impl) { }
-    virtual ~FliStartupCbHdl() { }
 
-    int arm_callback();
-    int run_callback();
+    int arm_callback() override;
+    int run_callback() override;
 };
 
 class FliShutdownCbHdl : public FliProcessCbHdl {
 public:
     FliShutdownCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                                FliProcessCbHdl(impl) { }
-    virtual ~FliShutdownCbHdl() { }
 
-    int arm_callback();
-    int run_callback();
+    int arm_callback() override;
+    int run_callback() override;
 };
 
 class FliTimedCbHdl : public FliProcessCbHdl {
 public:
     FliTimedCbHdl(GpiImplInterface *impl, uint64_t time_ps);
-    virtual ~FliTimedCbHdl() { }
 
-    int arm_callback();
+    int arm_callback() override;
     void reset_time(uint64_t new_time) {
         m_time_ps = new_time;
     }
-    int cleanup_callback();
+    int cleanup_callback() override;
 private:
     uint64_t m_time_ps;
 };
@@ -159,7 +149,7 @@ public:
                m_acc_type(acc_type),
                m_acc_full_type(acc_full_type) { }
 
-    virtual ~FliObj() { }
+    virtual ~FliObj() = default;
 
     int get_acc_type() { return m_acc_type; }
     int get_acc_full_type() { return m_acc_full_type; }
@@ -189,9 +179,8 @@ public:
                   GpiObjHdl(impl, hdl, objtype, is_const),
                   FliObj(acc_type, acc_full_type) { }
 
-    virtual ~FliObjHdl() { }
 
-    virtual int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 };
 
 class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
@@ -210,10 +199,9 @@ public:
                         m_falling_cb(impl, this, GPI_FALLING),
                         m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }
 
-    virtual ~FliSignalObjHdl() { }
 
-    virtual GpiCbHdl *value_change_cb(unsigned int edge);
-    virtual int initialise(std::string &name, std::string &fq_name);
+    GpiCbHdl *value_change_cb(unsigned int edge) override;
+    int initialise(std::string &name, std::string &fq_name) override;
 
     bool is_var() { return m_is_var; }
 
@@ -241,25 +229,25 @@ public:
                        m_val_buff(NULL),
                        m_sub_hdls(NULL) { }
 
-    virtual ~FliValueObjHdl() {
+    ~FliValueObjHdl() override {
         if (m_val_buff != NULL)
             free(m_val_buff);
         if (m_sub_hdls != NULL)
             mti_VsimFree(m_sub_hdls);
     }
 
-    virtual const char* get_signal_value_binstr();
-    virtual const char* get_signal_value_str();
-    virtual double get_signal_value_real();
-    virtual long get_signal_value_long();
+    const char* get_signal_value_binstr() override;
+    const char* get_signal_value_str() override;
+    double get_signal_value_real() override;
+    long get_signal_value_long() override;
 
-    virtual int set_signal_value(long value);
-    virtual int set_signal_value(double value);
-    virtual int set_signal_value(std::string &value);
+    int set_signal_value(long value) override;
+    int set_signal_value(double value) override;
+    int set_signal_value(std::string &value) override;
 
-    virtual void *get_sub_hdl(int index);
+    void *get_sub_hdl(int index);
 
-    virtual int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 
     mtiTypeKindT get_fli_typekind() { return m_fli_type; }
     mtiTypeIdT   get_fli_typeid() { return m_val_type; }
@@ -286,15 +274,14 @@ public:
                       m_value_enum(NULL),
                       m_num_enum(0) { }
 
-    virtual ~FliEnumObjHdl() { }
 
-    const char* get_signal_value_str();
-    long get_signal_value_long();
+    const char* get_signal_value_str() override;
+    long get_signal_value_long() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value);
+    int set_signal_value(long value) override;
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 
 private:
     char             **m_value_enum;    // Do Not Free
@@ -326,18 +313,18 @@ public:
                        m_num_enum(0),
                        m_enum_map() { }
 
-    virtual ~FliLogicObjHdl() {
+    ~FliLogicObjHdl() override {
         if (m_mti_buff != NULL)
             free(m_mti_buff);
     }
 
-    const char* get_signal_value_binstr();
+    const char* get_signal_value_binstr() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value);
-    int set_signal_value(std::string &value);
+    int set_signal_value(long value) override;
+    int set_signal_value(std::string &value) override;
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 
 
 private:
@@ -360,15 +347,14 @@ public:
                  mtiTypeKindT typeKind) :
                      FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type, is_var, valType, typeKind) { }
 
-    virtual ~FliIntObjHdl() { }
 
-    const char* get_signal_value_binstr();
-    long get_signal_value_long();
+    const char* get_signal_value_binstr() override;
+    long get_signal_value_long() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value);
+    int set_signal_value(long value) override;
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 };
 
 class FliRealObjHdl : public FliValueObjHdl {
@@ -385,17 +371,17 @@ public:
                       FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type, is_var, valType, typeKind),
                       m_mti_buff(NULL) { }
 
-    virtual ~FliRealObjHdl() {
+    ~FliRealObjHdl() override {
         if (m_mti_buff != NULL)
             free(m_mti_buff);
     }
 
-    double get_signal_value_real();
+    double get_signal_value_real() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(double value);
+    int set_signal_value(double value) override;
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 
 private:
     double *m_mti_buff;
@@ -415,17 +401,17 @@ public:
                       FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type, is_var, valType, typeKind),
                       m_mti_buff(NULL) { }
 
-    virtual ~FliStringObjHdl() {
+    ~FliStringObjHdl() override {
         if (m_mti_buff != NULL)
             free(m_mti_buff);
     }
 
-    const char* get_signal_value_str();
+    const char* get_signal_value_str() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(std::string &value);
+    int set_signal_value(std::string &value) override;
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 
 private:
     char *m_mti_buff;
@@ -434,7 +420,6 @@ private:
 class FliTimerCache {
 public:
     FliTimerCache(FliImpl* impl) : impl(impl) { }
-    ~FliTimerCache() { }
 
     FliTimedCbHdl* get_timer(uint64_t time_ps);
     void put_timer(FliTimedCbHdl*);
@@ -457,9 +442,7 @@ public:
 
     FliIterator(GpiImplInterface *impl, GpiObjHdl *hdl);
 
-    virtual ~FliIterator() { };
-
-    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl);
+    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl) override;
 
 private:
     void populate_handle_list(OneToMany childType);
@@ -485,26 +468,26 @@ public:
                                        m_readwrite_cbhdl(this) { }
 
      /* Sim related */
-    void sim_end();
-    void get_sim_time(uint32_t *high, uint32_t *low);
-    void get_sim_precision(int32_t *precision);
+    void sim_end() override;
+    void get_sim_time(uint32_t *high, uint32_t *low) override;
+    void get_sim_precision(int32_t *precision) override;
 
     /* Hierachy related */
-    GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
-    GpiObjHdl* native_check_create(int32_t index, GpiObjHdl *parent);
-    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *paret);
-    GpiObjHdl *get_root_handle(const char *name);
-    GpiIterator *iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type);
+    GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) override;
+    GpiObjHdl* native_check_create(int32_t index, GpiObjHdl *parent) override;
+    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *paret) override;
+    GpiObjHdl *get_root_handle(const char *name) override;
+    GpiIterator *iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type) override;
 
     /* Callback related, these may (will) return the same handle*/
-    GpiCbHdl *register_timed_callback(uint64_t time_ps);
-    GpiCbHdl *register_readonly_callback();
-    GpiCbHdl *register_nexttime_callback();
-    GpiCbHdl *register_readwrite_callback();
-    int deregister_callback(GpiCbHdl *obj_hdl);
+    GpiCbHdl *register_timed_callback(uint64_t time_ps) override;
+    GpiCbHdl *register_readonly_callback() override;
+    GpiCbHdl *register_nexttime_callback() override;
+    GpiCbHdl *register_readwrite_callback() override;
+    int deregister_callback(GpiCbHdl *obj_hdl) override;
 
     /* Method to provide strings from operation types */
-    const char *reason_to_string(int reason);
+    const char *reason_to_string(int reason) override;
 
     /* Method to provide strings from operation types */
     GpiObjHdl *create_gpi_obj_from_handle(void *hdl, std::string &name, std::string &fq_name, int accType, int accFullType);

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -65,7 +65,7 @@ class GpiHdl {
 public:
     GpiHdl(GpiImplInterface *impl) : m_impl(impl), m_obj_hdl(NULL) { }
     GpiHdl(GpiImplInterface *impl, void *hdl) : m_impl(impl), m_obj_hdl(hdl) { }
-    virtual ~GpiHdl() { }
+    virtual ~GpiHdl() = default;
 
 
     template<typename T> T get_handle() const {
@@ -118,7 +118,7 @@ public:
                                                                           m_fullname("unknown"),
                                                                           m_type(objtype),
                                                                           m_const(is_const) { }
-    virtual ~GpiObjHdl() { }
+    virtual ~GpiObjHdl() = default;
 
     virtual const char* get_name_str();
     virtual const char* get_fullname_str();
@@ -167,7 +167,7 @@ public:
     GpiSignalObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype, bool is_const) :
                                                          GpiObjHdl(impl, hdl, objtype, is_const),
                                                          m_length(0) { }
-    virtual ~GpiSignalObjHdl() { }
+    virtual ~GpiSignalObjHdl() = default;
     // Provide public access to the implementation (composition vs inheritance)
     virtual const char* get_signal_value_binstr() = 0;
     virtual const char* get_signal_value_str() = 0;
@@ -218,9 +218,7 @@ protected:
 class GpiValueCbHdl : public virtual GpiCbHdl {
 public:
     GpiValueCbHdl(GpiImplInterface *impl, GpiSignalObjHdl *signal, int edge);
-    virtual ~GpiValueCbHdl() { }
-    virtual int run_callback();
-    virtual int cleanup_callback() = 0;
+    int run_callback() override;
 
 protected:
     std::string required_value;
@@ -249,7 +247,7 @@ public:
 
     GpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiHdl(impl),
                                                           m_parent(hdl) { }
-    virtual ~GpiIterator() { }
+    virtual ~GpiIterator() = default;
 
     virtual Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl) {
         COCOTB_UNUSED(raw_hdl);
@@ -306,7 +304,7 @@ public:
     GpiImplInterface(const std::string& name) : m_name(name) { }
     const char *get_name_c();
     const std::string& get_name_s();
-    virtual ~GpiImplInterface() { }
+    virtual ~GpiImplInterface() = default;
 
     /* Sim related */
     virtual void sim_end() = 0;

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -88,10 +88,9 @@ static inline int __check_vhpi_error(const char *file, const char *func, long li
 class VhpiCbHdl : public virtual GpiCbHdl {
 public:
     VhpiCbHdl(GpiImplInterface *impl);
-    virtual ~VhpiCbHdl() { }
 
-    virtual int arm_callback();
-    virtual int cleanup_callback();
+    int arm_callback() override;
+    int cleanup_callback() override;
 
 protected:
     vhpiCbDataT cb_data;
@@ -103,8 +102,7 @@ class VhpiSignalObjHdl;
 class VhpiValueCbHdl : public VhpiCbHdl, public GpiValueCbHdl {
 public:
     VhpiValueCbHdl(GpiImplInterface *impl, VhpiSignalObjHdl *sig, int edge);
-    virtual ~VhpiValueCbHdl() { }
-    int cleanup_callback() {
+    int cleanup_callback() override {
         return VhpiCbHdl::cleanup_callback();
     }
 private:
@@ -114,48 +112,42 @@ private:
 class VhpiTimedCbHdl : public VhpiCbHdl {
 public:
     VhpiTimedCbHdl(GpiImplInterface *impl, uint64_t time_ps);
-    virtual ~VhpiTimedCbHdl() { }
-    int cleanup_callback();
+    int cleanup_callback() override;
 };
 
 class VhpiReadOnlyCbHdl : public VhpiCbHdl {
 public:
     VhpiReadOnlyCbHdl(GpiImplInterface *impl);
-    virtual ~VhpiReadOnlyCbHdl() { }
 };
 
 class VhpiNextPhaseCbHdl : public VhpiCbHdl {
 public:
     VhpiNextPhaseCbHdl(GpiImplInterface *impl);
-    virtual ~VhpiNextPhaseCbHdl() { }
 };
 
 class VhpiStartupCbHdl : public VhpiCbHdl {
 public:
     VhpiStartupCbHdl(GpiImplInterface *impl);
-    int run_callback();
-    int cleanup_callback() {
+    int run_callback() override;
+    int cleanup_callback() override {
         /* Too many simulators get upset with this so we override to do nothing */
         return 0;
     }
-    virtual ~VhpiStartupCbHdl() { }
 };
 
 class VhpiShutdownCbHdl : public VhpiCbHdl {
 public:
     VhpiShutdownCbHdl(GpiImplInterface *impl);
-    int run_callback();
-    int cleanup_callback() {
+    int run_callback() override;
+    int cleanup_callback() override {
         /* Too many simulators get upset with this so we override to do nothing */
         return 0;
     }
-    virtual ~VhpiShutdownCbHdl() { }
 };
 
 class VhpiReadwriteCbHdl : public VhpiCbHdl {
 public:
     VhpiReadwriteCbHdl(GpiImplInterface *impl);
-    virtual ~VhpiReadwriteCbHdl() { }
 };
 
 class VhpiArrayObjHdl : public GpiObjHdl {
@@ -163,9 +155,9 @@ public:
     VhpiArrayObjHdl(GpiImplInterface *impl,
                     vhpiHandleT hdl,
                     gpi_objtype_t objtype) : GpiObjHdl(impl, hdl, objtype) { }
-    virtual ~VhpiArrayObjHdl();
+    ~VhpiArrayObjHdl() override;
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 };
 
 class VhpiObjHdl : public GpiObjHdl {
@@ -173,9 +165,9 @@ public:
     VhpiObjHdl(GpiImplInterface *impl,
                vhpiHandleT hdl,
                gpi_objtype_t objtype) : GpiObjHdl(impl, hdl, objtype) { }
-    virtual ~VhpiObjHdl();
+    ~VhpiObjHdl() override;
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 };
 
 class VhpiSignalObjHdl : public GpiSignalObjHdl {
@@ -187,21 +179,21 @@ public:
                                       m_rising_cb(impl, this, GPI_RISING),
                                       m_falling_cb(impl, this, GPI_FALLING),
                                       m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }
-    virtual ~VhpiSignalObjHdl();
+    ~VhpiSignalObjHdl() override;
 
-    virtual const char* get_signal_value_binstr();
-    virtual const char* get_signal_value_str();
-    virtual double get_signal_value_real();
-    virtual long get_signal_value_long();
+    const char* get_signal_value_binstr() override;
+    const char* get_signal_value_str() override;
+    double get_signal_value_real() override;
+    long get_signal_value_long() override;
 
     using GpiSignalObjHdl::set_signal_value;
-    virtual int set_signal_value(long value);
-    virtual int set_signal_value(double value);
-    virtual int set_signal_value(std::string &value);
+    int set_signal_value(long value) override;
+    int set_signal_value(double value) override;
+    int set_signal_value(std::string &value) override;
 
     /* Value change callback accessor */
-    virtual GpiCbHdl *value_change_cb(unsigned int edge);
-    virtual int initialise(std::string &name, std::string &fq_name);
+    GpiCbHdl *value_change_cb(unsigned int edge) override;
+    int initialise(std::string &name, std::string &fq_name) override;
 
 protected:
     vhpiEnumT chr2vhpi(char value);
@@ -219,22 +211,21 @@ public:
                          gpi_objtype_t objtype,
                          bool is_const) : VhpiSignalObjHdl(impl, hdl, objtype, is_const) { }
 
-    virtual ~VhpiLogicSignalObjHdl() { }
 
     using GpiSignalObjHdl::set_signal_value;
-    int set_signal_value(long value);
-    int set_signal_value(std::string &value);
+    int set_signal_value(long value) override;
+    int set_signal_value(std::string &value) override;
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 };
 
 class VhpiIterator : public GpiIterator {
 public:
     VhpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl);
 
-    virtual ~VhpiIterator();
+    ~VhpiIterator() override;
 
-    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl);
+    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl) override;
 
 private:
     vhpiHandleT m_iterator;
@@ -252,25 +243,25 @@ public:
                                         m_read_only(this) { }
 
      /* Sim related */
-    void sim_end();
-    void get_sim_time(uint32_t *high, uint32_t *low);
-    void get_sim_precision(int32_t *precision);
+    void sim_end() override;
+    void get_sim_time(uint32_t *high, uint32_t *low) override;
+    void get_sim_precision(int32_t *precision) override;
 
     /* Hierachy related */
-    GpiObjHdl *get_root_handle(const char *name);
-    GpiIterator *iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type);
+    GpiObjHdl *get_root_handle(const char *name) override;
+    GpiIterator *iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type) override;
 
     /* Callback related, these may (will) return the same handle*/
-    GpiCbHdl *register_timed_callback(uint64_t time_ps);
-    GpiCbHdl *register_readonly_callback();
-    GpiCbHdl *register_nexttime_callback();
-    GpiCbHdl *register_readwrite_callback();
-    int deregister_callback(GpiCbHdl *obj_hdl);
-    GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
-    GpiObjHdl* native_check_create(int32_t index, GpiObjHdl *parent);
-    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *parent);
+    GpiCbHdl *register_timed_callback(uint64_t time_ps) override;
+    GpiCbHdl *register_readonly_callback() override;
+    GpiCbHdl *register_nexttime_callback() override;
+    GpiCbHdl *register_readwrite_callback() override;
+    int deregister_callback(GpiCbHdl *obj_hdl) override;
+    GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) override;
+    GpiObjHdl* native_check_create(int32_t index, GpiObjHdl *parent) override;
+    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *parent) override;
 
-    const char * reason_to_string(int reason);
+    const char * reason_to_string(int reason) override;
     const char * format_to_string(int format);
 
     GpiObjHdl *create_gpi_obj_from_handle(vhpiHandleT new_hdl,

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -84,10 +84,9 @@ class VpiReadOnlyCbHdl;
 class VpiCbHdl : public virtual GpiCbHdl {
 public:
     VpiCbHdl(GpiImplInterface *impl);
-    virtual ~VpiCbHdl() { }
 
-    virtual int arm_callback();
-    virtual int cleanup_callback();
+    int arm_callback() override;
+    int cleanup_callback() override;
 
 protected:
     s_cb_data cb_data;
@@ -99,8 +98,7 @@ class VpiSignalObjHdl;
 class VpiValueCbHdl : public VpiCbHdl, public GpiValueCbHdl {
 public:
     VpiValueCbHdl(GpiImplInterface *impl, VpiSignalObjHdl *sig, int edge);
-    virtual ~VpiValueCbHdl() { }
-    int cleanup_callback();
+    int cleanup_callback() override;
 private:
     s_vpi_value m_vpi_value;
 };
@@ -108,66 +106,58 @@ private:
 class VpiTimedCbHdl : public VpiCbHdl {
 public:
     VpiTimedCbHdl(GpiImplInterface *impl, uint64_t time_ps);
-    virtual ~VpiTimedCbHdl() { }
-    int cleanup_callback();
+    int cleanup_callback() override;
 };
 
 class VpiReadOnlyCbHdl : public VpiCbHdl {
 public:
     VpiReadOnlyCbHdl(GpiImplInterface *impl);
-    virtual ~VpiReadOnlyCbHdl() { }
 };
 
 class VpiNextPhaseCbHdl : public VpiCbHdl {
 public:
     VpiNextPhaseCbHdl(GpiImplInterface *impl);
-    virtual ~VpiNextPhaseCbHdl() { }
 };
 
 class VpiReadwriteCbHdl : public VpiCbHdl {
 public:
     VpiReadwriteCbHdl(GpiImplInterface *impl);
-    virtual ~VpiReadwriteCbHdl() { }
 };
 
 class VpiStartupCbHdl : public VpiCbHdl {
 public:
     VpiStartupCbHdl(GpiImplInterface *impl);
-    int run_callback();
-    int cleanup_callback() {
+    int run_callback() override;
+    int cleanup_callback() override {
         /* Too many sims get upset with this so we override to do nothing */
         return 0;
     }
-    virtual ~VpiStartupCbHdl() { }
 };
 
 class VpiShutdownCbHdl : public VpiCbHdl {
 public:
     VpiShutdownCbHdl(GpiImplInterface *impl);
-    int run_callback();
-    int cleanup_callback() {
+    int run_callback() override;
+    int cleanup_callback() override{
         /* Too many sims get upset with this so we override to do nothing */
         return 0;
     }
-    virtual ~VpiShutdownCbHdl() { }
 };
 
 class VpiArrayObjHdl : public GpiObjHdl {
 public:
     VpiArrayObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype) :
                                                              GpiObjHdl(impl, hdl, objtype) { }
-    virtual ~VpiArrayObjHdl() { }
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 };
 
 class VpiObjHdl : public GpiObjHdl {
 public:
     VpiObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype) :
                                                              GpiObjHdl(impl, hdl, objtype) { }
-    virtual ~VpiObjHdl() { }
 
-    int initialise(std::string &name, std::string &fq_name);
+    int initialise(std::string &name, std::string &fq_name) override;
 };
 
 class VpiSignalObjHdl : public GpiSignalObjHdl {
@@ -177,20 +167,19 @@ public:
                                                              m_rising_cb(impl, this, GPI_RISING),
                                                              m_falling_cb(impl, this, GPI_FALLING),
                                                              m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }
-    virtual ~VpiSignalObjHdl() { }
 
-    const char* get_signal_value_binstr();
-    const char* get_signal_value_str();
-    double get_signal_value_real();
-    long get_signal_value_long();
+    const char* get_signal_value_binstr() override;
+    const char* get_signal_value_str() override;
+    double get_signal_value_real() override;
+    long get_signal_value_long() override;
 
-    int set_signal_value(const long value);
-    int set_signal_value(const double value);
-    int set_signal_value(std::string &value);
+    int set_signal_value(const long value) override;
+    int set_signal_value(const double value) override;
+    int set_signal_value(std::string &value) override;
 
     /* Value change callback accessor */
-    GpiCbHdl *value_change_cb(unsigned int edge);
-    int initialise(std::string &name, std::string &fq_name);
+    GpiCbHdl *value_change_cb(unsigned int edge) override;
+    int initialise(std::string &name, std::string &fq_name) override;
 
 private:
     int set_signal_value(s_vpi_value value);
@@ -205,9 +194,9 @@ class VpiIterator : public GpiIterator {
 public:
     VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl);
 
-    virtual ~VpiIterator();
+    ~VpiIterator() override;
 
-    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl);
+    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl) override;
 
 private:
     vpiHandle m_iterator;
@@ -233,8 +222,7 @@ public:
         }
     }
 
-    virtual ~VpiSingleIterator() { }
-    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl);
+    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl) override;
 
 protected:
     vpiHandle m_iterator;
@@ -249,25 +237,25 @@ public:
                                        m_read_only(this) { }
 
      /* Sim related */
-    void sim_end();
-    void get_sim_time(uint32_t *high, uint32_t *low);
-    void get_sim_precision(int32_t *precision);
+    void sim_end(void) override;
+    void get_sim_time(uint32_t *high, uint32_t *low) override;
+    void get_sim_precision(int32_t *precision) override;
 
     /* Hierarchy related */
-    GpiObjHdl *get_root_handle(const char *name);
-    GpiIterator *iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type);
+    GpiObjHdl *get_root_handle(const char *name) override;
+    GpiIterator *iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type) override;
     GpiObjHdl *next_handle(GpiIterator *iter);
 
     /* Callback related, these may (will) return the same handle*/
-    GpiCbHdl *register_timed_callback(uint64_t time_ps);
-    GpiCbHdl *register_readonly_callback();
-    GpiCbHdl *register_nexttime_callback();
-    GpiCbHdl *register_readwrite_callback();
-    int deregister_callback(GpiCbHdl *obj_hdl);
-    GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
-    GpiObjHdl* native_check_create(int32_t index, GpiObjHdl *parent);
-    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *parent);
-    const char * reason_to_string(int reason);
+    GpiCbHdl *register_timed_callback(uint64_t time_ps) override;
+    GpiCbHdl *register_readonly_callback() override;
+    GpiCbHdl *register_nexttime_callback() override;
+    GpiCbHdl *register_readwrite_callback() override;
+    int deregister_callback(GpiCbHdl *obj_hdl) override;
+    GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) override;
+    GpiObjHdl* native_check_create(int32_t index, GpiObjHdl *parent) override;
+    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *parent) override;
+    const char * reason_to_string(int reason) override;
     GpiObjHdl* create_gpi_obj_from_handle(vpiHandle new_hdl,
                                           std::string &name,
                                           std::string &fq_name);


### PR DESCRIPTION
By doing this, it means that a typo in a virtual function signature results in a compilation error, rather than silently not overriding the intended function.

Also:
* removes a bunch of empty destructors which are the compiler-generated default.
* configures the compiler to require the use of the override keyword

Note that I was only able to test the `Vpi*` changes locally, the `Vhpi*` and `Fli*` changes have not been verified by a compiler.