### PR TITLE
Simplify traceback propagation

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -37,7 +37,7 @@ import os
 import cocotb
 from cocotb.log import SimLog
 from cocotb.result import ReturnValue
-from cocotb.utils import get_sim_time, lazy_property
+from cocotb.utils import get_sim_time, lazy_property, remove_traceback_frames
 from cocotb import outcomes
 from cocotb import _py_compat
 
@@ -152,7 +152,7 @@ class RunningTask(object):
             self._outcome = outcomes.Value(retval)
             raise CoroutineComplete()
         except BaseException as e:
-            self._outcome = outcomes.Error(e).without_frames(['_advance', 'send'])
+            self._outcome = outcomes.Error(remove_traceback_frames(e, ['_advance', 'send']))
             raise CoroutineComplete()
 
     def send(self, value):

--- a/cocotb/outcomes.py
+++ b/cocotb/outcomes.py
@@ -5,8 +5,6 @@ An outcome is similar to the builtin `concurrent.futures.Future`
 or `asyncio.Future`, but without being tied to a particular task model.
 """
 import abc
-import copy
-import sys
 
 from cocotb import _py_compat
 from cocotb.utils import remove_traceback_frames
@@ -17,6 +15,7 @@ def capture(fn, *args, **kwargs):
     try:
         return Value(fn(*args, **kwargs))
     except BaseException as e:
+        e = remove_traceback_frames(e, ['capture'])
         return Error(e)
 
 
@@ -44,59 +43,15 @@ class Value(Outcome):
         return "Value({!r})".format(self.value)
 
 
-class _ErrorBase(Outcome):
+class Error(Outcome):
     def __init__(self, error):
         self.error = error
 
+    def send(self, gen):
+        return gen.throw(self.error)
+
+    def get(self):
+        raise self.error
+
     def __repr__(self):
         return "Error({!r})".format(self.error)
-
-
-if sys.version_info.major >= 3:
-    class Error(_ErrorBase):
-        def send(self, gen):
-            return gen.throw(self.error)
-
-        def get(self):
-            raise self.error
-
-        # Once we drop Python 2, this can be inlined at the caller, it's here
-        # just for convenience writing code that works on both versions
-        def without_frames(self, frame_names):
-            return Error(remove_traceback_frames(self.error, frame_names))
-
-else:
-    # Python 2 needs extra work to preserve tracebacks
-    class Error(_ErrorBase):
-        def __init__(self, error):
-            super(Error, self).__init__(error)
-            # guess the traceback
-            t, e, tb = sys.exc_info()
-            if e is error:
-                self.error_type = t
-                self.error_tb = tb
-            else:
-                # no traceback - this might be a new exception
-                self.error_type = type(error)
-                self.error_tb = None
-
-        def send(self, gen):
-            return gen.throw(self.error_type, self.error, self.error_tb)
-
-        def without_frames(self, frame_names):
-            ret = copy.copy(self)
-            ret.error_tb = remove_traceback_frames(ret.error_tb, frame_names)
-            return ret
-
-        # We need a wrapper function to ensure the traceback is the same
-        # depth as on Python 3 - `raise type, val, tb` is not included in the
-        # stack trace in Python 2.
-        _py_compat.exec_("""def _get(self):
-            try:
-                raise self.error_type, self.error, self.error_tb
-            finally:
-                del self
-        """)
-
-        def get(self):
-            return self._get()

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -63,6 +63,7 @@ from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly,
                              NextTimeStep, ReadWrite, Event, Join, NullTrigger)
 from cocotb.log import SimLog
 from cocotb.result import TestComplete, ReturnValue
+from cocotb.utils import remove_traceback_frames
 from cocotb import _py_compat
 
 # On python 3.7 onwards, `dict` is guaranteed to preserve insertion order.
@@ -505,11 +506,11 @@ class Scheduler(object):
                 coro._outcome.get()
             except (TestComplete, AssertionError) as e:
                 coro.log.info("Test stopped by this forked coroutine")
-                outcome = outcomes.Error(e).without_frames(['unschedule', 'get'])
+                outcome = outcomes.Error(remove_traceback_frames(e, ['unschedule', 'get']))
                 self._test._force_outcome(outcome)
             except Exception as e:
                 coro.log.error("Exception raised by this forked coroutine")
-                outcome = outcomes.Error(e).without_frames(['unschedule', 'get'])
+                outcome = outcomes.Error(remove_traceback_frames(e, ['unschedule', 'get']))
                 self._test._force_outcome(outcome)
 
     def save_write(self, handle, value):

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -41,7 +41,7 @@ from cocotb.log import SimLog
 from cocotb.result import ReturnValue
 from cocotb.utils import (
     get_sim_steps, get_time_from_sim_steps, ParametrizedSingleton,
-    lazy_property,
+    lazy_property, remove_traceback_frames,
 )
 from cocotb import decorators
 from cocotb import outcomes
@@ -691,7 +691,7 @@ def _wait_callback(trigger, callback):
         ret = outcomes.Value((yield trigger))
     except BaseException as exc:
         # hide this from the traceback
-        ret = outcomes.Error(exc).without_frames(['_wait_callback'])
+        ret = outcomes.Error(remove_traceback_frames(exc, ['_wait_callback']))
     callback(ret)
 
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -539,11 +539,6 @@ def remove_traceback_frames(tb_or_exc, frame_names):
     # self-invoking overloads
     if isinstance(tb_or_exc, BaseException):
         exc = tb_or_exc
-        if sys.version_info < (3,):
-            raise RuntimeError(
-                "Cannot use remove_traceback_frames on exceptions in python 2. "
-                "Call it directly on the traceback object instead.")
-
         return exc.with_traceback(
             remove_traceback_frames(exc.__traceback__, frame_names)
         )


### PR DESCRIPTION
This commit removes all the workarounds that were necessary to propagate tracebacks on Python 2.7 and 3.4 - now that our minimum supported version is Python 3.5.

This reverts most of gh-1100, along with some other exc_info-related cleanup.

xref #1289 