### PR TITLE
Fix incorrect use of tabs in makefiles

### DIFF
--- a/cocotb/share/makefiles/Makefile.pylib.Linux
+++ b/cocotb/share/makefiles/Makefile.pylib.Linux
@@ -30,10 +30,10 @@
 # All common python related rules
 
 ifneq ($(COCOTB_PYTHON_DEBUG),)
-	DBG_PYTHON_VERSION=$(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')
-	PYTHON_BIN?=python$(DBG_PYTHON_VERSION)-dbg
+    DBG_PYTHON_VERSION=$(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')
+    PYTHON_BIN?=python$(DBG_PYTHON_VERSION)-dbg
 else
-	PYTHON_BIN?=python
+    PYTHON_BIN?=python
 endif
 
 NATIVE_ARCH=$(shell uname -m)
@@ -45,8 +45,8 @@ PYTHON_DYNLIBDIR:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_functio
 # Nasty hack but there's no way in Python properly get the directories for 32-bit Python on a 64-bit system
 # TODO: Under OSX we can use "export VERSIONER_PYTHON_PREFER_32_BIT=yes", no Linux equivalent though
 ifneq ($(NATIVE_ARCH),$(ARCH))
-	PYTHON_LIBDIR:=$(subst 64,,$(PYTHON_LIBDIR))
-	PYTHON_DYNLIBDIR:=$(subst 64,,$(PYTHON_DYNLIBDIR))
+    PYTHON_LIBDIR:=$(subst 64,,$(PYTHON_LIBDIR))
+    PYTHON_DYNLIBDIR:=$(subst 64,,$(PYTHON_DYNLIBDIR))
 endif
 
 PYLIBS:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; from distutils import sysconfig; import os; print("-l"+os.path.splitext(sysconfig.get_config_var("LDLIBRARY"))[0][3:])')

--- a/cocotb/share/makefiles/Makefile.pylib.Msys
+++ b/cocotb/share/makefiles/Makefile.pylib.Msys
@@ -31,12 +31,12 @@
 
 # if not explicitly set, auto-detect python dir from system path
 ifeq ($(PYTHON_DIR),)
-	PYTHON_DIR ?= $(shell dirname $(shell :; command -v python))
+    PYTHON_DIR ?= $(shell dirname $(shell :; command -v python))
 endif
 
 # make sure python dir was set properly
 ifeq ($(PYTHON_DIR),)
-	$(error "Path to Python directory must be included in system path or defined in PYTHON_DIR environment variable")
+    $(error "Path to Python directory must be included in system path or defined in PYTHON_DIR environment variable")
 endif
 
 PYTHON_BIN?=$(PYTHON_DIR)/python.exe

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -49,7 +49,7 @@ HAVE_SIMULATOR = $(shell if [ -f $(COCOTB_SHARE_DIR)/makefiles/simulators/Makefi
 AVAILABLE_SIMULATORS = $(patsubst .%,%,$(suffix $(wildcard $(COCOTB_SHARE_DIR)/makefiles/simulators/Makefile.*)))
 
 ifeq ($(HAVE_SIMULATOR),0)
-$(error "Couldn't find makefile for simulator: "$(SIM_LOWERCASE)"! Available simulators: $(AVAILABLE_SIMULATORS)")
+    $(error "Couldn't find makefile for simulator: "$(SIM_LOWERCASE)"! Available simulators: $(AVAILABLE_SIMULATORS)")
 endif
 
 # Depend on all Python from the cocotb package. This triggers a

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -45,7 +45,7 @@ endif
 ifeq (, $(CMD))
     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	ALDEC_BIN_DIR := $(shell dirname $(CMD))
+    ALDEC_BIN_DIR := $(shell dirname $(CMD))
     export ALDEC_BIN_DIR
 endif
 

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -46,7 +46,7 @@ endif
 ifeq (, $(CMD))
     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	CVC_BIN_DIR := $(shell dirname $(CMD))
+    CVC_BIN_DIR := $(shell dirname $(CMD))
     export CVC_BIN_DIR
 endif
 

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -46,7 +46,7 @@ endif
 ifeq (, $(CMD))
     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	GHDL_BIN_DIR := $(shell dirname $(CMD))
+    GHDL_BIN_DIR := $(shell dirname $(CMD))
     export GHDL_BIN_DIR
 endif
 

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -48,7 +48,7 @@ endif
 ifeq (, $(CMD))
     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	ICARUS_BIN_DIR := $(shell dirname $(CMD))
+    ICARUS_BIN_DIR := $(shell dirname $(CMD))
     export ICARUS_BIN_DIR
 endif
 

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -41,7 +41,7 @@ endif
 ifeq (, $(CMD))
     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	IUS_BIN_DIR := $(shell dirname $(CMD))
+    IUS_BIN_DIR := $(shell dirname $(CMD))
     export IUS_BIN_DIR
 endif
 

--- a/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -9,7 +9,7 @@ clean::
 else
 
 ifeq ($(COCOTB_NVC_TRACE), 1)
-	TRACE :=--vhpi-trace
+    TRACE :=--vhpi-trace
 endif
 
 CMD_BIN := nvc
@@ -24,7 +24,7 @@ endif
 ifeq (, $(CMD))
     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	NVC_BIN_DIR := $(shell dirname $(CMD))
+    NVC_BIN_DIR := $(shell dirname $(CMD))
     export NVC_BIN_DIR
 endif
 

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -39,7 +39,7 @@ endif
 ifeq (, $(CMD))
     $(error "Unable to locate command >$(CMD_BIN)<")
 else
-	MODELSIM_BIN_DIR := $(shell dirname $(CMD))
+    MODELSIM_BIN_DIR := $(shell dirname $(CMD))
     export MODELSIM_BIN_DIR
 endif
 


### PR DESCRIPTION
These tabs cause the variable assignments to become part of the preceding recipe, which is not what was intended here.