### PR TITLE
Windows: Print error messages in DLL functions.

### DIFF
--- a/cocotb/share/lib/utils/cocotb_utils.c
+++ b/cocotb/share/lib/utils/cocotb_utils.c
@@ -66,7 +66,17 @@ void* utils_dyn_open(const char* lib_name)
     SetErrorMode(0);
     ret = LoadLibrary(lib_name);
     if (!ret) {
-        printf("Unable to open lib %s\n", lib_name);
+        printf("Unable to open lib %s", lib_name);
+        LPSTR msg_ptr;
+        if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
+                           FORMAT_MESSAGE_ALLOCATE_BUFFER, NULL,
+                           GetLastError(),
+                           MAKELANGID(LANG_NEUTRAL, SUBLANG_SYS_DEFAULT),
+                           (LPSTR)&msg_ptr, 255, NULL)) {
+            printf(": %s", msg_ptr);
+            LocalFree(msg_ptr);
+        } else
+            printf("\n");
     }
 #else
     /* Clear status */
@@ -86,7 +96,17 @@ void* utils_dyn_sym(void *handle, const char* sym_name)
 #if ! defined(__linux__) && ! defined(__APPLE__)
     entry_point = GetProcAddress(handle, sym_name);
     if (!entry_point) {
-        printf("Unable to find symbol %s\n", sym_name);
+        printf("Unable to find symbol %s", sym_name);
+        LPSTR msg_ptr;
+        if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
+                           FORMAT_MESSAGE_ALLOCATE_BUFFER, NULL,
+                           GetLastError(),
+                           MAKELANGID(LANG_NEUTRAL, SUBLANG_SYS_DEFAULT),
+                           (LPSTR)&msg_ptr, 255, NULL)) {
+            printf(": %s", msg_ptr);
+            LocalFree(msg_ptr);
+        } else
+            printf("\n");
     }
 #else
     entry_point = dlsym(handle, sym_name);


### PR DESCRIPTION
When `utils_dyn_open()` or `utils_dyn_sym()` fail, get the system error message and print it.