### PR TITLE
Use syntax for keyword-only arguments

### DIFF
--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -299,8 +299,7 @@ class ValidatedBusDriver(BusDriver):
             ``(valid, invalid)`` cycles to insert.
     """
 
-    def __init__(self, entity, name, clock, **kwargs):
-        valid_generator = kwargs.pop("valid_generator", None)
+    def __init__(self, entity, name, clock, *, valid_generator=None, **kwargs):
         BusDriver.__init__(self, entity, name, clock, **kwargs)
         self.set_valid_generator(valid_generator=valid_generator)
 

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -512,8 +512,7 @@ class AvalonST(ValidatedBusDriver):
 
     _default_config = {"firstSymbolInHighOrderBits" : True}
 
-    def __init__(self, entity, name, clock, **kwargs):
-        config = kwargs.pop('config', {})
+    def __init__(self, entity, name, clock, *, config={}, **kwargs):
         ValidatedBusDriver.__init__(self, entity, name, clock, **kwargs)
 
         self.config = AvalonST._default_config.copy()
@@ -605,8 +604,7 @@ class AvalonSTPkts(ValidatedBusDriver):
         "readyLatency"                  : 0
     }
 
-    def __init__(self, entity, name, clock, **kwargs):
-        config = kwargs.pop('config', {})
+    def __init__(self, entity, name, clock, *, config={}, **kwargs):
         ValidatedBusDriver.__init__(self, entity, name, clock, **kwargs)
 
         self.config = AvalonSTPkts._default_config.copy()

--- a/cocotb/monitors/avalon.py
+++ b/cocotb/monitors/avalon.py
@@ -55,8 +55,7 @@ class AvalonST(BusMonitor):
 
     _default_config = {"firstSymbolInHighOrderBits": True}
 
-    def __init__(self, entity, name, clock, **kwargs):
-        config = kwargs.pop('config', {})
+    def __init__(self, entity, name, clock, *, config={}, **kwargs):
         BusMonitor.__init__(self, entity, name, clock, **kwargs)
 
         self.config = self._default_config.copy()
@@ -109,9 +108,7 @@ class AvalonSTPkts(BusMonitor):
         "invalidTimeout"                : 0,
     }
 
-    def __init__(self, entity, name, clock, **kwargs):
-        config = kwargs.pop('config', {})
-        report_channel = kwargs.pop('report_channel', False)
+    def __init__(self, entity, name, clock, *, config={}, report_channel=False, **kwargs):
         BusMonitor.__init__(self, entity, name , clock, **kwargs)
 
         self.config = self._default_config.copy()

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -459,7 +459,15 @@ def reject_remaining_kwargs(name, kwargs):
 
         def func(x1, *, a=1, b=2):
             ...
+
+    .. deprecated:: 1.4
+        Since the minimum supported Python version is now 3.5, this function
+        is not needed.
     """
+    warnings.warn(
+        "reject_remaining_kwargs is deprecated and will be removed, use "
+        "Python 3 keyword-only arguments directly.", DeprecationWarning,
+        stacklevel=2)
     if kwargs:
         # match the error message to what Python 3 produces
         bad_arg = next(iter(kwargs))

--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -29,7 +29,6 @@ from collections import OrderedDict, defaultdict
 import cocotb
 from cocotb.bus import Bus
 from cocotb.triggers import RisingEdge, ReadOnly
-from cocotb.utils import reject_remaining_kwargs
 
 
 class Wavedrom(object):
@@ -129,11 +128,8 @@ class trace(object):
             j = waves.dumpj()
     """
 
-    def __init__(self, *args, **kwargs):
-        # emulate keyword-only arguments in python 2
-        self._clock = kwargs.pop("clk", None)
-        reject_remaining_kwargs('__init__', kwargs)
-
+    def __init__(self, *args, clk=None):
+        self._clock = clk
         self._signals = []
         for arg in args:
             self._signals.append(Wavedrom(arg))

--- a/documentation/source/newsfragments/1339.removal.rst
+++ b/documentation/source/newsfragments/1339.removal.rst
@@ -1,0 +1,2 @@
+:func:`cocotb.utils.reject_remaining_kwargs` is deprecated, as it is no longer
+needed now that we only support Python 3.5 and newer.


### PR DESCRIPTION
This avoids the need for popping kwargs from dictionaries.
It also leads to better documentation both in sphinx and from the `help` builtin.

This removes the last caller of `reject_remaining_kwargs`, although we leave the function around for now in case downstream users are using it.