### PR TITLE
WIP: Raise KilledError in killed coroutines.

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -166,15 +166,9 @@ class RunningTask(object):
 
     def kill(self):
         """Kill a coroutine."""
-        if self._outcome is not None:
-            # already finished, nothing to kill
-            return
-
         if _debug:
             self.log.debug("kill() called on coroutine")
-        # todo: probably better to throw an exception for anyone waiting on the coroutine
-        self._outcome = outcomes.Value(None)
-        cocotb.scheduler.unschedule(self)
+        cocotb.scheduler.kill(self)
 
     def join(self):
         """Return a trigger that will fire when the wrapped coroutine exits."""

--- a/cocotb/outcomes.py
+++ b/cocotb/outcomes.py
@@ -44,6 +44,14 @@ class Value(Outcome):
         return "Value({!r})".format(self.value)
 
 
+class KilledError(Exception):
+    """
+    This exception is thrown in a coroutine which has been explicity killed and
+    can then bubble up into coroutines that were awaiting that coroutine.
+    """
+    pass
+
+
 class _ErrorBase(Outcome):
     def __init__(self, error):
         self.error = error

--- a/tests/test_cases/issue_1348/Makefile
+++ b/tests/test_cases/issue_1348/Makefile
@@ -1,0 +1,3 @@
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_1348

--- a/tests/test_cases/issue_1348/issue_1348.py
+++ b/tests/test_cases/issue_1348/issue_1348.py
@@ -1,0 +1,58 @@
+import os
+import logging
+
+import cocotb
+from cocotb import triggers, outcomes
+from cocotb_test import run
+
+logger = logging.getLogger(__name__)
+
+
+@cocotb.coroutine
+async def clock(clock_signal, period=2, units='ns'):
+    assert period % 2 == 0
+    while True:
+        clock_signal <= 0
+        await triggers.Timer(period//2, units=units)
+        clock_signal <= 1
+        await triggers.Timer(period//2, units=units)
+
+
+@cocotb.coroutine
+async def killable(dut, state):
+    state['killed'] = True
+    state['cleanup'] = False
+    try:
+        await triggers.RisingEdge(dut.clk)
+        await triggers.RisingEdge(dut.clk)
+        # We expect this coroutine to get killed before the second clock edge.
+        state['killed'] = False
+    finally:
+        # We expect this to run after the coroutine is killed.
+        state['cleanup'] = True
+
+@cocotb.coroutine
+async def killer(dut, killable_task):
+    await triggers.RisingEdge(dut.clk)
+    killable_task.kill()
+
+
+@cocotb.coroutine
+async def allow_kill(coro):
+    try:
+        await coro
+    except outcomes.KilledError:
+        pass
+
+@cocotb.test()
+async def test(dut):
+    cocotb.fork(clock(dut.clk))
+    state = {}
+    pB = killable(dut, state)
+    pA = killer(dut, pB)
+    cocotb.fork(pA)
+    cocotb.fork(allow_kill(pB))
+    for i in range(3):
+        await triggers.RisingEdge(dut.clk)
+    assert state['killed']
+    assert state['cleanup']


### PR DESCRIPTION
…es have been killed in scheduler.

Currently the kill method of a coroutine can fail if a coroutine tries to kill another coroutine when the scheduler is looping over an iterable containing both coroutines.  Here I take the simple approach of adding a tag to the RunningCoroutine instance to mark it as killed.  The scheduler can then check this tag. This addresses issue #1348.

Presumably this approach problems for coroutines that are not instances of RunningCoroutine.