### PR TITLE
Document extension conventions

### DIFF
--- a/documentation/source/extensions.rst
+++ b/documentation/source/extensions.rst
@@ -1,0 +1,110 @@
+Writing cocotb extensions
+=========================
+
+This guide explains how to write cocotb extensions, with a focus on the conventions that should be followed.
+
+Cocotb gives its users a framework to build Python testbenches for hardware designs.
+But sometimes the functionality provided by cocotb is too low-level.
+One common example are bus drivers and monitors:
+instead of creating a bus adapter from scratch for each new project, wouldn't it be nice to share this component, and build on top it?
+In the verification world, such extensions are often called "verification IP" (VIP).
+
+In cocotb, such functionality can be packaged and distributed as extensions.
+Technically, cocotb extensions are normal Python packages, and all standard Python packaging and distribution techniques can be used.
+Additionally, the cocotb community has agreed on a set of conventions to make extensions easier to use and to discover.
+
+Naming conventions
+------------------
+
+Cocotb extensions are normal Python modules which follow these naming conventions.
+
+Assuming an extension named ``EXTNAME`` (all lower-case),
+
+- the package is in the ``cocotbext.EXTNAME`` namespace, and
+- the distribution (package) name is prefixed with ``cocotbext-EXTNAME``.
+
+Example:
+An SPI bus extension might be packaged as ``cocotbext-spi``, and its functionality would live in the ``cocotbext.spi`` namespace.
+The module can then be installed with ``pip3 install cocotbext-spi``, and used with ``import cocotbext.spi``.
+
+Types of cocotb extensions
+--------------------------
+
+For some types of cocotb extensions we have developed conventions which go beyond naming.
+These conventions help to achieve a consistent behavior across extensions of the same type.
+
+Bus extensions
+~~~~~~~~~~~~~~
+
+A cocotb extension which interacts with a bus or an interface (such as SPI or AXI) should build on top of a common set of classes to provide a uniform interface for its users.
+Typically, a bus extension provides three pieces of functionality:
+an abstraction of the bus itself, a bus driver, and a bus monitor.
+
+A bus driver is the "active" part, it drives the signals that make up the bus to request reads or writes from the bus.
+A bus monitor is the "passive" part, it observes signal changes on the bus and assigns meaning to them.
+Monitors can also check the bus behavior against a standard to ensure no invalid states are being observed.
+
+The signals which make up the bus should be grouped in a class inheriting from :any:`cocotb.bus.Bus`.
+Bus drivers should inherit from the :any:`cocotb.drivers.BusDriver` class.
+Bus monitors should inherit from the :any:`cocotb.monitors.BusMonitor` class.
+
+Packaging extensions
+--------------------
+
+To package a cocotb extension as Python package follow the :ref:`naming conventions <Naming conventions>`, and the `normal Python packaging rules <https://packaging.python.org/tutorials/packaging-projects/>`_.
+Extensions namespaced packages, implemented using the `native namespacing <https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages>`_ approach discussed in :pep:`420`.
+The module file hierarchy should be as follows (replace ``EXTNAME`` with the name of the extension, e.g. ``spi``).
+
+.. code-block::
+
+  # file structure of the cocotbext-EXTNAME repository
+  ├── cocotbext/
+  │   │   # No __init__.py here.
+  │   └── EXTNAME/
+  │       └── __init__.py
+  ├── README.md
+  └── setup.py
+
+The Python source code should go into the :file:`EXTNAME` directory, next to the :file:`__init__.py` file.
+All packaging metadata goes into :file:`setup.py`.
+
+.. code-block:: python3
+
+  # Minimal setup.py. Extend as needed.
+  from setuptools import setup, find_namespace_packages
+
+  setup(name = 'cocotbext-EXTNAME',
+        version = '0.1',
+        packages = find_namespace_packages(include=['cocotbext.*']),
+        install_requires = ['cocotb'],
+        python_requires = '>=3.5',
+        classifiers = [
+          "Programming Language :: Python :: 3",
+          "Operating System :: OS Independent",
+          "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)"])
+
+With this file structure in place the cocotb extension can be installed through ``pip`` in development mode ::
+
+  $ python3 -m pip install -e .
+
+Once the extension has been `uploaded to PyPi <https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives>`_, it can be installed by name.
+
+.. code-block: command
+
+  $ python3 -m pip install cocotbext-EXTNAME
+
+To use the functionality in the extension module, import it into your testbench.
+
+.. code-block:: python3
+
+  # Examples for importing (parts of) the extension
+  import cocotbext.EXTNAME
+  from cocotbext import EXTNAME
+  from cocotbext.EXTNAME import MyVerificationClass
+
+Code hosting
+------------
+
+The source code of cocotb extensions can be hosted anywhere.
+If authors wish to do so, extensions can also be hosted on GitHub in the `cocotb GitHub organization <https://github.com/cocotb>`_ (e.g. ``github.com/cocotb/cocotbext-EXTNAME``).
+Please file a `GitHub issue in the cocotb repository <https://github.com/cocotb/cocotb/issues>`_ if you'd like to discuss that.

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -9,6 +9,7 @@ Contents:
    introduction
    quickstart
    building
+   writing_testbenches
    coroutines
    triggers
    testbench_tools

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -21,6 +21,7 @@ Contents:
    examples
    troubleshooting
    simulator_support
+   extensions
    roadmap
    release_notes
 

--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -1,0 +1,14 @@
+Writing Testbenches
+===================
+
+Handling Errors
+---------------
+
+It may not be clear when to raise an exception and when to use ``log.error()``.
+
+* Use ``raise`` if the caller called your function in an invalid way, and it doesn't make sense to continue.
+* Use ``log.error()`` if the hardware itself is misbehaving, and throwing an error immediately would leave it an invalid state.
+
+Even if you do eventually throw an exception (if you weren't able to do it immediately), you should also ``log.error()`` so that the simulation time of when things went wrong is recorded.
+
+TL;DR: ``log.error()`` is for humans only, ``raise`` is for both humans and code.


### PR DESCRIPTION
This is a follow-up to #1141.

When fiddling with the wording in ##1141 I realized there are some changes I'd like to make, and I thought the easiest way of doing so is in a new PR. Thanks @Martoni for a great starting point, and for sticking with us through all of that discussion!

This PR keeps the basic content the same as agreed on in #1141, but modifies the structure slightly.
- It now documents cocotb extensions in general, not only bus extensions.
- The error handling bits go into a separate document, since they felt rather out of place in the extension documentation.

Please have a look and let me know what you think!