### PR TITLE
Alternative to 1255

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -76,18 +76,18 @@ class CoroutineComplete(Exception):
         Exception.__init__(self, text)
 
 
-class RunningCoroutine(object):
-    """Per instance wrapper around an function to turn it into a coroutine.
+class RunningTask(object):
+    """Per instance wrapper around a running generator.
 
     Provides the following:
 
-        coro.join() creates a Trigger that will fire when this coroutine
+        task.join() creates a Trigger that will fire when this coroutine
         completes.
 
-        coro.kill() will destroy a coroutine instance (and cause any Join
+        task.kill() will destroy a coroutine instance (and cause any Join
         triggers to fire.
     """
-    def __init__(self, inst, parent):
+    def __init__(self, inst):
         if hasattr(inst, "__name__"):
             self.__name__ = "%s" % inst.__name__
 
@@ -99,10 +99,6 @@ class RunningCoroutine(object):
             self._coro = inst
         self._started = False
         self._callbacks = []
-        self._parent = parent
-        self.__doc__ = parent._func.__doc__
-        self.module = parent._func.__module__
-        self.funcname = parent._func.__name__
         self._outcome = None
 
         if not hasattr(self._coro, "send"):
@@ -215,6 +211,20 @@ class RunningCoroutine(object):
     __bool__ = __nonzero__
 
 
+class RunningCoroutine(RunningTask):
+    r"""
+    A compatibility wrapper for running :class:`coroutine`\ s.
+
+    All this class does is provide some extra attributes
+    """
+    def __init__(self, inst, parent):
+        RunningTask.__init__(inst)
+        self._parent = parent
+        self.__doc__ = parent._func.__doc__
+        self.module = parent._func.__module__
+        self.funcname = parent._func.__name__
+
+
 class RunningTest(RunningCoroutine):
     """Add some useful Test functionality to a RunningCoroutine."""
 
@@ -267,7 +277,7 @@ class RunningTest(RunningCoroutine):
         self._outcome = outcome
         cocotb.scheduler.unschedule(self)
 
-    # like RunningCoroutine.kill(), but with a way to inject a failure
+    # like RunningTask.kill(), but with a way to inject a failure
     def abort(self, exc):
         """Force this test to end early, without executing any cleanup.
 
@@ -292,7 +302,7 @@ class coroutine(object):
 
     ``log`` methods will log to ``cocotb.coroutine.name``.
 
-    :meth:`~cocotb.decorators.RunningCoroutine.join` method returns an event which will fire when the coroutine exits.
+    :meth:`~cocotb.decorators.RunningTask.join` method returns an event which will fire when the coroutine exits.
 
     Used as ``@cocotb.coroutine``.
     """

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -214,11 +214,6 @@ class RunningCoroutine(object):
 
     __bool__ = __nonzero__
 
-    def sort_name(self):
-        if self.stage is None:
-            return "%s.%s" % (self.module, self.funcname)
-        else:
-            return "%s.%d.%s" % (self.module, self.stage, self.funcname)
 
 class RunningTest(RunningCoroutine):
     """Add some useful Test functionality to a RunningCoroutine."""
@@ -284,6 +279,12 @@ class RunningTest(RunningCoroutine):
         aborting.
         """
         return self._force_outcome(outcomes.Error(exc))
+
+    def sort_name(self):
+        if self.stage is None:
+            return "%s.%s" % (self.module, self.funcname)
+        else:
+            return "%s.%d.%s" % (self.module, self.stage, self.funcname)
 
 
 class coroutine(object):

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -710,6 +710,9 @@ class Scheduler(object):
             else:
                 return self._trigger_from_started_coro(result)
 
+        if sys.version_info >= (3, 5) and inspect.iscoroutine(result):
+            return self._trigger_from_unstarted_coro(cocotb.decorators.RunningTask(result))
+
         if isinstance(result, list):
             return self._trigger_from_list(result)
 

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -39,6 +39,7 @@ import os
 import sys
 import logging
 import threading
+import inspect
 
 # Debug mode controlled by environment variables
 if "COCOTB_ENABLE_PROFILING" in os.environ:
@@ -641,6 +642,9 @@ class Scheduler(object):
                 "decorator?"
                 .format(coroutine)
             )
+
+        if sys.version_info[:2] >= (3, 5) and inspect.iscoroutine(coroutine):
+            return self.add(cocotb.decorators.RunningTask(coroutine))
 
         elif not isinstance(coroutine, cocotb.decorators.RunningTask):
             raise TypeError(

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -642,7 +642,7 @@ class Scheduler(object):
                 .format(coroutine)
             )
 
-        elif not isinstance(coroutine, cocotb.decorators.RunningCoroutine):
+        elif not isinstance(coroutine, cocotb.decorators.RunningTask):
             raise TypeError(
                 "Attempt to add a object of type {} to the scheduler, which "
                 "isn't a coroutine: {!r}\n"
@@ -666,19 +666,19 @@ class Scheduler(object):
 
     # This collection of functions parses a trigger out of the object
     # that was yielded by a coroutine, converting `list` -> `Waitable`,
-    # `Waitable` -> `RunningCoroutine`, `RunningCoroutine` -> `Trigger`.
+    # `Waitable` -> `RunningTask`, `RunningTask` -> `Trigger`.
     # Doing them as separate functions allows us to avoid repeating unencessary
     # `isinstance` checks.
 
     def _trigger_from_started_coro(self, result):
-        # type: (cocotb.decorators.RunningCoroutine) -> Trigger
+        # type: (cocotb.decorators.RunningTask) -> Trigger
         if _debug:
             self.log.debug("Joining to already running coroutine: %s" %
                            result.__name__)
         return result.join()
 
     def _trigger_from_unstarted_coro(self, result):
-        # type: (cocotb.decorators.RunningCoroutine) -> Trigger
+        # type: (cocotb.decorators.RunningTask) -> Trigger
         self.queue(result)
         if _debug:
             self.log.debug("Scheduling nested coroutine: %s" %
@@ -700,7 +700,7 @@ class Scheduler(object):
         if isinstance(result, Trigger):
             return result
 
-        if isinstance(result, cocotb.decorators.RunningCoroutine):
+        if isinstance(result, cocotb.decorators.RunningTask):
             if not result.has_started():
                 return self._trigger_from_unstarted_coro(result)
             else:

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -598,7 +598,7 @@ class _AggregateWaitable(Waitable):
 
         # Do some basic type-checking up front, rather than waiting until we
         # yield them.
-        allowed_types = (Trigger, Waitable, decorators.RunningCoroutine)
+        allowed_types = (Trigger, Waitable, decorators.RunningTask)
         for trigger in self.triggers:
             if not isinstance(trigger, allowed_types):
                 raise TypeError(

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -51,9 +51,9 @@ Interacting with the Simulator
 
 .. autofunction:: cocotb.fork
 
-.. autofunction:: cocotb.decorators.RunningCoroutine.join
+.. autofunction:: cocotb.decorators.RunningTask.join
 
-.. autofunction:: cocotb.decorators.RunningCoroutine.kill
+.. autofunction:: cocotb.decorators.RunningTask.kill
 
 Triggers
 --------

--- a/tests/test_cases/test_cocotb/test_cocotb_35.py
+++ b/tests/test_cases/test_cocotb/test_cocotb_35.py
@@ -116,3 +116,16 @@ async def test_await_causes_start(dut):
     assert not coro.has_started()
     await coro
     assert coro.has_started()
+
+
+@cocotb.test()
+def test_undecorated_coroutine_fork(dut):
+    ran = False
+
+    async def example():
+        nonlocal ran
+        await cocotb.triggers.Timer(1, 'ns')
+        ran = True
+
+    yield cocotb.fork(example()).join()
+    assert ran

--- a/tests/test_cases/test_cocotb/test_cocotb_35.py
+++ b/tests/test_cases/test_cocotb/test_cocotb_35.py
@@ -129,3 +129,16 @@ def test_undecorated_coroutine_fork(dut):
 
     yield cocotb.fork(example()).join()
     assert ran
+
+@cocotb.test()
+def test_undecorated_coroutine_yield(dut):
+    ran = False
+
+    async def example():
+        nonlocal ran
+        await cocotb.triggers.Timer(1, 'ns')
+        ran = True
+
+    yield example()
+    assert ran
+


### PR DESCRIPTION
@ktbarrett: Created this because it was easier that writing a comment on your PR.

This is #1255 without the deprecations. Last two commits are @ktbarrett's.

Instead of deprecating some of the members of `RunningCoroutine`, this extracts a base class `RunningTask` which does not contain the offending members.

That way, new code can construct the base class for simplicity, and old code will continue to get the attributes it expects.

Instead of deprecating the attributes of `RunningCoroutine`, I think we should just (slowly) push users away from using `cocotb.coroutine` at all, which will naturally phase out all uses of `RunningCoroutine`.

The name `RunningTask` is inspired by `asyncio.Task`.


