### PR TITLE
Aliasing of bus signals

### DIFF
--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -37,7 +37,6 @@ from cocotb.triggers import (Event, RisingEdge, ReadOnly, NextTimeStep,
                              Edge)
 from cocotb.bus import Bus
 from cocotb.log import SimLog
-from cocotb.utils import reject_remaining_kwargs
 
 
 class BitDriver(object):
@@ -221,26 +220,23 @@ class BusDriver(Driver):
                 bus-signals in an interface or a ``modport``.
                 (untested on ``struct``/``record``, but could work here as well).
             clock (SimHandle): A handle to the clock associated with this bus.
-            array_idx (int or None, optional): Optional index when signal is an array.
-            bus_separator (str, optional): Character(s) to use as separator between bus
-                name and signal name. Defaults to '_'.
+        Kwargs:
+            The kwargs are passed on to __init__ of the created .bus field.
+            See ``cocotb.Bus.__init__()`` for more information.
 
     """
     
     _optional_signals = []
 
     def __init__(self, entity, name, clock, **kwargs):
-        # emulate keyword-only arguments in python 2
-        index = kwargs.pop("array_idx", None)
-        bus_separator = kwargs.pop("bus_separator", "_")
-        reject_remaining_kwargs('__init__', kwargs)
+        index = kwargs.get("array_idx")
+        kwargs["optional_signals"] = self._optional_signals + kwargs.get("optional_signals", [])
 
         self.log = SimLog("cocotb.%s.%s" % (entity._name, name))
         Driver.__init__(self)
         self.entity = entity
         self.clock = clock
-        self.bus = Bus(self.entity, name, self._signals,
-                       self._optional_signals, bus_separator=bus_separator, array_idx=index)
+        self.bus = Bus(self.entity, name, self._signals, **kwargs)
 
         # Give this instance a unique name
         self.name = name if index is None else "%s_%d" % (name, index)

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -51,8 +51,8 @@ class AXI4LiteMaster(BusDriver):
                 "ARVALID", "ARADDR", "ARREADY",        # Read address channel
                 "RVALID", "RREADY", "RRESP", "RDATA"]  # Read data channel
 
-    def __init__(self, entity, name, clock):
-        BusDriver.__init__(self, entity, name, clock)
+    def __init__(self, entity, name, clock, **kwargs):
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
 
         # Drive some sensible defaults (setimmediatevalue to avoid x asserts)
         self.bus.AWVALID.setimmediatevalue(0)
@@ -237,9 +237,9 @@ class AXI4Slave(BusDriver):
     ]
 
     def __init__(self, entity, name, clock, memory, callback=None, event=None,
-                 big_endian=False):
+                 big_endian=False, **kwargs):
 
-        BusDriver.__init__(self, entity, name, clock)
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
         self.clock = clock
 
         self.big_endian = big_endian

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -245,8 +245,8 @@ class AvalonMemory(BusDriver):
             }
 
     def __init__(self, entity, name, clock, readlatency_min=1,
-                 readlatency_max=1, memory=None, avl_properties={}):
-        BusDriver.__init__(self, entity, name, clock)
+                 readlatency_max=1, memory=None, avl_properties={}, **kwargs):
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
 
         if avl_properties != {}:
             for key, value in self._avalon_properties.items():

--- a/cocotb/drivers/opb.py
+++ b/cocotb/drivers/opb.py
@@ -47,8 +47,8 @@ class OPBMaster(BusDriver):
     _optional_signals = ["seqAddr"]
     _max_cycles = 16
 
-    def __init__(self, entity, name, clock):
-        BusDriver.__init__(self, entity, name, clock)
+    def __init__(self, entity, name, clock, **kwargs):
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
         self.bus.select.setimmediatevalue(0)
         self.log.debug("OPBMaster created")
         self.busy_event = Event("%s_busy" % name)

--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -174,14 +174,16 @@ class BusMonitor(Monitor):
     _optional_signals = []
 
     def __init__(self, entity, name, clock, reset=None, reset_n=None,
-                 callback=None, event=None, bus_separator="_", array_idx=None):
+                 callback=None, event=None, bus_separator="_", array_idx=None,
+                 **kwargs):
         self.log = SimLog("cocotb.%s.%s" % (entity._name, name))
         self.entity = entity
         self.name = name
         self.clock = clock
         self.bus = Bus(self.entity, self.name, self._signals,
                        optional_signals=self._optional_signals,
-                       bus_separator=bus_separator, array_idx=array_idx)
+                       bus_separator=bus_separator, array_idx=array_idx,
+                       **kwargs)
         self._reset = reset
         self._reset_n = reset_n
         Monitor.__init__(self, callback=callback, event=event)


### PR DESCRIPTION
I use this feature in my wishbone code to map standard conformant dat_i/dat_o to datwr/datrd of cocotb Wishbone bus. I have also seen other namings like dat_miso/dat_mosi and that should all be able to be handled by this patch.
