### PR TITLE
Don't log all 30k objects in the test

### DIFF
--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -47,7 +47,7 @@ def recursive_discovery(dut):
         count = 0
         for thing in parent:
             count += 1
-            tlog.info("Found %s.%s (%s)", parent._name, thing._name, type(thing))
+            tlog.debug("Found %s.%s (%s)", parent._name, thing._name, type(thing))
             count += dump_all_the_things(thing)
         return count
     total = dump_all_the_things(dut)


### PR DESCRIPTION
This creates tremendously large log files, which are hard to sort through.

This is VHDL test so our CI currently does not run it anyway, but it can be ran locally if the right simulator is installed.

The default log level is INFO, so these will only appear if someone explicitly asks for them.