### PR TITLE
Allow users to load into any Python code from GPI

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -56,6 +56,7 @@ from ._version import __version__
 
 # GPI logging instance
 if "COCOTB_SIM" in os.environ:
+    import simulator
 
     def _reopen_stream_with_buffering(stream_name):
         try:
@@ -134,9 +135,14 @@ def _initialise_testbench(argv_):
     """
     _rlock.acquire()
 
-    global argc, argv
+    global argc, argv, SIM_NAME, SIM_VERSION
     argv = argv_
     argc = len(argv)
+    SIM_NAME = simulator.product()
+    SIM_VERSION = simulator.version()
+
+    cocotb.log.info("Running on {} version {}".format(SIM_NAME, SIM_VERSION))
+    cocotb.log.info("Python interpreter initialized and cocotb loaded!")
 
     root_name = os.getenv("TOPLEVEL", None)
     if root_name is not None:

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -112,6 +112,8 @@ fork = scheduler.add
 # FIXME is this really required?
 _rlock = threading.RLock()
 
+LANGUAGE = os.getenv("TOPLEVEL_LANG")
+
 
 def mem_debug(port):
     import cocotb.memdebug

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -120,7 +120,7 @@ def mem_debug(port):
     cocotb.memdebug.start(port)
 
 
-def _initialise_testbench(root_name):
+def _initialise_testbench():
     """Initialize testbench.
 
     This function is called after the simulator has elaborated all
@@ -133,6 +133,13 @@ def _initialise_testbench(root_name):
     comma-separated list of modules to be executed before the first test.
     """
     _rlock.acquire()
+
+    root_name = os.getenv("TOPLEVEL", None)
+    if root_name is not None:
+        if root_name == "":
+            root_name = None
+        elif '.' in root_name:
+            root_name = root_name.split(".", 1)[1]
 
     memcheck_port = os.getenv('MEMCHECK')
     if memcheck_port is not None:

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -120,7 +120,7 @@ def mem_debug(port):
     cocotb.memdebug.start(port)
 
 
-def _initialise_testbench():
+def _initialise_testbench(argv_):
     """Initialize testbench.
 
     This function is called after the simulator has elaborated all
@@ -133,6 +133,10 @@ def _initialise_testbench():
     comma-separated list of modules to be executed before the first test.
     """
     _rlock.acquire()
+
+    global argc, argv
+    argv = argv_
+    argc = len(argv)
 
     root_name = os.getenv("TOPLEVEL", None)
     if root_name is not None:

--- a/cocotb/_gpi_embed.py
+++ b/cocotb/_gpi_embed.py
@@ -1,0 +1,22 @@
+import logging
+
+
+def _filter_from_c(logger_name, level):
+    return logging.getLogger(logger_name).isEnabledFor(level)
+
+
+def _log_from_c(logger_name, level, filename, lineno, msg, function_name):
+    """Log from the C world, allowing to insert C stack information."""
+    logger = logging.getLogger(logger_name)
+    if logger.isEnabledFor(level):
+        record = logger.makeRecord(
+            logger.name,
+            level,
+            filename,
+            lineno,
+            msg,
+            None,
+            None,
+            function_name
+        )
+        logger.handle(record)

--- a/cocotb/_gpi_embed.py
+++ b/cocotb/_gpi_embed.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import importlib
+from functools import reduce
 
 
 def _filter_from_c(logger_name, level):
@@ -20,3 +23,19 @@ def _log_from_c(logger_name, level, filename, lineno, msg, function_name):
             function_name
         )
         logger.handle(record)
+
+
+def _load_entry():
+    """Gather entry point information by parsing :envar:`COCOTB_ENTRY_POINT`."""
+    entry_point_str = os.environ.get("COCOTB_ENTRY", "cocotb:_initialise_testbench")
+    try:
+        if ":" not in entry_point_str:
+            raise ValueError("Invalid COCOTB_ENTRY, missing entry function (no colon).")
+        entry_module_str, entry_func_str = entry_point_str.split(":", 1)
+        entry_module = importlib.import_module(entry_module_str)
+        entry_func = reduce(getattr, entry_func_str.split('.'), entry_module)
+    except Exception as e:
+        raise RuntimeError("Failure to parse COCOTB_ENTRY ('{}')".format(entry_point_str)) from e
+    entry_sim_event = getattr(entry_module, "_sim_event")
+    assert callable(entry_sim_event)  # won't be called immediately, so we check now for time's sake
+    return (entry_module, entry_func, entry_sim_event)

--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -241,27 +241,3 @@ class SimColourLogFormatter(SimLogFormatter):
                  record.levelname.ljust(_LEVEL_CHARS))
 
         return self._format(level, record, msg, coloured=True)
-
-
-def _filter_from_c(logger_name, level):
-    return logging.getLogger(logger_name).isEnabledFor(level)
-
-
-def _log_from_c(logger_name, level, filename, lineno, msg, function_name):
-    """
-    This is for use from the C world, and allows us to insert C stack
-    information.
-    """
-    logger = logging.getLogger(logger_name)
-    if logger.isEnabledFor(level):
-        record = logger.makeRecord(
-            logger.name,
-            level,
-            filename,
-            lineno,
-            msg,
-            None,
-            None,
-            function_name
-        )
-        logger.handle(record)

--- a/cocotb/share/include/embed.h
+++ b/cocotb/share/include/embed.h
@@ -41,7 +41,7 @@ extern "C" {
 
 extern void embed_init_python(void);
 extern void embed_sim_cleanup(void);
-extern int embed_sim_init(gpi_sim_info_t *info);
+extern int embed_sim_init(int argc, char const* const* argv);
 extern void embed_sim_event(gpi_event_t level, const char *msg);
 
 #ifdef __cplusplus

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -82,15 +82,6 @@ typedef enum gpi_event_e {
     SIM_FAIL = 2,
 } gpi_event_t;
 
-typedef struct gpi_sim_info_s
-{
-    int32_t   argc;
-    char      **argv;
-    char      *product;
-    char      *version;
-    int32_t   *reserved[4];
-} gpi_sim_info_t;
-
 // Define a type for our simulation handle.
 typedef void * gpi_sim_hdl;
 
@@ -109,6 +100,8 @@ void gpi_cleanup(void);
 void gpi_get_sim_time(uint32_t *high, uint32_t *low);
 void gpi_get_sim_precision(int32_t *precision);
 
+const char *gpi_get_sim_product(void);
+const char *gpi_get_sim_version(void);
 
 // Functions for extracting a gpi_sim_hdl to an object
 // Returns a handle to the root simulation object,

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -232,7 +232,7 @@ int embed_sim_init(int argc, char const* const* argv)
         return ret;
 
     PyObject *cocotb_module, *cocotb_init, *cocotb_retval;
-    PyObject *cocotb_log_module = NULL;
+    PyObject *cocotb_gpi_module = NULL;
     PyObject *simlog_func;
     PyObject *argv_list;
 
@@ -245,12 +245,12 @@ int embed_sim_init(int argc, char const* const* argv)
     if (get_module_ref("cocotb", &cocotb_module))
         goto cleanup;
 
-    if (get_module_ref("cocotb.log", &cocotb_log_module)) {
+    if (get_module_ref("cocotb._gpi_embed", &cocotb_gpi_module)) {
         goto cleanup;
     }
 
     // Obtain the function to use when logging from C code
-    simlog_func = PyObject_GetAttrString(cocotb_log_module, "_log_from_c");      // New reference
+    simlog_func = PyObject_GetAttrString(cocotb_gpi_module, "_log_from_c");      // New reference
     if (simlog_func == NULL) {
         PyErr_Print();
         LOG_ERROR("Failed to get the _log_from_c function");
@@ -265,7 +265,7 @@ int embed_sim_init(int argc, char const* const* argv)
     set_log_handler(simlog_func);                                       // Note: This function steals a reference to simlog_func.
 
     // Obtain the function to check whether to call log function
-    simlog_func = PyObject_GetAttrString(cocotb_log_module, "_filter_from_c");   // New reference
+    simlog_func = PyObject_GetAttrString(cocotb_gpi_module, "_filter_from_c");   // New reference
     if (simlog_func == NULL) {
         PyErr_Print();
         LOG_ERROR("Failed to get the _filter_from_c method");
@@ -344,7 +344,7 @@ cleanup:
     ret = -1;
 ok:
     Py_XDECREF(cocotb_module);
-    Py_XDECREF(cocotb_log_module);
+    Py_XDECREF(cocotb_gpi_module);
 
     PyGILState_Release(gstate);
     to_simulator();

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -242,8 +242,9 @@ int embed_sim_init(int argc, char const* const* argv)
     PyGILState_STATE gstate = PyGILState_Ensure();
     to_python();
 
-    if (get_module_ref("cocotb", &cocotb_module))
+    if (get_module_ref("cocotb", &cocotb_module)) {
         goto cleanup;
+    }
 
     if (get_module_ref("cocotb._gpi_embed", &cocotb_gpi_module)) {
         goto cleanup;
@@ -256,11 +257,6 @@ int embed_sim_init(int argc, char const* const* argv)
         LOG_ERROR("Failed to get the _log_from_c function");
         goto cleanup;
     }
-    if (!PyCallable_Check(simlog_func)) {
-        LOG_ERROR("_log_from_c is not callable");
-        Py_DECREF(simlog_func);
-        goto cleanup;
-    }
 
     set_log_handler(simlog_func);                                       // Note: This function steals a reference to simlog_func.
 
@@ -269,11 +265,6 @@ int embed_sim_init(int argc, char const* const* argv)
     if (simlog_func == NULL) {
         PyErr_Print();
         LOG_ERROR("Failed to get the _filter_from_c method");
-        goto cleanup;
-    }
-    if (!PyCallable_Check(simlog_func)) {
-        LOG_ERROR("_filter_from_c is not callable");
-        Py_DECREF(simlog_func);
         goto cleanup;
     }
 
@@ -285,22 +276,11 @@ int embed_sim_init(int argc, char const* const* argv)
         LOG_ERROR("Failed to get the _sim_event method");
         goto cleanup;
     }
-    if (!PyCallable_Check(pEventFn)) {
-        LOG_ERROR("cocotb._sim_event is not callable");
-        Py_DECREF(pEventFn);
-        pEventFn = NULL;
-        goto cleanup;
-    }
 
     cocotb_init = PyObject_GetAttrString(cocotb_module, "_initialise_testbench");   // New reference
     if (cocotb_init == NULL) {
         PyErr_Print();
         LOG_ERROR("Failed to get the _initialise_testbench method");
-        goto cleanup;
-    }
-    if (!PyCallable_Check(cocotb_init)) {
-        LOG_ERROR("cocotb._initialise_testbench is not callable");
-        Py_DECREF(cocotb_init);
         goto cleanup;
     }
 

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -230,22 +230,6 @@ int embed_sim_init(gpi_sim_info_t *info)
     if (pEventFn)
         return ret;
 
-    // Find the simulation root
-    const char *dut = getenv("TOPLEVEL");
-
-    if (dut != NULL) {
-        if (!strcmp("", dut)) {
-            /* Empty string passed in, treat as NULL */
-            dut = NULL;
-        } else {
-            // Skip any library component of the toplevel
-            char *dot = strchr(dut, '.');
-            if (dot != NULL) {
-                dut += (dot - dut + 1);
-            }
-        }
-    }
-
     PyObject *cocotb_module, *cocotb_init, *cocotb_retval;
     PyObject *cocotb_log_module = NULL;
     PyObject *simlog_func;
@@ -370,21 +354,7 @@ int embed_sim_init(gpi_sim_info_t *info)
         goto cleanup;
     }
 
-    PyObject *dut_arg;
-    if (dut == NULL) {
-        Py_INCREF(Py_None);
-        dut_arg = Py_None;
-    } else {
-        dut_arg = PyUnicode_FromString(dut);                            // New reference
-    }
-    if (dut_arg == NULL) {
-        PyErr_Print();
-        LOG_ERROR("Unable to create Python object for dut argument of _initialise_testbench");
-        goto cleanup;
-    }
-
-    cocotb_retval = PyObject_CallFunctionObjArgs(cocotb_init, dut_arg, NULL);
-    Py_DECREF(dut_arg);
+    cocotb_retval = PyObject_CallFunctionObjArgs(cocotb_init, NULL);
     Py_DECREF(cocotb_init);
 
     if (cocotb_retval != NULL) {

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -345,28 +345,6 @@ int embed_sim_init(gpi_sim_info_t *info)
         goto cleanup;
     }
 
-    // Set language in use as an attribute to cocotb module, or None if not provided
-    const char *lang = getenv("TOPLEVEL_LANG");
-    PyObject *PyLang;
-    if (lang) {
-        PyLang = PyUnicode_FromString(lang);                            // New reference
-    } else {
-        Py_INCREF(Py_None);
-        PyLang = Py_None;
-    }
-    if (PyLang == NULL) {
-        PyErr_Print();
-        LOG_ERROR("Unable to create Python object for cocotb.LANGUAGE");
-        goto cleanup;
-    }
-    if (-1 == PyObject_SetAttrString(cocotb_module, "LANGUAGE", PyLang)) {
-        PyErr_Print();
-        LOG_ERROR("Unable to set LANGUAGE");
-        Py_DECREF(PyLang);
-        goto cleanup;
-    }
-    Py_DECREF(PyLang);
-
     pEventFn = PyObject_GetAttrString(cocotb_module, "_sim_event");     // New reference
     if (pEventFn == NULL) {
         PyErr_Print();

--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -192,42 +192,16 @@ static std::vector<std::string> get_argv()
 
 int FliStartupCbHdl::run_callback()
 {
-    gpi_sim_info_t sim_info;
 
-    char *c_info       = mti_GetProductVersion();      // Returned pointer must not be freed
-    std::string info   = c_info;
-    std::string search = " Version ";
-    std::size_t found  = info.find(search);
-
-    std::string product_str = c_info;
-    std::string version_str = c_info;
-
-    if (found != std::string::npos) {
-        product_str = info.substr(0,found);
-        version_str = info.substr(found+search.length());
-
-        LOG_DEBUG("Found Version string at %d", found);
-        LOG_DEBUG("   product: %s", product_str.c_str());
-        LOG_DEBUG("   version: %s", version_str.c_str());
-    }
-
-    std::vector<char> product(product_str.begin(), product_str.end());
-    std::vector<char> version(version_str.begin(), version_str.end());
-    product.push_back('\0');
-    version.push_back('\0');
-
-    sim_info.product = &product[0];
-    sim_info.version = &version[0];
-
-    std::vector<std::string> argv = get_argv();
-    std::vector<char*> argv_cstr;
-    for (const auto& arg : argv) {
+    std::vector<std::string> argv_storage = get_argv();
+    std::vector<const char*> argv_cstr;
+    for (const auto& arg : argv_storage) {
         argv_cstr.push_back(const_cast<char*>(arg.c_str()));
     }
-    sim_info.argc = static_cast<int>(argv.size());
-    sim_info.argv = argv_cstr.data();
+    int argc = argv_cstr.size();
+    const char** argv = argv_cstr.data();
 
-    gpi_embed_init(&sim_info);
+    gpi_embed_init(argc, argv);
 
     return 0;
 }

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -434,6 +434,41 @@ void FliImpl::get_sim_precision(int32_t *precision)
     *precision = mti_GetResolutionLimit();
 }
 
+const char *FliImpl::get_sim_product()
+{
+    if (m_product.size() == 0) {
+        char *c_info       = mti_GetProductVersion();      // Returned pointer must not be freed
+        std::string info   = c_info;
+        std::string search = " Version ";
+        std::size_t found  = info.find(search);
+
+        std::string product_str = c_info;
+        std::string version_str = c_info;
+
+        if (found != std::string::npos) {
+            product_str = info.substr(0, found);
+            version_str = info.substr(found+search.length());
+
+            LOG_DEBUG("Found Version string at %d", found);
+            LOG_DEBUG("   product: %s", product_str.c_str());
+            LOG_DEBUG("   version: %s", version_str.c_str());
+        }
+
+        m_product = std::vector<char>(product_str.begin(), product_str.end());
+        m_version = std::vector<char>(version_str.begin(), version_str.end());
+        m_product.push_back('\0');
+        m_version.push_back('\0');
+    }
+
+    return m_product.data();
+}
+
+const char *FliImpl::get_sim_version()
+{
+    get_sim_product();
+    return m_version.data();
+}
+
 /**
  * @name    Find the root handle
  * @brief   Find the root handle using an optional name

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -472,6 +472,8 @@ public:
     void sim_end() override;
     void get_sim_time(uint32_t *high, uint32_t *low) override;
     void get_sim_precision(int32_t *precision) override;
+    const char *get_sim_product() override;
+    const char *get_sim_version() override;
 
     /* Hierachy related */
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) override;
@@ -508,6 +510,8 @@ private:
     FliReadOnlyCbHdl  m_readonly_cbhdl;
     FliNextPhaseCbHdl m_nexttime_cbhdl;
     FliReadWriteCbHdl m_readwrite_cbhdl;
+    std::vector<char> m_product;
+    std::vector<char> m_version;
 };
 
 #endif /*COCOTB_FLI_IMPL_H_ */

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -122,9 +122,9 @@ int gpi_register_impl(GpiImplInterface *func_tbl)
     return 0;
 }
 
-void gpi_embed_init(gpi_sim_info_t *info)
+void gpi_embed_init(int argc, char const* const* argv)
 {
-    if (embed_sim_init(info))
+    if (embed_sim_init(argc, argv))
         gpi_embed_end();
 }
 
@@ -233,6 +233,16 @@ void gpi_get_sim_precision(int32_t *precision)
 
     *precision = val;
 
+}
+
+const char *gpi_get_sim_product()
+{
+    return registered_impls[0]->get_sim_product();
+}
+
+const char *gpi_get_sim_version()
+{
+    return registered_impls[0]->get_sim_version();
 }
 
 gpi_sim_hdl gpi_get_root_handle(const char *name)

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -300,6 +300,8 @@ public:
     virtual void sim_end() = 0;
     virtual void get_sim_time(uint32_t *high, uint32_t *low) = 0;
     virtual void get_sim_precision(int32_t *precision) = 0;
+    virtual const char* get_sim_product() = 0;
+    virtual const char* get_sim_version() = 0;
 
     /* Hierarchy related */
     virtual GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) = 0;
@@ -325,7 +327,7 @@ private:
 /* Called from implementation layers back up the stack */
 int gpi_register_impl(GpiImplInterface *func_tbl);
 
-void gpi_embed_init(gpi_sim_info_t *info);
+void gpi_embed_init(int argc, char const* const* argv);
 void gpi_cleanup();
 void gpi_embed_end();
 void gpi_embed_event(gpi_event_t level, const char *msg);

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -1020,6 +1020,24 @@ static PyObject *error_out(PyObject *m, PyObject *args)
     return NULL;
 }
 
+static PyObject *get_sim_product(PyObject *m, PyObject *args)
+{
+    COCOTB_UNUSED(m);
+    COCOTB_UNUSED(args);
+    const char *product_string = gpi_get_sim_product();
+    PyObject *result = Py_BuildValue("s", product_string);
+    return result;
+}
+
+static PyObject *get_sim_version(PyObject *m, PyObject *args)
+{
+    COCOTB_UNUSED(m);
+    COCOTB_UNUSED(args);
+    const char *version_string = gpi_get_sim_version();
+    PyObject *result = Py_BuildValue("s", version_string);
+    return result;
+}
+
 static int simulator_traverse(PyObject *m, visitproc visit, void *arg) {
     Py_VISIT(GETSTATE(m)->error);
     return 0;

--- a/cocotb/share/lib/simulator/simulatormodule.h
+++ b/cocotb/share/lib/simulator/simulatormodule.h
@@ -87,6 +87,8 @@ static PyObject *next(PyObject *self, PyObject *args);
 
 static PyObject *get_sim_time(PyObject *self, PyObject *args);
 static PyObject *get_precision(PyObject *self, PyObject *args);
+static PyObject *get_sim_product(PyObject *self, PyObject *args);
+static PyObject *get_sim_version(PyObject *self, PyObject *args);
 static PyObject *deregister_callback(PyObject *self, PyObject *args);
 
 static PyObject *log_level(PyObject *self, PyObject *args);
@@ -127,6 +129,8 @@ static PyMethodDef SimulatorMethods[] = {
     {"get_precision", get_precision, METH_VARARGS, "Get the precision of the simulator"},
     {"deregister_callback", deregister_callback, METH_VARARGS, "De-register a callback"},
     {"error_out", error_out, METH_NOARGS, NULL},
+    {"product", get_sim_product, METH_NOARGS, "Simulator product information"},
+    {"version", get_sim_version, METH_NOARGS, "Simulator product version information"},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -847,16 +847,11 @@ VhpiStartupCbHdl::VhpiStartupCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
 
 int VhpiStartupCbHdl::run_callback() {
     vhpiHandleT tool, argv_iter, argv_hdl;
-    gpi_sim_info_t sim_info;
     char **tool_argv = NULL;
     int tool_argc = 0;
     int i = 0;
 
     tool = vhpi_handle(vhpiTool, NULL);
-
-    sim_info.product = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiNameP, tool)));
-    sim_info.version = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiToolVersionP, tool)));
-
     if (tool) {
         tool_argc = static_cast<int>(vhpi_get(vhpiArgcP, tool));
         tool_argv = new char*[tool_argc];
@@ -870,13 +865,11 @@ int VhpiStartupCbHdl::run_callback() {
             }
             vhpi_release_handle(argv_iter);
         }
-        sim_info.argc = tool_argc;
-        sim_info.argv = tool_argv;
 
         vhpi_release_handle(tool);
     }
 
-    gpi_embed_init(&sim_info);
+    gpi_embed_init(tool_argc, tool_argv);
     delete [] tool_argv;
 
     return 0;

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -110,6 +110,30 @@ void VhpiImpl::get_sim_precision(int32_t *precision)
     *precision = log10int(femtoseconds) - 15;
 }
 
+const char *VhpiImpl::get_sim_product()
+{
+    if (!m_product) {
+        vhpiHandleT tool = vhpi_handle(vhpiTool, NULL);
+        if (tool) {
+            m_product = static_cast<const char*>(vhpi_get_str(vhpiNameP, tool));
+            vhpi_release_handle(tool);
+        }
+    }
+    return m_product;
+}
+
+const char *VhpiImpl::get_sim_version()
+{
+    if (!m_version) {
+        vhpiHandleT tool = vhpi_handle(vhpiTool, NULL);
+        if (tool) {
+            m_version = static_cast<const char*>(vhpi_get_str(vhpiToolVersionP, tool));
+            vhpi_release_handle(tool);
+        }
+    }
+    return m_version;
+}
+
 // Determine whether a VHPI object type is a constant or not
 bool is_const(vhpiHandleT hdl)
 {

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -241,12 +241,16 @@ public:
     VhpiImpl(const std::string& name) : GpiImplInterface(name),
                                         m_read_write(this),
                                         m_next_phase(this),
-                                        m_read_only(this) { }
+                                        m_read_only(this),
+                                        m_product(NULL),
+                                        m_version(NULL) { }
 
      /* Sim related */
     void sim_end() override;
     void get_sim_time(uint32_t *high, uint32_t *low) override;
     void get_sim_precision(int32_t *precision) override;
+    const char *get_sim_product() override;
+    const char *get_sim_version() override;
 
     /* Hierachy related */
     GpiObjHdl *get_root_handle(const char *name) override;
@@ -273,6 +277,8 @@ private:
     VhpiReadwriteCbHdl m_read_write;
     VhpiNextPhaseCbHdl m_next_phase;
     VhpiReadOnlyCbHdl m_read_only;
+    const char *m_product;
+    const char *m_version;
 };
 
 #endif /*COCOTB_VHPI_IMPL_H_  */

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -486,16 +486,10 @@ VpiStartupCbHdl::VpiStartupCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
 
 int VpiStartupCbHdl::run_callback() {
     s_vpi_vlog_info info;
-    gpi_sim_info_t sim_info;
 
     vpi_get_vlog_info(&info);
 
-    sim_info.argc = info.argc;
-    sim_info.argv = info.argv;
-    sim_info.product = info.product;
-    sim_info.version = info.version;
-
-    gpi_embed_init(&sim_info);
+    gpi_embed_init(info.argc, info.argv);
 
     return 0;
 }

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -72,6 +72,20 @@ void VpiImpl::get_sim_precision(int32_t *precision)
     *precision = vpi_get(vpiTimePrecision, NULL);
 }
 
+const char *VpiImpl::get_sim_product()
+{
+    s_vpi_vlog_info info;
+    vpi_get_vlog_info(&info);
+    return info.product;
+}
+
+const char *VpiImpl::get_sim_version()
+{
+    s_vpi_vlog_info info;
+    vpi_get_vlog_info(&info);
+    return info.version;
+}
+
 gpi_objtype_t to_gpi_objtype(int32_t vpitype)
 {
     switch (vpitype) {

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -241,6 +241,8 @@ public:
     void sim_end(void) override;
     void get_sim_time(uint32_t *high, uint32_t *low) override;
     void get_sim_precision(int32_t *precision) override;
+    const char *get_sim_product() override;
+    const char *get_sim_version() override;
 
     /* Hierarchy related */
     GpiObjHdl *get_root_handle(const char *name) override;

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -73,6 +73,7 @@ MODULE                    Modules to search for test functions (comma-separated)
 TESTCASE                  Test function(s) to run (comma-separated list)
 COCOTB_RESULTS_FILE       File name for xUnit XML tests results
 SCRIPT_FILE               Simulator script to run (for e.g. wave traces)
+COCOTB_ENTRY              Python entry point (default: cocotb._initialise_testbench)
 
 Additional Environment Variables
 --------------------------------

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -207,6 +207,16 @@ Environment Variables
     You can usually write out such a file from the simulator's GUI.
     This is currently supported for the Mentor Questa, Mentor ModelSim and Aldec Riviera simulators.
 
+.. envvar:: COCOTB_ENTRY
+
+        The Python framework entry point from the GPI.
+        The entry point is specified as the module to load and the function in that module to run at initialization.
+        The format is ``entry.module.name:entry_function_name``.
+        By default this is ``cocotb._initialize_testbench``; this starts the cocotb regression manager.
+        Entry modules and functions have certain requirements, see :ref:`custom-entry-point`.
+
+        .. versionadded:: 1.4
+
 
 Additional Environment Variables
 --------------------------------

--- a/documentation/source/cocotb_entry_point.rst
+++ b/documentation/source/cocotb_entry_point.rst
@@ -1,0 +1,46 @@
+
+.. _custom-entry-point:
+
+******************
+Cocotb Entry Point
+******************
+
+By default, when cocotb is loaded, it perfoms some basic initialization and starts the regression manager.
+However, there are many reasons why a user might want to do something different:
+
+* select an alternative regression system
+* override cocotb initializations
+* experiment
+
+To support this, the environment variable :envvar:`COCOTB_ENTRY` can be used to specify an alternative Python module and function to load after the Python interpreter has been initialized.
+
+.. warning:: This is intended for advanced users only
+
+.. versionadded:: 1.4
+
+How It Works
+============
+
+Once the Python/GPI ``embed`` library is loaded, it does the following:
+
+- starts the Python interpreter
+- loads the ``cocotb`` module
+- calls the ``_initialise_testbench`` function in the ``cocotb`` module
+- ``_initialise_testbench`` starts the regression manager.
+
+The :envvar:`COCOTB_ENTRY` variable allows the user to load a module other than ``cocotb``, and run an entry function other than ``_initialise_testbench``.
+See the documentation for :envvar:`COCOTB_ENTRY` for details on the entry point specification.
+
+Entry Point Interface Requirements
+==================================
+
+The Python/GPI ``embed`` library expects the following functions to be implemented in the entry module. The names are required.
+
+.. py:function:: _sim_event(level: int, message: str) -> None
+
+Finally, there is the entry function itself.
+An entry function is not required to be named the same, and an entry module can contain multiple entry functions.
+
+.. py:function:: _main(argv: List[str]) -> None
+
+Entry functions take an argument list, much like any Python ``main`` function, that returns nothing. If the entry function encounters an error, it should raise an exception.

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -14,6 +14,7 @@ Contents:
    coroutines
    triggers
    testbench_tools
+   cocotb_entry_point
    library_reference
    library_reference_c
    endian_swapper

--- a/documentation/source/newsfragments/1293.feature.rst
+++ b/documentation/source/newsfragments/1293.feature.rst
@@ -1,0 +1,1 @@
+Added :envvar:`COCOTB_ENTRY`, a custom entry point from C into Python. This allows the user to enter into any arbitrary module or function to extend or replace the default regression manager entry point. See :ref:`custom-entry-point` for more details.

--- a/tests/test_cases/test_cocotb_entry/.gitignore
+++ b/tests/test_cases/test_cocotb_entry/.gitignore
@@ -1,0 +1,1 @@
+results.txt

--- a/tests/test_cases/test_cocotb_entry/Makefile
+++ b/tests/test_cases/test_cocotb_entry/Makefile
@@ -1,0 +1,8 @@
+
+.PHONY: custom_entry_test
+custom_entry_test:
+	$(MAKE) all COCOTB_ENTRY=example_entry:entry_object.entry_func
+	# ensure custom entry point is loaded and run as expected
+	python check_results.py
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_cocotb_entry/check_results.py
+++ b/tests/test_cases/test_cocotb_entry/check_results.py
@@ -1,0 +1,11 @@
+import re
+
+
+result = open("results.txt").read()
+
+expected = r"""Ran entry_func: \[.*\]
+Ran event_func: 2, Simulator shutdown prematurely
+Shutting down
+"""
+
+assert re.match(expected, result)

--- a/tests/test_cases/test_cocotb_entry/example_entry.py
+++ b/tests/test_cases/test_cocotb_entry/example_entry.py
@@ -1,0 +1,28 @@
+import os
+from cocotb.xunit_reporter import XUnitReporter
+
+
+class EntryClass():
+
+    def __init__(self):
+        self.file = open('results.txt', 'w')
+        print("Created entry_object")
+
+    def entry_func(self, argv):
+        print("Ran entry_func: {}".format(argv), file=self.file)
+
+    def event_func(self, level, message):
+        print("Ran event_func: {}, {}".format(level, message), file=self.file)
+
+    def __del__(self):
+        print("Shutting down", file=self.file)
+        self.file.close()
+
+
+entry_object = EntryClass()
+
+_sim_event = entry_object.event_func
+
+# horrible hack around the fact the makefiles expect a results.xml from every test
+results_filename = os.getenv('COCOTB_RESULTS_FILE', "results.xml")
+XUnitReporter(filename=results_filename).write()


### PR DESCRIPTION
Adds `PYTHON_ENTRY` environment variable for users to enter into a custom environment rather than loading into the `cocotb` Python module as described in #1225. Also tried to shrink the interface between `gpi_embed` and the `cocotb` module by pushing much of what `embed_sim_init` into Python, and communicating the rest by passing by argument to the entry point.

This is best reviewed commit by commit.

### Interface
 - `_sim_event` in entry module
 - `_log_from_c` in entry module
 - `_filter_from_c` in entry module
 - entry function in entry module
  - takes `argc`, `argv`, and simulator details

### TODO
 - [x] document `COCOTB_ENTRY`
 - [x] document custom entry point's interface requirements
 - [x] more thorough `COCOTB_ENTRY` spec checking
 - [x] cleanup `gpi_embed` to reduce interface requirements on custom module
 - [x] Add example