### PR TITLE
Show inheritance for classes in handle.py

### DIFF
--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -30,7 +30,7 @@
 """Common bus related functionality.
 A bus is simply defined as a collection of signals.
 """
-from cocotb.handle import AssignmentResult
+from cocotb.handle import _AssignmentResult
 
 def _build_sig_attr_dict(signals):
     if isinstance(signals, dict):
@@ -194,4 +194,4 @@ class Bus(object):
     def __le__(self, value):
         """Overload the less than or equal to operator for value assignment"""
         self.drive(value)
-        return AssignmentResult(self, value)
+        return _AssignmentResult(self, value)

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -368,7 +368,7 @@ class HierarchyArrayObject(RegionObject):
         raise TypeError("Not permissible to set %s at index %d" % (self._name, index))
 
 
-class AssignmentResult(object):
+class _AssignmentResult(object):
     """
     An object that exists solely to provide an error message if the caller
     is not aware of cocotb's meaning of ``<=``.
@@ -418,7 +418,7 @@ class NonHierarchyObject(SimHandleBase):
         >>> module.signal <= 2
         """
         self.value = value
-        return AssignmentResult(self, value)
+        return _AssignmentResult(self, value)
 
     def __eq__(self, other):
         if isinstance(other, SimHandleBase):

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinxcontrib.makedomain',
     'sphinx.ext.autosectionlabel',
+    'sphinx.ext.inheritance_diagram',
     'cairosvgconverter',
     'breathe',
     'sphinx_issues',
@@ -331,3 +332,7 @@ spelling_word_list_filename = ["spelling_wordlist.txt", "c_symbols.txt"]
 spelling_ignore_pypi_package_names = False
 spelling_ignore_wiki_words = False
 spelling_show_suggestions = True
+
+# -- Setup for inheritance_diagram directive which uses graphviz ---------------
+
+graphviz_output_format = 'svg'

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -148,6 +148,9 @@ Utilities
 Simulation Object Handles
 =========================
 
+.. inheritance-diagram:: cocotb.handle
+   :parts: 1
+
 .. currentmodule:: cocotb.handle
 
 .. automodule:: cocotb.handle


### PR DESCRIPTION
Visualizing the class hierarchy in ``handle.py`` is quite useful as can be seen in https://external-builds.readthedocs.io/html/cocotb/1232/library_reference.html#simulation-object-handles