### PR TITLE
object.__getattr__ does not exist

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -143,7 +143,7 @@ class SimHandleBase(object):
                 _deprecation_warned[name] = True
             return getattr(self, self._compat_mapping[name])
         else:
-            return object.__getattr__(self, name)
+            return object.__getattribute__(self, name)
 
 class RegionObject(SimHandleBase):
     """A region object, such as a scope or namespace.

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -1266,5 +1266,16 @@ def test_expect_exception_list(dut):
     raise MyException()
 
 
+@cocotb.test()
+def test_bad_attr(dut):
+    yield cocotb.triggers.NullTrigger()
+    try:
+        _ = dut.stream_in_data.whoops
+    except AttributeError as e:
+        assert 'whoops' in str(e)
+    else:
+        assert False, "Expected AttributeError"
+
+
 if sys.version_info[:2] >= (3, 5):
     from test_cocotb_35 import *


### PR DESCRIPTION
If accessing a non-existent attribute you get an error about `object` not having an attribute `__getattr__` instead of the attribute you actually tried to incorrectly use. Using `__getattribute__` instead should work.