### PR TITLE
Stop setting `logger.propagate=True` on every logger

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -229,7 +229,13 @@ class RunningTest(RunningCoroutine):
             logging.Handler.__init__(self, level=logging.DEBUG)
 
         def handle(self, record):
-            self.fn(self.format(record))
+            # For historical reasons, only logs sent directly to the `cocotb`
+            # logger are recorded - logs to `cocotb.scheduler` for instance
+            # are not recorded. Changing this behavior may have significant
+            # memory usage implications, so should not be done without some
+            # thought.
+            if record.name == 'cocotb':
+                self.fn(self.format(record))
 
     def __init__(self, inst, parent):
         self.error_messages = []


### PR DESCRIPTION
There are two ways to configure logger handlers in python:

1. Attach a handler to the root logger, and use the fact that records logged to child loggers will automatically inherit this handler by default.
2. Attach a handler to every logger, and disable propagation for every single one.

Up to this commit, we use approach 2, by subclassing `logging.Logger` to use this behavior by default.
The problem with this approach is it makes it very difficult for a user to set their own logging format, as their nested loggers will not propagate as they are used to.

This commit changes us to use the approach 1.
To most cocotb application which do not attempt to reconfigure the logger, this will have no effect.
Applications which configure their own loggers will find that nested loggers now work as they expected.

This also moves all of the logging initialization out of `___init__.py` to `log.py`, to keep everything together.

Another side effect of this change is that `logging.basicConfig` can now be used to remove the cocotb formatting and handlers.

Closes #1212, with the answer being "for backwards compatibility only"