### PR TITLE
Push external/function code out of decorators.py and into the scheduler

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -30,7 +30,6 @@ import sys
 import time
 import logging
 import functools
-import threading
 import inspect
 import textwrap
 import os
@@ -327,35 +326,19 @@ class function(object):
     externally appear to yield.
     """
     def __init__(self, func):
-        self._func = func
+        self._coro = cocotb.coroutine(func)
 
     @lazy_property
     def log(self):
-        return SimLog("cocotb.function.%s" % self._func.__name__, id(self))
+        return SimLog("cocotb.function.%s" % self._coro.__name__, id(self))
 
     def __call__(self, *args, **kwargs):
-
-        @coroutine
-        def execute_function(self, event):
-            coro = cocotb.coroutine(self._func)(*args, **kwargs)
-            try:
-                _outcome = outcomes.Value((yield coro))
-            except BaseException as e:
-                _outcome = outcomes.Error(e)
-            event.outcome = _outcome
-            event.set()
-
-        event = threading.Event()
-        waiter = cocotb.scheduler.queue_function(execute_function(self, event))
-        # This blocks the calling external thread until the coroutine finishes
-        event.wait()
-        waiter.thread_resume()
-        return event.outcome.get()
+        return cocotb.scheduler.queue_function(self._coro(*args, **kwargs))
 
     def __get__(self, obj, type=None):
         """Permit the decorator to be used on class methods
             and standalone functions"""
-        return self.__class__(self._func.__get__(obj, type))
+        return self.__class__(self._coro._func.__get__(obj, type))
 
 @public
 class external(object):
@@ -368,16 +351,7 @@ class external(object):
         self._log = SimLog("cocotb.external.%s" % self._func.__name__, id(self))
 
     def __call__(self, *args, **kwargs):
-
-        @coroutine
-        def wrapper():
-            ext = cocotb.scheduler.run_in_executor(self._func, *args, **kwargs)
-            yield ext.event.wait()
-
-            ret = ext.result  # raises if there was an exception
-            raise ReturnValue(ret)
-
-        return wrapper()
+        return cocotb.scheduler.run_in_executor(self._func, *args, **kwargs)
 
     def __get__(self, obj, type=None):
         """Permit the decorator to be used on class methods

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -62,7 +62,7 @@ import cocotb.decorators
 from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly,
                              NextTimeStep, ReadWrite, Event, Join, NullTrigger)
 from cocotb.log import SimLog
-from cocotb.result import TestComplete
+from cocotb.result import TestComplete, ReturnValue
 from cocotb import _py_compat
 
 # On python 3.7 onwards, `dict` is guaranteed to preserve insertion order.
@@ -561,7 +561,7 @@ class Scheduler(object):
         """Queue a coroutine for execution"""
         self._pending_coros.append(coroutine)
 
-    def queue_function(self, coroutine):
+    def queue_function(self, coro):
         """Queue a coroutine for execution and move the containing thread
         so that it does not block execution of the main thread any longer.
         """
@@ -578,9 +578,22 @@ class Scheduler(object):
         # each entry always has a unique thread.
         t, = matching_threads
 
+        @cocotb.coroutine
+        def wrapper():
+            try:
+                _outcome = outcomes.Value((yield coro))
+            except BaseException as e:
+                _outcome = outcomes.Error(e)
+            event.outcome = _outcome
+            event.set()
+
+        event = threading.Event()
         t.thread_suspend()
-        self._pending_coros.append(coroutine)
-        return t
+        self._pending_coros.append(wrapper())
+        # This blocks the calling external thread until the coroutine finishes
+        event.wait()
+        t.thread_resume()
+        return event.outcome.get()
 
     def run_in_executor(self, func, *args, **kwargs):
         """Run the coroutine in a separate execution thread
@@ -598,15 +611,22 @@ class Scheduler(object):
                 self.log.debug("Execution of external routine done %s" % threading.current_thread())
             _waiter.thread_done()
 
-        waiter = external_waiter()
-        thread = threading.Thread(group=None, target=execute_external,
-                                  name=func.__name__ + "_thread",
-                                  args=([func, waiter]), kwargs={})
+        @cocotb.coroutine
+        def wrapper():
+            waiter = external_waiter()
+            thread = threading.Thread(group=None, target=execute_external,
+                                      name=func.__name__ + "_thread",
+                                      args=([func, waiter]), kwargs={})
 
-        waiter.thread = thread
-        self._pending_threads.append(waiter)
+            waiter.thread = thread
+            self._pending_threads.append(waiter)
 
-        return waiter
+            yield waiter.event.wait()
+
+            ret = waiter.result  # raises if there was an exception
+            raise ReturnValue(ret)
+
+        return wrapper()
 
     def add(self, coroutine):
         """Add a new coroutine.


### PR DESCRIPTION
Inspired by #1171 - this pushes all the code from `function.__call__` and `external.__call__` into `scheduler.run_in_executor` and `scheduler.queue_function`.

Neither `scheduler.run_in_executor` nor `scheduler.queue_function` were remotely safe to use directly anyway, and were heavily entangled with the design of the decorators.

After this change, the decorators become nothing but syntactic sugar.