### PR TITLE
Monitor: transaction log helper

### DIFF
--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -113,15 +113,6 @@ class Monitor(object):
                        callback.__name__)
         self._callbacks.append(callback)
 
-    def log_transaction(self, transaction):
-        """Helper to easily log a received transaction.
-
-        Typical usage: ``moni_obj.add_callback(moni_obj.log_transaction)``
-        
-        .. versionadded:: 1.3
-        """
-        self.log.info("Transaction received: {!r}".format(transaction))
-
     @coroutine
     def wait_for_recv(self, timeout=None):
         """With *timeout*, :meth:`.wait` for transaction to arrive on monitor

--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -113,6 +113,15 @@ class Monitor(object):
                        callback.__name__)
         self._callbacks.append(callback)
 
+    def log_transaction(self, transaction):
+        """Helper to easily log a received transaction.
+
+        Typical usage: ``moni_obj.add_callback(moni_obj.log_transaction)``
+        
+        .. versionadded:: 1.3
+        """
+        self.log.info("Transaction received: {!r}".format(transaction))
+
     @coroutine
     def wait_for_recv(self, timeout=None):
         """With *timeout*, :meth:`.wait` for transaction to arrive on monitor

--- a/tests/test_cases/test_avalon_stream/test_avalon_stream.py
+++ b/tests/test_cases/test_avalon_stream/test_avalon_stream.py
@@ -24,7 +24,11 @@ class AvalonSTTB(object):
 
         self.stream_in = AvalonSTDriver(self.dut, "asi", dut.clk)
         self.stream_out = AvalonSTMonitor(self.dut, "aso", dut.clk)
-        self.stream_out.add_callback(self.stream_out.log_transaction)
+        self.stream_out.add_callback(
+            lambda transaction: self.stream_out.log.info(
+                "Transaction received {!r}".format(transaction)
+            )
+        )
         self.scoreboard = Scoreboard(self.dut, fail_immediately=True)
 
         self.expected_output = []

--- a/tests/test_cases/test_avalon_stream/test_avalon_stream.py
+++ b/tests/test_cases/test_avalon_stream/test_avalon_stream.py
@@ -24,6 +24,7 @@ class AvalonSTTB(object):
 
         self.stream_in = AvalonSTDriver(self.dut, "asi", dut.clk)
         self.stream_out = AvalonSTMonitor(self.dut, "aso", dut.clk)
+        self.stream_out.add_callback(self.stream_out.log_transaction)
         self.scoreboard = Scoreboard(self.dut, fail_immediately=True)
 
         self.expected_output = []


### PR DESCRIPTION
A Monitor method that can be used to easily log a transaction.