### PR TITLE
Ensure handle docstrings are inherited

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -67,6 +67,8 @@ class SimHandleBase(object):
 
     def __init__(self, handle, path):
         """
+        .. Constructor. This RST comment works around sphinx-doc/sphinx#6885
+
         Args:
             handle (int): The GPI handle to the simulator object.
             path (str): Path to this handle, ``None`` if root.
@@ -145,14 +147,11 @@ class SimHandleBase(object):
         else:
             return object.__getattr__(self, name)
 
+
 class RegionObject(SimHandleBase):
     """A region object, such as a scope or namespace.
 
     Region objects don't have values, they are effectively scopes or namespaces.
-
-    Args:
-        handle (int): The GPI handle to the simulator object.
-        path (str): Path to this handle, ``None`` if root.
     """
     def __init__(self, handle, path):
         SimHandleBase.__init__(self, handle, path)
@@ -389,15 +388,7 @@ class AssignmentResult(object):
 
 
 class NonHierarchyObject(SimHandleBase):
-    """Common base class for all non-hierarchy objects.
-
-    Args:
-        handle (int): The GPI handle to the simulator object.
-        path (str): Path to this handle, ``None`` if root.
-    """
-
-    def __init__(self, handle, path):
-        SimHandleBase.__init__(self, handle, path)
+    """Common base class for all non-hierarchy objects."""
 
     def __iter__(self):
         return iter(())
@@ -450,20 +441,22 @@ class NonHierarchyObject(SimHandleBase):
     def __hash__(self):
         return SimHandleBase.__hash__(self)
 
+
 class ConstantObject(NonHierarchyObject):
     """An object which has a value that can be read, but not set.
 
     We can also cache the value since it is fixed at elaboration time and
     won't change within a simulation.
-
-    Args:
-        handle (int): The GPI handle to the simulator object.
-        path (str): Path to this handle, ``None`` if root.
-        handle_type: The type of the handle 
-            (``simulator.INTEGER``, ``simulator.ENUM``, 
-            ``simulator.REAL``, ``simulator.STRING``).
     """
     def __init__(self, handle, path, handle_type):
+        """
+        Args:
+            handle (int): The GPI handle to the simulator object.
+            path (str): Path to this handle, ``None`` if root.
+            handle_type: The type of the handle 
+                (``simulator.INTEGER``, ``simulator.ENUM``, 
+                ``simulator.REAL``, ``simulator.STRING``).
+        """
         NonHierarchyObject.__init__(self, handle, path)
         if handle_type in [simulator.INTEGER, simulator.ENUM]:
             self._value = simulator.get_signal_val_long(self._handle)
@@ -491,14 +484,10 @@ class ConstantObject(NonHierarchyObject):
     def __str__(self):
         return str(self.value)
 
-class NonHierarchyIndexableObject(NonHierarchyObject):
-    def __init__(self, handle, path):
-        """A non-hierarchy indexable object.
 
-        Args:
-            handle (int): FLI/VPI/VHPI handle to the simulator object.
-            path (str): Path to this handle, ``None`` if root.
-        """
+class NonHierarchyIndexableObject(NonHierarchyObject):
+    """ A non-hierarchy indexable object. """
+    def __init__(self, handle, path):
         NonHierarchyObject.__init__(self, handle, path)
         self._range = simulator.get_range(self._handle)
 
@@ -557,17 +546,10 @@ class NonHierarchyIndexableObject(NonHierarchyObject):
         except GeneratorExit:
             pass
 
+
 class NonConstantObject(NonHierarchyIndexableObject):
+    """ A non-constant object"""
     # FIXME: what is the difference to ModifiableObject? Explain in docstring.
-
-    def __init__(self, handle, path):
-        """A non-constant object.
-
-        Args:
-            handle (int): FLI/VPI/VHPI handle to the simulator object.
-            path (str): Path to this handle, ``None`` if root.
-        """
-        NonHierarchyIndexableObject.__init__(self, handle, path)
 
     def drivers(self):
         """An iterator for gathering all drivers for a signal."""
@@ -659,6 +641,7 @@ class ModifiableObject(NonConstantObject):
     def __str__(self):
         return str(self.value)
 
+
 class RealObject(ModifiableObject):
     """Specific object handle for Real signals and variables."""
 
@@ -686,6 +669,7 @@ class RealObject(ModifiableObject):
 
     def __float__(self):
         return float(self.value)
+
 
 class EnumObject(ModifiableObject):
     """Specific object handle for enumeration signals and variables."""
@@ -741,6 +725,7 @@ class IntegerObject(ModifiableObject):
 
     def _getvalue(self):
         return simulator.get_signal_val_long(self._handle)
+
 
 class StringObject(ModifiableObject):
     """Specific object handle for String variables."""


### PR DESCRIPTION
By putting the argument docstrings in `__init__`, we ensure they are inherited automatically by subclasses with either:

* Do not define `__init__`
* Define `__init__` with no docstring

By clearing up the inconsistency, this also fixes a rendering bug in the sphinx docs where some argument lists appeared twice:

> ![image](https://user-images.githubusercontent.com/425260/70183911-a54c1900-16de-11ea-9b98-5e59b604cec2.png)


This also adds some blank lines to appease flake8 a little more.

cc @cmarqu, alternative to parts of #1205