### PR TITLE
documentation: explain how to get waveforms

### DIFF
--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -34,8 +34,8 @@ Make Variables
       Selects which simulator Makefile to use.  Attempts to include a simulator specific makefile from :file:`cocotb/share/makefiles/makefile.$(SIM)`
 
     ``WAVES``
-      Set this to 1 to enable wave traces dump for Aldec and Questa simulator.
-      To get wave traces in Icarus verilog see Simulator Support chapter.
+      Set this to 1 to enable wave traces dump for the Aldec and Questa simulators.
+      To get wave traces in Icarus Verilog see :ref:`Simulator Support` chapter.
 
     ``VERILOG_SOURCES``
       A list of the Verilog source files to include.

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -33,6 +33,10 @@ Make Variables
     ``SIM``
       Selects which simulator Makefile to use.  Attempts to include a simulator specific makefile from :file:`cocotb/share/makefiles/makefile.$(SIM)`
 
+    ``WAVES``
+      Set this to 1 to enable wave traces dump for Aldec and Questa simulator.
+      To get wave traces in Icarus verilog see Simulator Support chapter.
+
     ``VERILOG_SOURCES``
       A list of the Verilog source files to include.
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.autosectionlabel',
     'cairosvgconverter',
     'breathe',
     'sphinx_issues',

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -7,6 +7,8 @@ This page documents any known quirks and gotchas in the various simulators.
 Icarus
 ------
 
+vector bug
+~~~~~~~~~~
 Accessing bits of a vector doesn't work:
 
 .. code-block:: python3
@@ -15,6 +17,34 @@ Accessing bits of a vector doesn't work:
 
 See ``access_single_bit`` test in :file:`examples/functionality/tests/test_discovery.py`.
 
+Wavefoms
+~~~~~~~~
+
+To get waveform in vcd format some verilog code must be added in the top
+component as example below:
+
+.. code-block:: verilog
+
+    module button_deb(
+        // sync design
+        input    clk,
+        input    rst,
+        // in-out
+        input    button_in,
+    output button_valid);
+    
+    //... verilog module code here
+    
+    // the "macro" to dump signals
+    `ifdef COCOTB_SIM
+    initial begin
+      $dumpfile ("button_deb.vcd");
+      $dumpvars (0, button_deb);
+      #1;
+    end
+    `endif
+    
+    endmodule
 
 Synopsys VCS
 ------------

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -7,8 +7,8 @@ This page documents any known quirks and gotchas in the various simulators.
 Icarus
 ------
 
-vector bug
-~~~~~~~~~~
+Accessing bits in a vector
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 Accessing bits of a vector doesn't work:
 
 .. code-block:: python3
@@ -20,21 +20,18 @@ See ``access_single_bit`` test in :file:`examples/functionality/tests/test_disco
 Wavefoms
 ~~~~~~~~
 
-To get waveform in vcd format some verilog code must be added in the top
-component as example below:
+To get waveform in VCD format some Verilog code must be added in the top component as example below:
 
 .. code-block:: verilog
 
     module button_deb(
-        // sync design
-        input    clk,
-        input    rst,
-        // in-out
-        input    button_in,
-    output button_valid);
-    
+        input  clk,
+        input  rst,
+        input  button_in,
+        output button_valid);
+
     //... verilog module code here
-    
+
     // the "macro" to dump signals
     `ifdef COCOTB_SIM
     initial begin
@@ -43,7 +40,6 @@ component as example below:
       #1;
     end
     `endif
-    
     endmodule
 
 Synopsys VCS


### PR DESCRIPTION
According to [this discussion](https://github.com/cocotb/cocotb/issues/1154), a waveforms documentation proposal.