### PR TITLE
Avoid recursing if get_sim_time logs

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -108,8 +108,13 @@ class SimLogFormatter(logging.Formatter):
         return string.rjust(chars)
 
     def _format(self, level, record, msg, coloured=False):
-        time_ns = get_sim_time('ns')
-        simtime = "%6.2fns" % (time_ns)
+        try:
+            time_ns = get_sim_time('ns')
+            simtime = "%6.2fns" % (time_ns)
+        except RecursionError:
+            # get_sim_time might have failed and tried to log - if this
+            # happens, better to discard the timestamp than skip the message
+            simtime = "  -.--ns"
         prefix = simtime.rjust(11) + ' ' + level + ' '
         if not _suppress:
             prefix += self.ljust(record.name, _RECORD_CHARS) + \


### PR DESCRIPTION
If `get_sim_time` tries to log, we enter an infinite recursion.

Ideally, we would cut this short immediately - but as an interim measure, let's at least recover gracefully when we cause a python RecursionError.

Found in #1313, but tangential to the original question.