### PR TITLE
Added --trace-structs to Makefile.verilator.

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -25,7 +25,7 @@ ifeq ($(VERILATOR_SIM_DEBUG), 1)
 endif
 
 ifeq ($(VERILATOR_TRACE),1)
-  EXTRA_ARGS += --trace
+  EXTRA_ARGS += --trace --trace-structs
 endif
 
 ifdef COCOTB_HDL_TIMEPRECISION


### PR DESCRIPTION
By default, structs are dumped as single dimensional packed vectors in
the VCD file. Adding this will make verilator dump structs as
hierarchial objects with struct fields as children.

### Code

```systemverilog
module t();

struct packed {
    logic [15:0] src;
    logic [15:0] dst;
} hdr;

assign hdr.src = 20;
assign hdr.dst = 40;

endmodule
```

### Before
![image](https://user-images.githubusercontent.com/1689958/71637688-5a86d800-2c6f-11ea-927a-5462ac1096bf.png)

### After
![image](https://user-images.githubusercontent.com/1689958/71637690-67a3c700-2c6f-11ea-911c-a867ad67642f.png)
