### PR TITLE
Use PEP383 to embed non-decodable bytes in argv

### DIFF
--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -307,7 +307,7 @@ int embed_sim_init(gpi_sim_info_t *info)
         PyObject *argv_item = PyUnicode_DecodeLocale(info->argv[i], "surrogateescape");  // New reference
         if (argv_item == NULL) {
             PyErr_Print();
-            LOG_ERROR("Unable to decode argv item");
+            LOG_ERROR("Unable to convert command line argument %d to Unicode string.", i);
             Py_DECREF(argv_list);
             goto cleanup;
         }

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -302,17 +302,9 @@ int embed_sim_init(gpi_sim_info_t *info)
         goto cleanup;
     }
     for (i = 0; i < info->argc; i++) {
-        PyObject *argv_item_raw = PyBytes_FromString(info->argv[i]);       // New reference
-        if (argv_item_raw == NULL) {
-            PyErr_Print();
-            LOG_ERROR("Unable to create argv item");
-            Py_DECREF(argv_list);
-            goto cleanup;
-        }
         // Decode, embedding non-decodable bytes using PEP-383. This can only
         // fail with MemoryError or similar.
-        PyObject *argv_item = PyUnicode_FromEncodedObject(argv_item_raw, NULL, "surrogateescape");
-        Py_DECREF(argv_item_raw);
+        PyObject *argv_item = PyUnicode_DecodeLocale(info->argv[i], "surrogateescape");  // New reference
         if (argv_item == NULL) {
             PyErr_Print();
             LOG_ERROR("Unable to decode argv item");


### PR DESCRIPTION
Users who need the original bytes can use `.encode('utf8', 'surrogateescape')` to get them back.
Without this change, passing non-decodable bytes would just cause cocotb to fail to startup.

This behavior is consistent with how `sys.argv` is handled on UNIX platforms by python itself.

Alternative to gh-1364, and probably the better choice.

Fixes #1363

---
Workaround for #1234, using the same approach as is used for `sys.argv` in normal python.