### PR TITLE
Convenience triggers

### DIFF
--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -33,7 +33,7 @@ from collections import deque
 
 import cocotb
 from cocotb.decorators import coroutine
-from cocotb.triggers import (Event, RisingEdge, ReadOnly, NextTimeStep,
+from cocotb.triggers import (Event, RisingEdge, readonly, nexttimestep,
                              Edge)
 from cocotb.bus import Bus
 from cocotb.log import SimLog
@@ -262,11 +262,11 @@ class BusDriver(Driver):
         to move to :class:`~cocotb.triggers.NextTimeStep` before
         registering more callbacks can occur.
         """
-        yield ReadOnly()
+        yield readonly
         while signal.value.integer != 1:
             yield RisingEdge(signal)
-            yield ReadOnly()
-        yield NextTimeStep()
+            yield readonly
+        yield nexttimestep
 
     @coroutine
     def _wait_for_nsignal(self, signal):
@@ -276,11 +276,11 @@ class BusDriver(Driver):
         to move to :class:`~cocotb.triggers.NextTimeStep` before
         registering more callbacks can occur.
         """
-        yield ReadOnly()
+        yield readonly
         while signal.value.integer != 0:
             yield Edge(signal)
-            yield ReadOnly()
-        yield NextTimeStep()
+            yield readonly
+        yield nexttimestep
 
     def __str__(self):
         """Provide the name of the bus"""

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -27,7 +27,7 @@
 """Drivers for Advanced Microcontroller Bus Architecture."""
 
 import cocotb
-from cocotb.triggers import RisingEdge, ReadOnly, Lock
+from cocotb.triggers import RisingEdge, readonly, Lock
 from cocotb.drivers import BusDriver
 from cocotb.result import ReturnValue
 from cocotb.binary import BinaryValue
@@ -79,7 +79,7 @@ class AXI4LiteMaster(BusDriver):
         self.bus.AWVALID <= 1
 
         while True:
-            yield ReadOnly()
+            yield readonly
             if self.bus.AWREADY.value:
                 break
             yield RisingEdge(self.clock)
@@ -99,7 +99,7 @@ class AXI4LiteMaster(BusDriver):
         self.bus.WSTRB <= byte_enable
 
         while True:
-            yield ReadOnly()
+            yield readonly
             if self.bus.WREADY.value:
                 break
             yield RisingEdge(self.clock)
@@ -146,7 +146,7 @@ class AXI4LiteMaster(BusDriver):
 
         # Wait for the response
         while True:
-            yield ReadOnly()
+            yield readonly
             if self.bus.BVALID.value and self.bus.BREADY.value:
                 result = self.bus.BRESP.value
                 break
@@ -182,7 +182,7 @@ class AXI4LiteMaster(BusDriver):
         self.bus.ARVALID <= 1
 
         while True:
-            yield ReadOnly()
+            yield readonly
             if self.bus.ARREADY.value:
                 break
             yield RisingEdge(self.clock)
@@ -191,7 +191,7 @@ class AXI4LiteMaster(BusDriver):
         self.bus.ARVALID <= 0
 
         while True:
-            yield ReadOnly()
+            yield readonly
             if self.bus.RVALID.value and self.bus.RREADY.value:
                 data = self.bus.RDATA.value
                 result = self.bus.RRESP.value
@@ -268,13 +268,13 @@ class AXI4Slave(BusDriver):
         while True:
             while True:
                 self.bus.WREADY <= 0
-                yield ReadOnly()
+                yield readonly
                 if self.bus.AWVALID.value:
                     self.bus.WREADY <= 1
                     break
                 yield clock_re
 
-            yield ReadOnly()
+            yield readonly
             _awaddr = int(self.bus.AWADDR)
             _awlen = int(self.bus.AWLEN)
             _awsize = int(self.bus.AWSIZE)
@@ -316,12 +316,12 @@ class AXI4Slave(BusDriver):
 
         while True:
             while True:
-                yield ReadOnly()
+                yield readonly
                 if self.bus.ARVALID.value:
                     break
                 yield clock_re
 
-            yield ReadOnly()
+            yield readonly
             _araddr = int(self.bus.ARADDR)
             _arlen = int(self.bus.ARLEN)
             _arsize = int(self.bus.ARSIZE)
@@ -348,7 +348,7 @@ class AXI4Slave(BusDriver):
 
             while True:
                 self.bus.RVALID <= 1
-                yield ReadOnly()
+                yield readonly
                 if self.bus.RREADY.value:
                     _burst_diff = burst_length - burst_count
                     _st = _araddr + (_burst_diff * bytes_in_beat)

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -36,7 +36,7 @@ import random
 
 import cocotb
 from cocotb.decorators import coroutine
-from cocotb.triggers import RisingEdge, FallingEdge, ReadOnly, NextTimeStep, Event
+from cocotb.triggers import RisingEdge, FallingEdge, readonly, nexttimestep, Event
 from cocotb.drivers import BusDriver, ValidatedBusDriver
 from cocotb.utils import hexdump
 from cocotb.binary import BinaryValue
@@ -166,7 +166,7 @@ class AvalonMaster(AvalonMM):
 
         if hasattr(self.bus, "readdatavalid"):
             while True:
-                yield ReadOnly()
+                yield readonly
                 if int(self.bus.readdatavalid):
                     break
                 yield RisingEdge(self.clock)
@@ -174,7 +174,7 @@ class AvalonMaster(AvalonMM):
             # Assume readLatency = 1 if no readdatavalid
             # FIXME need to configure this,
             # should take a dictionary of Avalon properties.
-            yield ReadOnly()
+            yield readonly
 
         # Get the data
         data = self.bus.readdata.value
@@ -379,7 +379,7 @@ class AvalonMemory(BusDriver):
                     self.bus.waitrequest <= 1
                     yield RisingEdge(self.clock)
             else:
-                yield NextTimeStep()
+                yield nexttimestep
 
             self.bus.waitrequest <= 0
 
@@ -392,7 +392,7 @@ class AvalonMemory(BusDriver):
             yield edge
             self._do_response()
 
-            yield ReadOnly()
+            yield readonly
 
             if self._readable and self.bus.read.value:
                 if not self._burstread:
@@ -425,7 +425,7 @@ class AvalonMemory(BusDriver):
 
                     # toggle waitrequest
                     # TODO: configure waitrequest time with Avalon properties
-                    yield NextTimeStep()  # can't write during read-only phase
+                    yield nexttimestep  # can't write during read-only phase
                     self.bus.waitrequest <= 1
                     yield edge
                     yield edge
@@ -490,7 +490,7 @@ class AvalonMemory(BusDriver):
 
                     for count in range(burstcount):
                         while self.bus.write.value == 0:
-                            yield NextTimeStep()
+                            yield nexttimestep
                         # self._mem is aligned on 8 bits words
                         yield self._writing_byte_value(addr + count*self.dataByteSize)
                         self.log.debug("writing %016X @ %08X",
@@ -536,10 +536,10 @@ class AvalonST(ValidatedBusDriver):
 
             FIXME assumes readyLatency of 0
         """
-        yield ReadOnly()
+        yield readonly
         while not self.bus.ready.value:
             yield RisingEdge(self.clock)
-            yield ReadOnly()
+            yield readonly
 
     @coroutine
     def _driver_send(self, value, sync=True):
@@ -669,10 +669,10 @@ class AvalonSTPkts(ValidatedBusDriver):
 
             FIXME assumes readyLatency of 0
         """
-        yield ReadOnly()
+        yield readonly
         while not self.bus.ready.value:
             yield RisingEdge(self.clock)
-            yield ReadOnly()
+            yield readonly
 
     @coroutine
     def _send_string(self, string, sync=True, channel=None):

--- a/cocotb/drivers/opb.py
+++ b/cocotb/drivers/opb.py
@@ -31,7 +31,7 @@ NOTE: Currently we only support a very small subset of functionality.
 """
 
 import cocotb
-from cocotb.triggers import RisingEdge, ReadOnly, Event
+from cocotb.triggers import RisingEdge, readonly, Event
 from cocotb.drivers import BusDriver
 from cocotb.result import ReturnValue
 
@@ -95,7 +95,7 @@ class OPBMaster(BusDriver):
         count = 0
         while not int(self.bus.xferAck.value):
             yield RisingEdge(self.clock)
-            yield ReadOnly()
+            yield readonly
             if int(self.bus.toutSup.value):
                 count = 0
             else:
@@ -136,7 +136,7 @@ class OPBMaster(BusDriver):
         count = 0
         while not int(self.bus.xferAck.value):
             yield RisingEdge(self.clock)
-            yield ReadOnly()
+            yield readonly
             if int(self.bus.toutSup.value):
                 count = 0
             else:

--- a/cocotb/monitors/avalon.py
+++ b/cocotb/monitors/avalon.py
@@ -37,7 +37,7 @@ import warnings
 from cocotb.utils import hexdump
 from cocotb.decorators import coroutine
 from cocotb.monitors import BusMonitor
-from cocotb.triggers import RisingEdge, ReadOnly
+from cocotb.triggers import RisingEdge, readonly
 from cocotb.binary import BinaryValue
 
 class AvalonProtocolError(Exception):
@@ -71,7 +71,6 @@ class AvalonST(BusMonitor):
 
         # Avoid spurious object creation by recycling
         clkedge = RisingEdge(self.clock)
-        rdonly = ReadOnly()
 
         def valid():
             if hasattr(self.bus, "ready"):
@@ -81,7 +80,7 @@ class AvalonST(BusMonitor):
         # NB could yield on valid here more efficiently?
         while True:
             yield clkedge
-            yield rdonly
+            yield readonly
             if valid():
                 vec = self.bus.data.value
                 vec.big_endian = self.config["firstSymbolInHighOrderBits"]
@@ -155,7 +154,6 @@ class AvalonSTPkts(BusMonitor):
 
         # Avoid spurious object creation by recycling
         clkedge = RisingEdge(self.clock)
-        rdonly = ReadOnly()
         pkt = ""
         in_pkt = False
         invalid_cyclecount = 0
@@ -168,7 +166,7 @@ class AvalonSTPkts(BusMonitor):
 
         while True:
             yield clkedge
-            yield rdonly
+            yield readonly
 
             if self.in_reset:
                 continue

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -39,6 +39,7 @@ import os
 import sys
 import logging
 import threading
+import warnings
 
 # Debug mode controlled by environment variables
 if "COCOTB_ENABLE_PROFILING" in os.environ:
@@ -212,6 +213,15 @@ class Scheduler(object):
 
     # Singleton events, recycled to avoid spurious object creation
     _timer1 = Timer(1)
+
+    @property
+    def _read_only(self):
+        warnings.warn(
+            "Use of Scheduler._read_only is deprecated\n"
+            "\tUse cocotb.triggers.readonly instead",
+            DeprecationWarning, stacklevel=2
+        )
+        return readonly
 
     def __init__(self):
 

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -59,8 +59,8 @@ else:
 
 import cocotb
 import cocotb.decorators
-from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly,
-                             NextTimeStep, ReadWrite, Event, Join, NullTrigger)
+from cocotb.triggers import (Trigger, GPITrigger, Timer, readonly,
+                             nexttimestep, readwrite, Event, Join, NullTrigger)
 from cocotb.log import SimLog
 from cocotb.result import TestComplete, ReturnValue
 from cocotb import _py_compat
@@ -211,9 +211,6 @@ class Scheduler(object):
     _MODE_TERM     = 4  # noqa
 
     # Singleton events, recycled to avoid spurious object creation
-    _next_time_step = NextTimeStep()
-    _read_write = ReadWrite()
-    _read_only = ReadOnly()
     _timer1 = Timer(1)
 
     def __init__(self):
@@ -257,9 +254,9 @@ class Scheduler(object):
         while True:
             yield self._writes_pending.wait()
             if self._mode != Scheduler._MODE_NORMAL:
-                yield self._next_time_step
+                yield nexttimestep
 
-            yield self._read_write
+            yield readwrite
 
             while self._writes:
                 handle, value = self._writes.popitem()
@@ -381,7 +378,7 @@ class Scheduler(object):
                                    str(trigger))
                 return
 
-            if trigger is self._read_only:
+            if trigger is readonly:
                 self._mode = Scheduler._MODE_READONLY
             # Only GPI triggers affect the simulator scheduling mode
             elif isinstance(trigger, GPITrigger):

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -152,10 +152,14 @@ class GPITrigger(Trigger):
 
     def unprime(self):
         """Disable a primed trigger, can be re-primed."""
-        if self.cbhdl != 0:
+        # Due to race condition in object global object we rely on may have been
+        # deleted. This will happen only right before exit so just skip over the
+        # action.
+        if self.cbhdl != 0 and simulator is not None:
             simulator.deregister_callback(self.cbhdl)
         self.cbhdl = 0
-        Trigger.unprime(self)
+        if Trigger is not None:
+            Trigger.unprime(self)
 
 
 class Timer(GPITrigger):

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -729,3 +729,10 @@ class ClockCycles(Waitable):
         for _ in range(self.num_cycles):
             yield trigger
         raise ReturnValue(self)
+
+
+# Global objects to allow using Triggers that don't have parameters to be used without
+# constructing/construction for each use.
+readonly = ReadOnly()
+readwrite = ReadWrite()
+nexttimestep = NextTimeStep()

--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -28,7 +28,7 @@ from collections import OrderedDict, defaultdict
 
 import cocotb
 from cocotb.bus import Bus
-from cocotb.triggers import RisingEdge, ReadOnly
+from cocotb.triggers import RisingEdge, readonly
 from cocotb.utils import reject_remaining_kwargs
 
 
@@ -149,7 +149,7 @@ class trace(object):
         self._clocks = 0
         while True:
             yield RisingEdge(self._clock)
-            yield ReadOnly()
+            yield readonly
             if not self._enabled:
                 continue
             self._clocks += 1

--- a/documentation/source/triggers.rst
+++ b/documentation/source/triggers.rst
@@ -75,3 +75,17 @@ These are used to synchronize coroutines with each other.
 .. autoclass:: cocotb.triggers.Lock
     :members:
     :member-order: bysource
+
+
+Convenience objects
+-------------------
+
+``cocotb.triggers`` provides some convenience global objects. These are object for Triggers
+that don't take any parameters:
+
+* ``cocotb.triggers.readonly``: ``cocotb.triggers.ReadOnly()``
+* ``cocotb.triggers.readwrite``: ``cocotb.triggers.ReadWrite()``
+* ``cocotb.triggers.nexttimestep``: ``cocotb.triggers.NextTimeStep()``
+
+It allows to avoid constructing/destructing these objects throughout your code;
+e.g. one can for example replace ``yield ReadOnly()`` with ``yield readonly``.


### PR DESCRIPTION
Avoid construction/destruction of Triggers without parameters by providing objects for the classes.

Some possible discussion:
* The second patch is need to avoid having exceptions during exit of a script. It seems that classes could have been set to ``None`` before the objects ``__del__()`` method is called. This leads to following output:
```console
[verhaegs@localhost test_avalon_stream]$ make
make results.xml
make[1]: Map '/home/verhaegs/eda/code/cocotb/tests/test_cases/test_avalon_stream' wordt binnengegaan
PYTHONPATH=/home/verhaegs/eda/code/cocotb/tests/test_cases/test_avalon_stream/build/libs/x86_64:/home/verhaegs/eda/code/cocotb/tests/test_cases/test_avalon_stream:/home/verhaegs/eda/code/cocotb: LD_LIBRARY_PATH=/home/verhaegs/eda/code/cocotb/tests/test_cases/test_avalon_stream/build/libs/x86_64:/home/verhaegs/software/lib:/home/verhaegs/software/lib64:/home/verhaegs/software/lib:/home/verhaegs/software/lib64::/usr/lib64:/usr/lib64:/usr/lib64:/usr/lib64 MODULE=test_avalon_stream \
        TESTCASE= TOPLEVEL=avalon_streaming TOPLEVEL_LANG=verilog COCOTB_SIM=1 \
        /home/verhaegs/software/bin/vvp -M /home/verhaegs/eda/code/cocotb/tests/test_cases/test_avalon_stream/build/libs/x86_64 -m gpivpi sim_build/sim.vvp   
     -.--ns INFO     cocotb.gpi                                  gpi_embed.c:78   in set_program_name_in_venv        Did not detect Python virtual environment. Using system-wide Python interpreter
     -.--ns INFO     cocotb.gpi                                GpiCommon.cpp:104  in gpi_print_registered_impl       VPI registered
     0.00ns INFO     cocotb.gpi                                  gpi_embed.c:347  in embed_sim_init                  Running on Icarus Verilog version 11.0 (devel)
     0.00ns INFO     cocotb.gpi                                  gpi_embed.c:348  in embed_sim_init                  Python interpreter initialized and cocotb loaded!
     0.00ns INFO     cocotb                                      __init__.py:131  in _initialise_testbench           Running tests with cocotb v1.2.0 from /home/verhaegs/eda/code/cocotb
     0.00ns INFO     cocotb                                      __init__.py:148  in _initialise_testbench           Seeding Python random module with 1574516959
     0.00ns INFO     cocotb.regression                         regression.py:190  in initialise                      Found test test_avalon_stream.test_avalon_stream
     0.00ns INFO     cocotb.regression                         regression.py:348  in execute                         Running test 1/1: test_avalon_stream
     0.00ns INFO     ..test_avalon_stream.0x7f5423e66990       decorators.py:253  in _advance                        Starting test: "test_avalon_stream"
                                                                                                                     Description: Test stream of avalon data
     0.00ns INFO     cocotb.scoreboard.avalon_streaming        scoreboard.py:216  in add_interface                   Created with reorder_depth 0
VCD info: dumpfile waveform.vcd opened for output.
VCD warning: $dumpvars: Unsupported argument type (vpiPackage)
681000000000.00ns INFO     cocotb.regression                         regression.py:288  in handle_result                   Test Passed: test_avalon_stream
681000000000.00ns INFO     cocotb.regression                         regression.py:213  in tear_down                       Passed 1 tests (0 skipped)
681000000000.00ns INFO     cocotb.regression                         regression.py:400  in _log_test_summary               ***********************************************************************************************
                                                                                                                           ** TEST                                   PASS/FAIL  SIM TIME(NS)  REAL TIME(S)  RATIO(NS/S) **
                                                                                                                           ***********************************************************************************************
                                                                                                                           ** test_avalon_stream.test_avalon_stream    PASS     681000000000.00          0.11   6359732066279.84  **
                                                                                                                           ***********************************************************************************************
                                                                                                                           
681000000000.00ns INFO     cocotb.regression                         regression.py:417  in _log_sim_summary                *************************************************************************************
                                                                                                                           **                                 ERRORS : 0                                      **
                                                                                                                           *************************************************************************************
                                                                                                                           **                               SIM TIME : 681000000000.00 NS                     **
                                                                                                                           **                              REAL TIME : 0.19 S                                 **
                                                                                                                           **                        SIM / REAL TIME : 3494026234056.32 NS/S                  **
                                                                                                                           *************************************************************************************
                                                                                                                           
681000000000.00ns INFO     cocotb.regression                         regression.py:222  in tear_down                       Shutting down...
Exception AttributeError: "'NoneType' object has no attribute 'unprime'" in <bound method ReadWrite.__del__ of <cocotb.triggers.ReadWrite object at 0x7f54241cda00>> ignored
Exception AttributeError: "'NoneType' object has no attribute 'unprime'" in <bound method ReadOnly.__del__ of <cocotb.triggers.ReadOnly object at 0x7f54241cd9b0>> ignored
Exception AttributeError: "'NoneType' object has no attribute 'unprime'" in <bound method NextTimeStep.__del__ of <cocotb.triggers.NextTimeStep object at 0x7f54241cda50>> ignored
make[1]: Map '/home/verhaegs/eda/code/cocotb/tests/test_cases/test_avalon_stream' wordt verlaten
```
* I provided a third patch to provide a possible back-wards compatibiliy problem for user code that would use Scheduler._read_only. Is user code actually supposed to use attributes starting with a `_`.