### PR TITLE
Deprecate the `log.colour` attribute

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -60,10 +60,8 @@ class SimBaseLog(logging.getLoggerClass()):
 
         if want_color_output():
             hdlr.setFormatter(SimColourLogFormatter())
-            self.colour = True
         else:
             hdlr.setFormatter(SimLogFormatter())
-            self.colour = False
 
         self.propagate = False
         self.addHandler(hdlr)
@@ -91,8 +89,16 @@ class SimBaseLog(logging.getLoggerClass()):
         warnings.warn(
             "the .logger attribute should not be used now that `SimLog` "
             "returns a native logger instance directly.",
-            DeprecationWarning)
+            DeprecationWarning, stacklevel=2)
         return self
+
+    @property
+    def colour(self):
+        warnings.warn(
+            "the .colour attribute may be removed in future, use the "
+            "equivalent `cocotb.utils.want_color_output()` instead",
+            DeprecationWarning, stacklevel=2)
+        return want_color_output()
 
 
 # this used to be a class, hence the unusual capitalization


### PR DESCRIPTION
This is really global state, so doesn't belong on the log instances - nor does setting it actually have any effect on whether colored output is used.
Lastly, this doesn't match the spelling of the other color function!

Removing this takes us a step closer to resolving gh-1212

cc @ktbarrett

Adding @stuarthodgson as a reviewer, since [he said](https://github.com/cocotb/cocotb/issues/1212#issuecomment-558808782)

> [this] is quite useful for me at least.

---

Once this and #1213 go in, the last piece to remove will be the `handler` and `propagate`, which can move to `__init__.py` as:
```
_cocotb_logger = logging.getLogger('cocotb')
_cocotb_logger.addHandler(...)
_cocotb_logger.propagate = False
```

With that in place, the user is free to reconfigure the logger as they wish, and will no longer need to recurse through all our loggers if they want to reconfigure them. It also means that our custom logger class has nothing left to do other than emit deprecation warnings, meaning users are free to not use it.