### PR TITLE
Rename libvhpi to libcocotbvhpi.

### DIFF
--- a/cocotb/share/lib/Makefile
+++ b/cocotb/share/lib/Makefile
@@ -48,7 +48,7 @@ $(LIB_DIR)/libcocotb.$(LIB_EXT): $(COCOTB_SHARE_DIR)/lib/embed/gpi_embed.c | $(L
 $(LIB_DIR)/libvpi.$(LIB_EXT): $(COCOTB_SHARE_DIR)/lib/vpi/VpiImpl.cpp $(COCOTB_SHARE_DIR)/lib/vpi/VpiCbHdl.cpp | $(LIB_DIR)
 	make -C $(COCOTB_SHARE_DIR)/lib/vpi EXTRA_LIBS=$(EXTRA_LIBS) EXTRA_LIBDIRS=$(EXTRA_LIBDIRS) SIM=$(SIM)
 
-$(LIB_DIR)/libvhpi.$(LIB_EXT): $(COCOTB_SHARE_DIR)/lib/vhpi/VhpiImpl.cpp $(COCOTB_SHARE_DIR)/lib/vhpi/VhpiCbHdl.cpp | $(LIB_DIR)
+$(LIB_DIR)/libcocotbvhpi.$(LIB_EXT): $(COCOTB_SHARE_DIR)/lib/vhpi/VhpiImpl.cpp $(COCOTB_SHARE_DIR)/lib/vhpi/VhpiCbHdl.cpp | $(LIB_DIR)
 	make -C $(COCOTB_SHARE_DIR)/lib/vhpi EXTRA_LIBS=$(EXTRA_LIBS) EXTRA_LIBDIRS=$(EXTRA_LIBDIRS) SIM=$(SIM)
 
 $(LIB_DIR)/libgpi.$(LIB_EXT): $(COCOTB_SHARE_DIR)/lib/gpi/GpiCommon.cpp $(COCOTB_SHARE_DIR)/lib/gpi/GpiCbHdl.cpp | $(LIB_DIR)
@@ -71,7 +71,7 @@ COCOTB_LIBS := $(LIB_DIR)/libcocotbutils.$(LIB_EXT) \
 
 COCOTB_VPI_LIB := $(LIB_DIR)/libvpi.$(LIB_EXT)
 
-COCOTB_VHPI_LIB := $(LIB_DIR)/libvhpi.$(LIB_EXT)
+COCOTB_VHPI_LIB := $(LIB_DIR)/libcocotbvhpi.$(LIB_EXT)
 
 COCOTB_FLI_LIB := $(LIB_DIR)/libfli.$(LIB_EXT)
 

--- a/cocotb/share/lib/vhpi/Makefile
+++ b/cocotb/share/lib/vhpi/Makefile
@@ -33,7 +33,7 @@ INCLUDES    +=
 GXX_ARGS    += -DVHPI_CHECKING
 LIBS        := $(EXTRA_LIBS) -lgpilog -lgpi -lstdc++
 LD_PATH     := $(EXTRA_LIBDIRS) -L$(LIB_DIR)
-LIB_NAME    := libvhpi
+LIB_NAME    := libcocotbvhpi
 
 SRCS        := VhpiImpl.cpp VhpiCbHdl.cpp
 

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -963,4 +963,4 @@ void vhpi_startup_routines_bootstrap() {
 
 }
 
-GPI_ENTRY_POINT(vhpi, register_embed)
+GPI_ENTRY_POINT(cocotbvhpi, register_embed)

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -90,9 +90,9 @@ endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
 
 ifeq ($(OS),Msys)
-    VHPI_LIB = $(shell sh -c 'cd $(LIB_DIR) && pwd -W')/libvhpi
+    VHPI_LIB = $(shell sh -c 'cd $(LIB_DIR) && pwd -W')/libcocotbvhpi
 else
-    VHPI_LIB = $(LIB_DIR)/libvhpi
+    VHPI_LIB = $(LIB_DIR)/libcocotbvhpi
 endif
 
     GPI_ARGS = -loadvhpi $(VHPI_LIB):vhpi_startup_routines_bootstrap

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -71,7 +71,7 @@ else
 endif
 
 # Xcelium loads VPI regardless of what is asked for, then VHPI if asked to,
-# which does not play nice with our multi language, so we supply GPI_EXTRA=vhpi if needed.
+# which does not play nice with our multi language, so we supply GPI_EXTRA=cocotbvhpi if needed.
 
 #GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
@@ -81,10 +81,11 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     EXTRA_ARGS += -top $(TOPLEVEL)
     ifneq ($(VHDL_SOURCES),)
         HDL_SOURCES += $(VHDL_SOURCES)
-        GPI_EXTRA = vhpi 
+        GPI_EXTRA = cocotbvhpi
     endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_EXTRA = vhpi
+    # GPI_EXTRA will internally be extended to lib<GPI_EXTRA>.so
+    GPI_EXTRA = cocotbvhpi
     EXTRA_ARGS += -top $(TOPLEVEL)
     RTL_LIBRARY ?= $(TOPLEVEL)
     MAKE_LIB = -makelib $(RTL_LIBRARY)


### PR DESCRIPTION
This is necessary to prevent a naming collision with a ``libvhpi.so`` that is shipped with Synopsys VCS-MX.
Related to #1103.