### PR TITLE
Fix the broken log record accumulation

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -243,21 +243,17 @@ class RunningTest(RunningCoroutine):
         self.skip = parent.skip
         self.stage = parent.stage
 
-        self.handler = RunningTest.ErrorLogHandler(self._handle_error_message)
-        cocotb.log.addHandler(self.handler)
+        # make sure not to create a circular reference here
+        self.handler = RunningTest.ErrorLogHandler(self.error_messages.append)
 
     def _advance(self, outcome):
         if not self.started:
-            self.error_messages = []
             self.log.info("Starting test: \"%s\"\nDescription: %s" %
                           (self.funcname, self.__doc__))
             self.start_time = time.time()
             self.start_sim_time = get_sim_time('ns')
             self.started = True
         return super(RunningTest, self)._advance(outcome)
-
-    def _handle_error_message(self, msg):
-        self.error_messages.append(msg)
 
     def _force_outcome(self, outcome):
         """

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -328,6 +328,9 @@ class RegressionManager(object):
             self._add_failure(result)
             result_pass = False
 
+        # stop capturing log output
+        cocotb.log.removeHandler(test.handler)
+
         self._store_test_result(test.module, test.funcname, result_pass, sim_time_ns, real_time, ratio_time)
 
         self.execute()
@@ -346,6 +349,9 @@ class RegressionManager(object):
                            self.count, self.ntests,
                            end,
                            self._running_test.funcname))
+
+            # start capturing log output
+            cocotb.log.addHandler(self._running_test.handler)
 
             cocotb.scheduler.add_test(self._running_test)
             self.count += 1

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -671,6 +671,12 @@ def test_logging_with_args(dut):
     dut._log.info("%s", counter)
     assert counter.str_counter == 1
 
+    # now try again on the root cocotb logger, which unlike nested loggers
+    # is captured
+    counter = StrCallCounter()
+    cocotb.log.info("%s", counter)
+    assert counter.str_counter == 2  # once for stdout, once for captured logs
+
     dut._log.info("No substitution")
 
     dut._log.warning("Testing multiple line\nmessage")


### PR DESCRIPTION
Before this commit, the assertion in this test would fail, and `str_counter` would be equal to the total number of tests.
The bug was that the log handlers would be installed at startup before any test was run, and never removed - so every test logged to the captured logs of every other tests.

Now the regression manager installs the handler before starting the test, and removes it when the test is complete.
As a result, log messages are recorded exactly twice - once in stdout, and once in the results.xml file.

Tested by injecting a failure in a test, and looking at results.xml manually to see that all the logs appear.

---

Split from #1266.