### PR TITLE
document that icarus ignores COCOTB_HDL_TIME* variables

### DIFF
--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -89,6 +89,8 @@ and
       Allowed values are 1, 10, and 100.
       Allowed units are ``s``, ``ms``, ``us``, ``ns``, ``ps``, ``fs``.
 
+      NOTE: Icarus Verilog does not support this variable
+
       .. versionadded:: 1.3
 
 .. make:var:: COCOTB_HDL_TIMEPRECISION
@@ -97,6 +99,8 @@ and
       If this isn't specified then it is assumed to be ``1ps``.
       Allowed values are 1, 10, and 100.
       Allowed units are ``s``, ``ms``, ``us``, ``ns``, ``ps``, ``fs``.
+
+      NOTE: Icarus Verilog does not support this variable
 
       .. versionadded:: 1.3
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -47,7 +47,7 @@ Time unit and precision
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Setting the time unit and time precision is not possible from the command-line,
-and therefore make variables :make:var:``COCOTB_HDL_TIMEUNIT`` and :make:var:``COCOTB_HDL_TIMEPRECISION`` are ignored.
+and therefore make variables :make:var:`COCOTB_HDL_TIMEUNIT` and :make:var:`COCOTB_HDL_TIMEPRECISION` are ignored.
 
 Verilator
 ---------

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -43,6 +43,11 @@ to the top component as shown in the example below:
     `endif
     endmodule
 
+Time unit and precision
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Setting the time unit and time precision is not possible from the command-line, and therefore make variables ``COCOTB_HDL_TIMEUNIT`` and ``COCOTB_HDL_TIMEPRECISION`` are ignored.
+
 Verilator
 ---------
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -46,7 +46,8 @@ to the top component as shown in the example below:
 Time unit and precision
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Setting the time unit and time precision is not possible from the command-line, and therefore make variables ``COCOTB_HDL_TIMEUNIT`` and ``COCOTB_HDL_TIMEPRECISION`` are ignored.
+Setting the time unit and time precision is not possible from the command-line,
+and therefore make variables :make:var:``COCOTB_HDL_TIMEUNIT`` and :make:var:``COCOTB_HDL_TIMEPRECISION`` are ignored.
 
 Verilator
 ---------


### PR DESCRIPTION
this is in response to #1102 , specifically this comment: https://github.com/cocotb/cocotb/issues/1102#issuecomment-576011634