### PR TITLE
Replace tabs with spaces in non-targets

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -30,7 +30,7 @@
 ifneq ($(VHDL_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):
-	@echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
+    @echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
 clean::
 
 else
@@ -38,25 +38,25 @@ else
 CMD_BIN := vcs
 
 ifdef VCS_BIN_DIR
-	CMD := $(shell :; command -v $(VCS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+     CMD := $(shell :; command -v $(VCS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
-	# auto-detect bin dir from system path
-	CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+     # auto-detect bin dir from system path
+     CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
 endif
 
 ifeq (, $(CMD))
-	$(error "Unable to locate command >$(CMD_BIN)<")
+     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	VCS_BIN_DIR := $(shell dirname $(CMD))
-	export VCS_BIN_DIR
+     VCS_BIN_DIR := $(shell dirname $(CMD))
+     export VCS_BIN_DIR
 endif
 
 ifeq ($(ARCH),x86_64)
-EXTRA_ARGS += -full64
+    EXTRA_ARGS += -full64
 endif
 
 ifeq ($(GUI),1)
-	EXTRA_ARGS += -gui
+    EXTRA_ARGS += -gui
 endif
 
 # TODO:


### PR DESCRIPTION
This fixes the "*** recipe commences before first target. Stop." error
that we would get otherwise (e.g. when the vcs command is not in PATH).