### PR TITLE
Remove -Werror

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -72,7 +72,7 @@ export INCLUDES := -I$(COCOTB_SHARE_DIR)/include -I$(PYTHON_INCLUDEDIR)
 LIB_EXT    := so
 PY_EXT     := so
 
-BASE_WARNS := -Wall -Wextra -Wconversion -Wcast-qual -Wwrite-strings -Werror
+BASE_WARNS := -Wall -Wextra -Wconversion -Wcast-qual -Wwrite-strings
 CC_WARNS   := $(BASE_WARNS) -Wstrict-prototypes -Waggregate-return
 CXX_WARNS  := $(BASE_WARNS) -Wnon-virtual-dtor -Woverloaded-virtual
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py27,py35
 
 [testenv]
+setenv =
+    CFLAGS = -Werror
+    CXXFLAGS = -Werror
 passenv =
     SIM
 


### PR DESCRIPTION
Addresses some issues in #1323. Removed the `-Werror` flag from the build scripts. This flag should only every be passed by CI system for compliance.