### PR TITLE
Added -std=c++11 to Makefile.verilator to support older gcc

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -32,6 +32,8 @@ ifdef COCOTB_HDL_TIMEPRECISION
   SIM_BUILD_FLAGS += -DVL_TIME_PRECISION_STR=$(COCOTB_HDL_TIMEPRECISION)
 endif
 
+SIM_BUILD_FLAGS += -std=c++11
+
 COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-L `dirname $(COCOTB_VPI_LIB)` -lvpi -lgpi -lcocotb -lgpilog -lcocotbutils"
 
 $(SIM_BUILD)/Vtop.mk: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp
@@ -39,7 +41,7 @@ $(SIM_BUILD)/Vtop.mk: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_SHARE_D
 
 # Compilation phase
 $(SIM_BUILD)/$(TOPLEVEL): $(SIM_BUILD)/Vtop.mk $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
-	CPPFLAGS=$(SIM_BUILD_FLAGS) make -C $(SIM_BUILD) -f Vtop.mk
+	CPPFLAGS="$(SIM_BUILD_FLAGS)" make -C $(SIM_BUILD) -f Vtop.mk
 
 ifeq ($(OS),Msys)
 


### PR DESCRIPTION
This change fixes the error mentioned here on older gcc. 
### Error
```
g++  -DVL_TIME_PRECISION_STR=1ps -I.  -MMD -I/tmp/verilator/include -I/tmp/verilator/include/vltstd -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=0 -Wno-sign-compare -Wno-uninitialized -Wno-unused-but-set-variable -Wno-unused-parameter -Wno-unused-variable -Wno-shadow       -c -o verilator.o /tmp/conda/envs/cocotb_verilator/lib/python3.7/site-packages/cocotb/share/lib/verilator/verilator.cpp
/tmp/conda/envs/cocotb_verilator/lib/python3.7/site-packages/cocotb/share/lib/verilator/verilator.cpp: In function ‘int main(int, char**)’:
/tmp/conda/envs/cocotb_verilator/lib/python3.7/site-packages/cocotb/share/lib/verilator/verilator.cpp:31:5: error: ‘unique_ptr’ is not a member of ‘std’
     std::unique_ptr<Vtop> top(new Vtop(""));
     ^
/tmp/conda/envs/cocotb_verilator/lib/python3.7/site-packages/cocotb/share/lib/verilator/verilator.cpp:31:25: error: expected primary-expression before ‘>’ token
     std::unique_ptr<Vtop> top(new Vtop(""));
                         ^
/tmp/conda/envs/cocotb_verilator/lib/python3.7/site-packages/cocotb/share/lib/verilator/verilator.cpp:31:43: error: ‘top’ was not declared in this scope
     std::unique_ptr<Vtop> top(new Vtop(""));
                                           ^
Vtop.mk:60: recipe for target 'verilator.o' failed
```

### My gcc info. 
```
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.12' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12) 
```