### PR TITLE
Don't use delayed expansion for setting GCC_ARGS on linux

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -92,7 +92,7 @@ else ifeq ($(OS),Linux)
 GXX_ARGS	+= -Werror -Wcast-qual -Wcast-align -Wwrite-strings \
 			-Wall -Wno-unused-parameter \
 			-fno-common -g -DDEBUG -fpic
-GCC_ARGS	= $(GXX_ARGS) -Wstrict-prototypes -Waggregate-return
+GCC_ARGS	:= $(GXX_ARGS) -Wstrict-prototypes -Waggregate-return
 else
 $(error "Unsupported os " $(OS))
 endif


### PR DESCRIPTION
This makes the behavior consistent with all of the other assignments to GCC_ARGS above

Extracted from gh-1149