### PR TITLE
Use a free function for `_log_from_c`

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -66,24 +66,6 @@ class SimBaseLog(logging.getLoggerClass()):
         self.propagate = False
         self.addHandler(hdlr)
 
-    def _logFromC(self, level, filename, lineno, msg, function):
-        """
-        This is for use from the C world, and allows us to insert C stack
-        information.
-        """
-        if self.isEnabledFor(level):
-            record = self.makeRecord(
-                self.name,
-                level,
-                filename,
-                lineno,
-                msg,
-                None,
-                None,
-                function
-            )
-            self.handle(record)
-
     @property
     def logger(self):
         warnings.warn(
@@ -190,3 +172,27 @@ class SimColourLogFormatter(SimLogFormatter):
                  record.levelname.ljust(_LEVEL_CHARS))
 
         return self._format(level, record, msg, coloured=True)
+
+
+def _filter_from_c(logger_name, level):
+    return logging.getLogger(logger_name).isEnabledFor(level)
+
+
+def _log_from_c(logger_name, level, filename, lineno, msg, function_name):
+    """
+    This is for use from the C world, and allows us to insert C stack
+    information.
+    """
+    logger = logging.getLogger(logger_name)
+    if logger.isEnabledFor(level):
+        record = logger.makeRecord(
+            logger.name,
+            level,
+            filename,
+            lineno,
+            msg,
+            None,
+            None,
+            function_name
+        )
+        logger.handle(record)

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -259,37 +259,32 @@ int embed_sim_init(gpi_sim_info_t *info)
     }
 
     PyObject *cocotb_module, *cocotb_init, *cocotb_retval;
-    PyObject *simlog_obj, *simlog_func;
+    PyObject *cocotb_log_module = NULL;
+    PyObject *simlog_func;
     PyObject *argv_list;
 
     cocotb_module = NULL;
-    simlog_obj = NULL;
 
     // Ensure that the current thread is ready to call the Python C API
     PyGILState_STATE gstate = PyGILState_Ensure();
     to_python();
 
-    if (get_module_ref(COCOTB_MODULE, &cocotb_module))
+    if (get_module_ref("cocotb", &cocotb_module))
         goto cleanup;
 
