### PR TITLE
Solved missing changes from 'potentialventures' to 'cocotb'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,14 @@ Have you fixed a bug in cocotb, or want to add new functionality to it?
 Cocotb follows the typical [GitHub flow](https://guides.github.com/introduction/flow/) and makes use of pull requests and reviews.
 Follow the steps below to get your changes merged, i.e. integrated into the main cocotb codebase.
 
-1. Create an issue ticket on [cocotb's GitHub issue tracker](https://github.com/potentialventures/cocotb/issues) describing the problem.
+1. Create an issue ticket on [cocotb's GitHub issue tracker](https://github.com/cocotb/cocotb/issues) describing the problem.
    Issues are also a good place to discuss design options with others before writing code.
-2. [Fork](https://help.github.com/articles/fork-a-repo/) the [cocotb GitHub repository](https://github.com/potentialventures/cocotb) into your personal namespace.
+2. [Fork](https://help.github.com/articles/fork-a-repo/) the [cocotb GitHub repository](https://github.com/cocotb/cocotb) into your personal namespace.
 3. Create a new branch off the `master` branch for your set of changes.
    Use one branch per "topic," i.e. per set of changes which belong together.
 4. Create one or multiple commits to address the issue.
    Make sure to read and follow the [Patch Requirements](#patch-requirements) when preparing your commits.
-5. Create new [pull request (PR)](https://github.com/potentialventures/cocotb/pulls).
+5. Create new [pull request (PR)](https://github.com/cocotb/cocotb/pulls).
 6. When you submit (or update) the pull request, a suite of regression tests will run.
    If any of them turns "red," i.e. reports a failure, you most likely need to fix your code before it can be merged.
 7. The pull request needs to be reviewed by at least one maintainer.
@@ -54,7 +54,7 @@ Patch Requirements
 All changes which should go into the main codebase of cocotb must follow this set of requirements.
 
 - The code must be within the [scope of cocotb](#architecture-and-scope-of-cocotb).
-- All code must be licensed under the [Revised BSD License](https://github.com/potentialventures/cocotb/blob/master/LICENSE).
+- All code must be licensed under the [Revised BSD License](https://github.com/cocotb/cocotb/blob/master/LICENSE).
   By contributing to this project you signal your agreement with these license terms.
 - All code must follow the established coding standards.
   For Python code, follow the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     name='cocotb',
     version=__version__,  # noqa: F821
     description='cocotb is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.',
-    url='https://github.com/potentialventures/cocotb',
+    url='https://github.com/cocotb/cocotb',
     license='BSD',
     long_description=read_file('README.md'),
     long_description_content_type='text/markdown',

--- a/tests/test_cases/issue_768_a/issue_768.py
+++ b/tests/test_cases/issue_768_a/issue_768.py
@@ -1,5 +1,5 @@
 """
-Control case for https://github.com/potentialventures/cocotb/issues/768.
+Control case.
 
 This passed before the bug fix, and should continue to pass
 

--- a/tests/test_cases/issue_768_b/issue_768.py
+++ b/tests/test_cases/issue_768_b/issue_768.py
@@ -1,5 +1,5 @@
 """
-Failing case for https://github.com/potentialventures/cocotb/issues/768.
+Failing case.
 
 Note that the bug only occurred if the test in question runs first - so
 no more tests can be added to this file.


### PR DESCRIPTION
A very simple contribution, but I detected that was missing and very easy to solve.

I made two commits because maybe somebody disagrees with the second one. Let me know.