### PR TITLE
Improve BinaryValue performance 

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -448,6 +448,9 @@ class BinaryValue:
     get_binstr = binstr.fget
     set_binstr = binstr.fset
 
+    def _set_trusted_binstr(self, string):
+        self._str = string
+
     @property
     def n_bits(self):
         """The number of bits of the binary value."""

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -157,17 +157,9 @@ class BinaryValue:
 
         self._n_bits = n_bits
 
-        self._convert_to = {
-            BinaryRepresentation.UNSIGNED         : self._convert_to_unsigned   ,
-            BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_to_signed_mag ,
-            BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_to_twos_comp  ,
-        }
+        self._convert_to = self._convert_to_map[self.binaryRepresentation].__get__(self, self.__class__)
 
-        self._convert_from = {
-            BinaryRepresentation.UNSIGNED         : self._convert_from_unsigned   ,
-            BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_from_signed_mag ,
-            BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_from_twos_comp  ,
-        }
+        self._convert_from = self._convert_from_map[self.binaryRepresentation].__get__(self, self.__class__)
 
         if value is not None:
             self.assign(value)
@@ -247,6 +239,18 @@ class BinaryValue:
             rv = int(x.translate(_resolve_table), 2)
         return rv
 
+    _convert_to_map = {
+        BinaryRepresentation.UNSIGNED         : _convert_to_unsigned,
+        BinaryRepresentation.SIGNED_MAGNITUDE : _convert_to_signed_mag,
+        BinaryRepresentation.TWOS_COMPLEMENT  : _convert_to_twos_comp,
+    }
+
+    _convert_from_map = {
+        BinaryRepresentation.UNSIGNED         : _convert_from_unsigned,
+        BinaryRepresentation.SIGNED_MAGNITUDE : _convert_from_signed_mag,
+        BinaryRepresentation.TWOS_COMPLEMENT  : _convert_from_twos_comp,
+    }
+
     def _invert(self, x):
         inverted = ''
         for bit in x:
@@ -322,11 +326,11 @@ class BinaryValue:
     @property
     def integer(self):
         """The integer representation of the underlying vector."""
-        return self._convert_from[self.binaryRepresentation](self._str)
+        return self._convert_from(self._str)
 
     @integer.setter
     def integer(self, val):
-        self._str = self._convert_to[self.binaryRepresentation](val)
+        self._str = self._convert_to(val)
 
     @property
     def value(self):

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -745,7 +745,9 @@ class ModifiableObject(NonConstantObject):
     @NonConstantObject.value.getter
     def value(self) -> BinaryValue:
         binstr = self._handle.get_signal_val_binstr()
-        result = BinaryValue(binstr, len(binstr))
+        # Skip BinaryValue.assign() as we know we are using a binstr
+        result = BinaryValue(n_bits=len(binstr))
+        result.binstr = binstr
         return result
 
     def __int__(self):

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -747,7 +747,8 @@ class ModifiableObject(NonConstantObject):
         binstr = self._handle.get_signal_val_binstr()
         # Skip BinaryValue.assign() as we know we are using a binstr
         result = BinaryValue(n_bits=len(binstr))
-        result.binstr = binstr
+        # Skip the permitted characters check as we trust the simulator
+        result._set_trusted_binstr(binstr)
         return result
 
     def __int__(self):

--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -309,3 +309,11 @@ def test_buff_little_endian():
         v.buff = b'\xC9\xF6'
     assert v.buff == orig_bytes
     assert v.binstr == orig_str
+
+
+def test_bad_binstr():
+    with pytest.raises(ValueError, match=r'Attempting to assign character 4 to a BinaryValue'):
+        BinaryValue(value="01XZ4")
+
+    with pytest.raises(ValueError, match=r'Attempting to assign character % to a BinaryValue'):
+        BinaryValue(value="Uu%")


### PR DESCRIPTION
Improving performance related to `BinaryValue` objects.

Relies on #1502 providing a performance regression test. The `matrix_multiplier` test makes heavy use of the `BinaryValue` class.

CI results
----------
Python | master (4eaf429c67739886fab45afd647b4eeb37436694) | PR (d43dcdf359a8ce41d50d51c46fddae470b4baa89) | improvement
------- | --------------- | ----- | --------------
3.8 | [825 NS/S](https://github.com/cocotb/cocotb/runs/1564866751?check_suite_focus=true#step:22:5077) | [1982 NS/S]() | +140%

Outdated results
-----------------

Running `test_matrix_multiplier` locally:

sim | 5b71032 average | 71ff728 average | improvement
--- | ---------- | -------- | ------------- 
icarus | 1583 NS/S | 2413 NS/S | +52% !
aldec (vhdl) | 1204 NS/S | 2046 NS/S | +70% !!

These numbers are outsized due to the `BinaryValue`-focused test, but I think other tests will see at least a small performance improvement.

@andresdemski could you run your test against this?