### PR TITLE
Bus cleanup patch

### DIFF
--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -37,7 +37,6 @@ from cocotb.triggers import (Event, RisingEdge, ReadOnly, NextTimeStep,
                              Edge)
 from cocotb.bus import Bus
 from cocotb.log import SimLog
-from cocotb.utils import reject_remaining_kwargs
 
 
 class BitDriver(object):
@@ -215,32 +214,30 @@ class BusDriver(Driver):
         * a name
         * an entity
 
-        Args:
-            entity (SimHandle): A handle to the simulator entity.
-            name (str or None): Name of this bus. ``None`` for a nameless bus, e.g.
-                bus-signals in an interface or a ``modport``.
-                (untested on ``struct``/``record``, but could work here as well).
-            clock (SimHandle): A handle to the clock associated with this bus.
-            array_idx (int or None, optional): Optional index when signal is an array.
-            bus_separator (str, optional): Character(s) to use as separator between bus
-                name and signal name. Defaults to '_'.
+    Args:
+        entity (SimHandle): A handle to the simulator entity.
+        name (str or None): Name of this bus. ``None`` for a nameless bus, e.g.
+            bus-signals in an interface or a ``modport``.
+            (untested on ``struct``/``record``, but could work here as well).
+        clock (SimHandle): A handle to the clock associated with this bus.
+        **kwargs (dict): Keyword arguments forwarded to :class:`cocotb.Bus`,
+            see docs for that class for more information.
 
     """
     
     _optional_signals = []
 
     def __init__(self, entity, name, clock, **kwargs):
-        # emulate keyword-only arguments in python 2
-        index = kwargs.pop("array_idx", None)
-        bus_separator = kwargs.pop("bus_separator", "_")
-        reject_remaining_kwargs('__init__', kwargs)
+        index = kwargs.get("array_idx", None)
 
         self.log = SimLog("cocotb.%s.%s" % (entity._name, name))
         Driver.__init__(self)
         self.entity = entity
         self.clock = clock
-        self.bus = Bus(self.entity, name, self._signals,
-                       self._optional_signals, bus_separator=bus_separator, array_idx=index)
+        self.bus = Bus(
+            self.entity, name, self._signals, optional_signals=self._optional_signals,
+            **kwargs
+        )
 
         # Give this instance a unique name
         self.name = name if index is None else "%s_%d" % (name, index)

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -51,8 +51,8 @@ class AXI4LiteMaster(BusDriver):
                 "ARVALID", "ARADDR", "ARREADY",        # Read address channel
                 "RVALID", "RREADY", "RRESP", "RDATA"]  # Read data channel
 
-    def __init__(self, entity, name, clock):
-        BusDriver.__init__(self, entity, name, clock)
+    def __init__(self, entity, name, clock, **kwargs):
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
 
         # Drive some sensible defaults (setimmediatevalue to avoid x asserts)
         self.bus.AWVALID.setimmediatevalue(0)
@@ -237,9 +237,9 @@ class AXI4Slave(BusDriver):
     ]
 
     def __init__(self, entity, name, clock, memory, callback=None, event=None,
-                 big_endian=False):
+                 big_endian=False, **kwargs):
 
-        BusDriver.__init__(self, entity, name, clock)
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
         self.clock = clock
 
         self.big_endian = big_endian

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -245,8 +245,8 @@ class AvalonMemory(BusDriver):
             }
 
     def __init__(self, entity, name, clock, readlatency_min=1,
-                 readlatency_max=1, memory=None, avl_properties={}):
-        BusDriver.__init__(self, entity, name, clock)
+                 readlatency_max=1, memory=None, avl_properties={}, **kwargs):
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
 
         if avl_properties != {}:
             for key, value in self._avalon_properties.items():

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -512,9 +512,9 @@ class AvalonST(ValidatedBusDriver):
 
     _default_config = {"firstSymbolInHighOrderBits" : True}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, entity, name, clock, **kwargs):
         config = kwargs.pop('config', {})
-        ValidatedBusDriver.__init__(self, *args, **kwargs)
+        ValidatedBusDriver.__init__(self, entity, name, clock, **kwargs)
 
         self.config = AvalonST._default_config.copy()
 
@@ -605,9 +605,9 @@ class AvalonSTPkts(ValidatedBusDriver):
         "readyLatency"                  : 0
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, entity, name, clock, **kwargs):
         config = kwargs.pop('config', {})
-        ValidatedBusDriver.__init__(self, *args, **kwargs)
+        ValidatedBusDriver.__init__(self, entity, name, clock, **kwargs)
 
         self.config = AvalonSTPkts._default_config.copy()
 

--- a/cocotb/drivers/opb.py
+++ b/cocotb/drivers/opb.py
@@ -47,8 +47,8 @@ class OPBMaster(BusDriver):
     _optional_signals = ["seqAddr"]
     _max_cycles = 16
 
-    def __init__(self, entity, name, clock):
-        BusDriver.__init__(self, entity, name, clock)
+    def __init__(self, entity, name, clock, **kwargs):
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
         self.bus.select.setimmediatevalue(0)
         self.log.debug("OPBMaster created")
         self.busy_event = Event("%s_busy" % name)

--- a/cocotb/monitors/avalon.py
+++ b/cocotb/monitors/avalon.py
@@ -55,9 +55,9 @@ class AvalonST(BusMonitor):
 
     _default_config = {"firstSymbolInHighOrderBits": True}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, entity, name, clock, **kwargs):
         config = kwargs.pop('config', {})
-        BusMonitor.__init__(self, *args, **kwargs)
+        BusMonitor.__init__(self, entity, name, clock, **kwargs)
 
         self.config = self._default_config.copy()
 
@@ -109,10 +109,10 @@ class AvalonSTPkts(BusMonitor):
         "invalidTimeout"                : 0,
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, entity, name, clock, **kwargs):
         config = kwargs.pop('config', {})
         report_channel = kwargs.pop('report_channel', False)
-        BusMonitor.__init__(self, *args, **kwargs)
+        BusMonitor.__init__(self, entity, name , clock, **kwargs)
 
         self.config = self._default_config.copy()
         self.report_channel = report_channel
@@ -243,10 +243,10 @@ class AvalonSTPktsWithChannel(AvalonSTPkts):
     This class is deprecated. Use AvalonSTPkts(..., report_channel=True, ...)
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, entity, name, clock, **kwargs):
         warnings.warn(
             "Use of AvalonSTPktsWithChannel is deprecated\n"
             "\tUse AvalonSTPkts(..., report_channel=True, ...)",
             DeprecationWarning, stacklevel=2
         )
-        AvalonSTPkts.__init__(self, *args, report_channel=True, **kwargs)
+        AvalonSTPkts.__init__(self, entity, name, clock, report_channel=True, **kwargs)


### PR DESCRIPTION
This is a clean-up patch to prepare for the TypedBus patch as discussed in #1186.
Some extra comments next to commit messages:
* I did delete AD9361 driver as it seemed to be wrongly subclassing ``BusDriver`` and I don't think this code is maintained. Alternatively I could have it subclass ``Driver`` but I have no way of checking that patch.
* I removed ``AvalonSTPktsWithChannel`` and added ``report_channel`` parameter to ``AvalanSTPkts.__init__()`` which I think should allow for the same functionality. I need input if that is not the case.
  It does mean that code using ``AvalonSTPktsWithChannel`` has to be adapted.
