### PR TITLE
Fix Avalon Memory with byteenable using Python 3

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -466,7 +466,7 @@ class AvalonMemory(BusDriver):
                         self.log.debug("Data in   : %x", data)
                         self.log.debug("Width     : %d", self._width)
                         self.log.debug("Byteenable: %x", byteenable)
-                        for i in range(self._width/8):
+                        for i in range(self._width//8):
                             if byteenable & 2**i:
                                 mask |= 0xFF << (8*i)
                             else:


### PR DESCRIPTION
Python 3 always returns a float for a normal division /. As range() does not accept a float value, the Avalon Memory can not be used bit bitenable using Python 3.

By using the floor division operator // the code works in Python 2 and 3.

Also see https://riptutorial.com/python/example/2797/integer-division