-    // Obtain the loggpi logger object
-    simlog_obj = PyObject_GetAttrString(cocotb_module, "loggpi");       // New reference
-
-    if (simlog_obj == NULL) {
-        PyErr_Print();
-        LOG_ERROR("Failed to get simlog object from loggpi\n");
+    if (get_module_ref("cocotb.log", &cocotb_log_module)) {
         goto cleanup;
     }
 
     // Obtain the function to use when logging from C code
-    simlog_func = PyObject_GetAttrString(simlog_obj, "_logFromC");      // New reference
+    simlog_func = PyObject_GetAttrString(cocotb_log_module, "_log_from_c");      // New reference
     if (simlog_func == NULL) {
         PyErr_Print();
-        LOG_ERROR("Failed to get the _logFromC method");
+        LOG_ERROR("Failed to get the _log_from_c function");
         goto cleanup;
     }
     if (!PyCallable_Check(simlog_func)) {
-        LOG_ERROR("_logFromC is not callable");
+        LOG_ERROR("_log_from_c is not callable");
         Py_DECREF(simlog_func);
         goto cleanup;
     }
@@ -297,14 +292,14 @@ int embed_sim_init(gpi_sim_info_t *info)
     set_log_handler(simlog_func);                                       // Note: This function steals a reference to simlog_func.
 
     // Obtain the function to check whether to call log function
-    simlog_func = PyObject_GetAttrString(simlog_obj, "isEnabledFor");   // New reference
+    simlog_func = PyObject_GetAttrString(cocotb_log_module, "_filter_from_c");   // New reference
     if (simlog_func == NULL) {
         PyErr_Print();
-        LOG_ERROR("Failed to get the isEnabledFor method");
+        LOG_ERROR("Failed to get the _filter_from_c method");
         goto cleanup;
     }
     if (!PyCallable_Check(simlog_func)) {
-        LOG_ERROR("isEnabledFor is not callable");
+        LOG_ERROR("_filter_from_c is not callable");
         Py_DECREF(simlog_func);
         goto cleanup;
     }
@@ -440,7 +435,7 @@ cleanup:
     ret = -1;
 ok:
     Py_XDECREF(cocotb_module);
-    Py_XDECREF(simlog_obj);
+    Py_XDECREF(cocotb_log_module);
 
     PyGILState_Release(gstate);
     to_simulator();

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -215,8 +215,6 @@ void embed_sim_cleanup(void)
  * Loads the Python module called cocotb and calls the _initialise_testbench function
  */
 
-#define COCOTB_MODULE "cocotb"
-
 int get_module_ref(const char *modname, PyObject **mod)
 {
     PyObject *pModule = PyImport_ImportModule(modname);

--- a/cocotb/share/lib/gpi_log/gpi_logging.c
+++ b/cocotb/share/lib/gpi_log/gpi_logging.c
@@ -211,7 +211,7 @@ void gpi_log(const char *name, long level, const char *pathname, const char *fun
         goto error;
     }
 
-    // Log function args are level, filename, lineno, msg, function
+    // Log function args are logger_name, level, filename, lineno, msg, function
     PyObject *handler_ret = PyObject_CallFunctionObjArgs(pLogHandler, logger_name_arg, level_arg, filename_arg, lineno_arg, msg_arg, function_arg, NULL);
     if (handler_ret == NULL) {
         goto error;

--- a/cocotb/share/lib/gpi_log/gpi_logging.c
+++ b/cocotb/share/lib/gpi_log/gpi_logging.c
@@ -158,14 +158,19 @@ void gpi_log(const char *name, long level, const char *pathname, const char *fun
     PyGILState_STATE gstate = PyGILState_Ensure();
 
     // Declared here in order to be initialized before any goto statements and refcount cleanup
-    PyObject *filename_arg = NULL, *lineno_arg = NULL, *msg_arg = NULL, *function_arg = NULL;
+    PyObject *logger_name_arg = NULL, *filename_arg = NULL, *lineno_arg = NULL, *msg_arg = NULL, *function_arg = NULL;
 
     PyObject *level_arg = PyLong_FromLong(level);                  // New reference
     if (level_arg == NULL) {
         goto error;
     }
 
-    PyObject *filter_ret = PyObject_CallFunctionObjArgs(pLogFilter, level_arg, NULL);
+    logger_name_arg = PyUnicode_FromString(name);      // New reference
+    if (logger_name_arg == NULL) {
+        goto error;
+    }
+
+    PyObject *filter_ret = PyObject_CallFunctionObjArgs(pLogFilter, logger_name_arg, level_arg, NULL);
     if (filter_ret == NULL) {
         goto error;
     }
@@ -207,7 +212,7 @@ void gpi_log(const char *name, long level, const char *pathname, const char *fun
     }
 
     // Log function args are level, filename, lineno, msg, function
-    PyObject *handler_ret = PyObject_CallFunctionObjArgs(pLogHandler, level_arg, filename_arg, lineno_arg, msg_arg, function_arg, NULL);
+    PyObject *handler_ret = PyObject_CallFunctionObjArgs(pLogHandler, logger_name_arg, level_arg, filename_arg, lineno_arg, msg_arg, function_arg, NULL);
     if (handler_ret == NULL) {
         goto error;
     }
@@ -218,6 +223,7 @@ error:
     PyErr_Print();
     LOG_ERROR("Error calling Python logging function from C");
 ok:
+    Py_XDECREF(logger_name_arg);
     Py_XDECREF(level_arg);
     Py_XDECREF(filename_arg);
     Py_XDECREF(lineno_arg);

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -652,7 +652,7 @@ static int system_function_overload(char *userdata)
         msg = argval.value.str;
     }
 
-    gpi_log("simulator", *userdata, vpi_get_str(vpiFile, systfref), "", (long)vpi_get(vpiLineNo, systfref), "%s", msg );
+    gpi_log("cocotb.simulator", *userdata, vpi_get_str(vpiFile, systfref), "", (long)vpi_get(vpiLineNo, systfref), "%s", msg );
 
     // Fail the test for critical errors
     if (GPICritical == *userdata)


### PR DESCRIPTION
As raised in gh-1212, there is no need to use subclassing here, and doing so removes flexibility from the user.

After this change, `libgpi` logging will work independently of whatever logging class is configured via the builtin `logging.setLoggerClass`. More importantly, it removes one more reason for `SimBaseLog` to exist - the ultimate goal is to remove that class entirely, since it's behavior is hostile to users wanting to use the logging module normally.

This also fixes a bug where the name argument of `gpilog` is ignored.