### PR TITLE
Add StableCondition and StableValue trigger.

### DIFF
--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -30,11 +30,11 @@
 """Set of common driver base classes."""
 
 from collections import deque
+import warnings
 
 import cocotb
 from cocotb.decorators import coroutine
-from cocotb.triggers import (Event, RisingEdge, ReadOnly, NextTimeStep,
-                             Edge)
+from cocotb.triggers import Event, RisingEdge, NextTimeStep, StableValue
 from cocotb.bus import Bus
 from cocotb.log import SimLog
 
@@ -262,10 +262,12 @@ class BusDriver(Driver):
         to move to :class:`~cocotb.triggers.NextTimeStep` before
         registering more callbacks can occur.
         """
-        yield ReadOnly()
-        while signal.value.integer != 1:
-            yield RisingEdge(signal)
-            yield ReadOnly()
+        warnings.warn(
+            "Use of BusDriver._wait_for_signal() is deprecated\n"
+            "\tPlease, use cocotb.trigggers.StableValue instead",
+            DeprecationWarning, stacklevel=2
+        )
+        yield StableValue(signal, 1)
         yield NextTimeStep()
 
     @coroutine
@@ -276,10 +278,12 @@ class BusDriver(Driver):
         to move to :class:`~cocotb.triggers.NextTimeStep` before
         registering more callbacks can occur.
         """
-        yield ReadOnly()
-        while signal.value.integer != 0:
-            yield Edge(signal)
-            yield ReadOnly()
+        warnings.warn(
+            "Use of BusDriver._wait_for_signal() is deprecated\n"
+            "\tPlease, use cocotb.triggers.StableValue instead",
+            DeprecationWarning, stacklevel=2
+        )
+        yield StableValue(signal, 0)
         yield NextTimeStep()
 
     def __str__(self):

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -41,7 +41,7 @@ from cocotb.log import SimLog
 from cocotb.result import ReturnValue
 from cocotb.utils import (
     get_sim_steps, get_time_from_sim_steps, ParametrizedSingleton,
-    lazy_property,
+    lazy_property, reject_remaining_kwargs
 )
 from cocotb import decorators
 from cocotb import outcomes
@@ -729,3 +729,73 @@ class ClockCycles(Waitable):
         for _ in range(self.num_cycles):
             yield trigger
         raise ReturnValue(self)
+
+
+class StableCondition(Waitable):
+    """
+    Wait until a given condition is True in ReadOnly state.
+
+    The trigger will first do ``yield ReadOnly()`` and then do the check.
+
+    Args:
+        condition (callable): Output of condition called without any parameters
+            is checked to be equivalent of logic True for condition to be met.
+        event (Trigger): event after which to check the condition; defaults to
+            :class:`NextTimeStep`.
+        extra_event (bool): whether to wait for an extra event after condition
+            is met; defaults to ``False``.
+
+    Example:
+
+    .. code-block:: python
+
+        # Wait for ack
+        yield StableCondition(
+            lambda: bus.cycle.integer and bus.ack.integer,
+            event=RisingEdge(dut.clk)
+        )
+
+    .. versionadded: 1.3
+    """
+    def __init__(self, condition, **kwargs):
+        event = kwargs.pop('event', NextTimeStep())
+        extra_event = kwargs.pop('extra_event', False)
+        reject_remaining_kwargs('StableCondition.__init__', kwargs)
+        self.condition = condition
+        self.event = event
+        self.extra_event = extra_event
+
+    @decorators.coroutine
+    def _wait(self):
+        while True:
+            yield ReadOnly()
+            if self.condition():
+                break
+            yield self.event
+        if self.extra_event:
+            yield self.event
+
+
+class StableValue(StableCondition):
+    """
+    Wait until a signal has a given value in ReadOnly state.
+
+    The trigger will first do ``yield ReadOnly()`` and then do the comparison.
+
+    Args:
+        signal (SimHandle): the signal to monitor.
+        value (int, 0 or 1): value to wait for.
+        **kwargs: keyword arguments passed on to :class:`StableCondition`.
+            The default for ``event`` is changed to ``Edge(signal)``. This is
+            equivalent to ``RisingEdge(signal)`` when waiting for 1 and
+            ``FallingEdge(signal)`` when waiting for 0.
+
+    .. versionadded: 1.3
+    """
+    def __init__(self, signal, value, **kwargs):
+        if value not in (0, 1):
+            raise ValueError("value has to be 0 or 1")
+        event = kwargs.pop('event', Edge(signal))
+
+        StableCondition.__init__(self, lambda: signal.value.integer == value,
+                                 event=event, **kwargs)

--- a/documentation/source/triggers.rst
+++ b/documentation/source/triggers.rst
@@ -38,6 +38,10 @@ Signals
 
 .. autoclass:: cocotb.triggers.ClockCycles
 
+.. autoclass:: cocotb.triggers.StableCondition
+
+.. autoclass:: cocotb.triggers.StableValue
+
 
 Timing
 ~~~~~~


### PR DESCRIPTION
These triggers allow to wait until a certain condition is met or a signal has a given value when in ReadOnly state. The event after which to do the check is configurable.

Some remarks:
* I'm open for naming suggestions. Alternatives I considered ConditionReadOnly/ValueReadOnly or ConditionInReadOnly/ValueInReadOnly.
* I deprecated BusDriver._wait_for_(n)signal() as I don't see a reason why these are methods. They don't use the object.
* For testing I used the Avalon tests. The amba changes have been done blindly. Would be good if a user could test this, or even better submit a test.