### PR TITLE
Do not ignore failures during test initialization

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -379,7 +379,8 @@ class RegressionManager(object):
                 self.log.error("Test error has lead to simulator shutting us "
                                "down", exc_info=exc_info)
                 result_pass = False
-                sim_failed = True
+            # whether we expected it or not, the simulation has failed unrecoverably
+            sim_failed = True
 
         elif test.expect_error:
             if isinstance(result, test.expect_error):

--- a/tests/test_cases/issue_1279/Makefile
+++ b/tests/test_cases/issue_1279/Makefile
@@ -1,0 +1,3 @@
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_1279

--- a/tests/test_cases/issue_1279/issue_1279.py
+++ b/tests/test_cases/issue_1279/issue_1279.py
@@ -1,0 +1,16 @@
+"""
+Test that once a SimFailure occurs, no further tests are run
+"""
+import cocotb
+
+
+@cocotb.test(expect_error=cocotb.result.SimFailure, stage=1)
+def test_sim_failure_a(dut):
+    # invoke a deadlock, as nothing is driving this clock
+    yield cocotb.triggers.RisingEdge(dut.clk)
+
+
+@cocotb.test(stage=2)
+def test_sim_failure_b(dut):
+    yield cocotb.triggers.NullTrigger()
+    raise cocotb.result.TestFailure("This test should never run")

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -82,7 +82,7 @@ def assert_raises(exc_type):
 # Tests relating to providing meaningful errors if we forget to use the
 # yield keyword correctly to turn a function into a coroutine
 
-@cocotb.test(expect_fail=True)
+@cocotb.test(expect_error=TypeError)
 def test_not_a_coroutine(dut):
     """Example of a failing to use the yield keyword in a test"""
     dut._log.warning("This test will fail because we don't yield anything")
@@ -176,11 +176,6 @@ def clock_yield(generator):
     global test_flag
     yield Join(generator)
     test_flag = True
-
-
-@cocotb.test(expect_fail=True)
-def test_duplicate_yield(dut):
-    """A trigger can not be yielded on twice"""
 
 
 @cocotb.test(expect_fail=False)


### PR DESCRIPTION
Fixes #1253. PEP8 fixes and comments.

There are two places in the RM that initialize coroutines, each had slightly different code, so this was factored out into a method `init_test`.

`init_test` can fail, and so can a test at any point in it's run (previous handled by `handle_result`), so scoring a test as a pass or a fail depending upon the result and expected behavior is factored out into a method `score_test`.

`score_test` can print out tracebacks on certain failures, and non-pertinent traceback frames are stripped. However because there are two entry points to `score_test`, the exception handling functionality had to be factored out into a static method `exception_info`.