### PR TITLE
Add AXI4Master driver

### DIFF
--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -37,7 +37,9 @@ from cocotb.triggers import ClockCycles, Combine, Lock, ReadOnly, RisingEdge
 
 
 class AXIProtocolError(Exception):
-    pass
+    def __init__(self,  message, xresp):
+        super().__init__(message)
+        self.xresp = xresp
 
 
 class AXIReadBurstLengthMismatch(Exception):
@@ -287,7 +289,7 @@ class AXI4Master(BusDriver):
 
                 raise AXIProtocolError(
                     err_msg.format(address, len(value), burst.name,
-                                   result.value, result.name))
+                                   result.value, result.name), result)
 
     @cocotb.coroutine
     async def read(self, address, length=1, *, size=None, burst=AXIBurst.INCR,
@@ -389,7 +391,7 @@ class AXI4Master(BusDriver):
                             address, beat_number + 1, length, burst,
                             beat_result.value, beat_result.name)
 
-                        raise AXIProtocolError(err_msg)
+                        raise AXIProtocolError(err_msg, beat_result)
 
                 return data
 

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -385,6 +385,8 @@ class AXI4Master(BusDriver):
 
                 await RisingEdge(self.clock)
 
+            await RisingEdge(self.clock)
+
             if len(data) != length:
                 raise AXIReadBurstLengthMismatch(
                     "AXI4 slave returned {} data than expected (requested {} "

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -263,10 +263,13 @@ Advanced Microcontroller Bus Architecture.
 
 .. currentmodule:: cocotb.drivers.amba
 
-.. autoclass:: AXI4LiteMaster
+.. autoclass:: AXI4Master
     :members:
     :member-order: bysource
 
+.. autoclass:: AXI4LiteMaster
+    :members:
+    :member-order: bysource
 
 .. autoclass:: AXI4Slave
     :members:

--- a/examples/axi_lite_slave/hdl/axi_lite_demo.v
+++ b/examples/axi_lite_slave/hdl/axi_lite_demo.v
@@ -69,7 +69,7 @@ module axi_lite_demo #(
 
 //Address Map
 localparam  ADDR_0      = 0;
-localparam  ADDR_1      = 1;
+localparam  ADDR_1      = 4;
 
 localparam  MAX_ADDR = ADDR_1;
 

--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -52,10 +52,10 @@ async def write_address_0(dut):
     dut.log.info("Write 0x%08X to address 0x%08X" % (int(value), ADDRESS))
 
 
-# Read back a value at address 0x01
+# Read back a value at address 0x04
 @cocotb.test()
-async def read_address_1(dut):
-    """Use cocotb to set the value of the register at address 0x01.
+async def read_address_4(dut):
+    """Use cocotb to set the value of the register at address 0x04.
     Use AXIML to read the contents of that register and
     compare the values.
 
@@ -72,7 +72,7 @@ async def read_address_1(dut):
     await Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
     await Timer(CLK_PERIOD_NS, units='ns')
-    ADDRESS = 0x01
+    ADDRESS = 0x04
     DATA = 0xCD
 
     dut.dut.r_temp_1 <= DATA
@@ -147,7 +147,7 @@ async def write_fail(dut):
     await Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
-    ADDRESS = 0x02
+    ADDRESS = 0x08
     DATA = 0xAB
 
     try:
@@ -180,7 +180,7 @@ async def read_fail(dut):
     await Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
-    ADDRESS = 0x02
+    ADDRESS = 0x08
     DATA = 0xAB
 
     try:

--- a/tests/designs/axi4_ram/Makefile
+++ b/tests/designs/axi4_ram/Makefile
@@ -1,0 +1,32 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
+TOPLEVEL := top
+
+PWD=$(shell pwd)
+
+COCOTB?=$(PWD)/../../..
+
+VERILOG_SOURCES = $(COCOTB)/tests/designs/axi4_ram/axi_register_rd.v
+VERILOG_SOURCES += $(COCOTB)/tests/designs/axi4_ram/axi_register_wr.v
+VERILOG_SOURCES += $(COCOTB)/tests/designs/axi4_ram/axi_register.v
+VERILOG_SOURCES += $(COCOTB)/tests/designs/axi4_ram/priority_encoder.v
+VERILOG_SOURCES += $(COCOTB)/tests/designs/axi4_ram/arbiter.v
+VERILOG_SOURCES += $(COCOTB)/tests/designs/axi4_ram/axi_interconnect.v
+VERILOG_SOURCES += $(COCOTB)/tests/designs/axi4_ram/axi_ram.v
+VERILOG_SOURCES += $(COCOTB)/tests/designs/axi4_ram/top.v
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+endif

--- a/tests/designs/axi4_ram/README.md
+++ b/tests/designs/axi4_ram/README.md
@@ -1,0 +1,3 @@
+# Verilog-AXI
+
+Verilog files taken taken from https://github.com/alexforencich/verilog-axi

--- a/tests/designs/axi4_ram/arbiter.v
+++ b/tests/designs/axi4_ram/arbiter.v
@@ -1,0 +1,153 @@
+/*
+
+Copyright (c) 2014-2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ns / 1ps
+
+/*
+ * Arbiter module
+ */
+module arbiter #
+(
+    parameter PORTS = 4,
+    // arbitration type: "PRIORITY" or "ROUND_ROBIN"
+    parameter TYPE = "PRIORITY",
+    // block type: "NONE", "REQUEST", "ACKNOWLEDGE"
+    parameter BLOCK = "NONE",
+    // LSB priority: "LOW", "HIGH"
+    parameter LSB_PRIORITY = "LOW"
+)
+(
+    input  wire                     clk,
+    input  wire                     rst,
+
+    input  wire [PORTS-1:0]         request,
+    input  wire [PORTS-1:0]         acknowledge,
+
+    output wire [PORTS-1:0]         grant,
+    output wire                     grant_valid,
+    output wire [$clog2(PORTS)-1:0] grant_encoded
+);
+
+reg [PORTS-1:0] grant_reg = 0, grant_next;
+reg grant_valid_reg = 0, grant_valid_next;
+reg [$clog2(PORTS)-1:0] grant_encoded_reg = 0, grant_encoded_next;
+
+assign grant_valid = grant_valid_reg;
+assign grant = grant_reg;
+assign grant_encoded = grant_encoded_reg;
+
+wire request_valid;
+wire [$clog2(PORTS)-1:0] request_index;
+wire [PORTS-1:0] request_mask;
+
+priority_encoder #(
+    .WIDTH(PORTS),
+    .LSB_PRIORITY(LSB_PRIORITY)
+)
+priority_encoder_inst (
+    .input_unencoded(request),
+    .output_valid(request_valid),
+    .output_encoded(request_index),
+    .output_unencoded(request_mask)
+);
+
+reg [PORTS-1:0] mask_reg = 0, mask_next;
+
+wire masked_request_valid;
+wire [$clog2(PORTS)-1:0] masked_request_index;
+wire [PORTS-1:0] masked_request_mask;
+
+priority_encoder #(
+    .WIDTH(PORTS),
+    .LSB_PRIORITY(LSB_PRIORITY)
+)
+priority_encoder_masked (
+    .input_unencoded(request & mask_reg),
+    .output_valid(masked_request_valid),
+    .output_encoded(masked_request_index),
+    .output_unencoded(masked_request_mask)
+);
+
+always @* begin
+    grant_next = 0;
+    grant_valid_next = 0;
+    grant_encoded_next = 0;
+    mask_next = mask_reg;
+
+    if (BLOCK == "REQUEST" && grant_reg & request) begin
+        // granted request still asserted; hold it
+        grant_valid_next = grant_valid_reg;
+        grant_next = grant_reg;
+        grant_encoded_next = grant_encoded_reg;
+    end else if (BLOCK == "ACKNOWLEDGE" && grant_valid && !(grant_reg & acknowledge)) begin
+        // granted request not yet acknowledged; hold it
+        grant_valid_next = grant_valid_reg;
+        grant_next = grant_reg;
+        grant_encoded_next = grant_encoded_reg;
+    end else if (request_valid) begin
+        if (TYPE == "PRIORITY") begin
+            grant_valid_next = 1;
+            grant_next = request_mask;
+            grant_encoded_next = request_index;
+        end else if (TYPE == "ROUND_ROBIN") begin
+            if (masked_request_valid) begin
+                grant_valid_next = 1;
+                grant_next = masked_request_mask;
+                grant_encoded_next = masked_request_index;
+                if (LSB_PRIORITY == "LOW") begin
+                    mask_next = {PORTS{1'b1}} >> (PORTS - masked_request_index);
+                end else begin
+                    mask_next = {PORTS{1'b1}} << (masked_request_index + 1);
+                end
+            end else begin
+                grant_valid_next = 1;
+                grant_next = request_mask;
+                grant_encoded_next = request_index;
+                if (LSB_PRIORITY == "LOW") begin
+                    mask_next = {PORTS{1'b1}} >> (PORTS - request_index);
+                end else begin
+                    mask_next = {PORTS{1'b1}} << (request_index + 1);
+                end
+            end
+        end
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        grant_reg <= 0;
+        grant_valid_reg <= 0;
+        grant_encoded_reg <= 0;
+        mask_reg <= 0;
+    end else begin
+        grant_reg <= grant_next;
+        grant_valid_reg <= grant_valid_next;
+        grant_encoded_reg <= grant_encoded_next;
+        mask_reg <= mask_next;
+    end
+end
+
+endmodule

--- a/tests/designs/axi4_ram/axi_interconnect.v
+++ b/tests/designs/axi4_ram/axi_interconnect.v
@@ -1,0 +1,941 @@
+/*
+
+Copyright (c) 2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ns / 1ps
+
+/*
+ * AXI4 interconnect
+ */
+module axi_interconnect #
+(
+    // Number of AXI inputs (slave interfaces)
+    parameter S_COUNT = 4,
+    // Number of AXI outputs (master interfaces)
+    parameter M_COUNT = 4,
+    // Width of data bus in bits
+    parameter DATA_WIDTH = 32,
+    // Width of address bus in bits
+    parameter ADDR_WIDTH = 32,
+    // Width of wstrb (width of data bus in words)
+    parameter STRB_WIDTH = (DATA_WIDTH/8),
+    // Width of ID signal
+    parameter ID_WIDTH = 8,
+    // Propagate awuser signal
+    parameter AWUSER_ENABLE = 0,
+    // Width of awuser signal
+    parameter AWUSER_WIDTH = 1,
+    // Propagate wuser signal
+    parameter WUSER_ENABLE = 0,
+    // Width of wuser signal
+    parameter WUSER_WIDTH = 1,
+    // Propagate buser signal
+    parameter BUSER_ENABLE = 0,
+    // Width of buser signal
+    parameter BUSER_WIDTH = 1,
+    // Propagate aruser signal
+    parameter ARUSER_ENABLE = 0,
+    // Width of aruser signal
+    parameter ARUSER_WIDTH = 1,
+    // Propagate ruser signal
+    parameter RUSER_ENABLE = 0,
+    // Width of ruser signal
+    parameter RUSER_WIDTH = 1,
+    // Propagate ID field
+    parameter FORWARD_ID = 0,
+    // Number of regions per master interface
+    parameter M_REGIONS = 1,
+    // Master interface base addresses
+    // M_COUNT concatenated fields of M_REGIONS concatenated fields of ADDR_WIDTH bits
+    // set to zero for default addressing based on M_ADDR_WIDTH
+    parameter M_BASE_ADDR = 0,
+    // Master interface address widths
+    // M_COUNT concatenated fields of M_REGIONS concatenated fields of 32 bits
+    parameter M_ADDR_WIDTH = {M_COUNT{{M_REGIONS{32'd24}}}},
+    // Read connections between interfaces
+    // M_COUNT concatenated fields of S_COUNT bits
+    parameter M_CONNECT_READ = {M_COUNT{{S_COUNT{1'b1}}}},
+    // Write connections between interfaces
+    // M_COUNT concatenated fields of S_COUNT bits
+    parameter M_CONNECT_WRITE = {M_COUNT{{S_COUNT{1'b1}}}},
+    // Secure master (fail operations based on awprot/arprot)
+    // M_COUNT bits
+    parameter M_SECURE = {M_COUNT{1'b0}}
+)
+(
+    input  wire                            clk,
+    input  wire                            rst,
+
+    /*
+     * AXI slave interfaces
+     */
+    input  wire [S_COUNT*ID_WIDTH-1:0]     s_axi_awid,
+    input  wire [S_COUNT*ADDR_WIDTH-1:0]   s_axi_awaddr,
+    input  wire [S_COUNT*8-1:0]            s_axi_awlen,
+    input  wire [S_COUNT*3-1:0]            s_axi_awsize,
+    input  wire [S_COUNT*2-1:0]            s_axi_awburst,
+    input  wire [S_COUNT-1:0]              s_axi_awlock,
+    input  wire [S_COUNT*4-1:0]            s_axi_awcache,
+    input  wire [S_COUNT*3-1:0]            s_axi_awprot,
+    input  wire [S_COUNT*4-1:0]            s_axi_awqos,
+    input  wire [S_COUNT*AWUSER_WIDTH-1:0] s_axi_awuser,
+    input  wire [S_COUNT-1:0]              s_axi_awvalid,
+    output wire [S_COUNT-1:0]              s_axi_awready,
+    input  wire [S_COUNT*DATA_WIDTH-1:0]   s_axi_wdata,
+    input  wire [S_COUNT*STRB_WIDTH-1:0]   s_axi_wstrb,
+    input  wire [S_COUNT-1:0]              s_axi_wlast,
+    input  wire [S_COUNT*WUSER_WIDTH-1:0]  s_axi_wuser,
+    input  wire [S_COUNT-1:0]              s_axi_wvalid,
+    output wire [S_COUNT-1:0]              s_axi_wready,
+    output wire [S_COUNT*ID_WIDTH-1:0]     s_axi_bid,
+    output wire [S_COUNT*2-1:0]            s_axi_bresp,
+    output wire [S_COUNT*BUSER_WIDTH-1:0]  s_axi_buser,
+    output wire [S_COUNT-1:0]              s_axi_bvalid,
+    input  wire [S_COUNT-1:0]              s_axi_bready,
+    input  wire [S_COUNT*ID_WIDTH-1:0]     s_axi_arid,
+    input  wire [S_COUNT*ADDR_WIDTH-1:0]   s_axi_araddr,
+    input  wire [S_COUNT*8-1:0]            s_axi_arlen,
+    input  wire [S_COUNT*3-1:0]            s_axi_arsize,
+    input  wire [S_COUNT*2-1:0]            s_axi_arburst,
+    input  wire [S_COUNT-1:0]              s_axi_arlock,
+    input  wire [S_COUNT*4-1:0]            s_axi_arcache,
+    input  wire [S_COUNT*3-1:0]            s_axi_arprot,
+    input  wire [S_COUNT*4-1:0]            s_axi_arqos,
+    input  wire [S_COUNT*ARUSER_WIDTH-1:0] s_axi_aruser,
+    input  wire [S_COUNT-1:0]              s_axi_arvalid,
+    output wire [S_COUNT-1:0]              s_axi_arready,
+    output wire [S_COUNT*ID_WIDTH-1:0]     s_axi_rid,
+    output wire [S_COUNT*DATA_WIDTH-1:0]   s_axi_rdata,
+    output wire [S_COUNT*2-1:0]            s_axi_rresp,
+    output wire [S_COUNT-1:0]              s_axi_rlast,
+    output wire [S_COUNT*RUSER_WIDTH-1:0]  s_axi_ruser,
+    output wire [S_COUNT-1:0]              s_axi_rvalid,
+    input  wire [S_COUNT-1:0]              s_axi_rready,
+
+    /*
+     * AXI master interfaces
+     */
+    output wire [M_COUNT*ID_WIDTH-1:0]     m_axi_awid,
+    output wire [M_COUNT*ADDR_WIDTH-1:0]   m_axi_awaddr,
+    output wire [M_COUNT*8-1:0]            m_axi_awlen,
+    output wire [M_COUNT*3-1:0]            m_axi_awsize,
+    output wire [M_COUNT*2-1:0]            m_axi_awburst,
+    output wire [M_COUNT-1:0]              m_axi_awlock,
+    output wire [M_COUNT*4-1:0]            m_axi_awcache,
+    output wire [M_COUNT*3-1:0]            m_axi_awprot,
+    output wire [M_COUNT*4-1:0]            m_axi_awqos,
+    output wire [M_COUNT*4-1:0]            m_axi_awregion,
+    output wire [M_COUNT*AWUSER_WIDTH-1:0] m_axi_awuser,
+    output wire [M_COUNT-1:0]              m_axi_awvalid,
+    input  wire [M_COUNT-1:0]              m_axi_awready,
+    output wire [M_COUNT*DATA_WIDTH-1:0]   m_axi_wdata,
+    output wire [M_COUNT*STRB_WIDTH-1:0]   m_axi_wstrb,
+    output wire [M_COUNT-1:0]              m_axi_wlast,
+    output wire [M_COUNT*WUSER_WIDTH-1:0]  m_axi_wuser,
+    output wire [M_COUNT-1:0]              m_axi_wvalid,
+    input  wire [M_COUNT-1:0]              m_axi_wready,
+    input  wire [M_COUNT*ID_WIDTH-1:0]     m_axi_bid,
+    input  wire [M_COUNT*2-1:0]            m_axi_bresp,
+    input  wire [M_COUNT*BUSER_WIDTH-1:0]  m_axi_buser,
+    input  wire [M_COUNT-1:0]              m_axi_bvalid,
+    output wire [M_COUNT-1:0]              m_axi_bready,
+    output wire [M_COUNT*ID_WIDTH-1:0]     m_axi_arid,
+    output wire [M_COUNT*ADDR_WIDTH-1:0]   m_axi_araddr,
+    output wire [M_COUNT*8-1:0]            m_axi_arlen,
+    output wire [M_COUNT*3-1:0]            m_axi_arsize,
+    output wire [M_COUNT*2-1:0]            m_axi_arburst,
+    output wire [M_COUNT-1:0]              m_axi_arlock,
+    output wire [M_COUNT*4-1:0]            m_axi_arcache,
+    output wire [M_COUNT*3-1:0]            m_axi_arprot,
+    output wire [M_COUNT*4-1:0]            m_axi_arqos,
+    output wire [M_COUNT*4-1:0]            m_axi_arregion,
+    output wire [M_COUNT*ARUSER_WIDTH-1:0] m_axi_aruser,
+    output wire [M_COUNT-1:0]              m_axi_arvalid,
+    input  wire [M_COUNT-1:0]              m_axi_arready,
+    input  wire [M_COUNT*ID_WIDTH-1:0]     m_axi_rid,
+    input  wire [M_COUNT*DATA_WIDTH-1:0]   m_axi_rdata,
+    input  wire [M_COUNT*2-1:0]            m_axi_rresp,
+    input  wire [M_COUNT-1:0]              m_axi_rlast,
+    input  wire [M_COUNT*RUSER_WIDTH-1:0]  m_axi_ruser,
+    input  wire [M_COUNT-1:0]              m_axi_rvalid,
+    output wire [M_COUNT-1:0]              m_axi_rready
+);
+
+parameter CL_S_COUNT = $clog2(S_COUNT);
+parameter CL_M_COUNT = $clog2(M_COUNT);
+
+parameter AUSER_WIDTH = AWUSER_WIDTH > ARUSER_WIDTH ? AWUSER_WIDTH : ARUSER_WIDTH;
+
+// default address computation
+function [M_COUNT*M_REGIONS*ADDR_WIDTH-1:0] calcBaseAddrs(input [31:0] dummy);
+    integer i;
+    reg [ADDR_WIDTH-1:0] base;
+    begin
+        calcBaseAddrs = {M_COUNT*M_REGIONS*ADDR_WIDTH{1'b0}};
+        base = 0;
+        for (i = 1; i < M_COUNT*M_REGIONS; i = i + 1) begin
+            if (M_ADDR_WIDTH[i*32 +: 32]) begin
+                base = base + 2**M_ADDR_WIDTH[(i-1)*32 +: 32]; // increment
+                base = base - (base % 2**M_ADDR_WIDTH[i*32 +: 32]); // align
+                calcBaseAddrs[i * ADDR_WIDTH +: ADDR_WIDTH] = base;
+            end
+        end
+    end
+endfunction
+
+parameter M_BASE_ADDR_INT = M_BASE_ADDR ? M_BASE_ADDR : calcBaseAddrs(0);
+
+integer i, j;
+
+// check configuration
+initial begin
+    if (M_REGIONS < 1 || M_REGIONS > 16) begin
+        $error("Error: M_REGIONS must be between 1 and 16 (instance %m)");
+        $finish;
+    end
+
+    for (i = 0; i < M_COUNT*M_REGIONS; i = i + 1) begin
+        if (M_ADDR_WIDTH[i*32 +: 32] && (M_ADDR_WIDTH[i*32 +: 32] < 12 || M_ADDR_WIDTH[i*32 +: 32] > ADDR_WIDTH)) begin
+            $error("Error: address width out of range (instance %m)");
+            $finish;
+        end
+    end
+
+    $display("Addressing configuration for axi_interconnect instance %m");
+    for (i = 0; i < M_COUNT*M_REGIONS; i = i + 1) begin
+        if (M_ADDR_WIDTH[i*32 +: 32]) begin
+            $display("%2d (%2d): %x / %2d -- %x-%x", i/M_REGIONS, i%M_REGIONS, M_BASE_ADDR_INT[i*ADDR_WIDTH +: ADDR_WIDTH], M_ADDR_WIDTH[i*32 +: 32], M_BASE_ADDR_INT[i*ADDR_WIDTH +: ADDR_WIDTH] & ({ADDR_WIDTH{1'b1}} << M_ADDR_WIDTH[i*32 +: 32]), M_BASE_ADDR_INT[i*ADDR_WIDTH +: ADDR_WIDTH] | ({ADDR_WIDTH{1'b1}} >> (ADDR_WIDTH - M_ADDR_WIDTH[i*32 +: 32])));
+        end
+    end
+
+    for (i = 0; i < M_COUNT*M_REGIONS; i = i + 1) begin
+        for (j = i+1; j < M_COUNT*M_REGIONS; j = j + 1) begin
+            if (M_ADDR_WIDTH[i*32 +: 32] && M_ADDR_WIDTH[j*32 +: 32]) begin
+                if (((M_BASE_ADDR_INT[i*ADDR_WIDTH +: ADDR_WIDTH] & ({ADDR_WIDTH{1'b1}} << M_ADDR_WIDTH[i*32 +: 32])) <= (M_BASE_ADDR_INT[j*ADDR_WIDTH +: ADDR_WIDTH] | ({ADDR_WIDTH{1'b1}} >> (ADDR_WIDTH - M_ADDR_WIDTH[j*32 +: 32])))) && ((M_BASE_ADDR_INT[j*ADDR_WIDTH +: ADDR_WIDTH] & ({ADDR_WIDTH{1'b1}} << M_ADDR_WIDTH[j*32 +: 32])) <= (M_BASE_ADDR_INT[i*ADDR_WIDTH +: ADDR_WIDTH] | ({ADDR_WIDTH{1'b1}} >> (ADDR_WIDTH - M_ADDR_WIDTH[i*32 +: 32]))))) begin
+                    $display("Overlapping regions:");
+                    $display("%2d (%2d): %x / %2d -- %x-%x", i/M_REGIONS, i%M_REGIONS, M_BASE_ADDR_INT[i*ADDR_WIDTH +: ADDR_WIDTH], M_ADDR_WIDTH[i*32 +: 32], M_BASE_ADDR_INT[i*ADDR_WIDTH +: ADDR_WIDTH] & ({ADDR_WIDTH{1'b1}} << M_ADDR_WIDTH[i*32 +: 32]), M_BASE_ADDR_INT[i*ADDR_WIDTH +: ADDR_WIDTH] | ({ADDR_WIDTH{1'b1}} >> (ADDR_WIDTH - M_ADDR_WIDTH[i*32 +: 32])));
+                    $display("%2d (%2d): %x / %2d -- %x-%x", j/M_REGIONS, j%M_REGIONS, M_BASE_ADDR_INT[j*ADDR_WIDTH +: ADDR_WIDTH], M_ADDR_WIDTH[j*32 +: 32], M_BASE_ADDR_INT[j*ADDR_WIDTH +: ADDR_WIDTH] & ({ADDR_WIDTH{1'b1}} << M_ADDR_WIDTH[j*32 +: 32]), M_BASE_ADDR_INT[j*ADDR_WIDTH +: ADDR_WIDTH] | ({ADDR_WIDTH{1'b1}} >> (ADDR_WIDTH - M_ADDR_WIDTH[j*32 +: 32])));
+                    $error("Error: address ranges overlap (instance %m)");
+                    $finish;
+                end
+            end
+        end
+    end
+end
+
+localparam [2:0]
+    STATE_IDLE = 3'd0,
+    STATE_DECODE = 3'd1,
+    STATE_WRITE = 3'd2,
+    STATE_WRITE_RESP = 3'd3,
+    STATE_WRITE_DROP = 3'd4,
+    STATE_READ = 3'd5,
+    STATE_READ_DROP = 3'd6,
+    STATE_WAIT_IDLE = 3'd7;
+
+reg [2:0] state_reg = STATE_IDLE, state_next;
+
+reg match;
+
+reg [CL_M_COUNT-1:0] m_select_reg = 2'd0, m_select_next;
+reg [ID_WIDTH-1:0] axi_id_reg = {ID_WIDTH{1'b0}}, axi_id_next;
+reg [ADDR_WIDTH-1:0] axi_addr_reg = {ADDR_WIDTH{1'b0}}, axi_addr_next;
+reg axi_addr_valid_reg = 1'b0, axi_addr_valid_next;
+reg [7:0] axi_len_reg = 8'd0, axi_len_next;
+reg [2:0] axi_size_reg = 3'd0, axi_size_next;
+reg [1:0] axi_burst_reg = 2'd0, axi_burst_next;
+reg axi_lock_reg = 1'b0, axi_lock_next;
+reg [3:0] axi_cache_reg = 4'd0, axi_cache_next;
+reg [2:0] axi_prot_reg = 3'b000, axi_prot_next;
+reg [3:0] axi_qos_reg = 4'd0, axi_qos_next;
+reg [3:0] axi_region_reg = 4'd0, axi_region_next;
+reg [AUSER_WIDTH-1:0] axi_auser_reg = {AUSER_WIDTH{1'b0}}, axi_auser_next;
+reg [1:0] axi_bresp_reg = 2'b00, axi_bresp_next;
+reg [BUSER_WIDTH-1:0] axi_buser_reg = {BUSER_WIDTH{1'b0}}, axi_buser_next;
+
+reg [S_COUNT-1:0] s_axi_awready_reg = 0, s_axi_awready_next;
+reg [S_COUNT-1:0] s_axi_wready_reg = 0, s_axi_wready_next;
+reg [S_COUNT-1:0] s_axi_bvalid_reg = 0, s_axi_bvalid_next;
+reg [S_COUNT-1:0] s_axi_arready_reg = 0, s_axi_arready_next;
+
+reg [M_COUNT-1:0] m_axi_awvalid_reg = 0, m_axi_awvalid_next;
+reg [M_COUNT-1:0] m_axi_bready_reg = 0, m_axi_bready_next;
+reg [M_COUNT-1:0] m_axi_arvalid_reg = 0, m_axi_arvalid_next;
+reg [M_COUNT-1:0] m_axi_rready_reg = 0, m_axi_rready_next;
+
+// internal datapath
+reg  [ID_WIDTH-1:0]    s_axi_rid_int;
+reg  [DATA_WIDTH-1:0]  s_axi_rdata_int;
+reg  [1:0]             s_axi_rresp_int;
+reg                    s_axi_rlast_int;
+reg  [RUSER_WIDTH-1:0] s_axi_ruser_int;
+reg                    s_axi_rvalid_int;
+reg                    s_axi_rready_int_reg = 1'b0;
+wire                   s_axi_rready_int_early;
+
+reg  [DATA_WIDTH-1:0]  m_axi_wdata_int;
+reg  [STRB_WIDTH-1:0]  m_axi_wstrb_int;
+reg                    m_axi_wlast_int;
+reg  [WUSER_WIDTH-1:0] m_axi_wuser_int;
+reg                    m_axi_wvalid_int;
+reg                    m_axi_wready_int_reg = 1'b0;
+wire                   m_axi_wready_int_early;
+
+assign s_axi_awready = s_axi_awready_reg;
+assign s_axi_wready = s_axi_wready_reg;
+assign s_axi_bid = {S_COUNT{axi_id_reg}};
+assign s_axi_bresp = {S_COUNT{axi_bresp_reg}};
+assign s_axi_buser = {S_COUNT{BUSER_ENABLE ? axi_buser_reg : {BUSER_WIDTH{1'b0}}}};
+assign s_axi_bvalid = s_axi_bvalid_reg;
+assign s_axi_arready = s_axi_arready_reg;
+
+assign m_axi_awid = {M_COUNT{FORWARD_ID ? axi_id_reg : {ID_WIDTH{1'b0}}}};
+assign m_axi_awaddr = {M_COUNT{axi_addr_reg}};
+assign m_axi_awlen = {M_COUNT{axi_len_reg}};
+assign m_axi_awsize = {M_COUNT{axi_size_reg}};
+assign m_axi_awburst = {M_COUNT{axi_burst_reg}};
+assign m_axi_awlock = {M_COUNT{axi_lock_reg}};
+assign m_axi_awcache = {M_COUNT{axi_cache_reg}};
+assign m_axi_awprot = {M_COUNT{axi_prot_reg}};
+assign m_axi_awqos = {M_COUNT{axi_qos_reg}};
+assign m_axi_awregion = {M_COUNT{axi_region_reg}};
+assign m_axi_awuser = {M_COUNT{AWUSER_ENABLE ? axi_auser_reg[AWUSER_WIDTH-1:0] : {AWUSER_WIDTH{1'b0}}}};
+assign m_axi_awvalid = m_axi_awvalid_reg;
+assign m_axi_bready = m_axi_bready_reg;
+assign m_axi_arid = {M_COUNT{FORWARD_ID ? axi_id_reg : {ID_WIDTH{1'b0}}}};
+assign m_axi_araddr = {M_COUNT{axi_addr_reg}};
+assign m_axi_arlen = {M_COUNT{axi_len_reg}};
+assign m_axi_arsize = {M_COUNT{axi_size_reg}};
+assign m_axi_arburst = {M_COUNT{axi_burst_reg}};
+assign m_axi_arlock = {M_COUNT{axi_lock_reg}};
+assign m_axi_arcache = {M_COUNT{axi_cache_reg}};
+assign m_axi_arprot = {M_COUNT{axi_prot_reg}};
+assign m_axi_arqos = {M_COUNT{axi_qos_reg}};
+assign m_axi_arregion = {M_COUNT{axi_region_reg}};
+assign m_axi_aruser = {M_COUNT{ARUSER_ENABLE ? axi_auser_reg[ARUSER_WIDTH-1:0] : {ARUSER_WIDTH{1'b0}}}};
+assign m_axi_arvalid = m_axi_arvalid_reg;
+assign m_axi_rready = m_axi_rready_reg;
+
+// slave side mux
+wire [(CL_S_COUNT > 0 ? CL_S_COUNT-1 : 0):0] s_select;
+
+wire [ID_WIDTH-1:0]     current_s_axi_awid      = s_axi_awid[s_select*ID_WIDTH +: ID_WIDTH];
+wire [ADDR_WIDTH-1:0]   current_s_axi_awaddr    = s_axi_awaddr[s_select*ADDR_WIDTH +: ADDR_WIDTH];
+wire [7:0]              current_s_axi_awlen     = s_axi_awlen[s_select*8 +: 8];
+wire [2:0]              current_s_axi_awsize    = s_axi_awsize[s_select*3 +: 3];
+wire [1:0]              current_s_axi_awburst   = s_axi_awburst[s_select*2 +: 2];
+wire                    current_s_axi_awlock    = s_axi_awlock[s_select];
+wire [3:0]              current_s_axi_awcache   = s_axi_awcache[s_select*4 +: 4];
+wire [2:0]              current_s_axi_awprot    = s_axi_awprot[s_select*3 +: 3];
+wire [3:0]              current_s_axi_awqos     = s_axi_awqos[s_select*4 +: 4];
+wire [AWUSER_WIDTH-1:0] current_s_axi_awuser    = s_axi_awuser[s_select*AWUSER_WIDTH +: AWUSER_WIDTH];
+wire                    current_s_axi_awvalid   = s_axi_awvalid[s_select];
+wire                    current_s_axi_awready   = s_axi_awready[s_select];
+wire [DATA_WIDTH-1:0]   current_s_axi_wdata     = s_axi_wdata[s_select*DATA_WIDTH +: DATA_WIDTH];
+wire [STRB_WIDTH-1:0]   current_s_axi_wstrb     = s_axi_wstrb[s_select*STRB_WIDTH +: STRB_WIDTH];
+wire                    current_s_axi_wlast     = s_axi_wlast[s_select];
+wire [WUSER_WIDTH-1:0]  current_s_axi_wuser     = s_axi_wuser[s_select*WUSER_WIDTH +: WUSER_WIDTH];
+wire                    current_s_axi_wvalid    = s_axi_wvalid[s_select];
+wire                    current_s_axi_wready    = s_axi_wready[s_select];
+wire [ID_WIDTH-1:0]     current_s_axi_bid       = s_axi_bid[s_select*ID_WIDTH +: ID_WIDTH];
+wire [1:0]              current_s_axi_bresp     = s_axi_bresp[s_select*2 +: 2];
+wire [BUSER_WIDTH-1:0]  current_s_axi_buser     = s_axi_buser[s_select*BUSER_WIDTH +: BUSER_WIDTH];
+wire                    current_s_axi_bvalid    = s_axi_bvalid[s_select];
+wire                    current_s_axi_bready    = s_axi_bready[s_select];
+wire [ID_WIDTH-1:0]     current_s_axi_arid      = s_axi_arid[s_select*ID_WIDTH +: ID_WIDTH];
+wire [ADDR_WIDTH-1:0]   current_s_axi_araddr    = s_axi_araddr[s_select*ADDR_WIDTH +: ADDR_WIDTH];
+wire [7:0]              current_s_axi_arlen     = s_axi_arlen[s_select*8 +: 8];
+wire [2:0]              current_s_axi_arsize    = s_axi_arsize[s_select*3 +: 3];
+wire [1:0]              current_s_axi_arburst   = s_axi_arburst[s_select*2 +: 2];
+wire                    current_s_axi_arlock    = s_axi_arlock[s_select];
+wire [3:0]              current_s_axi_arcache   = s_axi_arcache[s_select*4 +: 4];
+wire [2:0]              current_s_axi_arprot    = s_axi_arprot[s_select*3 +: 3];
+wire [3:0]              current_s_axi_arqos     = s_axi_arqos[s_select*4 +: 4];
+wire [ARUSER_WIDTH-1:0] current_s_axi_aruser    = s_axi_aruser[s_select*ARUSER_WIDTH +: ARUSER_WIDTH];
+wire                    current_s_axi_arvalid   = s_axi_arvalid[s_select];
+wire                    current_s_axi_arready   = s_axi_arready[s_select];
+wire [ID_WIDTH-1:0]     current_s_axi_rid       = s_axi_rid[s_select*ID_WIDTH +: ID_WIDTH];
+wire [DATA_WIDTH-1:0]   current_s_axi_rdata     = s_axi_rdata[s_select*DATA_WIDTH +: DATA_WIDTH];
+wire [1:0]              current_s_axi_rresp     = s_axi_rresp[s_select*2 +: 2];
+wire                    current_s_axi_rlast     = s_axi_rlast[s_select];
+wire [RUSER_WIDTH-1:0]  current_s_axi_ruser     = s_axi_ruser[s_select*RUSER_WIDTH +: RUSER_WIDTH];
+wire                    current_s_axi_rvalid    = s_axi_rvalid[s_select];
+wire                    current_s_axi_rready    = s_axi_rready[s_select];
+
+// master side mux
+wire [ID_WIDTH-1:0]     current_m_axi_awid      = m_axi_awid[m_select_reg*ID_WIDTH +: ID_WIDTH];
+wire [ADDR_WIDTH-1:0]   current_m_axi_awaddr    = m_axi_awaddr[m_select_reg*ADDR_WIDTH +: ADDR_WIDTH];
+wire [7:0]              current_m_axi_awlen     = m_axi_awlen[m_select_reg*8 +: 8];
+wire [2:0]              current_m_axi_awsize    = m_axi_awsize[m_select_reg*3 +: 3];
+wire [1:0]              current_m_axi_awburst   = m_axi_awburst[m_select_reg*2 +: 2];
+wire                    current_m_axi_awlock    = m_axi_awlock[m_select_reg];
+wire [3:0]              current_m_axi_awcache   = m_axi_awcache[m_select_reg*4 +: 4];
+wire [2:0]              current_m_axi_awprot    = m_axi_awprot[m_select_reg*3 +: 3];
+wire [3:0]              current_m_axi_awqos     = m_axi_awqos[m_select_reg*4 +: 4];
+wire [3:0]              current_m_axi_awregion  = m_axi_awregion[m_select_reg*4 +: 4];
+wire [AWUSER_WIDTH-1:0] current_m_axi_awuser    = m_axi_awuser[m_select_reg*AWUSER_WIDTH +: AWUSER_WIDTH];
+wire                    current_m_axi_awvalid   = m_axi_awvalid[m_select_reg];
+wire                    current_m_axi_awready   = m_axi_awready[m_select_reg];
+wire [DATA_WIDTH-1:0]   current_m_axi_wdata     = m_axi_wdata[m_select_reg*DATA_WIDTH +: DATA_WIDTH];
+wire [STRB_WIDTH-1:0]   current_m_axi_wstrb     = m_axi_wstrb[m_select_reg*STRB_WIDTH +: STRB_WIDTH];
+wire                    current_m_axi_wlast     = m_axi_wlast[m_select_reg];
+wire [WUSER_WIDTH-1:0]  current_m_axi_wuser     = m_axi_wuser[m_select_reg*WUSER_WIDTH +: WUSER_WIDTH];
+wire                    current_m_axi_wvalid    = m_axi_wvalid[m_select_reg];
+wire                    current_m_axi_wready    = m_axi_wready[m_select_reg];
+wire [ID_WIDTH-1:0]     current_m_axi_bid       = m_axi_bid[m_select_reg*ID_WIDTH +: ID_WIDTH];
+wire [1:0]              current_m_axi_bresp     = m_axi_bresp[m_select_reg*2 +: 2];
+wire [BUSER_WIDTH-1:0]  current_m_axi_buser     = m_axi_buser[m_select_reg*BUSER_WIDTH +: BUSER_WIDTH];
+wire                    current_m_axi_bvalid    = m_axi_bvalid[m_select_reg];
+wire                    current_m_axi_bready    = m_axi_bready[m_select_reg];
+wire [ID_WIDTH-1:0]     current_m_axi_arid      = m_axi_arid[m_select_reg*ID_WIDTH +: ID_WIDTH];
+wire [ADDR_WIDTH-1:0]   current_m_axi_araddr    = m_axi_araddr[m_select_reg*ADDR_WIDTH +: ADDR_WIDTH];
+wire [7:0]              current_m_axi_arlen     = m_axi_arlen[m_select_reg*8 +: 8];
+wire [2:0]              current_m_axi_arsize    = m_axi_arsize[m_select_reg*3 +: 3];
+wire [1:0]              current_m_axi_arburst   = m_axi_arburst[m_select_reg*2 +: 2];
+wire                    current_m_axi_arlock    = m_axi_arlock[m_select_reg];
+wire [3:0]              current_m_axi_arcache   = m_axi_arcache[m_select_reg*4 +: 4];
+wire [2:0]              current_m_axi_arprot    = m_axi_arprot[m_select_reg*3 +: 3];
+wire [3:0]              current_m_axi_arqos     = m_axi_arqos[m_select_reg*4 +: 4];
+wire [3:0]              current_m_axi_arregion  = m_axi_arregion[m_select_reg*4 +: 4];
+wire [ARUSER_WIDTH-1:0] current_m_axi_aruser    = m_axi_aruser[m_select_reg*ARUSER_WIDTH +: ARUSER_WIDTH];
+wire                    current_m_axi_arvalid   = m_axi_arvalid[m_select_reg];
+wire                    current_m_axi_arready   = m_axi_arready[m_select_reg];
+wire [ID_WIDTH-1:0]     current_m_axi_rid       = m_axi_rid[m_select_reg*ID_WIDTH +: ID_WIDTH];
+wire [DATA_WIDTH-1:0]   current_m_axi_rdata     = m_axi_rdata[m_select_reg*DATA_WIDTH +: DATA_WIDTH];
+wire [1:0]              current_m_axi_rresp     = m_axi_rresp[m_select_reg*2 +: 2];
+wire                    current_m_axi_rlast     = m_axi_rlast[m_select_reg];
+wire [RUSER_WIDTH-1:0]  current_m_axi_ruser     = m_axi_ruser[m_select_reg*RUSER_WIDTH +: RUSER_WIDTH];
+wire                    current_m_axi_rvalid    = m_axi_rvalid[m_select_reg];
+wire                    current_m_axi_rready    = m_axi_rready[m_select_reg];
+
+// arbiter instance
+wire [S_COUNT*2-1:0] request;
+wire [S_COUNT*2-1:0] acknowledge;
+wire [S_COUNT*2-1:0] grant;
+wire grant_valid;
+wire [CL_S_COUNT:0] grant_encoded;
+
+wire read = grant_encoded[0];
+assign s_select = grant_encoded >> 1;
+
+arbiter #(
+    .PORTS(S_COUNT*2),
+    .TYPE("ROUND_ROBIN"),
+    .BLOCK("ACKNOWLEDGE"),
+    .LSB_PRIORITY("HIGH")
+)
+arb_inst (
+    .clk(clk),
+    .rst(rst),
+    .request(request),
+    .acknowledge(acknowledge),
+    .grant(grant),
+    .grant_valid(grant_valid),
+    .grant_encoded(grant_encoded)
+);
+
+genvar n;
+
+// request generation
+generate
+for (n = 0; n < S_COUNT; n = n + 1) begin
+    assign request[2*n]   = s_axi_awvalid[n];
+    assign request[2*n+1] = s_axi_arvalid[n];
+end
+endgenerate
+
+// acknowledge generation
+generate
+for (n = 0; n < S_COUNT; n = n + 1) begin
+    assign acknowledge[2*n]   = grant[2*n]   && s_axi_bvalid[n] && s_axi_bready[n];
+    assign acknowledge[2*n+1] = grant[2*n+1] && s_axi_rvalid[n] && s_axi_rready[n] && s_axi_rlast[n];
+end
+endgenerate
+
+always @* begin
+    state_next = STATE_IDLE;
+
+    match = 1'b0;
+
+    m_select_next = m_select_reg;
+    axi_id_next = axi_id_reg;
+    axi_addr_next = axi_addr_reg;
+    axi_addr_valid_next = axi_addr_valid_reg;
+    axi_len_next = axi_len_reg;
+    axi_size_next = axi_size_reg;
+    axi_burst_next = axi_burst_reg;
+    axi_lock_next = axi_lock_reg;
+    axi_cache_next = axi_cache_reg;
+    axi_prot_next = axi_prot_reg;
+    axi_qos_next = axi_qos_reg;
+    axi_region_next = axi_region_reg;
+    axi_auser_next = axi_auser_reg;
+    axi_bresp_next = axi_bresp_reg;
+    axi_buser_next = axi_buser_reg;
+
+    s_axi_awready_next = 0;
+    s_axi_wready_next = 0;
+    s_axi_bvalid_next = s_axi_bvalid_reg & ~s_axi_bready;
+    s_axi_arready_next = 0;
+
+    m_axi_awvalid_next = m_axi_awvalid_reg & ~m_axi_awready;
+    m_axi_bready_next = 0;
+    m_axi_arvalid_next = m_axi_arvalid_reg & ~m_axi_arready;
+    m_axi_rready_next = 0;
+
+    s_axi_rid_int = axi_id_reg;
+    s_axi_rdata_int = current_m_axi_rdata;
+    s_axi_rresp_int = current_m_axi_rresp;
+    s_axi_rlast_int = current_m_axi_rlast;
+    s_axi_ruser_int = current_m_axi_ruser;
+    s_axi_rvalid_int = 1'b0;
+
+    m_axi_wdata_int = current_s_axi_wdata;
+    m_axi_wstrb_int = current_s_axi_wstrb;
+    m_axi_wlast_int = current_s_axi_wlast;
+    m_axi_wuser_int = current_s_axi_wuser;
+    m_axi_wvalid_int = 1'b0;
+
+    case (state_reg)
+        STATE_IDLE: begin
+            // idle state; wait for arbitration
+
+            if (grant_valid) begin
+
+                axi_addr_valid_next = 1'b1;
+
+                if (read) begin
+                    // reading
+                    axi_addr_next = current_s_axi_araddr;
+                    axi_prot_next = current_s_axi_arprot;
+                    axi_id_next = current_s_axi_arid;
+                    axi_addr_next = current_s_axi_araddr;
+                    axi_len_next = current_s_axi_arlen;
+                    axi_size_next = current_s_axi_arsize;
+                    axi_burst_next = current_s_axi_arburst;
+                    axi_lock_next = current_s_axi_arlock;
+                    axi_cache_next = current_s_axi_arcache;
+                    axi_prot_next = current_s_axi_arprot;
+                    axi_qos_next = current_s_axi_arqos;
+                    axi_auser_next = current_s_axi_aruser;
+                    s_axi_arready_next[s_select] = 1'b1;
+                end else  begin
+                    // writing
+                    axi_addr_next = current_s_axi_awaddr;
+                    axi_prot_next = current_s_axi_awprot;
+                    axi_id_next = current_s_axi_awid;
+                    axi_addr_next = current_s_axi_awaddr;
+                    axi_len_next = current_s_axi_awlen;
+                    axi_size_next = current_s_axi_awsize;
+                    axi_burst_next = current_s_axi_awburst;
+                    axi_lock_next = current_s_axi_awlock;
+                    axi_cache_next = current_s_axi_awcache;
+                    axi_prot_next = current_s_axi_awprot;
+                    axi_qos_next = current_s_axi_awqos;
+                    axi_auser_next = current_s_axi_awuser;
+                    s_axi_awready_next[s_select] = 1'b1;
+                end
+
+                state_next = STATE_DECODE;
+            end else begin
+                state_next = STATE_IDLE;
+            end
+        end
+        STATE_DECODE: begin
+            // decode state; determine master interface
+
+            match = 1'b0;
+            for (i = 0; i < M_COUNT; i = i + 1) begin
+                for (j = 0; j < M_REGIONS; j = j + 1) begin
+                    if (M_ADDR_WIDTH[(i*M_REGIONS+j)*32 +: 32] && (!M_SECURE[i] || !axi_prot_reg[1]) && ((read ? M_CONNECT_READ : M_CONNECT_WRITE) & (1 << (s_select+i*S_COUNT))) && (axi_addr_reg >> M_ADDR_WIDTH[(i*M_REGIONS+j)*32 +: 32]) == (M_BASE_ADDR_INT[(i*M_REGIONS+j)*ADDR_WIDTH +: ADDR_WIDTH] >> M_ADDR_WIDTH[(i*M_REGIONS+j)*32 +: 32])) begin
+                        m_select_next = i;
+                        axi_region_next = j;
+                        match = 1'b1;
+                    end
+                end
+            end
+
+            if (match) begin
+                if (read) begin
+                    // reading
+                    m_axi_rready_next[m_select_reg] = s_axi_rready_int_early;
+                    state_next = STATE_READ;
+                end else begin
+                    // writing
+                    s_axi_wready_next[s_select] = m_axi_wready_int_early;
+                    state_next = STATE_WRITE;
+                end
+            end else begin
+                // no match; return decode error
+                if (read) begin
+                    // reading
+                    state_next = STATE_READ_DROP;
+                end else begin
+                    // writing
+                    axi_bresp_next = 2'b11;
+                    s_axi_wready_next[s_select] = 1'b1;
+                    state_next = STATE_WRITE_DROP;
+                end
+            end
+        end
+        STATE_WRITE: begin
+            // write state; store and forward write data
+            s_axi_wready_next[s_select] = m_axi_wready_int_early;
+
+            if (axi_addr_valid_reg) begin
+                m_axi_awvalid_next[m_select_reg] = 1'b1;
+            end
+            axi_addr_valid_next = 1'b0;
+
+            if (current_s_axi_wready && current_s_axi_wvalid) begin
+                m_axi_wdata_int = current_s_axi_wdata;
+                m_axi_wstrb_int = current_s_axi_wstrb;
+                m_axi_wlast_int = current_s_axi_wlast;
+                m_axi_wuser_int = current_s_axi_wuser;
+                m_axi_wvalid_int = 1'b1;
+
+                if (current_s_axi_wlast) begin
+                    s_axi_wready_next[s_select] = 1'b0;
+                    m_axi_bready_next[m_select_reg] = 1'b1;
+                    state_next = STATE_WRITE_RESP;
+                end else begin
+                    state_next = STATE_WRITE;
+                end
+            end else begin
+                state_next = STATE_WRITE;
+            end
+        end
+        STATE_WRITE_RESP: begin
+            // write response state; store and forward write response
+            m_axi_bready_next[m_select_reg] = 1'b1;
+
+            if (current_m_axi_bready && current_m_axi_bvalid) begin
+                m_axi_bready_next[m_select_reg] = 1'b0;
+                axi_bresp_next = current_m_axi_bresp;
+                s_axi_bvalid_next[s_select] = 1'b1;
+                state_next = STATE_WAIT_IDLE;
+            end else begin
+                state_next = STATE_WRITE_RESP;
+            end
+        end
+        STATE_WRITE_DROP: begin
+            // write drop state; drop write data
+            s_axi_wready_next[s_select] = 1'b1;
+
+            axi_addr_valid_next = 1'b0;
+
+            if (current_s_axi_wready && current_s_axi_wvalid && current_s_axi_wlast) begin
+                s_axi_wready_next[s_select] = 1'b0;
+                s_axi_bvalid_next[s_select] = 1'b1;
+                state_next = STATE_WAIT_IDLE;
+            end else begin
+                state_next = STATE_WRITE_DROP;
+            end
+        end
+        STATE_READ: begin
+            // read state; store and forward read response
+            m_axi_rready_next[m_select_reg] = s_axi_rready_int_early;
+
+            if (axi_addr_valid_reg) begin
+                m_axi_arvalid_next[m_select_reg] = 1'b1;
+            end
+            axi_addr_valid_next = 1'b0;
+
+            if (current_m_axi_rready && current_m_axi_rvalid) begin
+                s_axi_rid_int = axi_id_reg;
+                s_axi_rdata_int = current_m_axi_rdata;
+                s_axi_rresp_int = current_m_axi_rresp;
+                s_axi_rlast_int = current_m_axi_rlast;
+                s_axi_ruser_int = current_m_axi_ruser;
+                s_axi_rvalid_int = 1'b1;
+
+                if (current_m_axi_rlast) begin
+                    m_axi_rready_next[m_select_reg] = 1'b0;
+                    state_next = STATE_WAIT_IDLE;
+                end else begin
+                    state_next = STATE_READ;
+                end
+            end else begin
+                state_next = STATE_READ;
+            end
+        end
+        STATE_READ_DROP: begin
+            // read drop state; generate decode error read response
+
+            s_axi_rid_int = axi_id_reg;
+            s_axi_rdata_int = {DATA_WIDTH{1'b0}};
+            s_axi_rresp_int = 2'b11;
+            s_axi_rlast_int = axi_len_reg == 0;
+            s_axi_ruser_int = {RUSER_WIDTH{1'b0}};
+            s_axi_rvalid_int = 1'b1;
+
+            if (s_axi_rready_int_reg) begin
+                axi_len_next = axi_len_reg - 1;
+                if (axi_len_reg == 0) begin
+                    state_next = STATE_WAIT_IDLE;
+                end else begin
+                    state_next = STATE_READ_DROP;
+                end
+            end else begin
+                state_next = STATE_READ_DROP;
+            end
+        end
+        STATE_WAIT_IDLE: begin
+            // wait for idle state; wait untl grant valid is deasserted
+
+            if (!grant_valid || acknowledge) begin
+                state_next = STATE_IDLE;
+            end else begin
+                state_next = STATE_WAIT_IDLE;
+            end
+        end
+    endcase
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        state_reg <= STATE_IDLE;
+
+        s_axi_awready_reg <= 0;
+        s_axi_wready_reg <= 0;
+        s_axi_bvalid_reg <= 0;
+        s_axi_arready_reg <= 0;
+
+        m_axi_awvalid_reg <= 0;
+        m_axi_bready_reg <= 0;
+        m_axi_arvalid_reg <= 0;
+        m_axi_rready_reg <= 0;
+    end else begin
+        state_reg <= state_next;
+
+        s_axi_awready_reg <= s_axi_awready_next;
+        s_axi_wready_reg <= s_axi_wready_next;
+        s_axi_bvalid_reg <= s_axi_bvalid_next;
+        s_axi_arready_reg <= s_axi_arready_next;
+
+        m_axi_awvalid_reg <= m_axi_awvalid_next;
+        m_axi_bready_reg <= m_axi_bready_next;
+        m_axi_arvalid_reg <= m_axi_arvalid_next;
+        m_axi_rready_reg <= m_axi_rready_next;
+    end
+
+    m_select_reg <= m_select_next;
+    axi_id_reg <= axi_id_next;
+    axi_addr_reg <= axi_addr_next;
+    axi_addr_valid_reg <= axi_addr_valid_next;
+    axi_len_reg <= axi_len_next;
+    axi_size_reg <= axi_size_next;
+    axi_burst_reg <= axi_burst_next;
+    axi_lock_reg <= axi_lock_next;
+    axi_cache_reg <= axi_cache_next;
+    axi_prot_reg <= axi_prot_next;
+    axi_qos_reg <= axi_qos_next;
+    axi_region_reg <= axi_region_next;
+    axi_auser_reg <= axi_auser_next;
+    axi_bresp_reg <= axi_bresp_next;
+    axi_buser_reg <= axi_buser_next;
+end
+
+// output datapath logic (R channel)
+reg [ID_WIDTH-1:0]    s_axi_rid_reg    = {ID_WIDTH{1'b0}};
+reg [DATA_WIDTH-1:0]  s_axi_rdata_reg  = {DATA_WIDTH{1'b0}};
+reg [1:0]             s_axi_rresp_reg  = 2'd0;
+reg                   s_axi_rlast_reg  = 1'b0;
+reg [RUSER_WIDTH-1:0] s_axi_ruser_reg  = 1'b0;
+reg [S_COUNT-1:0]     s_axi_rvalid_reg = 1'b0, s_axi_rvalid_next;
+
+reg [ID_WIDTH-1:0]    temp_s_axi_rid_reg    = {ID_WIDTH{1'b0}};
+reg [DATA_WIDTH-1:0]  temp_s_axi_rdata_reg  = {DATA_WIDTH{1'b0}};
+reg [1:0]             temp_s_axi_rresp_reg  = 2'd0;
+reg                   temp_s_axi_rlast_reg  = 1'b0;
+reg [RUSER_WIDTH-1:0] temp_s_axi_ruser_reg  = 1'b0;
+reg                   temp_s_axi_rvalid_reg = 1'b0, temp_s_axi_rvalid_next;
+
+// datapath control
+reg store_axi_r_int_to_output;
+reg store_axi_r_int_to_temp;
+reg store_axi_r_temp_to_output;
+
+assign s_axi_rid = {S_COUNT{s_axi_rid_reg}};
+assign s_axi_rdata = {S_COUNT{s_axi_rdata_reg}};
+assign s_axi_rresp = {S_COUNT{s_axi_rresp_reg}};
+assign s_axi_rlast = {S_COUNT{s_axi_rlast_reg}};
+assign s_axi_ruser = {S_COUNT{RUSER_ENABLE ? s_axi_ruser_reg : {RUSER_WIDTH{1'b0}}}};
+assign s_axi_rvalid = s_axi_rvalid_reg;
+
+// enable ready input next cycle if output is ready or the temp reg will not be filled on the next cycle (output reg empty or no input)
+assign s_axi_rready_int_early = current_s_axi_rready | (~temp_s_axi_rvalid_reg & (~current_s_axi_rvalid | ~s_axi_rvalid_int));
+
+always @* begin
+    // transfer sink ready state to source
+    s_axi_rvalid_next = s_axi_rvalid_reg;
+    temp_s_axi_rvalid_next = temp_s_axi_rvalid_reg;
+
+    store_axi_r_int_to_output = 1'b0;
+    store_axi_r_int_to_temp = 1'b0;
+    store_axi_r_temp_to_output = 1'b0;
+
+    if (s_axi_rready_int_reg) begin
+        // input is ready
+        if (current_s_axi_rready | ~current_s_axi_rvalid) begin
+            // output is ready or currently not valid, transfer data to output
+            s_axi_rvalid_next[s_select] = s_axi_rvalid_int;
+            store_axi_r_int_to_output = 1'b1;
+        end else begin
+            // output is not ready, store input in temp
+            temp_s_axi_rvalid_next = s_axi_rvalid_int;
+            store_axi_r_int_to_temp = 1'b1;
+        end
+    end else if (current_s_axi_rready) begin
+        // input is not ready, but output is ready
+        s_axi_rvalid_next[s_select] = temp_s_axi_rvalid_reg;
+        temp_s_axi_rvalid_next = 1'b0;
+        store_axi_r_temp_to_output = 1'b1;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        s_axi_rvalid_reg <= 1'b0;
+        s_axi_rready_int_reg <= 1'b0;
+        temp_s_axi_rvalid_reg <= 1'b0;
+    end else begin
+        s_axi_rvalid_reg <= s_axi_rvalid_next;
+        s_axi_rready_int_reg <= s_axi_rready_int_early;
+        temp_s_axi_rvalid_reg <= temp_s_axi_rvalid_next;
+    end
+
+    // datapath
+    if (store_axi_r_int_to_output) begin
+        s_axi_rid_reg <= s_axi_rid_int;
+        s_axi_rdata_reg <= s_axi_rdata_int;
+        s_axi_rresp_reg <= s_axi_rresp_int;
+        s_axi_rlast_reg <= s_axi_rlast_int;
+        s_axi_ruser_reg <= s_axi_ruser_int;
+    end else if (store_axi_r_temp_to_output) begin
+        s_axi_rid_reg <= temp_s_axi_rid_reg;
+        s_axi_rdata_reg <= temp_s_axi_rdata_reg;
+        s_axi_rresp_reg <= temp_s_axi_rresp_reg;
+        s_axi_rlast_reg <= temp_s_axi_rlast_reg;
+        s_axi_ruser_reg <= temp_s_axi_ruser_reg;
+    end
+
+    if (store_axi_r_int_to_temp) begin
+        temp_s_axi_rid_reg <= s_axi_rid_int;
+        temp_s_axi_rdata_reg <= s_axi_rdata_int;
+        temp_s_axi_rresp_reg <= s_axi_rresp_int;
+        temp_s_axi_rlast_reg <= s_axi_rlast_int;
+        temp_s_axi_ruser_reg <= s_axi_ruser_int;
+    end
+end
+
+// output datapath logic (W channel)
+reg [DATA_WIDTH-1:0]  m_axi_wdata_reg  = {DATA_WIDTH{1'b0}};
+reg [STRB_WIDTH-1:0]  m_axi_wstrb_reg  = {STRB_WIDTH{1'b0}};
+reg                   m_axi_wlast_reg  = 1'b0;
+reg [WUSER_WIDTH-1:0] m_axi_wuser_reg  = 1'b0;
+reg [M_COUNT-1:0]     m_axi_wvalid_reg = 1'b0, m_axi_wvalid_next;
+
+reg [DATA_WIDTH-1:0]  temp_m_axi_wdata_reg  = {DATA_WIDTH{1'b0}};
+reg [STRB_WIDTH-1:0]  temp_m_axi_wstrb_reg  = {STRB_WIDTH{1'b0}};
+reg                   temp_m_axi_wlast_reg  = 1'b0;
+reg [WUSER_WIDTH-1:0] temp_m_axi_wuser_reg  = 1'b0;
+reg                   temp_m_axi_wvalid_reg = 1'b0, temp_m_axi_wvalid_next;
+
+// datapath control
+reg store_axi_w_int_to_output;
+reg store_axi_w_int_to_temp;
+reg store_axi_w_temp_to_output;
+
+assign m_axi_wdata = {M_COUNT{m_axi_wdata_reg}};
+assign m_axi_wstrb = {M_COUNT{m_axi_wstrb_reg}};
+assign m_axi_wlast = {M_COUNT{m_axi_wlast_reg}};
+assign m_axi_wuser = {M_COUNT{WUSER_ENABLE ? m_axi_wuser_reg : {WUSER_WIDTH{1'b0}}}};
+assign m_axi_wvalid = m_axi_wvalid_reg;
+
+// enable ready input next cycle if output is ready or the temp reg will not be filled on the next cycle (output reg empty or no input)
+assign m_axi_wready_int_early = current_m_axi_wready | (~temp_m_axi_wvalid_reg & (~current_m_axi_wvalid | ~m_axi_wvalid_int));
+
+always @* begin
+    // transfer sink ready state to source
+    m_axi_wvalid_next = m_axi_wvalid_reg;
+    temp_m_axi_wvalid_next = temp_m_axi_wvalid_reg;
+
+    store_axi_w_int_to_output = 1'b0;
+    store_axi_w_int_to_temp = 1'b0;
+    store_axi_w_temp_to_output = 1'b0;
+
+    if (m_axi_wready_int_reg) begin
+        // input is ready
+        if (current_m_axi_wready | ~current_m_axi_wvalid) begin
+            // output is ready or currently not valid, transfer data to output
+            m_axi_wvalid_next[m_select_reg] = m_axi_wvalid_int;
+            store_axi_w_int_to_output = 1'b1;
+        end else begin
+            // output is not ready, store input in temp
+            temp_m_axi_wvalid_next = m_axi_wvalid_int;
+            store_axi_w_int_to_temp = 1'b1;
+        end
+    end else if (current_m_axi_wready) begin
+        // input is not ready, but output is ready
+        m_axi_wvalid_next[m_select_reg] = temp_m_axi_wvalid_reg;
+        temp_m_axi_wvalid_next = 1'b0;
+        store_axi_w_temp_to_output = 1'b1;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        m_axi_wvalid_reg <= 1'b0;
+        m_axi_wready_int_reg <= 1'b0;
+        temp_m_axi_wvalid_reg <= 1'b0;
+    end else begin
+        m_axi_wvalid_reg <= m_axi_wvalid_next;
+        m_axi_wready_int_reg <= m_axi_wready_int_early;
+        temp_m_axi_wvalid_reg <= temp_m_axi_wvalid_next;
+    end
+
+    // datapath
+    if (store_axi_w_int_to_output) begin
+        m_axi_wdata_reg <= m_axi_wdata_int;
+        m_axi_wstrb_reg <= m_axi_wstrb_int;
+        m_axi_wlast_reg <= m_axi_wlast_int;
+        m_axi_wuser_reg <= m_axi_wuser_int;
+    end else if (store_axi_w_temp_to_output) begin
+        m_axi_wdata_reg <= temp_m_axi_wdata_reg;
+        m_axi_wstrb_reg <= temp_m_axi_wstrb_reg;
+        m_axi_wlast_reg <= temp_m_axi_wlast_reg;
+        m_axi_wuser_reg <= temp_m_axi_wuser_reg;
+    end
+
+    if (store_axi_w_int_to_temp) begin
+        temp_m_axi_wdata_reg <= m_axi_wdata_int;
+        temp_m_axi_wstrb_reg <= m_axi_wstrb_int;
+        temp_m_axi_wlast_reg <= m_axi_wlast_int;
+        temp_m_axi_wuser_reg <= m_axi_wuser_int;
+    end
+end
+
+endmodule

--- a/tests/designs/axi4_ram/axi_ram.v
+++ b/tests/designs/axi4_ram/axi_ram.v
@@ -1,0 +1,370 @@
+/*
+
+Copyright (c) 2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ns / 1ps
+
+/*
+ * AXI4 RAM
+ */
+module axi_ram #
+(
+    // Width of data bus in bits
+    parameter DATA_WIDTH = 32,
+    // Width of address bus in bits
+    parameter ADDR_WIDTH = 16,
+    // Width of wstrb (width of data bus in words)
+    parameter STRB_WIDTH = (DATA_WIDTH/8),
+    // Width of ID signal
+    parameter ID_WIDTH = 8,
+    // Extra pipeline register on output
+    parameter PIPELINE_OUTPUT = 0
+)
+(
+    input  wire                   clk,
+    input  wire                   rst,
+
+    input  wire [ID_WIDTH-1:0]    s_axi_awid,
+    input  wire [ADDR_WIDTH-1:0]  s_axi_awaddr,
+    input  wire [7:0]             s_axi_awlen,
+    input  wire [2:0]             s_axi_awsize,
+    input  wire [1:0]             s_axi_awburst,
+    input  wire                   s_axi_awlock,
+    input  wire [3:0]             s_axi_awcache,
+    input  wire [2:0]             s_axi_awprot,
+    input  wire                   s_axi_awvalid,
+    output wire                   s_axi_awready,
+    input  wire [DATA_WIDTH-1:0]  s_axi_wdata,
+    input  wire [STRB_WIDTH-1:0]  s_axi_wstrb,
+    input  wire                   s_axi_wlast,
+    input  wire                   s_axi_wvalid,
+    output wire                   s_axi_wready,
+    output wire [ID_WIDTH-1:0]    s_axi_bid,
+    output wire [1:0]             s_axi_bresp,
+    output wire                   s_axi_bvalid,
+    input  wire                   s_axi_bready,
+    input  wire [ID_WIDTH-1:0]    s_axi_arid,
+    input  wire [ADDR_WIDTH-1:0]  s_axi_araddr,
+    input  wire [7:0]             s_axi_arlen,
+    input  wire [2:0]             s_axi_arsize,
+    input  wire [1:0]             s_axi_arburst,
+    input  wire                   s_axi_arlock,
+    input  wire [3:0]             s_axi_arcache,
+    input  wire [2:0]             s_axi_arprot,
+    input  wire                   s_axi_arvalid,
+    output wire                   s_axi_arready,
+    output wire [ID_WIDTH-1:0]    s_axi_rid,
+    output wire [DATA_WIDTH-1:0]  s_axi_rdata,
+    output wire [1:0]             s_axi_rresp,
+    output wire                   s_axi_rlast,
+    output wire                   s_axi_rvalid,
+    input  wire                   s_axi_rready
+);
+
+parameter VALID_ADDR_WIDTH = ADDR_WIDTH - $clog2(STRB_WIDTH);
+parameter WORD_WIDTH = STRB_WIDTH;
+parameter WORD_SIZE = DATA_WIDTH/WORD_WIDTH;
+
+// bus width assertions
+initial begin
+    if (WORD_SIZE * STRB_WIDTH != DATA_WIDTH) begin
+        $error("Error: AXI data width not evenly divisble (instance %m)");
+        $finish;
+    end
+
+    if (2**$clog2(WORD_WIDTH) != WORD_WIDTH) begin
+        $error("Error: AXI word width must be even power of two (instance %m)");
+        $finish;
+    end
+end
+
+localparam [0:0]
+    READ_STATE_IDLE = 1'd0,
+    READ_STATE_BURST = 1'd1;
+
+reg [0:0] read_state_reg = READ_STATE_IDLE, read_state_next;
+
+localparam [1:0]
+    WRITE_STATE_IDLE = 2'd0,
+    WRITE_STATE_BURST = 2'd1,
+    WRITE_STATE_RESP = 2'd2;
+
+reg [1:0] write_state_reg = WRITE_STATE_IDLE, write_state_next;
+
+reg mem_wr_en;
+reg mem_rd_en;
+
+reg [ID_WIDTH-1:0] read_id_reg = {ID_WIDTH{1'b0}}, read_id_next;
+reg [ADDR_WIDTH-1:0] read_addr_reg = {ADDR_WIDTH{1'b0}}, read_addr_next;
+reg [7:0] read_count_reg = 8'd0, read_count_next;
+reg [2:0] read_size_reg = 3'd0, read_size_next;
+reg [1:0] read_burst_reg = 2'd0, read_burst_next;
+reg [ID_WIDTH-1:0] write_id_reg = {ID_WIDTH{1'b0}}, write_id_next;
+reg [ADDR_WIDTH-1:0] write_addr_reg = {ADDR_WIDTH{1'b0}}, write_addr_next;
+reg [7:0] write_count_reg = 8'd0, write_count_next;
+reg [2:0] write_size_reg = 3'd0, write_size_next;
+reg [1:0] write_burst_reg = 2'd0, write_burst_next;
+
+reg s_axi_awready_reg = 1'b0, s_axi_awready_next;
+reg s_axi_wready_reg = 1'b0, s_axi_wready_next;
+reg [ID_WIDTH-1:0] s_axi_bid_reg = {ID_WIDTH{1'b0}}, s_axi_bid_next;
+reg s_axi_bvalid_reg = 1'b0, s_axi_bvalid_next;
+reg s_axi_arready_reg = 1'b0, s_axi_arready_next;
+reg [ID_WIDTH-1:0] s_axi_rid_reg = {ID_WIDTH{1'b0}}, s_axi_rid_next;
+reg [DATA_WIDTH-1:0] s_axi_rdata_reg = {DATA_WIDTH{1'b0}}, s_axi_rdata_next;
+reg s_axi_rlast_reg = 1'b0, s_axi_rlast_next;
+reg s_axi_rvalid_reg = 1'b0, s_axi_rvalid_next;
+reg [ID_WIDTH-1:0] s_axi_rid_pipe_reg = {ID_WIDTH{1'b0}};
+reg [DATA_WIDTH-1:0] s_axi_rdata_pipe_reg = {DATA_WIDTH{1'b0}};
+reg s_axi_rlast_pipe_reg = 1'b0;
+reg s_axi_rvalid_pipe_reg = 1'b0;
+
+// (* RAM_STYLE="BLOCK" *)
+reg [DATA_WIDTH-1:0] mem[(2**VALID_ADDR_WIDTH)-1:0];
+
+wire [VALID_ADDR_WIDTH-1:0] s_axi_awaddr_valid = s_axi_awaddr >> (ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] s_axi_araddr_valid = s_axi_araddr >> (ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] read_addr_valid = read_addr_reg >> (ADDR_WIDTH - VALID_ADDR_WIDTH);
+wire [VALID_ADDR_WIDTH-1:0] write_addr_valid = write_addr_reg >> (ADDR_WIDTH - VALID_ADDR_WIDTH);
+
+assign s_axi_awready = s_axi_awready_reg;
+assign s_axi_wready = s_axi_wready_reg;
+assign s_axi_bid = s_axi_bid_reg;
+assign s_axi_bresp = 2'b00;
+assign s_axi_bvalid = s_axi_bvalid_reg;
+assign s_axi_arready = s_axi_arready_reg;
+assign s_axi_rid = PIPELINE_OUTPUT ? s_axi_rid_pipe_reg : s_axi_rid_reg;
+assign s_axi_rdata = PIPELINE_OUTPUT ? s_axi_rdata_pipe_reg : s_axi_rdata_reg;
+assign s_axi_rresp = 2'b00;
+assign s_axi_rlast = PIPELINE_OUTPUT ? s_axi_rlast_pipe_reg : s_axi_rlast_reg;
+assign s_axi_rvalid = PIPELINE_OUTPUT ? s_axi_rvalid_pipe_reg : s_axi_rvalid_reg;
+
+integer i, j;
+
+initial begin
+    // two nested loops for smaller number of iterations per loop
+    // workaround for synthesizer complaints about large loop counts
+    for (i = 0; i < 2**VALID_ADDR_WIDTH; i = i + 2**(VALID_ADDR_WIDTH/2)) begin
+        for (j = i; j < i + 2**(VALID_ADDR_WIDTH/2); j = j + 1) begin
+            mem[j] = 0;
+        end
+    end
+end
+
+always @* begin
+    write_state_next = WRITE_STATE_IDLE;
+
+    mem_wr_en = 1'b0;
+
+    write_id_next = write_id_reg;
+    write_addr_next = write_addr_reg;
+    write_count_next = write_count_reg;
+    write_size_next = write_size_reg;
+    write_burst_next = write_burst_reg;
+
+    s_axi_awready_next = 1'b0;
+    s_axi_wready_next = 1'b0;
+    s_axi_bid_next = s_axi_bid_reg;
+    s_axi_bvalid_next = s_axi_bvalid_reg && !s_axi_bready;
+
+    case (write_state_reg)
+        WRITE_STATE_IDLE: begin
+            s_axi_awready_next = 1'b1;
+
+            if (s_axi_awready && s_axi_awvalid) begin
+                write_id_next = s_axi_awid;
+                write_addr_next = s_axi_awaddr;
+                write_count_next = s_axi_awlen;
+                write_size_next = s_axi_awsize < $clog2(STRB_WIDTH) ? s_axi_awsize : $clog2(STRB_WIDTH);
+                write_burst_next = s_axi_awburst;
+
+                s_axi_awready_next = 1'b0;
+                s_axi_wready_next = 1'b1;
+                write_state_next = WRITE_STATE_BURST;
+            end else begin
+                write_state_next = WRITE_STATE_IDLE;
+            end
+        end
+        WRITE_STATE_BURST: begin
+            s_axi_wready_next = 1'b1;
+
+            if (s_axi_wready && s_axi_wvalid) begin
+                mem_wr_en = 1'b1;
+                if (write_burst_reg != 2'b00) begin
+                    write_addr_next = write_addr_reg + (1 << write_size_reg);
+                end
+                write_count_next = write_count_reg - 1;
+                if (write_count_reg > 0) begin
+                    write_state_next = WRITE_STATE_BURST;
+                end else begin
+                    s_axi_wready_next = 1'b0;
+                    if (s_axi_bready || !s_axi_bvalid) begin
+                        s_axi_bid_next = write_id_reg;
+                        s_axi_bvalid_next = 1'b1;
+                        s_axi_awready_next = 1'b1;
+                        write_state_next = WRITE_STATE_IDLE;
+                    end else begin
+                        write_state_next = WRITE_STATE_RESP;
+                    end
+                end
+            end else begin
+                write_state_next = WRITE_STATE_BURST;
+            end
+        end
+        WRITE_STATE_RESP: begin
+            if (s_axi_bready || !s_axi_bvalid) begin
+                s_axi_bid_next = write_id_reg;
+                s_axi_bvalid_next = 1'b1;
+                s_axi_awready_next = 1'b1;
+                write_state_next = WRITE_STATE_IDLE;
+            end else begin
+                write_state_next = WRITE_STATE_RESP;
+            end
+        end
+    endcase
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        write_state_reg <= WRITE_STATE_IDLE;
+        s_axi_awready_reg <= 1'b0;
+        s_axi_wready_reg <= 1'b0;
+        s_axi_bvalid_reg <= 1'b0;
+    end else begin
+        write_state_reg <= write_state_next;
+        s_axi_awready_reg <= s_axi_awready_next;
+        s_axi_wready_reg <= s_axi_wready_next;
+        s_axi_bvalid_reg <= s_axi_bvalid_next;
+    end
+
+    write_id_reg <= write_id_next;
+    write_addr_reg <= write_addr_next;
+    write_count_reg <= write_count_next;
+    write_size_reg <= write_size_next;
+    write_burst_reg <= write_burst_next;
+
+    s_axi_bid_reg <= s_axi_bid_next;
+
+    for (i = 0; i < WORD_WIDTH; i = i + 1) begin
+        if (mem_wr_en & s_axi_wstrb[i]) begin
+            mem[write_addr_valid][WORD_SIZE*i +: WORD_SIZE] <= s_axi_wdata[WORD_SIZE*i +: WORD_SIZE];
+        end
+    end
+end
+
+always @* begin
+    read_state_next = READ_STATE_IDLE;
+
+    mem_rd_en = 1'b0;
+
+    s_axi_rid_next = s_axi_rid_reg;
+    s_axi_rlast_next = s_axi_rlast_reg;
+    s_axi_rvalid_next = s_axi_rvalid_reg && !(s_axi_rready || (PIPELINE_OUTPUT && !s_axi_rvalid_pipe_reg));
+
+    read_id_next = read_id_reg;
+    read_addr_next = read_addr_reg;
+    read_count_next = read_count_reg;
+    read_size_next = read_size_reg;
+    read_burst_next = read_burst_reg;
+
+    s_axi_arready_next = 1'b0;
+
+    case (read_state_reg)
+        READ_STATE_IDLE: begin
+            s_axi_arready_next = 1'b1;
+
+            if (s_axi_arready && s_axi_arvalid) begin
+                read_id_next = s_axi_arid;
+                read_addr_next = s_axi_araddr;
+                read_count_next = s_axi_arlen;
+                read_size_next = s_axi_arsize < $clog2(STRB_WIDTH) ? s_axi_arsize : $clog2(STRB_WIDTH);
+                read_burst_next = s_axi_arburst;
+
+                s_axi_arready_next = 1'b0;
+                read_state_next = READ_STATE_BURST;
+            end else begin
+                read_state_next = READ_STATE_IDLE;
+            end
+        end
+        READ_STATE_BURST: begin
+            if (s_axi_rready || (PIPELINE_OUTPUT && !s_axi_rvalid_pipe_reg) || !s_axi_rvalid_reg) begin
+                mem_rd_en = 1'b1;
+                s_axi_rvalid_next = 1'b1;
+                s_axi_rid_next = read_id_reg;
+                s_axi_rlast_next = read_count_reg == 0;
+                if (read_burst_reg != 2'b00) begin
+                    read_addr_next = read_addr_reg + (1 << read_size_reg);
+                end
+                read_count_next = read_count_reg - 1;
+                if (read_count_reg > 0) begin
+                    read_state_next = READ_STATE_BURST;
+                end else begin
+                    s_axi_arready_next = 1'b1;
+                    read_state_next = READ_STATE_IDLE;
+                end
+            end else begin
+                read_state_next = READ_STATE_BURST;
+            end
+        end
+    endcase
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        read_state_reg <= READ_STATE_IDLE;
+        s_axi_arready_reg <= 1'b0;
+        s_axi_rvalid_reg <= 1'b0;
+        s_axi_rvalid_pipe_reg <= 1'b0;
+    end else begin
+        read_state_reg <= read_state_next;
+        s_axi_arready_reg <= s_axi_arready_next;
+        s_axi_rvalid_reg <= s_axi_rvalid_next;
+
+        if (!s_axi_rvalid_pipe_reg || s_axi_rready) begin
+            s_axi_rvalid_pipe_reg <= s_axi_rvalid_reg;
+        end
+    end
+
+    read_id_reg <= read_id_next;
+    read_addr_reg <= read_addr_next;
+    read_count_reg <= read_count_next;
+    read_size_reg <= read_size_next;
+    read_burst_reg <= read_burst_next;
+
+    s_axi_rid_reg <= s_axi_rid_next;
+    s_axi_rlast_reg <= s_axi_rlast_next;
+
+    if (mem_rd_en) begin
+        s_axi_rdata_reg <= mem[read_addr_valid];
+    end
+
+    if (!s_axi_rvalid_pipe_reg || s_axi_rready) begin
+        s_axi_rid_pipe_reg <= s_axi_rid_reg;
+        s_axi_rdata_pipe_reg <= s_axi_rdata_reg;
+        s_axi_rlast_pipe_reg <= s_axi_rlast_reg;
+    end
+end
+
+endmodule

--- a/tests/designs/axi4_ram/axi_register.v
+++ b/tests/designs/axi4_ram/axi_register.v
@@ -1,0 +1,320 @@
+/*
+
+Copyright (c) 2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ns / 1ps
+
+/*
+ * AXI4 register
+ */
+module axi_register #
+(
+    // Width of data bus in bits
+    parameter DATA_WIDTH = 32,
+    // Width of address bus in bits
+    parameter ADDR_WIDTH = 32,
+    // Width of wstrb (width of data bus in words)
+    parameter STRB_WIDTH = (DATA_WIDTH/8),
+    // Width of ID signal
+    parameter ID_WIDTH = 8,
+    // Propagate awuser signal
+    parameter AWUSER_ENABLE = 0,
+    // Width of awuser signal
+    parameter AWUSER_WIDTH = 1,
+    // Propagate wuser signal
+    parameter WUSER_ENABLE = 0,
+    // Width of wuser signal
+    parameter WUSER_WIDTH = 1,
+    // Propagate buser signal
+    parameter BUSER_ENABLE = 0,
+    // Width of buser signal
+    parameter BUSER_WIDTH = 1,
+    // Propagate aruser signal
+    parameter ARUSER_ENABLE = 0,
+    // Width of aruser signal
+    parameter ARUSER_WIDTH = 1,
+    // Propagate ruser signal
+    parameter RUSER_ENABLE = 0,
+    // Width of ruser signal
+    parameter RUSER_WIDTH = 1,
+    // AW channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter AW_REG_TYPE = 1,
+    // W channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter W_REG_TYPE = 2,
+    // B channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter B_REG_TYPE = 1,
+    // AR channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter AR_REG_TYPE = 1,
+    // R channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter R_REG_TYPE = 2
+)
+(
+    input  wire                     clk,
+    input  wire                     rst,
+
+    /*
+     * AXI slave interface
+     */
+    input  wire [ID_WIDTH-1:0]      s_axi_awid,
+    input  wire [ADDR_WIDTH-1:0]    s_axi_awaddr,
+    input  wire [7:0]               s_axi_awlen,
+    input  wire [2:0]               s_axi_awsize,
+    input  wire [1:0]               s_axi_awburst,
+    input  wire                     s_axi_awlock,
+    input  wire [3:0]               s_axi_awcache,
+    input  wire [2:0]               s_axi_awprot,
+    input  wire [3:0]               s_axi_awqos,
+    input  wire [3:0]               s_axi_awregion,
+    input  wire [AWUSER_WIDTH-1:0]  s_axi_awuser,
+    input  wire                     s_axi_awvalid,
+    output wire                     s_axi_awready,
+    input  wire [DATA_WIDTH-1:0]    s_axi_wdata,
+    input  wire [STRB_WIDTH-1:0]    s_axi_wstrb,
+    input  wire                     s_axi_wlast,
+    input  wire [WUSER_WIDTH-1:0]   s_axi_wuser,
+    input  wire                     s_axi_wvalid,
+    output wire                     s_axi_wready,
+    output wire [ID_WIDTH-1:0]      s_axi_bid,
+    output wire [1:0]               s_axi_bresp,
+    output wire [BUSER_WIDTH-1:0]   s_axi_buser,
+    output wire                     s_axi_bvalid,
+    input  wire                     s_axi_bready,
+    input  wire [ID_WIDTH-1:0]      s_axi_arid,
+    input  wire [ADDR_WIDTH-1:0]    s_axi_araddr,
+    input  wire [7:0]               s_axi_arlen,
+    input  wire [2:0]               s_axi_arsize,
+    input  wire [1:0]               s_axi_arburst,
+    input  wire                     s_axi_arlock,
+    input  wire [3:0]               s_axi_arcache,
+    input  wire [2:0]               s_axi_arprot,
+    input  wire [3:0]               s_axi_arqos,
+    input  wire [3:0]               s_axi_arregion,
+    input  wire [ARUSER_WIDTH-1:0]  s_axi_aruser,
+    input  wire                     s_axi_arvalid,
+    output wire                     s_axi_arready,
+    output wire [ID_WIDTH-1:0]      s_axi_rid,
+    output wire [DATA_WIDTH-1:0]    s_axi_rdata,
+    output wire [1:0]               s_axi_rresp,
+    output wire                     s_axi_rlast,
+    output wire [RUSER_WIDTH-1:0]   s_axi_ruser,
+    output wire                     s_axi_rvalid,
+    input  wire                     s_axi_rready,
+
+    /*
+     * AXI master interface
+     */
+    output wire [ID_WIDTH-1:0]      m_axi_awid,
+    output wire [ADDR_WIDTH-1:0]    m_axi_awaddr,
+    output wire [7:0]               m_axi_awlen,
+    output wire [2:0]               m_axi_awsize,
+    output wire [1:0]               m_axi_awburst,
+    output wire                     m_axi_awlock,
+    output wire [3:0]               m_axi_awcache,
+    output wire [2:0]               m_axi_awprot,
+    output wire [3:0]               m_axi_awqos,
+    output wire [3:0]               m_axi_awregion,
+    output wire [AWUSER_WIDTH-1:0]  m_axi_awuser,
+    output wire                     m_axi_awvalid,
+    input  wire                     m_axi_awready,
+    output wire [DATA_WIDTH-1:0]    m_axi_wdata,
+    output wire [STRB_WIDTH-1:0]    m_axi_wstrb,
+    output wire                     m_axi_wlast,
+    output wire [WUSER_WIDTH-1:0]   m_axi_wuser,
+    output wire                     m_axi_wvalid,
+    input  wire                     m_axi_wready,
+    input  wire [ID_WIDTH-1:0]      m_axi_bid,
+    input  wire [1:0]               m_axi_bresp,
+    input  wire [BUSER_WIDTH-1:0]   m_axi_buser,
+    input  wire                     m_axi_bvalid,
+    output wire                     m_axi_bready,
+    output wire [ID_WIDTH-1:0]      m_axi_arid,
+    output wire [ADDR_WIDTH-1:0]    m_axi_araddr,
+    output wire [7:0]               m_axi_arlen,
+    output wire [2:0]               m_axi_arsize,
+    output wire [1:0]               m_axi_arburst,
+    output wire                     m_axi_arlock,
+    output wire [3:0]               m_axi_arcache,
+    output wire [2:0]               m_axi_arprot,
+    output wire [3:0]               m_axi_arqos,
+    output wire [3:0]               m_axi_arregion,
+    output wire [ARUSER_WIDTH-1:0]  m_axi_aruser,
+    output wire                     m_axi_arvalid,
+    input  wire                     m_axi_arready,
+    input  wire [ID_WIDTH-1:0]      m_axi_rid,
+    input  wire [DATA_WIDTH-1:0]    m_axi_rdata,
+    input  wire [1:0]               m_axi_rresp,
+    input  wire                     m_axi_rlast,
+    input  wire [RUSER_WIDTH-1:0]   m_axi_ruser,
+    input  wire                     m_axi_rvalid,
+    output wire                     m_axi_rready
+);
+
+axi_register_wr #(
+    .DATA_WIDTH(DATA_WIDTH),
+    .ADDR_WIDTH(ADDR_WIDTH),
+    .STRB_WIDTH(STRB_WIDTH),
+    .ID_WIDTH(ID_WIDTH),
+    .AWUSER_ENABLE(AWUSER_ENABLE),
+    .AWUSER_WIDTH(AWUSER_WIDTH),
+    .WUSER_ENABLE(WUSER_ENABLE),
+    .WUSER_WIDTH(WUSER_WIDTH),
+    .BUSER_ENABLE(BUSER_ENABLE),
+    .BUSER_WIDTH(BUSER_WIDTH),
+    .AW_REG_TYPE(AW_REG_TYPE),
+    .W_REG_TYPE(W_REG_TYPE),
+    .B_REG_TYPE(B_REG_TYPE)
+)
+axi_register_wr_inst (
+    .clk(clk),
+    .rst(rst),
+
+    /*
+     * AXI slave interface
+     */
+    .s_axi_awid(s_axi_awid),
+    .s_axi_awaddr(s_axi_awaddr),
+    .s_axi_awlen(s_axi_awlen),
+    .s_axi_awsize(s_axi_awsize),
+    .s_axi_awburst(s_axi_awburst),
+    .s_axi_awlock(s_axi_awlock),
+    .s_axi_awcache(s_axi_awcache),
+    .s_axi_awprot(s_axi_awprot),
+    .s_axi_awqos(s_axi_awqos),
+    .s_axi_awregion(s_axi_awregion),
+    .s_axi_awuser(s_axi_awuser),
+    .s_axi_awvalid(s_axi_awvalid),
+    .s_axi_awready(s_axi_awready),
+    .s_axi_wdata(s_axi_wdata),
+    .s_axi_wstrb(s_axi_wstrb),
+    .s_axi_wlast(s_axi_wlast),
+    .s_axi_wuser(s_axi_wuser),
+    .s_axi_wvalid(s_axi_wvalid),
+    .s_axi_wready(s_axi_wready),
+    .s_axi_bid(s_axi_bid),
+    .s_axi_bresp(s_axi_bresp),
+    .s_axi_buser(s_axi_buser),
+    .s_axi_bvalid(s_axi_bvalid),
+    .s_axi_bready(s_axi_bready),
+
+    /*
+     * AXI master interface
+     */
+    .m_axi_awid(m_axi_awid),
+    .m_axi_awaddr(m_axi_awaddr),
+    .m_axi_awlen(m_axi_awlen),
+    .m_axi_awsize(m_axi_awsize),
+    .m_axi_awburst(m_axi_awburst),
+    .m_axi_awlock(m_axi_awlock),
+    .m_axi_awcache(m_axi_awcache),
+    .m_axi_awprot(m_axi_awprot),
+    .m_axi_awqos(m_axi_awqos),
+    .m_axi_awregion(m_axi_awregion),
+    .m_axi_awuser(m_axi_awuser),
+    .m_axi_awvalid(m_axi_awvalid),
+    .m_axi_awready(m_axi_awready),
+    .m_axi_wdata(m_axi_wdata),
+    .m_axi_wstrb(m_axi_wstrb),
+    .m_axi_wlast(m_axi_wlast),
+    .m_axi_wuser(m_axi_wuser),
+    .m_axi_wvalid(m_axi_wvalid),
+    .m_axi_wready(m_axi_wready),
+    .m_axi_bid(m_axi_bid),
+    .m_axi_bresp(m_axi_bresp),
+    .m_axi_buser(m_axi_buser),
+    .m_axi_bvalid(m_axi_bvalid),
+    .m_axi_bready(m_axi_bready)
+);
+
+axi_register_rd #(
+    .DATA_WIDTH(DATA_WIDTH),
+    .ADDR_WIDTH(ADDR_WIDTH),
+    .STRB_WIDTH(STRB_WIDTH),
+    .ID_WIDTH(ID_WIDTH),
+    .ARUSER_ENABLE(ARUSER_ENABLE),
+    .ARUSER_WIDTH(ARUSER_WIDTH),
+    .RUSER_ENABLE(RUSER_ENABLE),
+    .RUSER_WIDTH(RUSER_WIDTH),
+    .AR_REG_TYPE(AR_REG_TYPE),
+    .R_REG_TYPE(R_REG_TYPE)
+)
+axi_register_rd_inst (
+    .clk(clk),
+    .rst(rst),
+
+    /*
+     * AXI slave interface
+     */
+    .s_axi_arid(s_axi_arid),
+    .s_axi_araddr(s_axi_araddr),
+    .s_axi_arlen(s_axi_arlen),
+    .s_axi_arsize(s_axi_arsize),
+    .s_axi_arburst(s_axi_arburst),
+    .s_axi_arlock(s_axi_arlock),
+    .s_axi_arcache(s_axi_arcache),
+    .s_axi_arprot(s_axi_arprot),
+    .s_axi_arqos(s_axi_arqos),
+    .s_axi_arregion(s_axi_arregion),
+    .s_axi_aruser(s_axi_aruser),
+    .s_axi_arvalid(s_axi_arvalid),
+    .s_axi_arready(s_axi_arready),
+    .s_axi_rid(s_axi_rid),
+    .s_axi_rdata(s_axi_rdata),
+    .s_axi_rresp(s_axi_rresp),
+    .s_axi_rlast(s_axi_rlast),
+    .s_axi_ruser(s_axi_ruser),
+    .s_axi_rvalid(s_axi_rvalid),
+    .s_axi_rready(s_axi_rready),
+
+    /*
+     * AXI master interface
+     */
+    .m_axi_arid(m_axi_arid),
+    .m_axi_araddr(m_axi_araddr),
+    .m_axi_arlen(m_axi_arlen),
+    .m_axi_arsize(m_axi_arsize),
+    .m_axi_arburst(m_axi_arburst),
+    .m_axi_arlock(m_axi_arlock),
+    .m_axi_arcache(m_axi_arcache),
+    .m_axi_arprot(m_axi_arprot),
+    .m_axi_arqos(m_axi_arqos),
+    .m_axi_arregion(m_axi_arregion),
+    .m_axi_aruser(m_axi_aruser),
+    .m_axi_arvalid(m_axi_arvalid),
+    .m_axi_arready(m_axi_arready),
+    .m_axi_rid(m_axi_rid),
+    .m_axi_rdata(m_axi_rdata),
+    .m_axi_rresp(m_axi_rresp),
+    .m_axi_rlast(m_axi_rlast),
+    .m_axi_ruser(m_axi_ruser),
+    .m_axi_rvalid(m_axi_rvalid),
+    .m_axi_rready(m_axi_rready)
+);
+
+endmodule

--- a/tests/designs/axi4_ram/axi_register_rd.v
+++ b/tests/designs/axi4_ram/axi_register_rd.v
@@ -1,0 +1,526 @@
+/*
+
+Copyright (c) 2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ns / 1ps
+
+/*
+ * AXI4 register (read)
+ */
+module axi_register_rd #
+(
+    // Width of data bus in bits
+    parameter DATA_WIDTH = 32,
+    // Width of address bus in bits
+    parameter ADDR_WIDTH = 32,
+    // Width of wstrb (width of data bus in words)
+    parameter STRB_WIDTH = (DATA_WIDTH/8),
+    // Width of ID signal
+    parameter ID_WIDTH = 8,
+    // Propagate aruser signal
+    parameter ARUSER_ENABLE = 0,
+    // Width of aruser signal
+    parameter ARUSER_WIDTH = 1,
+    // Propagate ruser signal
+    parameter RUSER_ENABLE = 0,
+    // Width of ruser signal
+    parameter RUSER_WIDTH = 1,
+    // AR channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter AR_REG_TYPE = 1,
+    // R channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter R_REG_TYPE = 2
+)
+(
+    input  wire                     clk,
+    input  wire                     rst,
+
+    /*
+     * AXI slave interface
+     */
+    input  wire [ID_WIDTH-1:0]      s_axi_arid,
+    input  wire [ADDR_WIDTH-1:0]    s_axi_araddr,
+    input  wire [7:0]               s_axi_arlen,
+    input  wire [2:0]               s_axi_arsize,
+    input  wire [1:0]               s_axi_arburst,
+    input  wire                     s_axi_arlock,
+    input  wire [3:0]               s_axi_arcache,
+    input  wire [2:0]               s_axi_arprot,
+    input  wire [3:0]               s_axi_arqos,
+    input  wire [3:0]               s_axi_arregion,
+    input  wire [ARUSER_WIDTH-1:0]  s_axi_aruser,
+    input  wire                     s_axi_arvalid,
+    output wire                     s_axi_arready,
+    output wire [ID_WIDTH-1:0]      s_axi_rid,
+    output wire [DATA_WIDTH-1:0]    s_axi_rdata,
+    output wire [1:0]               s_axi_rresp,
+    output wire                     s_axi_rlast,
+    output wire [RUSER_WIDTH-1:0]   s_axi_ruser,
+    output wire                     s_axi_rvalid,
+    input  wire                     s_axi_rready,
+
+    /*
+     * AXI master interface
+     */
+    output wire [ID_WIDTH-1:0]      m_axi_arid,
+    output wire [ADDR_WIDTH-1:0]    m_axi_araddr,
+    output wire [7:0]               m_axi_arlen,
+    output wire [2:0]               m_axi_arsize,
+    output wire [1:0]               m_axi_arburst,
+    output wire                     m_axi_arlock,
+    output wire [3:0]               m_axi_arcache,
+    output wire [2:0]               m_axi_arprot,
+    output wire [3:0]               m_axi_arqos,
+    output wire [3:0]               m_axi_arregion,
+    output wire [ARUSER_WIDTH-1:0]  m_axi_aruser,
+    output wire                     m_axi_arvalid,
+    input  wire                     m_axi_arready,
+    input  wire [ID_WIDTH-1:0]      m_axi_rid,
+    input  wire [DATA_WIDTH-1:0]    m_axi_rdata,
+    input  wire [1:0]               m_axi_rresp,
+    input  wire                     m_axi_rlast,
+    input  wire [RUSER_WIDTH-1:0]   m_axi_ruser,
+    input  wire                     m_axi_rvalid,
+    output wire                     m_axi_rready
+);
+
+generate
+
+// AR channel
+
+if (AR_REG_TYPE > 1) begin
+// skid buffer, no bubble cycles
+
+// datapath registers
+reg                    s_axi_arready_reg = 1'b0;
+
+reg [ID_WIDTH-1:0]     m_axi_arid_reg     = {ID_WIDTH{1'b0}};
+reg [ADDR_WIDTH-1:0]   m_axi_araddr_reg   = {ADDR_WIDTH{1'b0}};
+reg [7:0]              m_axi_arlen_reg    = 8'd0;
+reg [2:0]              m_axi_arsize_reg   = 3'd0;
+reg [1:0]              m_axi_arburst_reg  = 2'd0;
+reg                    m_axi_arlock_reg   = 1'b0;
+reg [3:0]              m_axi_arcache_reg  = 4'd0;
+reg [2:0]              m_axi_arprot_reg   = 3'd0;
+reg [3:0]              m_axi_arqos_reg    = 4'd0;
+reg [3:0]              m_axi_arregion_reg = 4'd0;
+reg [ARUSER_WIDTH-1:0] m_axi_aruser_reg   = {ARUSER_WIDTH{1'b0}};
+reg                    m_axi_arvalid_reg  = 1'b0, m_axi_arvalid_next;
+
+reg [ID_WIDTH-1:0]     temp_m_axi_arid_reg     = {ID_WIDTH{1'b0}};
+reg [ADDR_WIDTH-1:0]   temp_m_axi_araddr_reg   = {ADDR_WIDTH{1'b0}};
+reg [7:0]              temp_m_axi_arlen_reg    = 8'd0;
+reg [2:0]              temp_m_axi_arsize_reg   = 3'd0;
+reg [1:0]              temp_m_axi_arburst_reg  = 2'd0;
+reg                    temp_m_axi_arlock_reg   = 1'b0;
+reg [3:0]              temp_m_axi_arcache_reg  = 4'd0;
+reg [2:0]              temp_m_axi_arprot_reg   = 3'd0;
+reg [3:0]              temp_m_axi_arqos_reg    = 4'd0;
+reg [3:0]              temp_m_axi_arregion_reg = 4'd0;
+reg [ARUSER_WIDTH-1:0] temp_m_axi_aruser_reg   = {ARUSER_WIDTH{1'b0}};
+reg                    temp_m_axi_arvalid_reg  = 1'b0, temp_m_axi_arvalid_next;
+
+// datapath control
+reg store_axi_ar_input_to_output;
+reg store_axi_ar_input_to_temp;
+reg store_axi_ar_temp_to_output;
+
+assign s_axi_arready  = s_axi_arready_reg;
+
+assign m_axi_arid     = m_axi_arid_reg;
+assign m_axi_araddr   = m_axi_araddr_reg;
+assign m_axi_arlen    = m_axi_arlen_reg;
+assign m_axi_arsize   = m_axi_arsize_reg;
+assign m_axi_arburst  = m_axi_arburst_reg;
+assign m_axi_arlock   = m_axi_arlock_reg;
+assign m_axi_arcache  = m_axi_arcache_reg;
+assign m_axi_arprot   = m_axi_arprot_reg;
+assign m_axi_arqos    = m_axi_arqos_reg;
+assign m_axi_arregion = m_axi_arregion_reg;
+assign m_axi_aruser   = ARUSER_ENABLE ? m_axi_aruser_reg : {ARUSER_WIDTH{1'b0}};
+assign m_axi_arvalid  = m_axi_arvalid_reg;
+
+// enable ready input next cycle if output is ready or the temp reg will not be filled on the next cycle (output reg empty or no input)
+wire s_axi_arready_early = m_axi_arready | (~temp_m_axi_arvalid_reg & (~m_axi_arvalid_reg | ~s_axi_arvalid));
+
+always @* begin
+    // transfer sink ready state to source
+    m_axi_arvalid_next = m_axi_arvalid_reg;
+    temp_m_axi_arvalid_next = temp_m_axi_arvalid_reg;
+
+    store_axi_ar_input_to_output = 1'b0;
+    store_axi_ar_input_to_temp = 1'b0;
+    store_axi_ar_temp_to_output = 1'b0;
+
+    if (s_axi_arready_reg) begin
+        // input is ready
+        if (m_axi_arready | ~m_axi_arvalid_reg) begin
+            // output is ready or currently not valid, transfer data to output
+            m_axi_arvalid_next = s_axi_arvalid;
+            store_axi_ar_input_to_output = 1'b1;
+        end else begin
+            // output is not ready, store input in temp
+            temp_m_axi_arvalid_next = s_axi_arvalid;
+            store_axi_ar_input_to_temp = 1'b1;
+        end
+    end else if (m_axi_arready) begin
+        // input is not ready, but output is ready
+        m_axi_arvalid_next = temp_m_axi_arvalid_reg;
+        temp_m_axi_arvalid_next = 1'b0;
+        store_axi_ar_temp_to_output = 1'b1;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        s_axi_arready_reg <= 1'b0;
+        m_axi_arvalid_reg <= 1'b0;
+        temp_m_axi_arvalid_reg <= 1'b0;
+    end else begin
+        s_axi_arready_reg <= s_axi_arready_early;
+        m_axi_arvalid_reg <= m_axi_arvalid_next;
+        temp_m_axi_arvalid_reg <= temp_m_axi_arvalid_next;
+    end
+
+    // datapath
+    if (store_axi_ar_input_to_output) begin
+        m_axi_arid_reg <= s_axi_arid;
+        m_axi_araddr_reg <= s_axi_araddr;
+        m_axi_arlen_reg <= s_axi_arlen;
+        m_axi_arsize_reg <= s_axi_arsize;
+        m_axi_arburst_reg <= s_axi_arburst;
+        m_axi_arlock_reg <= s_axi_arlock;
+        m_axi_arcache_reg <= s_axi_arcache;
+        m_axi_arprot_reg <= s_axi_arprot;
+        m_axi_arqos_reg <= s_axi_arqos;
+        m_axi_arregion_reg <= s_axi_arregion;
+        m_axi_aruser_reg <= s_axi_aruser;
+    end else if (store_axi_ar_temp_to_output) begin
+        m_axi_arid_reg <= temp_m_axi_arid_reg;
+        m_axi_araddr_reg <= temp_m_axi_araddr_reg;
+        m_axi_arlen_reg <= temp_m_axi_arlen_reg;
+        m_axi_arsize_reg <= temp_m_axi_arsize_reg;
+        m_axi_arburst_reg <= temp_m_axi_arburst_reg;
+        m_axi_arlock_reg <= temp_m_axi_arlock_reg;
+        m_axi_arcache_reg <= temp_m_axi_arcache_reg;
+        m_axi_arprot_reg <= temp_m_axi_arprot_reg;
+        m_axi_arqos_reg <= temp_m_axi_arqos_reg;
+        m_axi_arregion_reg <= temp_m_axi_arregion_reg;
+        m_axi_aruser_reg <= temp_m_axi_aruser_reg;
+    end
+
+    if (store_axi_ar_input_to_temp) begin
+        temp_m_axi_arid_reg <= s_axi_arid;
+        temp_m_axi_araddr_reg <= s_axi_araddr;
+        temp_m_axi_arlen_reg <= s_axi_arlen;
+        temp_m_axi_arsize_reg <= s_axi_arsize;
+        temp_m_axi_arburst_reg <= s_axi_arburst;
+        temp_m_axi_arlock_reg <= s_axi_arlock;
+        temp_m_axi_arcache_reg <= s_axi_arcache;
+        temp_m_axi_arprot_reg <= s_axi_arprot;
+        temp_m_axi_arqos_reg <= s_axi_arqos;
+        temp_m_axi_arregion_reg <= s_axi_arregion;
+        temp_m_axi_aruser_reg <= s_axi_aruser;
+    end
+end
+
+end else if (AR_REG_TYPE == 1) begin
+// simple register, inserts bubble cycles
+
+// datapath registers
+reg                    s_axi_arready_reg = 1'b0;
+
+reg [ID_WIDTH-1:0]     m_axi_arid_reg     = {ID_WIDTH{1'b0}};
+reg [ADDR_WIDTH-1:0]   m_axi_araddr_reg   = {ADDR_WIDTH{1'b0}};
+reg [7:0]              m_axi_arlen_reg    = 8'd0;
+reg [2:0]              m_axi_arsize_reg   = 3'd0;
+reg [1:0]              m_axi_arburst_reg  = 2'd0;
+reg                    m_axi_arlock_reg   = 1'b0;
+reg [3:0]              m_axi_arcache_reg  = 4'd0;
+reg [2:0]              m_axi_arprot_reg   = 3'd0;
+reg [3:0]              m_axi_arqos_reg    = 4'd0;
+reg [3:0]              m_axi_arregion_reg = 4'd0;
+reg [ARUSER_WIDTH-1:0] m_axi_aruser_reg   = {ARUSER_WIDTH{1'b0}};
+reg                    m_axi_arvalid_reg  = 1'b0, m_axi_arvalid_next;
+
+// datapath control
+reg store_axi_ar_input_to_output;
+
+assign s_axi_arready  = s_axi_arready_reg;
+
+assign m_axi_arid     = m_axi_arid_reg;
+assign m_axi_araddr   = m_axi_araddr_reg;
+assign m_axi_arlen    = m_axi_arlen_reg;
+assign m_axi_arsize   = m_axi_arsize_reg;
+assign m_axi_arburst  = m_axi_arburst_reg;
+assign m_axi_arlock   = m_axi_arlock_reg;
+assign m_axi_arcache  = m_axi_arcache_reg;
+assign m_axi_arprot   = m_axi_arprot_reg;
+assign m_axi_arqos    = m_axi_arqos_reg;
+assign m_axi_arregion = m_axi_arregion_reg;
+assign m_axi_aruser   = ARUSER_ENABLE ? m_axi_aruser_reg : {ARUSER_WIDTH{1'b0}};
+assign m_axi_arvalid  = m_axi_arvalid_reg;
+
+// enable ready input next cycle if output buffer will be empty
+wire s_axi_arready_early = !m_axi_arvalid_next;
+
+always @* begin
+    // transfer sink ready state to source
+    m_axi_arvalid_next = m_axi_arvalid_reg;
+
+    store_axi_ar_input_to_output = 1'b0;
+
+    if (s_axi_arready_reg) begin
+        m_axi_arvalid_next = s_axi_arvalid;
+        store_axi_ar_input_to_output = 1'b1;
+    end else if (m_axi_arready) begin
+        m_axi_arvalid_next = 1'b0;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        s_axi_arready_reg <= 1'b0;
+        m_axi_arvalid_reg <= 1'b0;
+    end else begin
+        s_axi_arready_reg <= s_axi_arready_early;
+        m_axi_arvalid_reg <= m_axi_arvalid_next;
+    end
+
+    // datapath
+    if (store_axi_ar_input_to_output) begin
+        m_axi_arid_reg <= s_axi_arid;
+        m_axi_araddr_reg <= s_axi_araddr;
+        m_axi_arlen_reg <= s_axi_arlen;
+        m_axi_arsize_reg <= s_axi_arsize;
+        m_axi_arburst_reg <= s_axi_arburst;
+        m_axi_arlock_reg <= s_axi_arlock;
+        m_axi_arcache_reg <= s_axi_arcache;
+        m_axi_arprot_reg <= s_axi_arprot;
+        m_axi_arqos_reg <= s_axi_arqos;
+        m_axi_arregion_reg <= s_axi_arregion;
+        m_axi_aruser_reg <= s_axi_aruser;
+    end
+end
+
+end else begin
+
+    // bypass AR channel
+    assign m_axi_arid = s_axi_arid;
+    assign m_axi_araddr = s_axi_araddr;
+    assign m_axi_arlen = s_axi_arlen;
+    assign m_axi_arsize = s_axi_arsize;
+    assign m_axi_arburst = s_axi_arburst;
+    assign m_axi_arlock = s_axi_arlock;
+    assign m_axi_arcache = s_axi_arcache;
+    assign m_axi_arprot = s_axi_arprot;
+    assign m_axi_arqos = s_axi_arqos;
+    assign m_axi_arregion = s_axi_arregion;
+    assign m_axi_aruser = ARUSER_ENABLE ? s_axi_aruser : {ARUSER_WIDTH{1'b0}};
+    assign m_axi_arvalid = s_axi_arvalid;
+    assign s_axi_arready = m_axi_arready;
+
+end
+
+// R channel
+
+if (R_REG_TYPE > 1) begin
+// skid buffer, no bubble cycles
+
+// datapath registers
+reg                   m_axi_rready_reg = 1'b0;
+
+reg [ID_WIDTH-1:0]    s_axi_rid_reg    = {ID_WIDTH{1'b0}};
+reg [DATA_WIDTH-1:0]  s_axi_rdata_reg  = {DATA_WIDTH{1'b0}};
+reg [1:0]             s_axi_rresp_reg  = 2'b0;
+reg                   s_axi_rlast_reg  = 1'b0;
+reg [RUSER_WIDTH-1:0] s_axi_ruser_reg  = {RUSER_WIDTH{1'b0}};
+reg                   s_axi_rvalid_reg = 1'b0, s_axi_rvalid_next;
+
+reg [ID_WIDTH-1:0]    temp_s_axi_rid_reg    = {ID_WIDTH{1'b0}};
+reg [DATA_WIDTH-1:0]  temp_s_axi_rdata_reg  = {DATA_WIDTH{1'b0}};
+reg [1:0]             temp_s_axi_rresp_reg  = 2'b0;
+reg                   temp_s_axi_rlast_reg  = 1'b0;
+reg [RUSER_WIDTH-1:0] temp_s_axi_ruser_reg  = {RUSER_WIDTH{1'b0}};
+reg                   temp_s_axi_rvalid_reg = 1'b0, temp_s_axi_rvalid_next;
+
+// datapath control
+reg store_axi_r_input_to_output;
+reg store_axi_r_input_to_temp;
+reg store_axi_r_temp_to_output;
+
+assign m_axi_rready = m_axi_rready_reg;
+
+assign s_axi_rid    = s_axi_rid_reg;
+assign s_axi_rdata  = s_axi_rdata_reg;
+assign s_axi_rresp  = s_axi_rresp_reg;
+assign s_axi_rlast  = s_axi_rlast_reg;
+assign s_axi_ruser  = RUSER_ENABLE ? s_axi_ruser_reg : {RUSER_WIDTH{1'b0}};
+assign s_axi_rvalid = s_axi_rvalid_reg;
+
+// enable ready input next cycle if output is ready or the temp reg will not be filled on the next cycle (output reg empty or no input)
+wire m_axi_rready_early = s_axi_rready | (~temp_s_axi_rvalid_reg & (~s_axi_rvalid_reg | ~m_axi_rvalid));
+
+always @* begin
+    // transfer sink ready state to source
+    s_axi_rvalid_next = s_axi_rvalid_reg;
+    temp_s_axi_rvalid_next = temp_s_axi_rvalid_reg;
+
+    store_axi_r_input_to_output = 1'b0;
+    store_axi_r_input_to_temp = 1'b0;
+    store_axi_r_temp_to_output = 1'b0;
+
+    if (m_axi_rready_reg) begin
+        // input is ready
+        if (s_axi_rready | ~s_axi_rvalid_reg) begin
+            // output is ready or currently not valid, transfer data to output
+            s_axi_rvalid_next = m_axi_rvalid;
+            store_axi_r_input_to_output = 1'b1;
+        end else begin
+            // output is not ready, store input in temp
+            temp_s_axi_rvalid_next = m_axi_rvalid;
+            store_axi_r_input_to_temp = 1'b1;
+        end
+    end else if (s_axi_rready) begin
+        // input is not ready, but output is ready
+        s_axi_rvalid_next = temp_s_axi_rvalid_reg;
+        temp_s_axi_rvalid_next = 1'b0;
+        store_axi_r_temp_to_output = 1'b1;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        m_axi_rready_reg <= 1'b0;
+        s_axi_rvalid_reg <= 1'b0;
+        temp_s_axi_rvalid_reg <= 1'b0;
+    end else begin
+        m_axi_rready_reg <= m_axi_rready_early;
+        s_axi_rvalid_reg <= s_axi_rvalid_next;
+        temp_s_axi_rvalid_reg <= temp_s_axi_rvalid_next;
+    end
+
+    // datapath
+    if (store_axi_r_input_to_output) begin
+        s_axi_rid_reg   <= m_axi_rid;
+        s_axi_rdata_reg <= m_axi_rdata;
+        s_axi_rresp_reg <= m_axi_rresp;
+        s_axi_rlast_reg <= m_axi_rlast;
+        s_axi_ruser_reg <= m_axi_ruser;
+    end else if (store_axi_r_temp_to_output) begin
+        s_axi_rid_reg   <= temp_s_axi_rid_reg;
+        s_axi_rdata_reg <= temp_s_axi_rdata_reg;
+        s_axi_rresp_reg <= temp_s_axi_rresp_reg;
+        s_axi_rlast_reg <= temp_s_axi_rlast_reg;
+        s_axi_ruser_reg <= temp_s_axi_ruser_reg;
+    end
+
+    if (store_axi_r_input_to_temp) begin
+        temp_s_axi_rid_reg   <= m_axi_rid;
+        temp_s_axi_rdata_reg <= m_axi_rdata;
+        temp_s_axi_rresp_reg <= m_axi_rresp;
+        temp_s_axi_rlast_reg <= m_axi_rlast;
+        temp_s_axi_ruser_reg <= m_axi_ruser;
+    end
+end
+
+end else if (R_REG_TYPE == 1) begin
+// simple register, inserts bubble cycles
+
+// datapath registers
+reg                   m_axi_rready_reg = 1'b0;
+
+reg [ID_WIDTH-1:0]    s_axi_rid_reg    = {ID_WIDTH{1'b0}};
+reg [DATA_WIDTH-1:0]  s_axi_rdata_reg  = {DATA_WIDTH{1'b0}};
+reg [1:0]             s_axi_rresp_reg  = 2'b0;
+reg                   s_axi_rlast_reg  = 1'b0;
+reg [RUSER_WIDTH-1:0] s_axi_ruser_reg  = {RUSER_WIDTH{1'b0}};
+reg                   s_axi_rvalid_reg = 1'b0, s_axi_rvalid_next;
+
+// datapath control
+reg store_axi_r_input_to_output;
+
+assign m_axi_rready = m_axi_rready_reg;
+
+assign s_axi_rid    = s_axi_rid_reg;
+assign s_axi_rdata  = s_axi_rdata_reg;
+assign s_axi_rresp  = s_axi_rresp_reg;
+assign s_axi_rlast  = s_axi_rlast_reg;
+assign s_axi_ruser  = RUSER_ENABLE ? s_axi_ruser_reg : {RUSER_WIDTH{1'b0}};
+assign s_axi_rvalid = s_axi_rvalid_reg;
+
+// enable ready input next cycle if output buffer will be empty
+wire m_axi_rready_early = !s_axi_rvalid_next;
+
+always @* begin
+    // transfer sink ready state to source
+    s_axi_rvalid_next = s_axi_rvalid_reg;
+
+    store_axi_r_input_to_output = 1'b0;
+
+    if (m_axi_rready_reg) begin
+        s_axi_rvalid_next = m_axi_rvalid;
+        store_axi_r_input_to_output = 1'b1;
+    end else if (s_axi_rready) begin
+        s_axi_rvalid_next = 1'b0;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        m_axi_rready_reg <= 1'b0;
+        s_axi_rvalid_reg <= 1'b0;
+    end else begin
+        m_axi_rready_reg <= m_axi_rready_early;
+        s_axi_rvalid_reg <= s_axi_rvalid_next;
+    end
+
+    // datapath
+    if (store_axi_r_input_to_output) begin
+        s_axi_rid_reg   <= m_axi_rid;
+        s_axi_rdata_reg <= m_axi_rdata;
+        s_axi_rresp_reg <= m_axi_rresp;
+        s_axi_rlast_reg <= m_axi_rlast;
+        s_axi_ruser_reg <= m_axi_ruser;
+    end
+end
+
+end else begin
+
+    // bypass R channel
+    assign s_axi_rid = m_axi_rid;
+    assign s_axi_rdata = m_axi_rdata;
+    assign s_axi_rresp = m_axi_rresp;
+    assign s_axi_rlast = m_axi_rlast;
+    assign s_axi_ruser = RUSER_ENABLE ? m_axi_ruser : {RUSER_WIDTH{1'b0}};
+    assign s_axi_rvalid = m_axi_rvalid;
+    assign m_axi_rready = s_axi_rready;
+
+end
+
+endgenerate
+
+endmodule

--- a/tests/designs/axi4_ram/axi_register_wr.v
+++ b/tests/designs/axi4_ram/axi_register_wr.v
@@ -1,0 +1,687 @@
+/*
+
+Copyright (c) 2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ns / 1ps
+
+/*
+ * AXI4 register (write)
+ */
+module axi_register_wr #
+(
+    // Width of data bus in bits
+    parameter DATA_WIDTH = 32,
+    // Width of address bus in bits
+    parameter ADDR_WIDTH = 32,
+    // Width of wstrb (width of data bus in words)
+    parameter STRB_WIDTH = (DATA_WIDTH/8),
+    // Width of ID signal
+    parameter ID_WIDTH = 8,
+    // Propagate awuser signal
+    parameter AWUSER_ENABLE = 0,
+    // Width of awuser signal
+    parameter AWUSER_WIDTH = 1,
+    // Propagate wuser signal
+    parameter WUSER_ENABLE = 0,
+    // Width of wuser signal
+    parameter WUSER_WIDTH = 1,
+    // Propagate buser signal
+    parameter BUSER_ENABLE = 0,
+    // Width of buser signal
+    parameter BUSER_WIDTH = 1,
+    // AW channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter AW_REG_TYPE = 1,
+    // W channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter W_REG_TYPE = 2,
+    // B channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter B_REG_TYPE = 1
+)
+(
+    input  wire                     clk,
+    input  wire                     rst,
+
+    /*
+     * AXI slave interface
+     */
+    input  wire [ID_WIDTH-1:0]      s_axi_awid,
+    input  wire [ADDR_WIDTH-1:0]    s_axi_awaddr,
+    input  wire [7:0]               s_axi_awlen,
+    input  wire [2:0]               s_axi_awsize,
+    input  wire [1:0]               s_axi_awburst,
+    input  wire                     s_axi_awlock,
+    input  wire [3:0]               s_axi_awcache,
+    input  wire [2:0]               s_axi_awprot,
+    input  wire [3:0]               s_axi_awqos,
+    input  wire [3:0]               s_axi_awregion,
+    input  wire [AWUSER_WIDTH-1:0]  s_axi_awuser,
+    input  wire                     s_axi_awvalid,
+    output wire                     s_axi_awready,
+    input  wire [DATA_WIDTH-1:0]    s_axi_wdata,
+    input  wire [STRB_WIDTH-1:0]    s_axi_wstrb,
+    input  wire                     s_axi_wlast,
+    input  wire [WUSER_WIDTH-1:0]   s_axi_wuser,
+    input  wire                     s_axi_wvalid,
+    output wire                     s_axi_wready,
+    output wire [ID_WIDTH-1:0]      s_axi_bid,
+    output wire [1:0]               s_axi_bresp,
+    output wire [BUSER_WIDTH-1:0]   s_axi_buser,
+    output wire                     s_axi_bvalid,
+    input  wire                     s_axi_bready,
+
+    /*
+     * AXI master interface
+     */
+    output wire [ID_WIDTH-1:0]      m_axi_awid,
+    output wire [ADDR_WIDTH-1:0]    m_axi_awaddr,
+    output wire [7:0]               m_axi_awlen,
+    output wire [2:0]               m_axi_awsize,
+    output wire [1:0]               m_axi_awburst,
+    output wire                     m_axi_awlock,
+    output wire [3:0]               m_axi_awcache,
+    output wire [2:0]               m_axi_awprot,
+    output wire [3:0]               m_axi_awqos,
+    output wire [3:0]               m_axi_awregion,
+    output wire [AWUSER_WIDTH-1:0]  m_axi_awuser,
+    output wire                     m_axi_awvalid,
+    input  wire                     m_axi_awready,
+    output wire [DATA_WIDTH-1:0]    m_axi_wdata,
+    output wire [STRB_WIDTH-1:0]    m_axi_wstrb,
+    output wire                     m_axi_wlast,
+    output wire [WUSER_WIDTH-1:0]   m_axi_wuser,
+    output wire                     m_axi_wvalid,
+    input  wire                     m_axi_wready,
+    input  wire [ID_WIDTH-1:0]      m_axi_bid,
+    input  wire [1:0]               m_axi_bresp,
+    input  wire [BUSER_WIDTH-1:0]   m_axi_buser,
+    input  wire                     m_axi_bvalid,
+    output wire                     m_axi_bready
+);
+
+generate
+
+// AW channel
+
+if (AW_REG_TYPE > 1) begin
+// skid buffer, no bubble cycles
+
+// datapath registers
+reg                    s_axi_awready_reg = 1'b0;
+
+reg [ID_WIDTH-1:0]     m_axi_awid_reg     = {ID_WIDTH{1'b0}};
+reg [ADDR_WIDTH-1:0]   m_axi_awaddr_reg   = {ADDR_WIDTH{1'b0}};
+reg [7:0]              m_axi_awlen_reg    = 8'd0;
+reg [2:0]              m_axi_awsize_reg   = 3'd0;
+reg [1:0]              m_axi_awburst_reg  = 2'd0;
+reg                    m_axi_awlock_reg   = 1'b0;
+reg [3:0]              m_axi_awcache_reg  = 4'd0;
+reg [2:0]              m_axi_awprot_reg   = 3'd0;
+reg [3:0]              m_axi_awqos_reg    = 4'd0;
+reg [3:0]              m_axi_awregion_reg = 4'd0;
+reg [AWUSER_WIDTH-1:0] m_axi_awuser_reg   = {AWUSER_WIDTH{1'b0}};
+reg                    m_axi_awvalid_reg  = 1'b0, m_axi_awvalid_next;
+
+reg [ID_WIDTH-1:0]     temp_m_axi_awid_reg     = {ID_WIDTH{1'b0}};
+reg [ADDR_WIDTH-1:0]   temp_m_axi_awaddr_reg   = {ADDR_WIDTH{1'b0}};
+reg [7:0]              temp_m_axi_awlen_reg    = 8'd0;
+reg [2:0]              temp_m_axi_awsize_reg   = 3'd0;
+reg [1:0]              temp_m_axi_awburst_reg  = 2'd0;
+reg                    temp_m_axi_awlock_reg   = 1'b0;
+reg [3:0]              temp_m_axi_awcache_reg  = 4'd0;
+reg [2:0]              temp_m_axi_awprot_reg   = 3'd0;
+reg [3:0]              temp_m_axi_awqos_reg    = 4'd0;
+reg [3:0]              temp_m_axi_awregion_reg = 4'd0;
+reg [AWUSER_WIDTH-1:0] temp_m_axi_awuser_reg   = {AWUSER_WIDTH{1'b0}};
+reg                    temp_m_axi_awvalid_reg  = 1'b0, temp_m_axi_awvalid_next;
+
+// datapath control
+reg store_axi_aw_input_to_output;
+reg store_axi_aw_input_to_temp;
+reg store_axi_aw_temp_to_output;
+
+assign s_axi_awready  = s_axi_awready_reg;
+
+assign m_axi_awid     = m_axi_awid_reg;
+assign m_axi_awaddr   = m_axi_awaddr_reg;
+assign m_axi_awlen    = m_axi_awlen_reg;
+assign m_axi_awsize   = m_axi_awsize_reg;
+assign m_axi_awburst  = m_axi_awburst_reg;
+assign m_axi_awlock   = m_axi_awlock_reg;
+assign m_axi_awcache  = m_axi_awcache_reg;
+assign m_axi_awprot   = m_axi_awprot_reg;
+assign m_axi_awqos    = m_axi_awqos_reg;
+assign m_axi_awregion = m_axi_awregion_reg;
+assign m_axi_awuser   = AWUSER_ENABLE ? m_axi_awuser_reg : {AWUSER_WIDTH{1'b0}};
+assign m_axi_awvalid  = m_axi_awvalid_reg;
+
+// enable ready input next cycle if output is ready or the temp reg will not be filled on the next cycle (output reg empty or no input)
+wire s_axi_awready_early = m_axi_awready | (~temp_m_axi_awvalid_reg & (~m_axi_awvalid_reg | ~s_axi_awvalid));
+
+always @* begin
+    // transfer sink ready state to source
+    m_axi_awvalid_next = m_axi_awvalid_reg;
+    temp_m_axi_awvalid_next = temp_m_axi_awvalid_reg;
+
+    store_axi_aw_input_to_output = 1'b0;
+    store_axi_aw_input_to_temp = 1'b0;
+    store_axi_aw_temp_to_output = 1'b0;
+
+    if (s_axi_awready_reg) begin
+        // input is ready
+        if (m_axi_awready | ~m_axi_awvalid_reg) begin
+            // output is ready or currently not valid, transfer data to output
+            m_axi_awvalid_next = s_axi_awvalid;
+            store_axi_aw_input_to_output = 1'b1;
+        end else begin
+            // output is not ready, store input in temp
+            temp_m_axi_awvalid_next = s_axi_awvalid;
+            store_axi_aw_input_to_temp = 1'b1;
+        end
+    end else if (m_axi_awready) begin
+        // input is not ready, but output is ready
+        m_axi_awvalid_next = temp_m_axi_awvalid_reg;
+        temp_m_axi_awvalid_next = 1'b0;
+        store_axi_aw_temp_to_output = 1'b1;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        s_axi_awready_reg <= 1'b0;
+        m_axi_awvalid_reg <= 1'b0;
+        temp_m_axi_awvalid_reg <= 1'b0;
+    end else begin
+        s_axi_awready_reg <= s_axi_awready_early;
+        m_axi_awvalid_reg <= m_axi_awvalid_next;
+        temp_m_axi_awvalid_reg <= temp_m_axi_awvalid_next;
+    end
+
+    // datapath
+    if (store_axi_aw_input_to_output) begin
+        m_axi_awid_reg <= s_axi_awid;
+        m_axi_awaddr_reg <= s_axi_awaddr;
+        m_axi_awlen_reg <= s_axi_awlen;
+        m_axi_awsize_reg <= s_axi_awsize;
+        m_axi_awburst_reg <= s_axi_awburst;
+        m_axi_awlock_reg <= s_axi_awlock;
+        m_axi_awcache_reg <= s_axi_awcache;
+        m_axi_awprot_reg <= s_axi_awprot;
+        m_axi_awqos_reg <= s_axi_awqos;
+        m_axi_awregion_reg <= s_axi_awregion;
+        m_axi_awuser_reg <= s_axi_awuser;
+    end else if (store_axi_aw_temp_to_output) begin
+        m_axi_awid_reg <= temp_m_axi_awid_reg;
+        m_axi_awaddr_reg <= temp_m_axi_awaddr_reg;
+        m_axi_awlen_reg <= temp_m_axi_awlen_reg;
+        m_axi_awsize_reg <= temp_m_axi_awsize_reg;
+        m_axi_awburst_reg <= temp_m_axi_awburst_reg;
+        m_axi_awlock_reg <= temp_m_axi_awlock_reg;
+        m_axi_awcache_reg <= temp_m_axi_awcache_reg;
+        m_axi_awprot_reg <= temp_m_axi_awprot_reg;
+        m_axi_awqos_reg <= temp_m_axi_awqos_reg;
+        m_axi_awregion_reg <= temp_m_axi_awregion_reg;
+        m_axi_awuser_reg <= temp_m_axi_awuser_reg;
+    end
+
+    if (store_axi_aw_input_to_temp) begin
+        temp_m_axi_awid_reg <= s_axi_awid;
+        temp_m_axi_awaddr_reg <= s_axi_awaddr;
+        temp_m_axi_awlen_reg <= s_axi_awlen;
+        temp_m_axi_awsize_reg <= s_axi_awsize;
+        temp_m_axi_awburst_reg <= s_axi_awburst;
+        temp_m_axi_awlock_reg <= s_axi_awlock;
+        temp_m_axi_awcache_reg <= s_axi_awcache;
+        temp_m_axi_awprot_reg <= s_axi_awprot;
+        temp_m_axi_awqos_reg <= s_axi_awqos;
+        temp_m_axi_awregion_reg <= s_axi_awregion;
+        temp_m_axi_awuser_reg <= s_axi_awuser;
+    end
+end
+
+end else if (AW_REG_TYPE == 1) begin
+// simple register, inserts bubble cycles
+
+// datapath registers
+reg                    s_axi_awready_reg = 1'b0;
+
+reg [ID_WIDTH-1:0]     m_axi_awid_reg     = {ID_WIDTH{1'b0}};
+reg [ADDR_WIDTH-1:0]   m_axi_awaddr_reg   = {ADDR_WIDTH{1'b0}};
+reg [7:0]              m_axi_awlen_reg    = 8'd0;
+reg [2:0]              m_axi_awsize_reg   = 3'd0;
+reg [1:0]              m_axi_awburst_reg  = 2'd0;
+reg                    m_axi_awlock_reg   = 1'b0;
+reg [3:0]              m_axi_awcache_reg  = 4'd0;
+reg [2:0]              m_axi_awprot_reg   = 3'd0;
+reg [3:0]              m_axi_awqos_reg    = 4'd0;
+reg [3:0]              m_axi_awregion_reg = 4'd0;
+reg [AWUSER_WIDTH-1:0] m_axi_awuser_reg   = {AWUSER_WIDTH{1'b0}};
+reg                    m_axi_awvalid_reg  = 1'b0, m_axi_awvalid_next;
+
+// datapath control
+reg store_axi_aw_input_to_output;
+
+assign s_axi_awready  = s_axi_awready_reg;
+
+assign m_axi_awid     = m_axi_awid_reg;
+assign m_axi_awaddr   = m_axi_awaddr_reg;
+assign m_axi_awlen    = m_axi_awlen_reg;
+assign m_axi_awsize   = m_axi_awsize_reg;
+assign m_axi_awburst  = m_axi_awburst_reg;
+assign m_axi_awlock   = m_axi_awlock_reg;
+assign m_axi_awcache  = m_axi_awcache_reg;
+assign m_axi_awprot   = m_axi_awprot_reg;
+assign m_axi_awqos    = m_axi_awqos_reg;
+assign m_axi_awregion = m_axi_awregion_reg;
+assign m_axi_awuser   = AWUSER_ENABLE ? m_axi_awuser_reg : {AWUSER_WIDTH{1'b0}};
+assign m_axi_awvalid  = m_axi_awvalid_reg;
+
+// enable ready input next cycle if output buffer will be empty
+wire s_axi_awready_eawly = !m_axi_awvalid_next;
+
+always @* begin
+    // transfer sink ready state to source
+    m_axi_awvalid_next = m_axi_awvalid_reg;
+
+    store_axi_aw_input_to_output = 1'b0;
+
+    if (s_axi_awready_reg) begin
+        m_axi_awvalid_next = s_axi_awvalid;
+        store_axi_aw_input_to_output = 1'b1;
+    end else if (m_axi_awready) begin
+        m_axi_awvalid_next = 1'b0;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        s_axi_awready_reg <= 1'b0;
+        m_axi_awvalid_reg <= 1'b0;
+    end else begin
+        s_axi_awready_reg <= s_axi_awready_eawly;
+        m_axi_awvalid_reg <= m_axi_awvalid_next;
+    end
+
+    // datapath
+    if (store_axi_aw_input_to_output) begin
+        m_axi_awid_reg <= s_axi_awid;
+        m_axi_awaddr_reg <= s_axi_awaddr;
+        m_axi_awlen_reg <= s_axi_awlen;
+        m_axi_awsize_reg <= s_axi_awsize;
+        m_axi_awburst_reg <= s_axi_awburst;
+        m_axi_awlock_reg <= s_axi_awlock;
+        m_axi_awcache_reg <= s_axi_awcache;
+        m_axi_awprot_reg <= s_axi_awprot;
+        m_axi_awqos_reg <= s_axi_awqos;
+        m_axi_awregion_reg <= s_axi_awregion;
+        m_axi_awuser_reg <= s_axi_awuser;
+    end
+end
+
+end else begin
+
+    // bypass AW channel
+    assign m_axi_awid = s_axi_awid;
+    assign m_axi_awaddr = s_axi_awaddr;
+    assign m_axi_awlen = s_axi_awlen;
+    assign m_axi_awsize = s_axi_awsize;
+    assign m_axi_awburst = s_axi_awburst;
+    assign m_axi_awlock = s_axi_awlock;
+    assign m_axi_awcache = s_axi_awcache;
+    assign m_axi_awprot = s_axi_awprot;
+    assign m_axi_awqos = s_axi_awqos;
+    assign m_axi_awregion = s_axi_awregion;
+    assign m_axi_awuser = AWUSER_ENABLE ? s_axi_awuser : {AWUSER_WIDTH{1'b0}};
+    assign m_axi_awvalid = s_axi_awvalid;
+    assign s_axi_awready = m_axi_awready;
+
+end
+
+// W channel
+
+if (W_REG_TYPE > 1) begin
+// skid buffer, no bubble cycles
+
+// datapath registers
+reg                   s_axi_wready_reg = 1'b0;
+
+reg [DATA_WIDTH-1:0]  m_axi_wdata_reg  = {DATA_WIDTH{1'b0}};
+reg [STRB_WIDTH-1:0]  m_axi_wstrb_reg  = {STRB_WIDTH{1'b0}};
+reg                   m_axi_wlast_reg  = 1'b0;
+reg [WUSER_WIDTH-1:0] m_axi_wuser_reg  = {WUSER_WIDTH{1'b0}};
+reg                   m_axi_wvalid_reg = 1'b0, m_axi_wvalid_next;
+
+reg [DATA_WIDTH-1:0]  temp_m_axi_wdata_reg  = {DATA_WIDTH{1'b0}};
+reg [STRB_WIDTH-1:0]  temp_m_axi_wstrb_reg  = {STRB_WIDTH{1'b0}};
+reg                   temp_m_axi_wlast_reg  = 1'b0;
+reg [WUSER_WIDTH-1:0] temp_m_axi_wuser_reg  = {WUSER_WIDTH{1'b0}};
+reg                   temp_m_axi_wvalid_reg = 1'b0, temp_m_axi_wvalid_next;
+
+// datapath control
+reg store_axi_w_input_to_output;
+reg store_axi_w_input_to_temp;
+reg store_axi_w_temp_to_output;
+
+assign s_axi_wready = s_axi_wready_reg;
+
+assign m_axi_wdata  = m_axi_wdata_reg;
+assign m_axi_wstrb  = m_axi_wstrb_reg;
+assign m_axi_wlast  = m_axi_wlast_reg;
+assign m_axi_wuser  = WUSER_ENABLE ? m_axi_wuser_reg : {WUSER_WIDTH{1'b0}};
+assign m_axi_wvalid = m_axi_wvalid_reg;
+
+// enable ready input next cycle if output is ready or the temp reg will not be filled on the next cycle (output reg empty or no input)
+wire s_axi_wready_early = m_axi_wready | (~temp_m_axi_wvalid_reg & (~m_axi_wvalid_reg | ~s_axi_wvalid));
+
+always @* begin
+    // transfer sink ready state to source
+    m_axi_wvalid_next = m_axi_wvalid_reg;
+    temp_m_axi_wvalid_next = temp_m_axi_wvalid_reg;
+
+    store_axi_w_input_to_output = 1'b0;
+    store_axi_w_input_to_temp = 1'b0;
+    store_axi_w_temp_to_output = 1'b0;
+
+    if (s_axi_wready_reg) begin
+        // input is ready
+        if (m_axi_wready | ~m_axi_wvalid_reg) begin
+            // output is ready or currently not valid, transfer data to output
+            m_axi_wvalid_next = s_axi_wvalid;
+            store_axi_w_input_to_output = 1'b1;
+        end else begin
+            // output is not ready, store input in temp
+            temp_m_axi_wvalid_next = s_axi_wvalid;
+            store_axi_w_input_to_temp = 1'b1;
+        end
+    end else if (m_axi_wready) begin
+        // input is not ready, but output is ready
+        m_axi_wvalid_next = temp_m_axi_wvalid_reg;
+        temp_m_axi_wvalid_next = 1'b0;
+        store_axi_w_temp_to_output = 1'b1;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        s_axi_wready_reg <= 1'b0;
+        m_axi_wvalid_reg <= 1'b0;
+        temp_m_axi_wvalid_reg <= 1'b0;
+    end else begin
+        s_axi_wready_reg <= s_axi_wready_early;
+        m_axi_wvalid_reg <= m_axi_wvalid_next;
+        temp_m_axi_wvalid_reg <= temp_m_axi_wvalid_next;
+    end
+
+    // datapath
+    if (store_axi_w_input_to_output) begin
+        m_axi_wdata_reg <= s_axi_wdata;
+        m_axi_wstrb_reg <= s_axi_wstrb;
+        m_axi_wlast_reg <= s_axi_wlast;
+        m_axi_wuser_reg <= s_axi_wuser;
+    end else if (store_axi_w_temp_to_output) begin
+        m_axi_wdata_reg <= temp_m_axi_wdata_reg;
+        m_axi_wstrb_reg <= temp_m_axi_wstrb_reg;
+        m_axi_wlast_reg <= temp_m_axi_wlast_reg;
+        m_axi_wuser_reg <= temp_m_axi_wuser_reg;
+    end
+
+    if (store_axi_w_input_to_temp) begin
+        temp_m_axi_wdata_reg <= s_axi_wdata;
+        temp_m_axi_wstrb_reg <= s_axi_wstrb;
+        temp_m_axi_wlast_reg <= s_axi_wlast;
+        temp_m_axi_wuser_reg <= s_axi_wuser;
+    end
+end
+
+end else if (W_REG_TYPE == 1) begin
+// simple register, inserts bubble cycles
+
+// datapath registers
+reg                   s_axi_wready_reg = 1'b0;
+
+reg [DATA_WIDTH-1:0]  m_axi_wdata_reg  = {DATA_WIDTH{1'b0}};
+reg [STRB_WIDTH-1:0]  m_axi_wstrb_reg  = {STRB_WIDTH{1'b0}};
+reg                   m_axi_wlast_reg  = 1'b0;
+reg [WUSER_WIDTH-1:0] m_axi_wuser_reg  = {WUSER_WIDTH{1'b0}};
+reg                   m_axi_wvalid_reg = 1'b0, m_axi_wvalid_next;
+
+// datapath control
+reg store_axi_w_input_to_output;
+
+assign s_axi_wready = s_axi_wready_reg;
+
+assign m_axi_wdata  = m_axi_wdata_reg;
+assign m_axi_wstrb  = m_axi_wstrb_reg;
+assign m_axi_wlast  = m_axi_wlast_reg;
+assign m_axi_wuser  = WUSER_ENABLE ? m_axi_wuser_reg : {WUSER_WIDTH{1'b0}};
+assign m_axi_wvalid = m_axi_wvalid_reg;
+
+// enable ready input next cycle if output buffer will be empty
+wire s_axi_wready_ewly = !m_axi_wvalid_next;
+
+always @* begin
+    // transfer sink ready state to source
+    m_axi_wvalid_next = m_axi_wvalid_reg;
+
+    store_axi_w_input_to_output = 1'b0;
+
+    if (s_axi_wready_reg) begin
+        m_axi_wvalid_next = s_axi_wvalid;
+        store_axi_w_input_to_output = 1'b1;
+    end else if (m_axi_wready) begin
+        m_axi_wvalid_next = 1'b0;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        s_axi_wready_reg <= 1'b0;
+        m_axi_wvalid_reg <= 1'b0;
+    end else begin
+        s_axi_wready_reg <= s_axi_wready_ewly;
+        m_axi_wvalid_reg <= m_axi_wvalid_next;
+    end
+
+    // datapath
+    if (store_axi_w_input_to_output) begin
+        m_axi_wdata_reg <= s_axi_wdata;
+        m_axi_wstrb_reg <= s_axi_wstrb;
+        m_axi_wlast_reg <= s_axi_wlast;
+        m_axi_wuser_reg <= s_axi_wuser;
+    end
+end
+
+end else begin
+
+    // bypass W channel
+    assign m_axi_wdata = s_axi_wdata;
+    assign m_axi_wstrb = s_axi_wstrb;
+    assign m_axi_wlast = s_axi_wlast;
+    assign m_axi_wuser = WUSER_ENABLE ? s_axi_wuser : {WUSER_WIDTH{1'b0}};
+    assign m_axi_wvalid = s_axi_wvalid;
+    assign s_axi_wready = m_axi_wready;
+
+end
+
+// B channel
+
+if (B_REG_TYPE > 1) begin
+// skid buffer, no bubble cycles
+
+// datapath registers
+reg                   m_axi_bready_reg = 1'b0;
+
+reg [ID_WIDTH-1:0]    s_axi_bid_reg    = {ID_WIDTH{1'b0}};
+reg [1:0]             s_axi_bresp_reg  = 2'b0;
+reg [BUSER_WIDTH-1:0] s_axi_buser_reg  = {BUSER_WIDTH{1'b0}};
+reg                   s_axi_bvalid_reg = 1'b0, s_axi_bvalid_next;
+
+reg [ID_WIDTH-1:0]    temp_s_axi_bid_reg    = {ID_WIDTH{1'b0}};
+reg [1:0]             temp_s_axi_bresp_reg  = 2'b0;
+reg [BUSER_WIDTH-1:0] temp_s_axi_buser_reg  = {BUSER_WIDTH{1'b0}};
+reg                   temp_s_axi_bvalid_reg = 1'b0, temp_s_axi_bvalid_next;
+
+// datapath control
+reg store_axi_b_input_to_output;
+reg store_axi_b_input_to_temp;
+reg store_axi_b_temp_to_output;
+
+assign m_axi_bready = m_axi_bready_reg;
+
+assign s_axi_bid    = s_axi_bid_reg;
+assign s_axi_bresp  = s_axi_bresp_reg;
+assign s_axi_buser  = BUSER_ENABLE ? s_axi_buser_reg : {BUSER_WIDTH{1'b0}};
+assign s_axi_bvalid = s_axi_bvalid_reg;
+
+// enable ready input next cycle if output is ready or the temp reg will not be filled on the next cycle (output reg empty or no input)
+wire m_axi_bready_early = s_axi_bready | (~temp_s_axi_bvalid_reg & (~s_axi_bvalid_reg | ~m_axi_bvalid));
+
+always @* begin
+    // transfer sink ready state to source
+    s_axi_bvalid_next = s_axi_bvalid_reg;
+    temp_s_axi_bvalid_next = temp_s_axi_bvalid_reg;
+
+    store_axi_b_input_to_output = 1'b0;
+    store_axi_b_input_to_temp = 1'b0;
+    store_axi_b_temp_to_output = 1'b0;
+
+    if (m_axi_bready_reg) begin
+        // input is ready
+        if (s_axi_bready | ~s_axi_bvalid_reg) begin
+            // output is ready or currently not valid, transfer data to output
+            s_axi_bvalid_next = m_axi_bvalid;
+            store_axi_b_input_to_output = 1'b1;
+        end else begin
+            // output is not ready, store input in temp
+            temp_s_axi_bvalid_next = m_axi_bvalid;
+            store_axi_b_input_to_temp = 1'b1;
+        end
+    end else if (s_axi_bready) begin
+        // input is not ready, but output is ready
+        s_axi_bvalid_next = temp_s_axi_bvalid_reg;
+        temp_s_axi_bvalid_next = 1'b0;
+        store_axi_b_temp_to_output = 1'b1;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        m_axi_bready_reg <= 1'b0;
+        s_axi_bvalid_reg <= 1'b0;
+        temp_s_axi_bvalid_reg <= 1'b0;
+    end else begin
+        m_axi_bready_reg <= m_axi_bready_early;
+        s_axi_bvalid_reg <= s_axi_bvalid_next;
+        temp_s_axi_bvalid_reg <= temp_s_axi_bvalid_next;
+    end
+
+    // datapath
+    if (store_axi_b_input_to_output) begin
+        s_axi_bid_reg   <= m_axi_bid;
+        s_axi_bresp_reg <= m_axi_bresp;
+        s_axi_buser_reg <= m_axi_buser;
+    end else if (store_axi_b_temp_to_output) begin
+        s_axi_bid_reg   <= temp_s_axi_bid_reg;
+        s_axi_bresp_reg <= temp_s_axi_bresp_reg;
+        s_axi_buser_reg <= temp_s_axi_buser_reg;
+    end
+
+    if (store_axi_b_input_to_temp) begin
+        temp_s_axi_bid_reg   <= m_axi_bid;
+        temp_s_axi_bresp_reg <= m_axi_bresp;
+        temp_s_axi_buser_reg <= m_axi_buser;
+    end
+end
+
+end else if (B_REG_TYPE == 1) begin
+// simple register, inserts bubble cycles
+
+// datapath registers
+reg                   m_axi_bready_reg = 1'b0;
+
+reg [ID_WIDTH-1:0]    s_axi_bid_reg    = {ID_WIDTH{1'b0}};
+reg [1:0]             s_axi_bresp_reg  = 2'b0;
+reg [BUSER_WIDTH-1:0] s_axi_buser_reg  = {BUSER_WIDTH{1'b0}};
+reg                   s_axi_bvalid_reg = 1'b0, s_axi_bvalid_next;
+
+// datapath control
+reg store_axi_b_input_to_output;
+
+assign m_axi_bready = m_axi_bready_reg;
+
+assign s_axi_bid    = s_axi_bid_reg;
+assign s_axi_bresp  = s_axi_bresp_reg;
+assign s_axi_buser  = BUSER_ENABLE ? s_axi_buser_reg : {BUSER_WIDTH{1'b0}};
+assign s_axi_bvalid = s_axi_bvalid_reg;
+
+// enable ready input next cycle if output buffer will be empty
+wire m_axi_bready_early = !s_axi_bvalid_next;
+
+always @* begin
+    // transfer sink ready state to source
+    s_axi_bvalid_next = s_axi_bvalid_reg;
+
+    store_axi_b_input_to_output = 1'b0;
+
+    if (m_axi_bready_reg) begin
+        s_axi_bvalid_next = m_axi_bvalid;
+        store_axi_b_input_to_output = 1'b1;
+    end else if (s_axi_bready) begin
+        s_axi_bvalid_next = 1'b0;
+    end
+end
+
+always @(posedge clk) begin
+    if (rst) begin
+        m_axi_bready_reg <= 1'b0;
+        s_axi_bvalid_reg <= 1'b0;
+    end else begin
+        m_axi_bready_reg <= m_axi_bready_early;
+        s_axi_bvalid_reg <= s_axi_bvalid_next;
+    end
+
+    // datapath
+    if (store_axi_b_input_to_output) begin
+        s_axi_bid_reg   <= m_axi_bid;
+        s_axi_bresp_reg <= m_axi_bresp;
+        s_axi_buser_reg <= m_axi_buser;
+    end
+end
+
+end else begin
+
+    // bypass B channel
+    assign s_axi_bid = m_axi_bid;
+    assign s_axi_bresp = m_axi_bresp;
+    assign s_axi_buser = BUSER_ENABLE ? m_axi_buser : {BUSER_WIDTH{1'b0}};
+    assign s_axi_bvalid = m_axi_bvalid;
+    assign m_axi_bready = s_axi_bready;
+
+end
+
+endgenerate
+
+endmodule

--- a/tests/designs/axi4_ram/priority_encoder.v
+++ b/tests/designs/axi4_ram/priority_encoder.v
@@ -1,0 +1,84 @@
+/*
+
+Copyright (c) 2014-2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`timescale 1ns / 1ps
+
+/*
+ * Priority encoder module
+ */
+module priority_encoder #
+(
+    parameter WIDTH = 4,
+    // LSB priority: "LOW", "HIGH"
+    parameter LSB_PRIORITY = "LOW"
+)
+(
+    input  wire [WIDTH-1:0]         input_unencoded,
+    output wire                     output_valid,
+    output wire [$clog2(WIDTH)-1:0] output_encoded,
+    output wire [WIDTH-1:0]         output_unencoded
+);
+
+parameter LEVELS = WIDTH > 2 ? $clog2(WIDTH) : 1;
+parameter W = 2**LEVELS;
+
+// pad input to even power of two
+wire [W-1:0] input_padded = {{W-WIDTH{1'b0}}, input_unencoded};
+
+wire [W/2-1:0] stage_valid[LEVELS-1:0];
+wire [W/2-1:0] stage_enc[LEVELS-1:0];
+
+generate
+    genvar l, n;
+
+    // process input bits; generate valid bit and encoded bit for each pair
+    for (n = 0; n < W/2; n = n + 1) begin : loop_in
+        assign stage_valid[0][n] = |input_padded[n*2+1:n*2];
+        if (LSB_PRIORITY == "LOW") begin
+            assign stage_enc[0][n] = input_padded[n*2+1];
+        end else begin
+            assign stage_enc[0][n] = !input_padded[n*2+0];
+        end
+    end
+
+    // compress down to single valid bit and encoded bus
+    for (l = 1; l < LEVELS; l = l + 1) begin : loop_levels
+        for (n = 0; n < W/(2*2**l); n = n + 1) begin : loop_compress
+            assign stage_valid[l][n] = |stage_valid[l-1][n*2+1:n*2];
+            if (LSB_PRIORITY == "LOW") begin
+                assign stage_enc[l][(n+1)*(l+1)-1:n*(l+1)] = stage_valid[l-1][n*2+1] ? {1'b1, stage_enc[l-1][(n*2+2)*l-1:(n*2+1)*l]} : {1'b0, stage_enc[l-1][(n*2+1)*l-1:(n*2+0)*l]};
+            end else begin
+                assign stage_enc[l][(n+1)*(l+1)-1:n*(l+1)] = stage_valid[l-1][n*2+0] ? {1'b0, stage_enc[l-1][(n*2+1)*l-1:(n*2+0)*l]} : {1'b1, stage_enc[l-1][(n*2+2)*l-1:(n*2+1)*l]};
+            end
+        end
+    end
+endgenerate
+
+assign output_valid = stage_valid[LEVELS-1];
+assign output_encoded = stage_enc[LEVELS-1];
+assign output_unencoded = 1 << output_encoded;
+
+endmodule

--- a/tests/designs/axi4_ram/top.v
+++ b/tests/designs/axi4_ram/top.v
@@ -1,0 +1,467 @@
+/*
+ * Copyright cocotb contributors
+ * Licensed under the Revised BSD License, see LICENSE for details.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// Language: Verilog 2001
+
+`timescale 1ns / 1ps
+
+/*
+ * AXI4 ram and interconnect
+ */
+
+ module top #
+ (
+    // Width of data bus in bits
+    parameter DATA_WIDTH = 32,
+    // Width of address bus in bits
+    parameter ADDR_WIDTH = 32,
+    // Width of wstrb (width of data bus in words)
+    parameter STRB_WIDTH = (DATA_WIDTH/8),
+    // Width of ID signal
+    parameter ID_WIDTH = 8,
+    // Width of awuser signal
+    parameter AWUSER_WIDTH = 8,
+    // Width of wuser signal
+    parameter WUSER_WIDTH = 8,
+    // Width of buser signal
+    parameter BUSER_WIDTH = 8,
+    // Width of aruser signal
+    parameter ARUSER_WIDTH = 8,
+    // Width of ruser signal
+    parameter RUSER_WIDTH = 8,
+    // Base RAM address
+    parameter RAM_BASE_ADDRESS = 32'h4000,
+    // RAM width (RAM size = 2^RAM_WIDTH)
+    parameter RAM_WIDTH = 13,
+    // Extra pipeline register on RAM output
+    parameter RAM_PIPELINE_OUTPUT = 1,
+    // AW channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter AW_REG_TYPE = 0,
+    // W channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter W_REG_TYPE = 2,
+    // B channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter B_REG_TYPE = 1,
+    // AR channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter AR_REG_TYPE = 0,
+    // R channel register type
+    // 0 to bypass, 1 for simple buffer, 2 for skid buffer
+    parameter R_REG_TYPE = 2
+ )
+ (
+    input  wire                   clk,
+    input  wire                   rstn,
+
+    input  wire [ID_WIDTH-1:0]    S_AXI_AWID,
+    input  wire [ADDR_WIDTH-1:0]  S_AXI_AWADDR,
+    input  wire [7:0]             S_AXI_AWLEN,
+    input  wire [2:0]             S_AXI_AWSIZE,
+    input  wire [1:0]             S_AXI_AWBURST,
+    input  wire                   S_AXI_AWLOCK,
+    input  wire [3:0]             S_AXI_AWCACHE,
+    input  wire [2:0]             S_AXI_AWPROT,
+    input  wire [3:0]             S_AXI_AWQOS,
+    input  wire [AWUSER_WIDTH-1:0] S_AXI_AWUSER,
+    input  wire                   S_AXI_AWVALID,
+    output wire                   S_AXI_AWREADY,
+    input  wire [DATA_WIDTH-1:0]  S_AXI_WDATA,
+    input  wire [STRB_WIDTH-1:0]  S_AXI_WSTRB,
+    input  wire                   S_AXI_WLAST,
+    input  wire [WUSER_WIDTH-1:0] S_AXI_WUSER,
+    input  wire                   S_AXI_WVALID,
+    output wire                   S_AXI_WREADY,
+    output wire [ID_WIDTH-1:0]    S_AXI_BID,
+    output wire [1:0]             S_AXI_BRESP,
+    output wire [BUSER_WIDTH-1:0] S_AXI_BUSER,
+    output wire                   S_AXI_BVALID,
+    input  wire                   S_AXI_BREADY,
+    input  wire [ID_WIDTH-1:0]    S_AXI_ARID,
+    input  wire [ADDR_WIDTH-1:0]  S_AXI_ARADDR,
+    input  wire [7:0]             S_AXI_ARLEN,
+    input  wire [2:0]             S_AXI_ARSIZE,
+    input  wire [1:0]             S_AXI_ARBURST,
+    input  wire                   S_AXI_ARLOCK,
+    input  wire [3:0]             S_AXI_ARCACHE,
+    input  wire [2:0]             S_AXI_ARPROT,
+    input  wire [3:0]             S_AXI_ARQOS,
+    input  wire [ARUSER_WIDTH-1:0] S_AXI_ARUSER,
+    input  wire                   S_AXI_ARVALID,
+    output wire                   S_AXI_ARREADY,
+    output wire [ID_WIDTH-1:0]    S_AXI_RID,
+    output wire [DATA_WIDTH-1:0]  S_AXI_RDATA,
+    output wire [1:0]             S_AXI_RRESP,
+    output wire                   S_AXI_RLAST,
+    output wire [RUSER_WIDTH-1:0] S_AXI_RUSER,
+    output wire                   S_AXI_RVALID,
+    input  wire                   S_AXI_RREADY
+);
+
+wire [ID_WIDTH-1:0]     reg_axi_awid;
+wire [ADDR_WIDTH-1:0]   reg_axi_awaddr;
+wire [7:0]              reg_axi_awlen;
+wire [2:0]              reg_axi_awsize;
+wire [1:0]              reg_axi_awburst;
+wire                    reg_axi_awlock;
+wire [3:0]              reg_axi_awcache;
+wire [2:0]              reg_axi_awprot;
+wire [3:0]              reg_axi_awqos;
+wire [3:0]              reg_axi_awregion;
+wire [AWUSER_WIDTH-1:0] reg_axi_awuser;
+wire                    reg_axi_awvalid;
+wire                    reg_axi_awready;
+wire [DATA_WIDTH-1:0]   reg_axi_wdata;
+wire [STRB_WIDTH-1:0]   reg_axi_wstrb;
+wire                    reg_axi_wlast;
+wire [WUSER_WIDTH-1:0]  reg_axi_wuser;
+wire                    reg_axi_wvalid;
+wire                    reg_axi_wready;
+wire [ID_WIDTH-1:0]     reg_axi_bid;
+wire [1:0]              reg_axi_bresp;
+wire [BUSER_WIDTH-1:0]  reg_axi_buser;
+wire                    reg_axi_bvalid;
+wire                    reg_axi_bready;
+wire [ID_WIDTH-1:0]     reg_axi_arid;
+wire [ADDR_WIDTH-1:0]   reg_axi_araddr;
+wire [7:0]              reg_axi_arlen;
+wire [2:0]              reg_axi_arsize;
+wire [1:0]              reg_axi_arburst;
+wire                    reg_axi_arlock;
+wire [3:0]              reg_axi_arcache;
+wire [2:0]              reg_axi_arprot;
+wire [3:0]              reg_axi_arqos;
+wire [3:0]              reg_axi_arregion;
+wire [ARUSER_WIDTH-1:0] reg_axi_aruser;
+wire                    reg_axi_arvalid;
+wire                    reg_axi_arready;
+wire [ID_WIDTH-1:0]     reg_axi_rid;
+wire [DATA_WIDTH-1:0]   reg_axi_rdata;
+wire [1:0]              reg_axi_rresp;
+wire                    reg_axi_rlast;
+wire [RUSER_WIDTH-1:0]  reg_axi_ruser;
+wire                    reg_axi_rvalid;
+wire                    reg_axi_rready;
+
+wire [ID_WIDTH-1:0]    int_axi_awid;
+wire [ADDR_WIDTH-1:0]  int_axi_awaddr;
+wire [7:0]             int_axi_awlen;
+wire [2:0]             int_axi_awsize;
+wire [1:0]             int_axi_awburst;
+wire                   int_axi_awlock;
+wire [3:0]             int_axi_awcache;
+wire [2:0]             int_axi_awprot;
+wire [3:0]             int_axi_awregion;
+wire                   int_axi_awvalid;
+wire                   int_axi_awready;
+wire [DATA_WIDTH-1:0]  int_axi_wdata;
+wire [STRB_WIDTH-1:0]  int_axi_wstrb;
+wire                   int_axi_wlast;
+wire                   int_axi_wvalid;
+wire                   int_axi_wready;
+wire [ID_WIDTH-1:0]    int_axi_bid;
+wire [1:0]             int_axi_bresp;
+wire                   int_axi_bvalid;
+wire                   int_axi_bready;
+wire [ID_WIDTH-1:0]    int_axi_arid;
+wire [ADDR_WIDTH-1:0]  int_axi_araddr;
+wire [7:0]             int_axi_arlen;
+wire [2:0]             int_axi_arsize;
+wire [1:0]             int_axi_arburst;
+wire                   int_axi_arlock;
+wire [3:0]             int_axi_arcache;
+wire [2:0]             int_axi_arprot;
+wire [3:0]             int_axi_arregion;
+wire                   int_axi_arvalid;
+wire                   int_axi_arready;
+wire [ID_WIDTH-1:0]    int_axi_rid;
+wire [DATA_WIDTH-1:0]  int_axi_rdata;
+wire [1:0]             int_axi_rresp;
+wire                   int_axi_rlast;
+wire                   int_axi_rvalid;
+wire                   int_axi_rready;
+
+axi_register #
+(
+    .DATA_WIDTH(DATA_WIDTH),
+    .ADDR_WIDTH(ADDR_WIDTH),
+    .STRB_WIDTH(STRB_WIDTH),
+    .ID_WIDTH(ID_WIDTH),
+    .AWUSER_ENABLE(1),
+    .AWUSER_WIDTH(AWUSER_WIDTH),
+    .WUSER_ENABLE(1),
+    .WUSER_WIDTH(WUSER_WIDTH),
+    .BUSER_ENABLE(1),
+    .BUSER_WIDTH(BUSER_WIDTH),
+    .ARUSER_ENABLE(1),
+    .ARUSER_WIDTH(ARUSER_WIDTH),
+    .RUSER_ENABLE(1),
+    .RUSER_WIDTH(RUSER_WIDTH),
+    .AW_REG_TYPE(AW_REG_TYPE),
+    .W_REG_TYPE(W_REG_TYPE),
+    .B_REG_TYPE(B_REG_TYPE),
+    .AR_REG_TYPE(AR_REG_TYPE),
+    .R_REG_TYPE(R_REG_TYPE)
+)
+axi_register_inst (
+    .clk(clk),
+    .rst(~rstn),
+
+    .s_axi_awid(S_AXI_AWID),
+    .s_axi_awaddr(S_AXI_AWADDR),
+    .s_axi_awlen(S_AXI_AWLEN),
+    .s_axi_awsize(S_AXI_AWSIZE),
+    .s_axi_awburst(S_AXI_AWBURST),
+    .s_axi_awlock(S_AXI_AWLOCK),
+    .s_axi_awcache(S_AXI_AWCACHE),
+    .s_axi_awprot(S_AXI_AWPROT),
+    .s_axi_awqos(S_AXI_AWQOS),
+    .s_axi_awuser(S_AXI_AWUSER),
+    .s_axi_awvalid(S_AXI_AWVALID),
+    .s_axi_awready(S_AXI_AWREADY),
+    .s_axi_wdata(S_AXI_WDATA),
+    .s_axi_wstrb(S_AXI_WSTRB),
+    .s_axi_wlast(S_AXI_WLAST),
+    .s_axi_wuser(S_AXI_WUSER),
+    .s_axi_wvalid(S_AXI_WVALID),
+    .s_axi_wready(S_AXI_WREADY),
+    .s_axi_bid(S_AXI_BID),
+    .s_axi_bresp(S_AXI_BRESP),
+    .s_axi_buser(S_AXI_BUSER),
+    .s_axi_bvalid(S_AXI_BVALID),
+    .s_axi_bready(S_AXI_BREADY),
+    .s_axi_arid(S_AXI_ARID),
+    .s_axi_araddr(S_AXI_ARADDR),
+    .s_axi_arlen(S_AXI_ARLEN),
+    .s_axi_arsize(S_AXI_ARSIZE),
+    .s_axi_arburst(S_AXI_ARBURST),
+    .s_axi_arlock(S_AXI_ARLOCK),
+    .s_axi_arcache(S_AXI_ARCACHE),
+    .s_axi_arprot(S_AXI_ARPROT),
+    .s_axi_arqos(S_AXI_ARQOS),
+    .s_axi_aruser(S_AXI_ARUSER),
+    .s_axi_arvalid(S_AXI_ARVALID),
+    .s_axi_arready(S_AXI_ARREADY),
+    .s_axi_rid(S_AXI_RID),
+    .s_axi_rdata(S_AXI_RDATA),
+    .s_axi_rresp(S_AXI_RRESP),
+    .s_axi_rlast(S_AXI_RLAST),
+    .s_axi_ruser(S_AXI_RUSER),
+    .s_axi_rvalid(S_AXI_RVALID),
+    .s_axi_rready(S_AXI_RREADY),
+
+    .m_axi_awid(reg_axi_awid),
+    .m_axi_awaddr(reg_axi_awaddr),
+    .m_axi_awlen(reg_axi_awlen),
+    .m_axi_awsize(reg_axi_awsize),
+    .m_axi_awburst(reg_axi_awburst),
+    .m_axi_awlock(reg_axi_awlock),
+    .m_axi_awcache(reg_axi_awcache),
+    .m_axi_awprot(reg_axi_awprot),
+    .m_axi_awqos(reg_axi_awqos),
+    .m_axi_awuser(reg_axi_awuser),
+    .m_axi_awvalid(reg_axi_awvalid),
+    .m_axi_awready(reg_axi_awready),
+    .m_axi_wdata(reg_axi_wdata),
+    .m_axi_wstrb(reg_axi_wstrb),
+    .m_axi_wlast(reg_axi_wlast),
+    .m_axi_wuser(reg_axi_wuser),
+    .m_axi_wvalid(reg_axi_wvalid),
+    .m_axi_wready(reg_axi_wready),
+    .m_axi_bid(reg_axi_bid),
+    .m_axi_bresp(reg_axi_bresp),
+    .m_axi_buser(reg_axi_buser),
+    .m_axi_bvalid(reg_axi_bvalid),
+    .m_axi_bready(reg_axi_bready),
+    .m_axi_arid(reg_axi_arid),
+    .m_axi_araddr(reg_axi_araddr),
+    .m_axi_arlen(reg_axi_arlen),
+    .m_axi_arsize(reg_axi_arsize),
+    .m_axi_arburst(reg_axi_arburst),
+    .m_axi_arlock(reg_axi_arlock),
+    .m_axi_arcache(reg_axi_arcache),
+    .m_axi_arprot(reg_axi_arprot),
+    .m_axi_arqos(reg_axi_arqos),
+    .m_axi_aruser(reg_axi_aruser),
+    .m_axi_arvalid(reg_axi_arvalid),
+    .m_axi_arready(reg_axi_arready),
+    .m_axi_rid(reg_axi_rid),
+    .m_axi_rdata(reg_axi_rdata),
+    .m_axi_rresp(reg_axi_rresp),
+    .m_axi_rlast(reg_axi_rlast),
+    .m_axi_ruser(reg_axi_ruser),
+    .m_axi_rvalid(reg_axi_rvalid),
+    .m_axi_rready(reg_axi_rready)
+);
+
+axi_interconnect #(
+    .S_COUNT(1),
+    .M_COUNT(1),
+    .DATA_WIDTH(DATA_WIDTH),
+    .ADDR_WIDTH(ADDR_WIDTH),
+    .STRB_WIDTH(STRB_WIDTH),
+    .ID_WIDTH(ID_WIDTH),
+    .AWUSER_ENABLE(1),
+    .AWUSER_WIDTH(AWUSER_WIDTH),
+    .WUSER_ENABLE(1),
+    .WUSER_WIDTH(WUSER_WIDTH),
+    .BUSER_ENABLE(1),
+    .BUSER_WIDTH(BUSER_WIDTH),
+    .ARUSER_ENABLE(1),
+    .ARUSER_WIDTH(ARUSER_WIDTH),
+    .RUSER_ENABLE(1),
+    .RUSER_WIDTH(RUSER_WIDTH),
+    .FORWARD_ID(1),
+    .M_REGIONS(1),
+    .M_BASE_ADDR({RAM_BASE_ADDRESS}),
+    .M_ADDR_WIDTH({RAM_WIDTH}),
+    .M_CONNECT_READ(1'b1),
+    .M_CONNECT_WRITE(1'b1),
+    .M_SECURE(1'b0)
+)
+axi_interconnect_inst (
+    .clk(clk),
+    .rst(~rstn),
+
+    .s_axi_awid(reg_axi_awid),
+    .s_axi_awaddr(reg_axi_awaddr),
+    .s_axi_awlen(reg_axi_awlen),
+    .s_axi_awsize(reg_axi_awsize),
+    .s_axi_awburst(reg_axi_awburst),
+    .s_axi_awlock(reg_axi_awlock),
+    .s_axi_awcache(reg_axi_awcache),
+    .s_axi_awprot(reg_axi_awprot),
+    .s_axi_awqos(reg_axi_awqos),
+    .s_axi_awuser(reg_axi_awuser),
+    .s_axi_awvalid(reg_axi_awvalid),
+    .s_axi_awready(reg_axi_awready),
+    .s_axi_wdata(reg_axi_wdata),
+    .s_axi_wstrb(reg_axi_wstrb),
+    .s_axi_wlast(reg_axi_wlast),
+    .s_axi_wuser(reg_axi_wuser),
+    .s_axi_wvalid(reg_axi_wvalid),
+    .s_axi_wready(reg_axi_wready),
+    .s_axi_bid(reg_axi_bid),
+    .s_axi_bresp(reg_axi_bresp),
+    .s_axi_buser(reg_axi_buser),
+    .s_axi_bvalid(reg_axi_bvalid),
+    .s_axi_bready(reg_axi_bready),
+    .s_axi_arid(reg_axi_arid),
+    .s_axi_araddr(reg_axi_araddr),
+    .s_axi_arlen(reg_axi_arlen),
+    .s_axi_arsize(reg_axi_arsize),
+    .s_axi_arburst(reg_axi_arburst),
+    .s_axi_arlock(reg_axi_arlock),
+    .s_axi_arcache(reg_axi_arcache),
+    .s_axi_arprot(reg_axi_arprot),
+    .s_axi_arqos(reg_axi_arqos),
+    .s_axi_aruser(reg_axi_aruser),
+    .s_axi_arvalid(reg_axi_arvalid),
+    .s_axi_arready(reg_axi_arready),
+    .s_axi_rid(reg_axi_rid),
+    .s_axi_rdata(reg_axi_rdata),
+    .s_axi_rresp(reg_axi_rresp),
+    .s_axi_rlast(reg_axi_rlast),
+    .s_axi_ruser(reg_axi_ruser),
+    .s_axi_rvalid(reg_axi_rvalid),
+    .s_axi_rready(reg_axi_rready),
+
+    .m_axi_awid(int_axi_awid),
+    .m_axi_awaddr(int_axi_awaddr),
+    .m_axi_awlen(int_axi_awlen),
+    .m_axi_awsize(int_axi_awsize),
+    .m_axi_awburst(int_axi_awburst),
+    .m_axi_awlock(int_axi_awlock),
+    .m_axi_awcache(int_axi_awcache),
+    .m_axi_awprot(int_axi_awprot),
+    .m_axi_awregion(int_axi_awregion),
+    .m_axi_awvalid(int_axi_awvalid),
+    .m_axi_awready(int_axi_awready),
+    .m_axi_wdata(int_axi_wdata),
+    .m_axi_wstrb(int_axi_wstrb),
+    .m_axi_wlast(int_axi_wlast),
+    .m_axi_wvalid(int_axi_wvalid),
+    .m_axi_wready(int_axi_wready),
+    .m_axi_bid(int_axi_bid),
+    .m_axi_bresp(int_axi_bresp),
+    .m_axi_bvalid(int_axi_bvalid),
+    .m_axi_bready(int_axi_bready),
+    .m_axi_arid(int_axi_arid),
+    .m_axi_araddr(int_axi_araddr),
+    .m_axi_arlen(int_axi_arlen),
+    .m_axi_arsize(int_axi_arsize),
+    .m_axi_arburst(int_axi_arburst),
+    .m_axi_arlock(int_axi_arlock),
+    .m_axi_arcache(int_axi_arcache),
+    .m_axi_arprot(int_axi_arprot),
+    .m_axi_arregion(int_axi_arregion),
+    .m_axi_arvalid(int_axi_arvalid),
+    .m_axi_arready(int_axi_arready),
+    .m_axi_rid(int_axi_rid),
+    .m_axi_rdata(int_axi_rdata),
+    .m_axi_rresp(int_axi_rresp),
+    .m_axi_rlast(int_axi_rlast),
+    .m_axi_rvalid(int_axi_rvalid),
+    .m_axi_rready(int_axi_rready)
+);
+
+axi_ram #(
+    .DATA_WIDTH(DATA_WIDTH),
+    .ADDR_WIDTH(RAM_WIDTH),
+    .STRB_WIDTH(STRB_WIDTH),
+    .ID_WIDTH(ID_WIDTH),
+    .PIPELINE_OUTPUT(RAM_PIPELINE_OUTPUT)
+)
+axi_ram_inst (
+    .clk(clk),
+    .rst(~rstn),
+
+    .s_axi_awid(int_axi_awid),
+    .s_axi_awaddr(int_axi_awaddr[RAM_WIDTH-1:0]),
+    .s_axi_awlen(int_axi_awlen),
+    .s_axi_awsize(int_axi_awsize),
+    .s_axi_awburst(int_axi_awburst),
+    .s_axi_awlock(int_axi_awlock),
+    .s_axi_awcache(int_axi_awcache),
+    .s_axi_awprot(int_axi_awprot),
+    .s_axi_awvalid(int_axi_awvalid),
+    .s_axi_awready(int_axi_awready),
+    .s_axi_wdata(int_axi_wdata),
+    .s_axi_wstrb(int_axi_wstrb),
+    .s_axi_wlast(int_axi_wlast),
+    .s_axi_wvalid(int_axi_wvalid),
+    .s_axi_wready(int_axi_wready),
+    .s_axi_bid(int_axi_bid),
+    .s_axi_bresp(int_axi_bresp),
+    .s_axi_bvalid(int_axi_bvalid),
+    .s_axi_bready(int_axi_bready),
+    .s_axi_arid(int_axi_arid),
+    .s_axi_araddr(int_axi_araddr[RAM_WIDTH-1:0]),
+    .s_axi_arlen(int_axi_arlen),
+    .s_axi_arsize(int_axi_arsize),
+    .s_axi_arburst(int_axi_arburst),
+    .s_axi_arlock(int_axi_arlock),
+    .s_axi_arcache(int_axi_arcache),
+    .s_axi_arprot(int_axi_arprot),
+    .s_axi_arvalid(int_axi_arvalid),
+    .s_axi_arready(int_axi_arready),
+    .s_axi_rid(int_axi_rid),
+    .s_axi_rdata(int_axi_rdata),
+    .s_axi_rresp(int_axi_rresp),
+    .s_axi_rlast(int_axi_rlast),
+    .s_axi_rvalid(int_axi_rvalid),
+    .s_axi_rready(int_axi_rready)
+);
+
+`ifdef COCOTB_SIM
+initial begin
+    $dumpfile ("waveforms.vcd");
+    $dumpvars;
+end
+`endif
+
+endmodule

--- a/tests/designs/axi4_ram/top.v
+++ b/tests/designs/axi4_ram/top.v
@@ -40,19 +40,19 @@
     parameter RAM_PIPELINE_OUTPUT = 1,
     // AW channel register type
     // 0 to bypass, 1 for simple buffer, 2 for skid buffer
-    parameter AW_REG_TYPE = 0,
+    parameter AW_REG_TYPE = 2,
     // W channel register type
     // 0 to bypass, 1 for simple buffer, 2 for skid buffer
-    parameter W_REG_TYPE = 2,
+    parameter W_REG_TYPE = 0,
     // B channel register type
     // 0 to bypass, 1 for simple buffer, 2 for skid buffer
     parameter B_REG_TYPE = 1,
     // AR channel register type
     // 0 to bypass, 1 for simple buffer, 2 for skid buffer
-    parameter AR_REG_TYPE = 0,
+    parameter AR_REG_TYPE = 2,
     // R channel register type
     // 0 to bypass, 1 for simple buffer, 2 for skid buffer
-    parameter R_REG_TYPE = 2
+    parameter R_REG_TYPE = 0
  )
  (
     input  wire                   clk,

--- a/tests/test_cases/test_axi4/Makefile
+++ b/tests/test_cases/test_axi4/Makefile
@@ -1,0 +1,3 @@
+include ../../designs/axi4_ram/Makefile
+
+MODULE = test_axi4

--- a/tests/test_cases/test_axi4/test_axi4.py
+++ b/tests/test_cases/test_axi4/test_axi4.py
@@ -243,7 +243,7 @@ async def test_4kB_boundary(dut):
 
 
 @cocotb.test()
-async def test_simultaneous(dut, num=10):
+async def test_simultaneous(dut, num=5):
     """Test simultaneous reads/writes"""
 
     axim = AXI4Master(dut, AXI_PREFIX, dut.clk)
@@ -261,13 +261,9 @@ async def test_simultaneous(dut, num=10):
 
     addresses = [base_address + i * data_width for i in range(num)]
     write_values = [randrange(0, 2**(data_width * 8)) for i in range(num)]
-    addr_latencies = [randrange(0, 10) for i in range(num)]
-    data_latencies = [randrange(0, 10) for i in range(num)]
 
-    writers = [axim.write(address, value, address_latency=address_latency,
-                          data_latency=data_latency)
-               for address, value, address_latency, data_latency
-               in zip(addresses, write_values, addr_latencies, data_latencies)]
+    writers = [axim.write(address, value)
+               for address, value in zip(addresses, write_values)]
 
     await Combine(*writers)
 

--- a/tests/test_cases/test_axi4/test_axi4.py
+++ b/tests/test_cases/test_axi4/test_axi4.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test to demonstrate functionality of the AXI4 master interface"""
+
+from random import randint, randrange
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.drivers.amba import (AXIBurst, AXI4LiteMaster, AXI4Master,
+                                 AXIProtocolError, AXIReadBurstLengthMismatch,
+                                 AXIxRESP)
+from cocotb.regression import TestFactory
+from cocotb.result import TestFailure
+from cocotb.triggers import ClockCycles, Combine, Join, RisingEdge
+
+
+CLK_PERIOD = (10, "ns")
+AXI_PREFIX = "S_AXI"
+
+
+def get_parameters(dut):
+    address_width = dut.ADDR_WIDTH.value // 8
+    data_width = dut.DATA_WIDTH.value // 8
+    ram_start = dut.RAM_BASE_ADDRESS.value
+    ram_stop = ram_start + 2**dut.RAM_WIDTH.value
+    return address_width, data_width, ram_start, ram_stop
+
+
+def add_wstrb_mask(data_width, previous_value, write_value, wstrb):
+    result = 0
+    for i in range(data_width):
+        source = write_value if wstrb & (1 << i) else previous_value
+        result |= (source & (0xff << (i * 8)))
+
+    return result
+
+
+async def setup_dut(dut):
+    cocotb.fork(Clock(dut.clk, *CLK_PERIOD).start())
+    dut.rstn <= 0
+    await ClockCycles(dut.clk, 2)
+    dut.rstn <= 1
+    await ClockCycles(dut.clk, 2)
+
+
+async def test_single_beat(dut, driver, address_latency, data_latency):
+    """Test single read/write"""
+
+    axim = driver(dut, AXI_PREFIX, dut.clk)
+    _, data_width, ram_start, ram_stop = get_parameters(dut)
+
+    await setup_dut(dut)
+
+    address = randrange(ram_start, ram_stop, data_width)
+    write_value = randrange(0, 2**(data_width * 8))
+    strobe = randrange(1, 2**data_width)
+
+    previous_value = await axim.read(address)
+    await axim.write(address, write_value, byte_enable=strobe,
+                     address_latency=address_latency,
+                     data_latency=data_latency)
+    read_value = await axim.read(address)
+
+    if isinstance(read_value, list):
+        previous_value = previous_value[0]
+        read_value = read_value[0]
+
+    expected_value = add_wstrb_mask(data_width, previous_value.integer,
+                                    write_value, strobe)
+
+    if read_value != expected_value:
+        raise TestFailure("Read {:#x} from {:#x} but was expecting {:#x} "
+                          "({:#x} with {:#x} as strobe and {:#x} as previous "
+                          "value)"
+                          .format(read_value.integer, address, expected_value,
+                                  write_value, strobe, previous_value))
+
+
+async def test_burst(dut, return_rresp):
+    """Test burst reads/writes"""
+
+    axim = AXI4Master(dut, AXI_PREFIX, dut.clk)
+    _, data_width, ram_start, ram_stop = get_parameters(dut)
+
+    await setup_dut(dut)
+
+    burst_length = randrange(2, 256)
+    base = randrange(ram_start, ram_stop, 4096)
+    offset = randrange(0, 4096 - (burst_length - 1) * data_width, data_width)
+    address = base + offset
+    write_values = \
+        [randrange(0, 2**(data_width * 8)) for i in range(burst_length)]
+
+    # Make strobe one item less than data, to test also that driver behavior
+    strobes = [randrange(0, 2**data_width)
+               for i in range(len(write_values) - 1)]
+
+    previous_values = await axim.read(address, len(write_values))
+    await axim.write(address, write_values, byte_enable=strobes)
+    read_values = await axim.read(address, len(write_values),
+                                  return_rresp=return_rresp)
+
+    if return_rresp:
+        read_values, rresp_list = zip(*read_values)
+        for i, rresp in enumerate(rresp_list):
+            if rresp is not AXIxRESP.OKAY:
+                raise TestFailure(
+                    "Read at beat {}/{} with starting address {:#x} failed "
+                    "with RRESP {} ({})"
+                    .format(i + 1, len(rresp_list), address, rresp.value,
+                            rresp.name))
+
+    strobes += [strobes[-1]]
+    expected_values = \
+        [add_wstrb_mask(data_width, previous_value, write_value, wstrb)
+         for previous_value, write_value, wstrb
+         in zip(previous_values, write_values, strobes)]
+
+    for i in range(len(read_values)):
+        if expected_values[i] != read_values[i]:
+            raise TestFailure(
+                "Read {:#x} at beat {}/{} with starting address {:#x}, but "
+                "was expecting {:#x} ({:#x} with {:#x} as strobe and {:#x} as "
+                "previous value)"
+                .format(read_values[i].integer, i + 1, burst_length, address,
+                        expected_values[i], write_values[i], strobes[i],
+                        previous_values[i].integer))
+
+
+async def test_unmapped(dut, driver):
+    """Check whether a read/write over an unmapped address returns a DECERR"""
+
+    axim = driver(dut, AXI_PREFIX, dut.clk)
+    address_width, data_width, ram_start, ram_stop = get_parameters(dut)
+
+    await setup_dut(dut)
+
+    for rw in ("Read", "Write"):
+        try:
+            address = randrange(0, ram_start - data_width, data_width)
+        except ValueError:
+            # If the RAM is mapped at the beginning of the address space, use
+            # an address after the end of the RAM
+            address = randrange(ram_stop, 2**(address_width * 8) - data_width,
+                                data_width)
+
+        try:
+            if rw == "Read":
+                try:
+                    await axim.read(address, length=2)
+                except TypeError:
+                    await axim.read(address)
+            else:
+                write_data = [randrange(0, 2**(data_width * 8))] * 2
+                try:
+                    await axim.write(address, write_data)
+                except ValueError:
+                    await axim.write(address, write_data[0])
+
+            raise TestFailure("{} at {:#x} should have failed, but did not"
+                              .format(rw, address))
+
+        except AXIProtocolError as e:
+            if e.xresp is not AXIxRESP.DECERR:
+                raise TestFailure("Was expecting DECERR, but received {}"
+                                  .format(e.xresp.name))
+
+
+@cocotb.test()
+async def test_illegal_operations(dut):
+    """Test whether illegal operations are correctly refused by the driver"""
+
+    axim = AXI4Master(dut, AXI_PREFIX, dut.clk)
+    _, data_width, ram_start, _ = get_parameters(dut)
+
+    illegal_operations = (
+        (AXIBurst.INCR, -1, None),
+        (AXIBurst.INCR, 0, None),
+        (AXIBurst.FIXED, 17, None),
+        (AXIBurst.INCR, 257, None),
+        (AXIBurst.WRAP, 3, None),
+        (AXIBurst.INCR, 4, -1),
+        (AXIBurst.INCR, 4, data_width - 1),
+        (AXIBurst.INCR, 4, data_width * 2),
+    )
+
+    await setup_dut(dut)
+
+    for rw in ("Read", "Write"):
+        for burst, length, size in illegal_operations:
+            try:
+                if rw == "Read":
+                    await axim.read(ram_start, length, size=size, burst=burst)
+                else:
+                    values = [randrange(0, 2**(data_width * 8))
+                              for i in range(length)]
+                    await axim.write(ram_start, values, size=size, burst=burst)
+
+                raise TestFailure(
+                    "{} with length={}, size={} and burst={} has been "
+                    "performed by the driver, but it is an illegal "
+                    "operation".format(rw, length, size, burst.name))
+
+            except ValueError:
+                pass
+
+
+@cocotb.test()
+async def test_4kB_boundary(dut):
+    """
+    Check that the driver raises an error when trying to cross a 4kB boundary
+    """
+
+    axim = AXI4Master(dut, AXI_PREFIX, dut.clk)
+    _, data_width, ram_start, ram_stop = get_parameters(dut)
+
+    await setup_dut(dut)
+
+    for rw in ("Read", "Write"):
+        burst_length = randint(2, 256)
+        base = randrange(ram_start, ram_stop - 4096, 4096)
+        offset = randrange(-(burst_length - 1) * data_width, 0, data_width)
+        address = base + offset
+        write_values = \
+            [randrange(0, 2**(data_width * 8)) for i in range(burst_length)]
+
+        try:
+            if rw == "Read":
+                await axim.read(address, burst_length)
+            else:
+                await axim.write(address, write_values)
+
+            raise TestFailure(
+                "{} from {:#x} to {:#x} crosses a 4kB boundary, but the "
+                "driver allowed it"
+                .format(rw, address,
+                        address + (burst_length - 1) * data_width))
+        except ValueError:
+            pass
+
+
+@cocotb.test()
+async def test_simultaneous(dut, num=10):
+    """Test simultaneous reads/writes"""
+
+    axim = AXI4Master(dut, AXI_PREFIX, dut.clk)
+    _, data_width, ram_start, _ = get_parameters(dut)
+
+    await setup_dut(dut)
+
+    # Avoid crossing the 4kB boundary by using just the first 4kB block
+    base_address = randrange(ram_start,
+                             ram_start + 4096 - 2 * num * data_width,
+                             data_width)
+
+    # Clear the memory cells
+    await axim.write(base_address, [0] * num)
+
+    addresses = [base_address + i * data_width for i in range(num)]
+    write_values = [randrange(0, 2**(data_width * 8)) for i in range(num)]
+    addr_latencies = [randrange(0, 10) for i in range(num)]
+    data_latencies = [randrange(0, 10) for i in range(num)]
+
+    writers = [axim.write(address, value, address_latency=address_latency,
+                          data_latency=data_latency)
+               for address, value, address_latency, data_latency
+               in zip(addresses, write_values, addr_latencies, data_latencies)]
+
+    await Combine(*writers)
+
+    readers = [cocotb.fork(axim.read(address)) for address in addresses]
+
+    dummy_addrs = [base_address + (num + i) * data_width for i in range(num)]
+    dummy_writers = [cocotb.fork(axim.write(address, value))
+                     for address, value in zip(dummy_addrs, write_values)]
+
+    read_values = []
+    for reader in readers:
+        read_values.append((await Join(reader))[0])
+    await Combine(*[Join(writer) for writer in dummy_writers])
+
+    for i, (written, read) in enumerate(zip(write_values, read_values)):
+        if written != read:
+            raise TestFailure("#{}: wrote {:#x} but read back {:#x}"
+                              .format(i, written, read.integer))
+
+
+@cocotb.test()
+async def test_axi4lite_write_burst(dut):
+    """Test that write bursts are correctly refused by the AXI4-Lite driver"""
+
+    axim = AXI4LiteMaster(dut, AXI_PREFIX, dut.clk)
+    _, data_width, ram_start, _ = get_parameters(dut)
+    length = randint(2, 16)
+
+    await setup_dut(dut)
+
+    try:
+        await axim.write(ram_start, [randrange(0, 2**(data_width * 8))
+                                     for i in range(length)])
+
+        raise TestFailure(
+            "Write with length={} has been performed by the driver, but "
+            "burst operations are not allowed on AXI4-Lite".format(length))
+
+    except ValueError:
+        pass
+
+
+@cocotb.test()
+async def test_read_length_mismatch(dut):
+    """Test that a mismatch in the read data length is correctly identified"""
+
+    class AXI4Master_unmanaged_arlen(AXI4Master):
+        _signals = [signal for signal in AXI4Master._signals
+                    if signal != "ARLEN"]
+
+    axim = AXI4Master_unmanaged_arlen(dut, AXI_PREFIX, dut.clk)
+    _, data_width, ram_start, ram_stop = get_parameters(dut)
+    length = randint(2, 16)
+
+    burst_length = randint(2, 255)
+    base = randrange(ram_start, ram_stop, 4096)
+    offset = randrange(0, 4096 - (burst_length - 1) * data_width, data_width)
+    address = base + offset
+
+    await setup_dut(dut)
+
+    for length_delta in (-1, 1):
+        try:
+            # Override the driver's ARLEN value, forcing a wrong one
+            await RisingEdge(dut.clk)
+            arlen = burst_length - 1 + length_delta
+            getattr(dut, AXI_PREFIX + '_ARLEN') <= arlen
+            await axim.read(address, burst_length)
+
+            raise TestFailure("Mismatch between ARLEN value ({}) and number "
+                              "of read words ({}), but the driver did not "
+                              "raise an exception"
+                              .format(arlen, burst_length))
+
+        except AXIReadBurstLengthMismatch:
+            pass
+
+
+single_beat = TestFactory(test_single_beat)
+single_beat.add_option('driver', (AXI4Master, AXI4LiteMaster))
+single_beat.add_option('address_latency', (0,))
+single_beat.add_option('data_latency', (0,))
+single_beat.generate_tests()
+
+single_beat_with_latency = TestFactory(test_single_beat)
+single_beat_with_latency.add_option('driver', (AXI4Master,))
+single_beat_with_latency.add_option('address_latency', (0, 5))
+single_beat_with_latency.add_option('data_latency', (1, 10))
+single_beat_with_latency.generate_tests(postfix="_latency")
+
+burst = TestFactory(test_burst)
+burst.add_option('return_rresp', (True, False))
+burst.generate_tests()
+
+unmapped = TestFactory(test_unmapped)
+unmapped.add_option('driver', [AXI4Master, AXI4LiteMaster])
+unmapped.generate_tests()


### PR DESCRIPTION
This is based on the existing AXI4Lite driver, which has been extended
to use the AXI4 signals.
The existing AXI4LiteMaster has been modified to wrap the AXI4Master
methods, providing so a backwards-compatible class.