### PR TITLE
Allow users to override the cocotb logger

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -39,7 +39,12 @@ import time
 
 import cocotb.handle
 from cocotb.scheduler import Scheduler
-from cocotb.log import SimBaseLog, SimLog
+try:
+    import cocotb_custom.log
+except ImportError:
+    from cocotb.log import SimLog
+else:
+    SimLog = cocotb_custom.log.SimLog
 from cocotb.regression import RegressionManager
 
 
@@ -53,8 +58,6 @@ from cocotb.decorators import test, coroutine, hook, function, external  # noqa:
 
 from ._version import __version__
 
-logging.basicConfig()
-logging.setLoggerClass(SimBaseLog)
 log = SimLog('cocotb')
 level = os.getenv("COCOTB_LOG_LEVEL", "INFO")
 try:

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -53,20 +53,21 @@ from cocotb.decorators import test, coroutine, hook, function, external  # noqa:
 
 from ._version import __version__
 
+logging.basicConfig()
+logging.setLoggerClass(SimBaseLog)
+log = SimLog('cocotb')
+level = os.getenv("COCOTB_LOG_LEVEL", "INFO")
+try:
+    _default_log = getattr(logging, level)
+except AttributeError:
+    log.error("Unable to set loging level to %s" % level)
+    _default_log = logging.INFO
+log.setLevel(_default_log)
+loggpi = SimLog('cocotb.gpi')
+
 # GPI logging instance
 if "COCOTB_SIM" in os.environ:
     import simulator
-    logging.basicConfig()
-    logging.setLoggerClass(SimBaseLog)
-    log = SimLog('cocotb')
-    level = os.getenv("COCOTB_LOG_LEVEL", "INFO")
-    try:
-        _default_log = getattr(logging, level)
-    except AttributeError as e:
-        log.error("Unable to set loging level to %s" % level)
-        _default_log = logging.INFO
-    log.setLevel(_default_log)
-    loggpi = SimLog('cocotb.gpi')
     # Notify GPI of log level
     simulator.log_level(_default_log)
 

--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -161,7 +161,7 @@ class SimLogFormatter(logging.Formatter):
 
 class SimColourLogFormatter(SimLogFormatter):
     """Log formatter to provide consistent log message handling."""
-    
+
     loglevel2colour = {
         logging.DEBUG   :       "%s",
         logging.INFO    :       ANSI.COLOR_INFO + "%s" + ANSI.COLOR_DEFAULT,
@@ -184,3 +184,6 @@ class SimColourLogFormatter(SimLogFormatter):
                  record.levelname.ljust(_LEVEL_CHARS))
 
         return self._format(level, record, msg, coloured=True)
+
+logging.basicConfig()
+logging.setLoggerClass(SimBaseLog)

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 # Copyright (c) 2013 Potential Ventures Ltd
 # Copyright (c) 2013 SolarFlare Communications Inc
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #     * Redistributions of source code must retain the above copyright
@@ -15,7 +15,7 @@ from __future__ import print_function, division
 #       SolarFlare Communications Inc nor the
 #       names of its contributors may be used to endorse or promote products
 #       derived from this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -73,6 +73,13 @@ def get_sim_time(units=None):
         result = get_time_from_sim_steps(result, units)
 
     return result
+
+
+if "COCOTB_SIM" not in os.environ:
+
+    @functools.wraps(get_sim_time)
+    def get_sim_time(units=None):
+        return 0
 
 
 def _ldexp10(frac, exp):
@@ -173,13 +180,13 @@ def unpack(ctypes_obj, string, bytes=None):
     """Unpack a Python string into a :mod:`ctypes` structure.
 
     If the length of *string* is not the correct size for the memory
-    footprint of the :mod:`ctypes` structure then the *bytes* keyword argument 
+    footprint of the :mod:`ctypes` structure then the *bytes* keyword argument
     must be used.
 
     Args:
         ctypes_obj (ctypes.Structure): The :mod:`ctypes` structure to pack into.
         string (str):  String to copy over the *ctypes_obj* memory space.
-        bytes (int, optional): Number of bytes to copy. 
+        bytes (int, optional): Number of bytes to copy.
             Defaults to ``None``, meaning the length of *string* is used.
 
     Raises:
@@ -284,7 +291,7 @@ def hexdiffs(x, y):
 
     def highlight(string, colour=ANSI.COLOR_HILITE_HEXDIFF_DEFAULT):
         """Highlight with ANSI colors if possible/requested and not running in GUI."""
-        
+
         if want_color_output():
             return colour + string + ANSI.COLOR_DEFAULT
         else:
@@ -501,8 +508,8 @@ def want_color_output():
     if os.getenv("GUI", default='0') == '1':
         want_color = False
     return want_color
-        
-    
+
+
 if __name__ == "__main__":
     import random
     a = ""


### PR DESCRIPTION
To ensure logging customization occurs before base loggers are made, logging customization must occur right after cocotb module entry. This provides the infrastructure to allow the user to do logger customization, while preserving current functionality.