### PR TITLE
Passing Questa arguments consistently

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -176,7 +176,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(COCOTB_LIBS) $(COCOTB_VHPI_LIB
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; cd $(SIM_BUILD) && PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 $(CMD) -do runsim.tcl | tee sim.log
+	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 $(CMD) $(RUN_ARGS) -do runsim.tcl | tee sim.log
 
 	# check that the file was actually created
 	test -f $(COCOTB_RESULTS_FILE)

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -148,7 +148,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(INT_LIBS)
 
 	set -o pipefail; $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 \
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) \
-	$(CMD) $(PLUSARGS) -do $(SIM_BUILD)/runsim.do 2>&1 | tee $(SIM_BUILD)/sim.log
+	$(CMD) $(RUN_ARGS) $(PLUSARGS) -do $(SIM_BUILD)/runsim.do 2>&1 | tee $(SIM_BUILD)/sim.log
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -77,6 +77,12 @@ and
 
       Any arguments or flags to pass to the execution of the compiled simulation.
 
+.. make:var:: RUN_ARGS
+
+      Any argument to be passed to the "first" invocation of a simulator that runs via a TCL script.
+      One motivating usage is to pass `-noautoldlibpath` to Questa to prevent it from loading the out-of-date libraries it ships with.
+      Used by Aldec Riviera-PRO and Mentor Graphics Questa simulator.
+
 .. make:var:: EXTRA_ARGS
 
       Passed to both the compile and execute phases of simulators with two rules, or passed to the single compile and run command for simulators which don't have a distinct compilation stage.

--- a/documentation/source/newsfragments/1244.feature.rst
+++ b/documentation/source/newsfragments/1244.feature.rst
@@ -1,0 +1,1 @@
+Simulators run through a TCL script (Aldec Riviera Pro and Mentor simulators) now support a new :make:var:`RUN_ARGS` Makefile variable, which is passed to the first invocation of the tool during runtime.


### PR DESCRIPTION
Fixes #1150. Tested locally, the plusargs test now passes and using `-noautoldlibpath` should be specified in `SIM_ARGS` and will be passed to both calls to vsim.