### PR TITLE
Do not crash if argv cannot be decoded

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -210,6 +210,10 @@ def process_plusargs():
     plusargs = {}
 
     for option in cocotb.argv:
+        # gh-1234: Sometimes we get non-strings in argv, just skip them
+        if not isinstance(option, str):
+            continue
+
         if option.startswith('+'):
             if option.find('=') != -1:
                 (name, value) = option[1:].split('=')


### PR DESCRIPTION
Note that we still crash if memory allocations fail while decoding, but that seems like a sensible choice.

If argv contains byte sequences that cannot be decoded as UTF8, we now just emit a warning, and pass the raw bytes into `cocotb.argv`.

Workaround for #1234, with the compromise being that `cocotb.argv` contains a mixture of `bytes` and `str`.