### PR TITLE
Mark all python warnings as errors

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -634,7 +634,7 @@ class BinaryValue(object):
                 _binstr = self.binstr[index]
             else:
                 _binstr = self.binstr[self._n_bits-1-index]
-        rv = BinaryValue(bits=len(_binstr), bigEndian=self.big_endian,
+        rv = BinaryValue(n_bits=len(_binstr), bigEndian=self.big_endian,
                          binaryRepresentation=self.binaryRepresentation)
         rv.set_binstr(_binstr)
         return rv

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -54,7 +54,7 @@ import cocotb
 import cocotb.ANSI as ANSI
 from cocotb.log import SimLog
 from cocotb.result import TestSuccess, SimFailure
-from cocotb.utils import get_sim_time, remove_traceback_frames
+from cocotb.utils import get_sim_time, remove_traceback_frames, want_color_output
 from cocotb.xunit_reporter import XUnitReporter
 from cocotb import _py_compat
 
@@ -337,7 +337,7 @@ class RegressionManager(object):
         if self._running_test:
             start = ''
             end   = ''
-            if self.log.colour:
+            if want_color_output():
                 start = ANSI.COLOR_TEST
                 end   = ANSI.COLOR_DEFAULT
             # Want this to stand out a little bit
@@ -386,7 +386,7 @@ class RegressionManager(object):
                 pass_fail_str = "PASS"
             else:
                 pass_fail_str = "FAIL"
-                if self.log.colour:
+                if want_color_output():
                     hilite = ANSI.COLOR_HILITE_SUMMARY
 
             summary += "{start}** {a:<{a_len}}  {b:^{b_len}}  {c:>{c_len}.2f}   {d:>{d_len}.2f}   {e:>{e_len}.2f}  **\n".format(a=result['test'],   a_len=TEST_FIELD_LEN,

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,6 +27,9 @@
 
 include ../makefiles/Makefile.inc
 
+# distutils warnings are caused by an old version of virtualenv in travis
+export PYTHONWARNINGS = error,ignore::DeprecationWarning:distutils
+
 REGRESSIONS :=  $(shell ls test_cases/)
 
 .PHONY: $(REGRESSIONS)

--- a/tests/test_cases/issue_253/issue_253.py
+++ b/tests/test_cases/issue_253/issue_253.py
@@ -10,17 +10,17 @@ from cocotb.binary import BinaryValue
 def toggle_clock(dut):
     dut.clk = 0
     yield Timer(10)
-    if dut.clk.value.integer is not 0:
+    if dut.clk.value.integer != 0:
         raise TestFailure("Clock not set to 0 as expected")
     dut.clk = 1
     yield Timer(10)
-    if dut.clk.value.integer is not 1:
+    if dut.clk.value.integer != 1:
         raise TestFailure("Clock not set to 1 as expected")
 
 @cocotb.test()
 def issue_253_empty(dut):
     yield toggle_clock(dut)
-  
+
 @cocotb.test()
 def issue_253_none(dut):
     yield toggle_clock(dut)

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -715,7 +715,7 @@ def test_binary_value(dut):
         raise TestFailure("Expecting our BinaryValue object to have the value 0.")
 
     dut._log.info("Checking single index assignment works as expected on a Little Endian BinaryValue.")
-    vec = BinaryValue(value=0, bits=16, bigEndian=False)
+    vec = BinaryValue(value=0, n_bits=16, bigEndian=False)
     if vec.big_endian:
         raise TestFailure("Our BinaryValue object is reporting it is Big Endian - was expecting Little Endian.")
     for x in range(vec.n_bits):
@@ -751,7 +751,9 @@ def test_binary_value_compat(dut):
     """
 
     dut._log.info("Checking the renaming of bits -> n_bits")
-    vec = BinaryValue(value=0, bits=16)
+    with assert_deprecated():
+        vec = BinaryValue(value=0, bits=16)
+
     if vec.n_bits != 16:
         raise TestFailure("n_bits is not set correctly - expected %d, got %d" % (16, vec.n_bits))
 
@@ -765,10 +767,6 @@ def test_binary_value_compat(dut):
         pass
     else:
         raise TestFailure("Expected TypeError when using bits and n_bits at the same time.")
-
-    # Test for the DeprecationWarning when using |bits|
-    with assert_deprecated():
-        vec = BinaryValue(value=0, bits=16)
 
     yield Timer(100)  # Make it do something with time
 


### PR DESCRIPTION
None of our tests should be emitting uncaught warnings in CI.

Milestoning as 1.3 since after #1228 users will see all of these in their logs.

@ktbarrett, I'd rather this went in before any of your deprecations, so we can sure that internally we do not use deprecated features.