### PR TITLE
Add towncrier to maintain release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ All changes which should go into the main codebase of cocotb must follow this se
 - All code must pass existing tests.
   New functionality must be accompanied by tests, and bug fixes should add tests to increase the test coverage and prevent regressions.
 - If code changes or enhances documented behavior the documentation should be updated.
+- If a change is user-visible, a newsfragment should be added to `documentation/source/newsfragments`.
 - All pull requests must be accepted by at least one maintainer, with no maintainer strongly objecting.
   Reviews must be performed by a person other than the primary author of the code.
 - All commits should follow established best practices when creating a commit message:

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -8,3 +8,4 @@ sphinxcontrib-spelling
 pyenchant
 sphinx-issues
 sphinx-argparse
+towncrier

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -334,6 +334,15 @@ spelling_ignore_pypi_package_names = False
 spelling_ignore_wiki_words = False
 spelling_show_suggestions = True
 
-# -- Setup for inheritance_diagram directive which uses graphviz ---------------
+# -- Extra setup for inheritance_diagram directive which uses graphviz ---------
 
 graphviz_output_format = 'svg'
+
+# -- Extra setup for towncrier -------------------------------------------------
+# see also https://towncrier.readthedocs.io/en/actual-freaking-docs/
+
+in_progress_notes = subprocess.check_output(['towncrier', '--draft'],
+                                            cwd='../..',
+                                            universal_newlines=True)
+with open('generated/master-notes.rst', 'w') as f:
+    f.write(in_progress_notes)

--- a/documentation/source/newsfragments/1255.feature.rst
+++ b/documentation/source/newsfragments/1255.feature.rst
@@ -1,0 +1,13 @@
+Cocotb now supports the following example of forking a *non-decorated* :ref:`async coroutine <async_functions>`.
+
+.. code-block:: python3
+
+   async def example():
+       for i in range(10):
+           await cocotb.triggers.Timer(10, "ns")
+
+   cocotb.fork(example())
+
+..
+   towncrier will append the issue number taken from the file name here:
+Issue

--- a/documentation/source/newsfragments/README.rst
+++ b/documentation/source/newsfragments/README.rst
@@ -1,0 +1,42 @@
+:orphan:
+
+Release Notes
+=============
+
+We are using `towncrier <https://pypi.org/project/towncrier/>`_ to handle
+our release notes, and this directory contains the input for it -
+"news fragments" which are short files that contain a small
+**ReST**-formatted text that will be added to the next version's
+Release Notes page.
+
+Each file should be named like ``<ISSUE_OR_PR>.<TYPE>.rst``,
+where ``<ISSUE_OR_PR>`` is an issue or a pull request number -
+whatever is most useful to link to,
+and ``<TYPE>`` is one of:
+
+* ``feature``: New user-facing feature.
+* ``bugfix``: A bug fix.
+* ``doc``: Documentation improvement.
+* ``removal``: Deprecation or removal of public API or behavior.
+* ``change``: A change in public API or behavior.
+
+In that file, make sure to use full sentences with correct case and punctuation,
+and do not use a bullet point at the beginning of the file.
+Use Sphinx references (see https://sphinx-tutorial.readthedocs.io/cheatsheet/)
+if you refer to added classes, methods etc.
+
+An example file could consist of the content between the marks:
+
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+Summary of a new feature.
+
+This is a second paragraph.
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+Note that the last paragraph should be a normal sentence and not e.g. code,
+because the issue number is appended there.
+
+Towncrier automatically assembles a list of unreleased changes when building Sphinx,
+meaning your notes will be visible in the documentation immediately after merging.
+When performing a release, ``towncrier`` should be run independently (in cocotb's root directory),
+which will delete all the merged newsfragments, and create new commits.

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -4,6 +4,10 @@ Release Notes
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
+.. include:: generated/master-notes.rst
+
+.. towncrier release notes start
+
 cocotb 1.3.0
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[tool.towncrier]
+    package = "cocotb"
+    directory = "documentation/source/newsfragments"
+    filename = "documentation/source/release_notes.rst"
+    issue_format = ":pr:`{issue}`"
+    underlines = '=-^"'  # the full list is '#*=-^"' but the two highest levels are not handled by towncrier
+    all_bullets = false
+
+    [[tool.towncrier.type]]
+        directory = "feature"
+        name = "Features"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "bugfix"
+        name = "Bugfixes"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "doc"
+        name = "Improved Documentation"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "removal"
+        name = "Deprecations and Removals"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "change"
+        name = "Changes"
+        showcontent = true


### PR DESCRIPTION
Towncrier (https://towncrier.readthedocs.io/en/actual-freaking-docs/) allows user-defined categories which we may want to use later, but this PR just uses the defaults for now.

https://external-builds.readthedocs.io/html/cocotb/1303/release_notes.html