### PR TITLE
PR: Added Logging to File.

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -34,6 +34,8 @@ import sys
 import logging
 import warnings
 
+from logging.handlers import RotatingFileHandler
+
 from cocotb.utils import get_sim_time, want_color_output
 
 import cocotb.ANSI as ANSI
@@ -67,6 +69,15 @@ class SimBaseLog(logging.getLoggerClass()):
 
         self.propagate = False
         self.addHandler(hdlr)
+
+        want_filelogger=os.getenv("COCOTB_FILE_LOGGER")
+        if want_filelogger is not None:
+            logfile=os.path.join(os.getenv("RESULT_PATH"),"results.log")
+            file_handler = RotatingFileHandler(
+                        logfile, maxBytes=(1048576*5), backupCount=4
+                        )
+            file_handler.setFormatter(SimLogFormatter())
+            self.addHandler(file_handler)
 
     def _logFromC(self, level, filename, lineno, msg, function):
         """

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -118,6 +118,9 @@ Environment Variables
     If defined, log lines displayed in terminal will be shorter. It will print only
     time, message type (``INFO``, ``WARNING``, ``ERROR``) and log message.
 
+.. envvar:: COCOTB_FILE_LOGGER
+    If defined, A log file named results.log is generated. The folder in which the log file is generated can be controlled by setting the RESULT_PATH environment variable to the appropriate folder.
+
 .. envvar:: MODULE
 
     The name of the module(s) to search for test functions.  Multiple modules can be specified using a comma-separated list.

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -119,7 +119,10 @@ Environment Variables
     time, message type (``INFO``, ``WARNING``, ``ERROR``) and log message.
 
 .. envvar:: COCOTB_FILE_LOGGER
-    If defined, A log file named results.log is generated. The folder in which the log file is generated can be controlled by setting the RESULT_PATH environment variable to the appropriate folder.
+
+    If defined, A log file named results.log is generated. The folder in which
+    the log file is generated can be controlled by setting the ``RESULT_PATH``
+    environment variable to the appropriate folder.
 
 .. envvar:: MODULE
 


### PR DESCRIPTION
This PR adds file logging with log file rotation.

Most of the times while debugging I prefer opening a log file in my editor instead of searching the (truncated) console log.
The immediate need for this changes was:

I am planning to run a week long testcase (1000*64000 packets) and If it fails at anypoint I need the detailed log at the point of failure which means every driver and monitor printing debug information. This has a potential to fillup the diskspace hence adding file logging + log rotation.
