### PR TITLE
Differentiate set_signal_value for logic string from ASCII string

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -625,7 +625,7 @@ class ModifiableObject(NonConstantObject):
             self._log.critical("Unsupported type for value assignment: %s (%s)", type(value), repr(value))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
-        simulator.set_signal_val_str(self._handle, value.binstr)
+        simulator.set_signal_val_binstr(self._handle, value.binstr)
 
     def _getvalue(self):
         binstr = simulator.get_signal_val_binstr(self._handle)

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -197,7 +197,8 @@ int gpi_is_indexable(gpi_sim_hdl gpi_hdl);
 // Functions for setting the properties of a handle
 void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value);
 void gpi_set_signal_value_long(gpi_sim_hdl gpi_hdl, long value);
-void gpi_set_signal_value_str(gpi_sim_hdl gpi_hdl, const char *str);    // String of binary char(s) [1, 0, x, z]
+void gpi_set_signal_value_binstr(gpi_sim_hdl gpi_hdl, const char *str); // String of binary char(s) [1, 0, x, z]
+void gpi_set_signal_value_str(gpi_sim_hdl gpi_hdl, const char *str);    // String of ASCII char(s)
 
 typedef enum gpi_edge {
     GPI_RISING = 1,

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -255,7 +255,8 @@ public:
 
     virtual int set_signal_value(const long value);
     virtual int set_signal_value(const double value);
-    virtual int set_signal_value(std::string &value);
+    virtual int set_signal_value_binstr(std::string &value);
+    virtual int set_signal_value_str(std::string &value);
 
     virtual void *get_sub_hdl(int index);
 
@@ -333,7 +334,7 @@ public:
     const char* get_signal_value_binstr();
 
     int set_signal_value(const long value);
-    int set_signal_value(std::string &value);
+    int set_signal_value_binstr(std::string &value);
 
     int initialise(std::string &name, std::string &fq_name);
 
@@ -418,7 +419,7 @@ public:
 
     const char* get_signal_value_str();
 
-    int set_signal_value(std::string &value);
+    int set_signal_value_str(std::string &value);
 
     int initialise(std::string &name, std::string &fq_name);
 

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -145,7 +145,13 @@ int FliValueObjHdl::set_signal_value(const long value)
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value(std::string &value)
+int FliValueObjHdl::set_signal_value_binstr(std::string &value)
+{
+    LOG_ERROR("Setting signal/variable value via string not supported for %s of type %d", m_fullname.c_str(), m_type);
+    return -1;
+}
+
+int FliValueObjHdl::set_signal_value_str(std::string &value)
 {
     LOG_ERROR("Setting signal/variable value via string not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
@@ -330,7 +336,7 @@ int FliLogicObjHdl::set_signal_value(const long value)
     return 0;
 }
 
-int FliLogicObjHdl::set_signal_value(std::string &value)
+int FliLogicObjHdl::set_signal_value_binstr(std::string &value)
 {
     if (m_fli_type == MTI_TYPE_ENUM) {
         mtiInt32T enumVal = m_enum_map[value.c_str()[0]];
@@ -501,7 +507,7 @@ const char* FliStringObjHdl::get_signal_value_str()
     return m_val_buff;
 }
 
-int FliStringObjHdl::set_signal_value(std::string &value)
+int FliStringObjHdl::set_signal_value_str(std::string &value)
 {
     strncpy(m_mti_buff, value.c_str(), m_num_elems);
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -501,11 +501,18 @@ void gpi_set_signal_value_long(gpi_sim_hdl sig_hdl, long value)
     obj_hdl->set_signal_value(value);
 }
 
+void gpi_set_signal_value_binstr(gpi_sim_hdl sig_hdl, const char *binstr)
+{
+    std::string value = binstr;
+    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    obj_hdl->set_signal_value_binstr(value);
+}
+
 void gpi_set_signal_value_str(gpi_sim_hdl sig_hdl, const char *str)
 {
     std::string value = str;
     GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
-    obj_hdl->set_signal_value(value);
+    obj_hdl->set_signal_value_str(value);
 }
 
 void gpi_set_signal_value_real(gpi_sim_hdl sig_hdl, double value)

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -178,7 +178,8 @@ public:
 
     virtual int set_signal_value(const long value) = 0;
     virtual int set_signal_value(const double value) = 0;
-    virtual int set_signal_value(std::string &value) = 0;
+    virtual int set_signal_value_str(std::string &value) = 0;
+    virtual int set_signal_value_binstr(std::string &value) = 0;
     //virtual GpiCbHdl monitor_value(bool rising_edge) = 0; this was for the triggers
     // but the explicit ones are probably better
 

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -621,8 +621,7 @@ static PyObject *get_signal_val_long(PyObject *self, PyObject *args)
     return retval;
 }
 
-
-static PyObject *set_signal_val_str(PyObject *self, PyObject *args)
+static PyObject *set_signal_val_binstr(PyObject *self, PyObject *args)
 {
     gpi_sim_hdl hdl;
     const char *binstr;
@@ -632,7 +631,23 @@ static PyObject *set_signal_val_str(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    gpi_set_signal_value_str(hdl, binstr);
+    gpi_set_signal_value_binstr(hdl, binstr);
+    res = Py_BuildValue("s", "OK!");
+
+    return res;
+}
+
+static PyObject *set_signal_val_str(PyObject *self, PyObject *args)
+{
+    gpi_sim_hdl hdl;
+    const char *str;
+    PyObject *res;
+
+    if (!PyArg_ParseTuple(args, "O&s", gpi_sim_hdl_converter, &hdl, &str)) {
+        return NULL;
+    }
+
+    gpi_set_signal_value_str(hdl, str);
     res = Py_BuildValue("s", "OK!");
 
     return res;

--- a/cocotb/share/lib/simulator/simulatormodule.h
+++ b/cocotb/share/lib/simulator/simulatormodule.h
@@ -64,6 +64,7 @@ static PyObject *get_signal_val_binstr(PyObject *self, PyObject *args);
 static PyObject *set_signal_val_long(PyObject *self, PyObject *args);
 static PyObject *set_signal_val_real(PyObject *self, PyObject *args);
 static PyObject *set_signal_val_str(PyObject *self, PyObject *args);
+static PyObject *set_signal_val_binstr(PyObject *self, PyObject *args);
 static PyObject *get_definition_name(PyObject *self, PyObject *args);
 static PyObject *get_definition_file(PyObject *self, PyObject *args);
 static PyObject *get_handle_by_name(PyObject *self, PyObject *args);
@@ -98,7 +99,8 @@ static PyMethodDef SimulatorMethods[] = {
     {"get_signal_val_binstr", get_signal_val_binstr, METH_VARARGS, "Get the value of a signal as a binary string"},
     {"get_signal_val_real", get_signal_val_real, METH_VARARGS, "Get the value of a signal as a double precision float"},
     {"set_signal_val_long", set_signal_val_long, METH_VARARGS, "Set the value of a signal using a long"},
-    {"set_signal_val_str", set_signal_val_str, METH_VARARGS, "Set the value of a signal using a binary string"},
+    {"set_signal_val_str", set_signal_val_str, METH_VARARGS, "Set the value of a signal using an ASCII string"},
+    {"set_signal_val_binstr", set_signal_val_binstr, METH_VARARGS, "Set the value of a signal using a binary string"},
     {"set_signal_val_real", set_signal_val_real, METH_VARARGS, "Set the value of a signal using a double precision float"},
     {"get_definition_name", get_definition_name, METH_VARARGS, "Get the name of a GPI object's definition"},
     {"get_definition_file", get_definition_file, METH_VARARGS, "Get the file that sources the object's definition"},

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -497,7 +497,7 @@ int VhpiLogicSignalObjHdl::set_signal_value(long value)
     return 0;
 }
 
-int VhpiLogicSignalObjHdl::set_signal_value(std::string &value)
+int VhpiLogicSignalObjHdl::set_signal_value_binstr(std::string &value)
 {
     switch (m_value.format) {
         case vhpiEnumVal:
@@ -614,7 +614,7 @@ int VhpiSignalObjHdl::set_signal_value(double value)
     return 0;
 }
 
-int VhpiSignalObjHdl::set_signal_value(std::string &value)
+int VhpiSignalObjHdl::set_signal_value_binstr(std::string &value)
 {
     switch (m_value.format) {
         case vhpiEnumVal:
@@ -644,6 +644,25 @@ int VhpiSignalObjHdl::set_signal_value(std::string &value)
 
             break;
         }
+
+        default: {
+            LOG_ERROR("VHPI: Unable to handle this format type %s",
+                      ((VhpiImpl*)GpiObjHdl::m_impl)->format_to_string(m_value.format));
+            return -1;
+        }
+    }
+
+    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, vhpiDepositPropagate)) {
+        check_vhpi_error();
+        return -1;
+    }
+
+    return 0;
+}
+
+int VhpiSignalObjHdl::set_signal_value_str(std::string &value)
+{
+    switch (m_value.format) {
 
         case vhpiStrVal: {
             std::vector<char> writable(value.begin(), value.end());

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -197,7 +197,8 @@ public:
 
     virtual int set_signal_value(const long value);
     virtual int set_signal_value(const double value);
-    virtual int set_signal_value(std::string &value);
+    virtual int set_signal_value_binstr(std::string &value);
+    virtual int set_signal_value_str(std::string &value);
 
     /* Value change callback accessor */
     virtual GpiCbHdl *value_change_cb(unsigned int edge);
@@ -222,7 +223,7 @@ public:
     virtual ~VhpiLogicSignalObjHdl() { }
 
     int set_signal_value(const long value);
-    int set_signal_value(std::string &value);
+    int set_signal_value_binstr(std::string &value);
 
     int initialise(std::string &name, std::string &fq_name);
 };

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -343,7 +343,7 @@ int VpiSignalObjHdl::set_signal_value(double value)
     return set_signal_value(value_s);
 }
 
-int VpiSignalObjHdl::set_signal_value(std::string &value)
+int VpiSignalObjHdl::set_signal_value_binstr(std::string &value)
 {
     s_vpi_value value_s;
 
@@ -352,6 +352,19 @@ int VpiSignalObjHdl::set_signal_value(std::string &value)
 
     value_s.value.str = &writable[0];
     value_s.format = vpiBinStrVal;
+
+    return set_signal_value(value_s);
+}
+
+int VpiSignalObjHdl::set_signal_value_str(std::string &value)
+{
+    s_vpi_value value_s;
+
+    std::vector<char> writable(value.begin(), value.end());
+    writable.push_back('\0');
+
+    value_s.value.str = &writable[0];
+    value_s.format = vpiStringVal;
 
     return set_signal_value(value_s);
 }

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -186,7 +186,8 @@ public:
 
     int set_signal_value(const long value);
     int set_signal_value(const double value);
-    int set_signal_value(std::string &value);
+    int set_signal_value_binstr(std::string &value);
+    int set_signal_value_str(std::string &value);
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(unsigned int edge);


### PR DESCRIPTION
Fixes #1254.

Previously there were two methods for getting string values from the simulator `get_signal_value_str` and `get_signal_value_binstr`, but there was only one method for setting strings `set_signal_value_str`. This was mostly enforced as binary string, however the VHPI handled both cases. Icarus worked with only this one method setting both binary strings and ASCII strings, but Questa does not. Questa expects strings to be set with `vpiStringVal` instead of `vpiBinStrVal` as discovered by #834.

`set_signal_value_str` has been split into two functions to mirror `get_signal_value_(bin)str`. Testing with Questa and other simulator should be done before acceptance.