### PR TITLE
Cleanup Python refcounts and call Py_Finalize

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -775,9 +775,13 @@ class Scheduler(object):
         """Directly call into the regression manager and end test
            once we return the sim will close us so no cleanup is needed.
         """
-        self.log.debug("Issue sim closedown result to regression object")
-        self._test.abort(exc)
-        cocotb.regression_manager.handle_result(self._test)
+        # If there is an error during cocotb initialization, self._test may not
+        # have been set yet. Don't cause another Python exception here.
+
+        if self._test:
+            self.log.debug("Issue sim closedown result to regression object")
+            self._test.abort(exc)
+            cocotb.regression_manager.handle_result(self._test)
 
     def cleanup(self):
         """Clear up all our state.

--- a/cocotb/share/include/embed.h
+++ b/cocotb/share/include/embed.h
@@ -40,6 +40,7 @@ extern "C" {
 #endif
 
 extern void embed_init_python(void);
+extern void embed_sim_cleanup(void);
 extern int embed_sim_init(gpi_sim_info_t *info);
 extern void embed_sim_event(gpi_event_t level, const char *msg);
 

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -108,6 +108,8 @@ typedef void * gpi_iterator_hdl;
 // Stop the simulator
 void gpi_sim_end(void);
 
+// Cleanup GPI resources during sim shutdown
+void gpi_cleanup(void);
 
 // Returns simulation time as two uints. Units are default sim units
 void gpi_get_sim_time(uint32_t *high, uint32_t *low);

--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -67,8 +67,10 @@ enum gpi_log_levels {
 // #endif
 
 void set_log_handler(void *handler);
+void clear_log_handler(void);
 void set_make_record(void *makerecord);
 void set_log_filter(void *filter);
+void clear_log_filter(void);
 void set_log_level(enum gpi_log_levels new_level);
 
 void gpi_log(const char *name, long level, const char *pathname, const char *funcname, long lineno, const char *msg, ...);

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -65,6 +65,17 @@ public:
         return handle_map.size();
     }
 
+    void clear() {
+        std::map<std::string, GpiObjHdl*>::iterator it;
+
+        // Delete the object handles before clearing the map
+        for (it = handle_map.begin(); it != handle_map.end(); it++)
+        {
+            delete (it->second);
+        }
+        handle_map.clear();
+    }
+
 private:
     std::map<std::string, GpiObjHdl*> handle_map;
 
@@ -73,10 +84,12 @@ private:
 static GpiHandleStore unique_handles;
 
 #define CHECK_AND_STORE(_x) unique_handles.check_and_store(_x)
+#define CLEAR_STORE() unique_handles.clear()
 
 #else
 
 #define CHECK_AND_STORE(_x) _x
+#define CLEAR_STORE() (void)0   // No-op
 
 #endif
 
@@ -116,14 +129,20 @@ void gpi_embed_init(gpi_sim_info_t *info)
 }
 
 void gpi_embed_end()
-
 {
     embed_sim_event(SIM_FAIL, "Simulator shutdown prematurely");
+    gpi_cleanup();
 }
 
 void gpi_sim_end()
 {
     registered_impls[0]->sim_end();
+}
+
+void gpi_cleanup(void)
+{
+    CLEAR_STORE();
+    embed_sim_cleanup();
 }
 
 void gpi_embed_event(gpi_event_t level, const char *msg)

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -337,6 +337,7 @@ private:
 int gpi_register_impl(GpiImplInterface *func_tbl);
 
 void gpi_embed_init(gpi_sim_info_t *info);
+void gpi_cleanup();
 void gpi_embed_end();
 void gpi_embed_event(gpi_event_t level, const char *msg);
 void gpi_load_extra_libs();

--- a/cocotb/share/lib/gpi_log/gpi_logging.c
+++ b/cocotb/share/lib/gpi_log/gpi_logging.c
@@ -41,9 +41,21 @@ void set_log_handler(void *handler)
     pLogHandler = (PyObject *)handler;      // Note: This function steals a reference to handler.
 }
 
+void clear_log_handler(void)
+{
+    Py_XDECREF(pLogHandler);
+    pLogHandler = NULL;
+}
+
 void set_log_filter(void *filter)
 {
     pLogFilter = (PyObject *)filter;        // Note: This function steals a reference to filter.
+}
+
+void clear_log_filter(void)
+{
+    Py_XDECREF(pLogFilter);
+    pLogFilter = NULL;
 }
 
 void set_log_level(enum gpi_log_levels new_level)

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -37,6 +37,8 @@
 static int takes = 0;
 static int releases = 0;
 
+static int sim_ending = 0;
+
 #include "simulatormodule.h"
 #include <cocotb_utils.h>
 
@@ -162,6 +164,7 @@ int handle_gpi_callback(void *user_data)
         }
 
         gpi_sim_end();
+        sim_ending = 1;
         ret = 0;
         goto out;
     }
@@ -183,6 +186,13 @@ out:
 
 err:
     to_simulator();
+
+    if (sim_ending) {
+        // This is the last callback of a successful run,
+        // so call the cleanup function as we'll never return
+        // to Python
+        gpi_cleanup();
+    }
     return ret;
 }
 
@@ -886,6 +896,7 @@ static PyObject *get_range(PyObject *self, PyObject *args)
 static PyObject *stop_simulator(PyObject *self, PyObject *args)
 {
     gpi_sim_end();
+    sim_ending = 1;
     return Py_BuildValue("s", "OK!");
 }
 

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -30,6 +30,20 @@
 
 extern "C" void handle_vhpi_callback(const vhpiCbDataT *cb_data);
 
+VhpiArrayObjHdl::~VhpiArrayObjHdl()
+{
+    LOG_DEBUG("Releasing VhpiArrayObjHdl handle at %p\n", (void *)get_handle<vhpiHandleT>());
+    if (vhpi_release_handle(get_handle<vhpiHandleT>()))
+        check_vhpi_error();
+}
+
+VhpiObjHdl::~VhpiObjHdl()
+{
+    LOG_DEBUG("Releasing VhpiObjHdl handle at %p\n", (void *)get_handle<vhpiHandleT>());
+    if (vhpi_release_handle(get_handle<vhpiHandleT>()))
+        check_vhpi_error();
+}
+
 VhpiSignalObjHdl::~VhpiSignalObjHdl()
 {
     switch (m_value.format) {
@@ -43,6 +57,10 @@ VhpiSignalObjHdl::~VhpiSignalObjHdl()
 
     if (m_binvalue.value.str)
         free(m_binvalue.value.str);
+
+    LOG_DEBUG("Releasing VhpiSignalObjHdl handle at %p\n", (void *)get_handle<vhpiHandleT>());
+    if (vhpi_release_handle(get_handle<vhpiHandleT>()))
+        check_vhpi_error();
 }
 
 bool get_range(vhpiHandleT hdl, vhpiIntT dim, int *left, int *right) {

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -163,7 +163,7 @@ public:
     VhpiArrayObjHdl(GpiImplInterface *impl,
                     vhpiHandleT hdl,
                     gpi_objtype_t objtype) : GpiObjHdl(impl, hdl, objtype) { }
-    virtual ~VhpiArrayObjHdl() { }
+    virtual ~VhpiArrayObjHdl();
 
     int initialise(std::string &name, std::string &fq_name);
 };
@@ -173,7 +173,7 @@ public:
     VhpiObjHdl(GpiImplInterface *impl,
                vhpiHandleT hdl,
                gpi_objtype_t objtype) : GpiObjHdl(impl, hdl, objtype) { }
-    virtual ~VhpiObjHdl() { }
+    virtual ~VhpiObjHdl();
 
     int initialise(std::string &name, std::string &fq_name);
 };


### PR DESCRIPTION
While working on getting cocotb to work with simulator restart, this cleanup was part of getting Py_Finalize() to not segfault.

Clean up embed_sim_init() to properly account for Python object references:
Add comment when new reference is created and properly decrement references when no longer needed.
Add comment when a function steals a reference.
Use exported Py_IncRef/Py_DecRef functions. These are exports of XINCREF/XDECREF and handle NULL pointers.

Cleanup GPI and Python on shutdown:
Clean up GpiHandleStore.
Clean up Python object reference counts and reset pointers to NULL.
Call Py_Finalize on shutdown from both successful and failed runs.
Release VHPI handles when handle objects are destroyed.

Fixes #1055.

I'm not sure if this is going to work with other simulators (tested with Aldec).