### PR TITLE
Remove BusDriver base class from AD9361

### DIFF
--- a/cocotb/drivers/ad9361.py
+++ b/cocotb/drivers/ad9361.py
@@ -9,7 +9,7 @@ from cocotb.binary import BinaryValue, BinaryRepresentation
 from collections import deque
 
 
-class AD9361:
+class AD9361(object):
     """Driver for the AD9361 RF Transceiver."""
 
     def __init__(self, dut, rx_channels=1, tx_channels=1,

--- a/cocotb/drivers/ad9361.py
+++ b/cocotb/drivers/ad9361.py
@@ -4,13 +4,12 @@
 
 import cocotb
 from cocotb.triggers import Timer, RisingEdge, Event
-from cocotb.drivers import BusDriver
 from cocotb.binary import BinaryValue, BinaryRepresentation
 
 from collections import deque
 
 
-class AD9361(BusDriver):
+class AD9361:
     """Driver for the AD9361 RF Transceiver."""
 
     def __init__(self, dut, rx_channels=1, tx_channels=1,


### PR DESCRIPTION
None of the base class methods or attributes are used by this class.

Additionally, `super().__init__()` is not called, so they wouldn't work properly if they were used.

Relates to #1191