### PR TITLE
Support non-decorated async coroutine in fork

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -214,11 +214,6 @@ class RunningCoroutine(object):
 
     __bool__ = __nonzero__
 
-    def sort_name(self):
-        if self.stage is None:
-            return "%s.%s" % (self.module, self.funcname)
-        else:
-            return "%s.%d.%s" % (self.module, self.stage, self.funcname)
 
 class RunningTest(RunningCoroutine):
     """Add some useful Test functionality to a RunningCoroutine."""
@@ -280,6 +275,12 @@ class RunningTest(RunningCoroutine):
         aborting.
         """
         return self._force_outcome(outcomes.Error(exc))
+
+    def sort_name(self):
+        if self.stage is None:
+            return "%s.%s" % (self.module, self.funcname)
+        else:
+            return "%s.%d.%s" % (self.module, self.stage, self.funcname)
 
 
 class coroutine(object):

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -88,24 +88,20 @@ class RunningTask(object):
         triggers to fire.
     """
     def __init__(self, inst):
-        if hasattr(inst, "__name__"):
-            self.__name__ = "%s" % inst.__name__
 
         if inspect.iscoroutine(inst):
             self._natively_awaitable = True
             self._coro = inst.__await__()
-        else:
+        elif inspect.isgenerator(inst):
             self._natively_awaitable = False
             self._coro = inst
+        else:
+            raise TypeError(
+                "%s isn't a valid coroutine! Did you forget to use the yield keyword?" % inst)
+        self.__name__ = "%s" % inst.__name__
         self._started = False
         self._callbacks = []
         self._outcome = None
-
-        if not hasattr(self._coro, "send"):
-            raise TypeError(
-                "%s isn't a valid coroutine! Did you use the yield "
-                "keyword?" % self.funcname
-            )
 
     @lazy_property
     def log(self):

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -38,6 +38,7 @@ import os
 import sys
 import logging
 import threading
+import inspect
 
 # Debug mode controlled by environment variables
 if "COCOTB_ENABLE_PROFILING" in os.environ:
@@ -653,6 +654,9 @@ class Scheduler(object):
                 "decorator?"
                 .format(coroutine)
             )
+
+        if inspect.iscoroutine(coroutine):
+            return self.add(cocotb.decorators.RunningTask(coroutine))
 
         elif not isinstance(coroutine, cocotb.decorators.RunningTask):
             raise TypeError(

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -654,7 +654,7 @@ class Scheduler(object):
                 .format(coroutine)
             )
 
-        elif not isinstance(coroutine, cocotb.decorators.RunningCoroutine):
+        elif not isinstance(coroutine, cocotb.decorators.RunningTask):
             raise TypeError(
                 "Attempt to add a object of type {} to the scheduler, which "
                 "isn't a coroutine: {!r}\n"
@@ -678,19 +678,19 @@ class Scheduler(object):
 
     # This collection of functions parses a trigger out of the object
     # that was yielded by a coroutine, converting `list` -> `Waitable`,
-    # `Waitable` -> `RunningCoroutine`, `RunningCoroutine` -> `Trigger`.
-    # Doing them as separate functions allows us to avoid repeating unnecessary
+    # `Waitable` -> `RunningTask`, `RunningTask` -> `Trigger`.
+    # Doing them as separate functions allows us to avoid repeating unencessary
     # `isinstance` checks.
 
     def _trigger_from_started_coro(self, result):
-        # type: (cocotb.decorators.RunningCoroutine) -> Trigger
+        # type: (cocotb.decorators.RunningTask) -> Trigger
         if _debug:
             self.log.debug("Joining to already running coroutine: %s" %
                            result.__name__)
         return result.join()
 
     def _trigger_from_unstarted_coro(self, result):
-        # type: (cocotb.decorators.RunningCoroutine) -> Trigger
+        # type: (cocotb.decorators.RunningTask) -> Trigger
         self.queue(result)
         if _debug:
             self.log.debug("Scheduling nested coroutine: %s" %
@@ -712,7 +712,7 @@ class Scheduler(object):
         if isinstance(result, Trigger):
             return result
 
-        if isinstance(result, cocotb.decorators.RunningCoroutine):
+        if isinstance(result, cocotb.decorators.RunningTask):
             if not result.has_started():
                 return self._trigger_from_unstarted_coro(result)
             else:

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -722,6 +722,9 @@ class Scheduler(object):
             else:
                 return self._trigger_from_started_coro(result)
 
+        if inspect.iscoroutine(result):
+            return self._trigger_from_unstarted_coro(cocotb.decorators.RunningTask(result))
+
         if isinstance(result, list):
             return self._trigger_from_list(result)
 

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -635,7 +635,7 @@ class _AggregateWaitable(Waitable):
 
         # Do some basic type-checking up front, rather than waiting until we
         # yield them.
-        allowed_types = (Trigger, Waitable, decorators.RunningCoroutine)
+        allowed_types = (Trigger, Waitable, decorators.RunningTask)
         for trigger in self.triggers:
             if not isinstance(trigger, allowed_types):
                 raise TypeError(

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -167,6 +167,11 @@ of :keyword:`yield`. Provided they are decorated with ``@cocotb.coroutine``,
 is determined by which type of function it appears in, not by the
 sub-coroutine being called.
 
+.. versionadded:: 1.4
+    The :any:`cocotb.coroutine` decorator is no longer necessary for ``async def`` coroutines.
+    ``async def`` coroutines can be used, without the ``@cocotb.coroutine`` decorator, wherever decorated coroutines are accepted,
+    including :keyword:`yield` statements and :any:`cocotb.fork`.
+
 .. note::
     It is not legal to ``await`` a list of triggers as can be done in
     ``yield``-based coroutine with ``yield [trig1, trig2]``. Use

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -51,9 +51,9 @@ Interacting with the Simulator
 
 .. autofunction:: cocotb.fork
 
-.. autofunction:: cocotb.decorators.RunningCoroutine.join
+.. autofunction:: cocotb.decorators.RunningTask.join
 
-.. autofunction:: cocotb.decorators.RunningCoroutine.kill
+.. autofunction:: cocotb.decorators.RunningTask.kill
 
 Triggers
 --------

--- a/tests/test_cases/test_cocotb/test_cocotb_35.py
+++ b/tests/test_cases/test_cocotb/test_cocotb_35.py
@@ -129,3 +129,15 @@ def test_undecorated_coroutine_fork(dut):
 
     yield cocotb.fork(example()).join()
     assert ran
+
+@cocotb.test()
+def test_undecorated_coroutine_yield(dut):
+    ran = False
+
+    async def example():
+        nonlocal ran
+        await cocotb.triggers.Timer(1, 'ns')
+        ran = True
+
+    yield example()
+    assert ran

--- a/tests/test_cases/test_cocotb/test_cocotb_35.py
+++ b/tests/test_cases/test_cocotb/test_cocotb_35.py
@@ -116,3 +116,16 @@ async def test_await_causes_start(dut):
     assert not coro.has_started()
     await coro
     assert coro.has_started()
+
+
+@cocotb.test()
+def test_undecorated_coroutine_fork(dut):
+    ran = False
+
+    async def example():
+        nonlocal ran
+        await cocotb.triggers.Timer(1, 'ns')
+        ran = True
+
+    yield cocotb.fork(example()).join()
+    assert ran


### PR DESCRIPTION
Resolves #1246. `scheduler.add` accepts non-decorated async coroutines.