### PR TITLE
Remove references to Python 2.7 from docs

### DIFF
--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -28,18 +28,11 @@ Coroutines may also yield other coroutines:
             yield wait_10ns()
 
 Coroutines can return a value, so that they can be used by other coroutines.
-Before Python 3.3, this requires a :any:`ReturnValue` to be raised.
 
 .. code-block:: python3
 
     @cocotb.coroutine
     def get_signal(clk, signal):
-        yield RisingEdge(clk)
-        raise ReturnValue(signal.value)
-
-    @cocotb.coroutine
-    def get_signal_python_33(clk, signal):
-        # newer versions of Python can use return normally
         yield RisingEdge(clk)
         return signal.value
 

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -10,11 +10,13 @@ Pre-requisites
 
 Cocotb has the following requirements:
 
-* Python 2.7, Python 3.5+ (recommended)
+* Python 3.5+
 * Python-dev packages
 * GCC 4.8.1+ or Clang 3.3+ and associated development packages
 * GNU Make
 * A Verilog or VHDL simulator, depending on your RTL source code
+
+.. versionchanged:: 1.4 Dropped Python 2 support
 
 Installation via PIP
 --------------------
@@ -27,12 +29,6 @@ Cocotb can be installed by running
 
     pip3 install cocotb
 
-or
-
-.. code-block:: bash
-
-    pip install cocotb
-
 For user local installation follow the
 `pip User Guide <https://pip.pypa.io/en/stable/user_guide/#user-installs/>`_.
 
@@ -41,7 +37,7 @@ To install the development version of cocotb:
 .. code-block:: bash
 
     git clone https://github.com/cocotb/cocotb
-    pip install -e ./cocotb
+    pip3 install -e ./cocotb
 
 
 Native Linux Installation


### PR DESCRIPTION
Addresses some points from #1289.