### PR TITLE
Install swig on linux ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
     - stage: SimTests
       python: 3.7
       before_install: &travis_linx_prep
-        - sudo apt-get install gperf
+        - sudo apt-get -y install gperf swig
         - if [[ ! -e "./iverilog/README.txt" ]]; then rm -rf iverilog; git clone https://github.com/steveicarus/iverilog.git --depth=1 --branch v10_2; fi
         - cd iverilog && autoconf && ./configure && make -j2 && sudo make install && cd ..
         - pip install tox


### PR DESCRIPTION
Addressing #1296

As far as I can see to make it do anything one needs to change `MODULE` to `test_endian_swapper_hal` here: https://github.com/cocotb/cocotb/blob/ccb8a8311271a1f333553897e58b392d1655487c/examples/endian_swapper/tests/Makefile#L55