### PR TITLE
Increase version number to 1.4.0 pre-release

### DIFF
--- a/cocotb/_version.py
+++ b/cocotb/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '1.3.0'
+__version__ = '1.4.0.dev0'


### PR DESCRIPTION
The next (planned) version of cocotb will be 1.4.0. Increase the in-tree
version number to reflect that.

The naming is based on the rules outlined in
https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning.