### PR TITLE
Fix target $(COCOTB_RESULTS_FILE) by using a tab

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -30,7 +30,7 @@
 ifneq ($(VHDL_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):
-    @echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
+	@echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
 clean::
 
 else


### PR DESCRIPTION
This problem would only show up with ``TOPLEVEL_LANG=vhdl``.