### PR TITLE
Fix compiler warnings in FliImpl

### DIFF
--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -220,6 +220,7 @@ GpiObjHdl *FliImpl::create_gpi_obj_from_handle(void *hdl, std::string &name, std
 
 GpiObjHdl* FliImpl::native_check_create(void *raw_hdl, GpiObjHdl *parent)
 {
+    COCOTB_UNUSED(parent);
     LOG_DEBUG("Trying to convert a raw handle to an FLI Handle.");
 
     const char * c_name     = acc_fetch_name(raw_hdl);
@@ -411,6 +412,7 @@ GpiObjHdl*  FliImpl::native_check_create(int32_t index, GpiObjHdl *parent)
 
 const char *FliImpl::reason_to_string(int reason)
 {
+    COCOTB_UNUSED(reason);
     return "Who can explain it, who can tell you why?";
 }
 

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -253,8 +253,8 @@ public:
     virtual double get_signal_value_real();
     virtual long get_signal_value_long();
 
-    virtual int set_signal_value(const long value);
-    virtual int set_signal_value(const double value);
+    virtual int set_signal_value(long value);
+    virtual int set_signal_value(double value);
     virtual int set_signal_value(std::string &value);
 
     virtual void *get_sub_hdl(int index);
@@ -291,7 +291,8 @@ public:
     const char* get_signal_value_str();
     long get_signal_value_long();
 
-    int set_signal_value(const long value);
+    using FliValueObjHdl::set_signal_value;
+    int set_signal_value(long value);
 
     int initialise(std::string &name, std::string &fq_name);
 
@@ -332,7 +333,8 @@ public:
 
     const char* get_signal_value_binstr();
 
-    int set_signal_value(const long value);
+    using FliValueObjHdl::set_signal_value;
+    int set_signal_value(long value);
     int set_signal_value(std::string &value);
 
     int initialise(std::string &name, std::string &fq_name);
@@ -363,7 +365,8 @@ public:
     const char* get_signal_value_binstr();
     long get_signal_value_long();
 
-    int set_signal_value(const long value);
+    using FliValueObjHdl::set_signal_value;
+    int set_signal_value(long value);
 
     int initialise(std::string &name, std::string &fq_name);
 };
@@ -389,7 +392,8 @@ public:
 
     double get_signal_value_real();
 
-    int set_signal_value(const double value);
+    using FliValueObjHdl::set_signal_value;
+    int set_signal_value(double value);
 
     int initialise(std::string &name, std::string &fq_name);
 
@@ -418,6 +422,7 @@ public:
 
     const char* get_signal_value_str();
 
+    using FliValueObjHdl::set_signal_value;
     int set_signal_value(std::string &value);
 
     int initialise(std::string &name, std::string &fq_name);

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -139,20 +139,23 @@ long FliValueObjHdl::get_signal_value_long()
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value(const long value)
+int FliValueObjHdl::set_signal_value(long value)
 {
+    COCOTB_UNUSED(value);
     LOG_ERROR("Setting signal/variable value via long not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }
 
 int FliValueObjHdl::set_signal_value(std::string &value)
 {
+    COCOTB_UNUSED(value);
     LOG_ERROR("Setting signal/variable value via string not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value(const double value)
+int FliValueObjHdl::set_signal_value(double value)
 {
+    COCOTB_UNUSED(value);
     LOG_ERROR("Setting signal/variable value via double not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }


### PR DESCRIPTION
This fixes:
* `-Wunused-parameter`
* `-Woverloaded-virtual`

cc @ktbarrett, @themperek 