### PR TITLE
Use command(1) rather than which(1) in Makefiles

### DIFF
--- a/cocotb/share/makefiles/Makefile.pylib.Msys
+++ b/cocotb/share/makefiles/Makefile.pylib.Msys
@@ -31,7 +31,7 @@
 
 # if not explicitly set, auto-detect python dir from system path
 ifeq ($(PYTHON_DIR),)
-	PYTHON_DIR ?= $(shell dirname $(shell which python))
+	PYTHON_DIR ?= $(shell dirname $(shell :; command -v python))
 endif
 
 # make sure python dir was set properly

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -36,10 +36,10 @@ else
 endif
 
 ifdef ALDEC_BIN_DIR
-    CMD := $(shell which $(ALDEC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(ALDEC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))
@@ -152,7 +152,7 @@ ifeq ($(OS),Msys)
 # we use the mingw lib used at build time and put this at the start of the path
 # before running
 
-MINGW_BIN_DIR = $(shell dirname $(shell which gcc))
+MINGW_BIN_DIR = $(shell dirname $(shell :; command -v gcc))
 
 EXTRA_LIBS := -laldecpli
 EXTRA_LIBDIRS := -L$(ALDEC_BIN_DIR)

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -37,10 +37,10 @@ else
 CMD_BIN := cvc64
 
 ifdef CVC_BIN_DIR
-    CMD := $(shell which $(CVC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CVC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -37,10 +37,10 @@ else
 CMD_BIN := ghdl
 
 ifdef GHDL_BIN_DIR
-    CMD := $(shell which $(GHDL_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(GHDL_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -39,10 +39,10 @@ else
 CMD_BIN := iverilog
 
 ifdef ICARUS_BIN_DIR
-    CMD := $(shell which $(ICARUS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(ICARUS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -32,10 +32,10 @@
 CMD_BIN := irun
 
 ifdef IUS_BIN_DIR
-    CMD := $(shell which $(IUS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(IUS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))

--- a/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -15,10 +15,10 @@ endif
 CMD_BIN := nvc
 
 ifdef NVC_BIN_DIR
-    CMD := $(shell which $(NVC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(NVC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -30,10 +30,10 @@
 CMD_BIN := vsim
 
 ifdef MODELSIM_BIN_DIR
-    CMD := $(shell which $(MODELSIM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(MODELSIM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))
@@ -122,7 +122,7 @@ ifeq ($(OS),Msys)
 # we use the mingw lib used at build time and put this at the start of the path
 # before running
 
-MINGW_BIN_DIR = $(shell dirname $(shell which gcc))
+MINGW_BIN_DIR = $(shell dirname $(shell :; command -v gcc))
 
 EXTRA_LIBS := -lmtipli
 EXTRA_LIBDIRS := -L$(MODELSIM_BIN_DIR)

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -38,10 +38,10 @@ else
 CMD_BIN := vcs
 
 ifdef VCS_BIN_DIR
-    CMD := $(shell which $(VCS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(VCS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -32,10 +32,10 @@
 CMD_BIN := xrun
 
 ifdef XCELIUM_BIN_DIR
-    CMD := $(shell which $(XCELIUM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(XCELIUM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
-    CMD := $(shell which $(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))


### PR DESCRIPTION
which(1) is not part of the POSIX standard, and is not present on
several systems and build environments out of the box (e.g. the
Nix sandbox). It's not actually part of GNU coreutils as many assume;
GNU has its own version (http://www.gnu.org/software/which/) but I
believe Debian might ship its own implementation.

`type -p` is a commonly-suggested alternative, but its output is
unfortunately not stable across systems. `command -v` is fully
portable across all POSIX systems.

We need to use $(shell :; command ...) because make tries to exec
programs directly rather than use the shell where possible, but the
logic for it is broken on old versions (omitting command(1) among other
shell builtins). This breaks things when command(1) is available only
as a shell builtin and not as an external command.

References:
* https://twitter.com/whitequark/status/1168670168173559808
* https://twitter.com/dev_console/status/1168672291271692288
* https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html
* https://git.savannah.gnu.org/cgit/make.git/tree/job.c?h=4.2&id=ec6198012261e11b72bd5a95bd9e5c4d895c5f22#n2433