### PR TITLE
Fixes warning related to -Wsign-conversion

### DIFF
--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -206,7 +206,7 @@ typedef enum gpi_edge {
 
 // The callback registering functions
 gpi_sim_hdl gpi_register_timed_callback                  (int (*gpi_function)(const void *), void *gpi_cb_data, uint64_t time_ps);
-gpi_sim_hdl gpi_register_value_change_callback           (int (*gpi_function)(const void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl, unsigned int edge);
+gpi_sim_hdl gpi_register_value_change_callback           (int (*gpi_function)(const void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl, int edge);
 gpi_sim_hdl gpi_register_readonly_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
 gpi_sim_hdl gpi_register_nexttime_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
 gpi_sim_hdl gpi_register_readwrite_callback              (int (*gpi_function)(const void *), void *gpi_cb_data);

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -72,7 +72,7 @@ static void set_program_name_in_venv(void)
         return;
     }
 
-    strncpy(venv_path, venv_path_home, sizeof(venv_path));
+    strncpy(venv_path, venv_path_home, sizeof(venv_path)-1);
     if (venv_path[sizeof(venv_path) - 1]) {
         LOG_ERROR("Unable to set Python Program Name using virtual environment. Path to virtual environment too long");
         return;

--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -125,9 +125,9 @@ int FliSimPhaseCbHdl::arm_callback()
 
 FliSignalCbHdl::FliSignalCbHdl(GpiImplInterface *impl,
                                FliSignalObjHdl *sig_hdl,
-                               unsigned int edge) : GpiCbHdl(impl),
-                                                    FliProcessCbHdl(impl),
-                                                    GpiValueCbHdl(impl, sig_hdl, edge)
+                               int edge) : GpiCbHdl(impl),
+                                           FliProcessCbHdl(impl),
+                                           GpiValueCbHdl(impl, sig_hdl, edge)
 {
     m_sig_hdl = m_signal->get_handle<mtiSignalIdT>();
 }

--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -56,7 +56,7 @@ FliTimedCbHdl::FliTimedCbHdl(GpiImplInterface *impl,
 int FliTimedCbHdl::arm_callback()
 {
     #if defined(__LP64__) || defined(_WIN64)
-        mti_ScheduleWakeup64(m_proc_hdl, m_time_ps);
+        mti_ScheduleWakeup64(m_proc_hdl, static_cast<mtiTime64T>(m_time_ps));
     #else
         mtiTime64T m_time_union_ps;
         MTI_TIME64_ASGN(m_time_union_ps, (mtiInt32T)((m_time_ps) >> 32), (mtiUInt32T)(m_time_ps));

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -425,8 +425,8 @@ const char *FliImpl::reason_to_string(int reason)
  */
 void FliImpl::get_sim_time(uint32_t *high, uint32_t *low)
 {
-    *high = mti_NowUpper();
-    *low = mti_Now();
+    *high = static_cast<uint32_t>(mti_NowUpper());  // these functions return a int32_t for some reason
+    *low = static_cast<uint32_t>(mti_Now());
 }
 
 void FliImpl::get_sim_precision(int32_t *precision)

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -65,7 +65,7 @@ class FliSignalCbHdl : public FliProcessCbHdl, public GpiValueCbHdl {
 public:
     FliSignalCbHdl(GpiImplInterface *impl,
                    FliSignalObjHdl *sig_hdl,
-                   unsigned int edge);
+                   int edge);
 
     int arm_callback() override;
     int cleanup_callback() override {
@@ -200,7 +200,7 @@ public:
                         m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }
 
 
-    GpiCbHdl *value_change_cb(unsigned int edge) override;
+    GpiCbHdl *value_change_cb(int edge) override;
     int initialise(std::string &name, std::string &fq_name) override;
 
     bool is_var() { return m_is_var; }

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -231,7 +231,7 @@ public:
 
     ~FliValueObjHdl() override {
         if (m_val_buff != NULL)
-            free(m_val_buff);
+            delete [] m_val_buff;
         if (m_sub_hdls != NULL)
             mti_VsimFree(m_sub_hdls);
     }
@@ -315,7 +315,7 @@ public:
 
     ~FliLogicObjHdl() override {
         if (m_mti_buff != NULL)
-            free(m_mti_buff);
+            delete [] m_mti_buff;
     }
 
     const char* get_signal_value_binstr() override;
@@ -373,7 +373,7 @@ public:
 
     ~FliRealObjHdl() override {
         if (m_mti_buff != NULL)
-            free(m_mti_buff);
+            delete m_mti_buff;
     }
 
     double get_signal_value_real() override;
@@ -403,7 +403,7 @@ public:
 
     ~FliStringObjHdl() override {
         if (m_mti_buff != NULL)
-            free(m_mti_buff);
+            delete [] m_mti_buff;
     }
 
     const char* get_signal_value_str() override;

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -249,7 +249,7 @@ int FliLogicObjHdl::initialise(std::string &name, std::string &fq_name)
                 m_value_enum  = mti_GetEnumValues(elemType);
                 m_num_enum    = mti_TickLength(elemType);
 
-                m_mti_buff    = new char[m_num_elems];
+                m_mti_buff    = new char[m_num_elems+1];
                 if (!m_mti_buff) {
                     LOG_CRITICAL("Unable to alloc mem for value object mti read buffer: ABORTING");
                     return -1;

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -78,6 +78,7 @@ int FliObjHdl::initialise(std::string &name, std::string &fq_name)
             break;
         case GPI_GENARRAY:
             m_indexable = true;
+            // fall through
         case GPI_MODULE:
             m_num_elems = 1;
             break;
@@ -248,7 +249,7 @@ int FliLogicObjHdl::initialise(std::string &name, std::string &fq_name)
                 m_value_enum  = mti_GetEnumValues(elemType);
                 m_num_enum    = mti_TickLength(elemType);
 
-                m_mti_buff    = (char*)malloc(sizeof(*m_mti_buff) * m_num_elems);
+                m_mti_buff    = new char[m_num_elems];
                 if (!m_mti_buff) {
                     LOG_CRITICAL("Unable to alloc mem for value object mti read buffer: ABORTING");
                     return -1;
@@ -264,7 +265,7 @@ int FliLogicObjHdl::initialise(std::string &name, std::string &fq_name)
         m_enum_map[m_value_enum[i][1]] = i;  // enum is of the format 'U' or '0', etc.
     }
 
-    m_val_buff = (char*)malloc(m_num_elems+1);
+    m_val_buff = new char[m_num_elems+1];
     if (!m_val_buff) {
         LOG_CRITICAL("Unable to alloc mem for value object read buffer: ABORTING");
     }
@@ -375,7 +376,7 @@ int FliIntObjHdl::initialise(std::string &name, std::string &fq_name)
 {
     m_num_elems   = 1;
 
-    m_val_buff = (char*)malloc(33);  // Integers are always 32-bits
+    m_val_buff = new char[33];  // Integers are always 32-bits
     if (!m_val_buff) {
         LOG_CRITICAL("Unable to alloc mem for value object read buffer: ABORTING");
         return -1;
@@ -395,7 +396,8 @@ const char* FliIntObjHdl::get_signal_value_binstr()
         val = mti_GetSignalValue(get_handle<mtiSignalIdT>());
     }
 
-    std::bitset<32> value((unsigned long)val);
+    unsigned long tmp = static_cast<unsigned long>(val);  // only way to keep next line from warning
+    std::bitset<32> value {tmp};
     std::string bin_str = value.to_string<char,std::string::traits_type, std::string::allocator_type>();
     snprintf(m_val_buff, 33, "%s", bin_str.c_str());
 
@@ -431,7 +433,7 @@ int FliRealObjHdl::initialise(std::string &name, std::string &fq_name)
 
     m_num_elems   = 1;
 
-    m_mti_buff    = (double*)malloc(sizeof(double));
+    m_mti_buff    = new double;
     if (!m_mti_buff) {
         LOG_CRITICAL("Unable to alloc mem for value object mti read buffer: ABORTING");
         return -1;
@@ -473,13 +475,13 @@ int FliStringObjHdl::initialise(std::string &name, std::string &fq_name)
     m_num_elems   = mti_TickLength(m_val_type);
     m_indexable   = true;
 
-    m_mti_buff    = (char*)malloc(sizeof(char) * m_num_elems);
+    m_mti_buff    = new char[m_num_elems];
     if (!m_mti_buff) {
         LOG_CRITICAL("Unable to alloc mem for value object mti read buffer: ABORTING");
         return -1;
     }
 
-    m_val_buff = (char*)malloc(m_num_elems+1);
+    m_val_buff    = new char[m_num_elems+1];
     if (!m_val_buff) {
         LOG_CRITICAL("Unable to alloc mem for value object read buffer: ABORTING");
         return -1;
@@ -497,7 +499,7 @@ const char* FliStringObjHdl::get_signal_value_str()
         mti_GetArraySignalValue(get_handle<mtiSignalIdT>(), m_mti_buff);
     }
 
-    strncpy(m_val_buff, m_mti_buff, m_num_elems);
+    strncpy(m_val_buff, m_mti_buff, static_cast<size_t>(m_num_elems));
 
     LOG_DEBUG("Retrieved \"%s\" for value object %s", m_val_buff, m_name.c_str());
 
@@ -506,7 +508,7 @@ const char* FliStringObjHdl::get_signal_value_str()
 
 int FliStringObjHdl::set_signal_value(std::string &value)
 {
-    strncpy(m_mti_buff, value.c_str(), m_num_elems);
+    strncpy(m_mti_buff, value.c_str(), static_cast<size_t>(m_num_elems));
 
     if (m_is_var) {
         mti_SetVarValue(get_handle<mtiVariableIdT>(), (mtiLongT)m_mti_buff);

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -31,7 +31,7 @@
 #include "FliImpl.h"
 #include "acc_vhdl.h"
 
-GpiCbHdl *FliSignalObjHdl::value_change_cb(unsigned int edge)
+GpiCbHdl *FliSignalObjHdl::value_change_cb(int edge)
 {
     FliSignalCbHdl *cb = NULL;
 

--- a/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -79,30 +79,6 @@ const std::string & GpiObjHdl::get_name()
 }
 
 /* Genertic base clss implementations */
-char *GpiHdl::gpi_copy_name(const char *name)
-{
-    size_t len;
-    char *result;
-    const char null[] = "NULL";
-
-    if (name)
-        len = strlen(name) + 1;
-    else {
-        LOG_WARN("GPI: attempt to use NULL from impl");
-        len = strlen(null);
-        name = null;
-    }
-
-    result = (char *)malloc(len + 1);
-    if (result == NULL) {
-        LOG_CRITICAL("GPI: Attempting allocate string buffer failed!");
-    }
-
-    snprintf(result, len, "%s", name);
-
-    return result;
-}
-
 bool GpiHdl::is_this_impl(GpiImplInterface *impl)
 {
     return impl == this->m_impl;

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -533,7 +533,7 @@ int gpi_get_range_right(gpi_sim_hdl sig_hdl)
 gpi_sim_hdl gpi_register_value_change_callback(int (*gpi_function)(const void *),
                                                void *gpi_cb_data,
                                                gpi_sim_hdl sig_hdl,
-                                               unsigned int edge)
+                                               int edge)
 {
 
     GpiSignalObjHdl *signal_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -77,7 +77,6 @@ private:
 
 public:
     GpiImplInterface *m_impl;                  // VPI/VHPI/FLI routines
-    char *gpi_copy_name(const char *name);     // Might not be needed
     bool is_this_impl(GpiImplInterface *impl); // Is the passed interface the one this object uses?
 
 protected:

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -182,7 +182,7 @@ public:
     //virtual GpiCbHdl monitor_value(bool rising_edge) = 0; this was for the triggers
     // but the explicit ones are probably better
 
-    virtual GpiCbHdl *value_change_cb(unsigned int edge) = 0;
+    virtual GpiCbHdl *value_change_cb(int edge) = 0;
 };
 
 

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -467,7 +467,7 @@ static PyObject *register_value_change_callback(PyObject *self, PyObject *args) 
     PyObject *function;
     gpi_sim_hdl sig_hdl;
     gpi_sim_hdl hdl;
-    unsigned int edge;
+    int edge;
 
     p_callback_data callback_data_p;
 
@@ -492,7 +492,7 @@ static PyObject *register_value_change_callback(PyObject *self, PyObject *args) 
     Py_INCREF(function);
 
     PyObject *pedge = PyTuple_GetItem(args, 2);
-    edge = (unsigned int)PyLong_AsLong(pedge);
+    edge = (int)PyLong_AsLong(pedge);
 
     // Remaining args for function
     fArgs = PyTuple_GetSlice(args, 3, numargs);   // New reference

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -766,7 +766,7 @@ long VhpiSignalObjHdl::get_signal_value_long()
 }
 
 
-GpiCbHdl * VhpiSignalObjHdl::value_change_cb(unsigned int edge)
+GpiCbHdl * VhpiSignalObjHdl::value_change_cb(int edge)
 {
     VhpiValueCbHdl *cb = NULL;
 

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -585,7 +585,7 @@ GpiObjHdl *VhpiImpl::native_check_create(int32_t index, GpiObjHdl *parent)
         }
 
         vhpiIntT    num_dim  = vhpi_get(vhpiNumDimensionsP, base_hdl);
-        uint32_t    idx      = 0;
+        int         idx      = 0;
 
         /* Need to translate the index into a zero-based flattened array index */
         if (num_dim > 1) {
@@ -683,9 +683,9 @@ GpiObjHdl *VhpiImpl::native_check_create(int32_t index, GpiObjHdl *parent)
                         int raw_idx = indices.back();
                         constraint  = constraints.back();
 
-                        vhpiIntT left  = vhpi_get(vhpiLeftBoundP, constraint);
-                        vhpiIntT right = vhpi_get(vhpiRightBoundP, constraint);
-                        vhpiIntT len   = 0;
+                        int left  = static_cast<int>(vhpi_get(vhpiLeftBoundP, constraint));
+                        int right = static_cast<int>(vhpi_get(vhpiRightBoundP, constraint));
+                        int len   = 0;
 
                         if (left > right) {
                             idx += (scale * (left - raw_idx));
@@ -726,7 +726,7 @@ GpiObjHdl *VhpiImpl::native_check_create(int32_t index, GpiObjHdl *parent)
 
                 vhpiHandleT iter = vhpi_iterator(vhpiIndexedNames, vhpi_hdl);
                 if (iter != NULL) {
-                    uint32_t curr_index = 0;
+                    int curr_index = 0;
                     while ((new_hdl = vhpi_scan(iter)) != NULL) {
                         if (idx == curr_index) {
                             vhpi_release_handle(iter);

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -192,7 +192,7 @@ public:
     int set_signal_value(std::string &value) override;
 
     /* Value change callback accessor */
-    GpiCbHdl *value_change_cb(unsigned int edge) override;
+    GpiCbHdl *value_change_cb(int edge) override;
     int initialise(std::string &name, std::string &fq_name) override;
 
 protected:

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -380,7 +380,7 @@ int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s)
     return 0;
 }
 
-GpiCbHdl * VpiSignalObjHdl::value_change_cb(unsigned int edge)
+GpiCbHdl * VpiSignalObjHdl::value_change_cb(int edge)
 {
     VpiValueCbHdl *cb = NULL;
 

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -178,7 +178,7 @@ public:
     int set_signal_value(std::string &value) override;
 
     /* Value change callback accessor */
-    GpiCbHdl *value_change_cb(unsigned int edge) override;
+    GpiCbHdl *value_change_cb(int edge) override;
     int initialise(std::string &name, std::string &fq_name) override;
 
 private:

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -72,7 +72,7 @@ export INCLUDES := -I$(COCOTB_SHARE_DIR)/include -I$(PYTHON_INCLUDEDIR)
 LIB_EXT    := so
 PY_EXT     := so
 
-BASE_WARNS := -Wall -Wextra -Wconversion -Wcast-qual -Wwrite-strings
+BASE_WARNS := -Wall -Wextra -Wconversion -Wcast-qual -Wwrite-strings -Wsign-conversion
 CC_WARNS   := $(BASE_WARNS) -Wstrict-prototypes -Waggregate-return
 CXX_WARNS  := $(BASE_WARNS) -Wnon-virtual-dtor -Woverloaded-virtual
 


### PR DESCRIPTION
As discussed in #1306, the Apple build adds in `-Wsign-conversion` and this causes things to fail the CI because it sets `-Werror`. This adds that warning to the list of warnings enabled by default. Then it fixes those warnings in the VHPI and FLI interfaces. It also fixes inconsistency with the type of the `edge` variable in several places that was causing a sign conversion warning.