### PR TITLE
Allow dropping into interactive pdb shell when hitting exception.  Ad…

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -33,6 +33,12 @@ from itertools import product
 import sys
 import os
 import traceback
+import pdb
+
+if "COCOTB_PDB_ON_EXCEPTION" in os.environ:
+    _pdb_on_exception = True
+else:
+    _pdb_on_exception = False
 
 if "COCOTB_SIM" in os.environ:
     import simulator
@@ -325,6 +331,12 @@ class RegressionManager(object):
 
         else:
             self.log.error("Test Failed: " + _result_was(), exc_info=exc_info)
+            if _pdb_on_exception:
+                if sys.version_info >= (3, 5):
+                    traceback = exc_info.__traceback__
+                else:
+                    traceback = exc_info[2]
+                pdb.post_mortem(traceback)
             self._add_failure(result)
             result_pass = False
 

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -149,6 +149,10 @@ Environment Variables
     If defined, log lines displayed in the terminal will be shorter. It will print only
     time, message type (``INFO``, ``WARNING``, ``ERROR``, ...) and the log message itself.
 
+.. envvar:: COCOTB_PDB_ON_EXCEPTION
+
+   If defined, cocotb will drop into the Python debugger (:mod:`pdb`) if a test fails with an exception.
+
 .. envvar:: MODULE
 
     The name of the module(s) to search for test functions.  Multiple modules can be specified using a comma-separated list.


### PR DESCRIPTION
…d COCOTB_PDB_ON_EXCEPTION environment variable.

I've been using this with cocotb-test, and has worked well for me.
I haven't checked that it works with the Makefile flow.

This makes it much easier to debug coroutines since when the the test fails you're dropped directly into the interactive pdb shell where you can better investigate why exactly the test failed.