### PR TITLE
Change tests to run in definition-order

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -249,6 +249,7 @@ class RunningTest(RunningCoroutine):
         self.expect_error = parent.expect_error
         self.skip = parent.skip
         self.stage = parent.stage
+        self._id = parent._id
 
         # make sure not to create a circular reference here
         self.handler = RunningTest.ErrorLogHandler(self.error_messages.append)
@@ -456,12 +457,19 @@ class test(_py_compat.with_metaclass(_decorator_helper, coroutine)):
         stage (int, optional)
             Order tests logically into stages, where multiple tests can share a stage.
     """
+
+    _id_count = 0  # used by the RegressionManager to sort tests in definition order
+
     def __init__(self, f, timeout_time=None, timeout_unit=None,
                  expect_fail=False, expect_error=False,
                  skip=False, stage=None):
 
+        self._id = self._id_count
+        type(self)._id_count += 1
+
         if timeout_time is not None:
             co = coroutine(f)
+
             @functools.wraps(f)
             def f(*args, **kwargs):
                 running_co = co(*args, **kwargs)

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -182,7 +182,7 @@ class RegressionManager(object):
                 if hasattr(thing, "im_test"):
                     self._init_test(thing)
 
-        self._queue.sort(key=lambda test: test.sort_name())
+        self._queue.sort(key=lambda test: (test.stage, test._id))
 
         for valid_tests in self._queue:
             self.log.info("Found test %s.%s" %

--- a/tests/test_cases/test_cocotb/test_cocotb_35.py
+++ b/tests/test_cases/test_cocotb/test_cocotb_35.py
@@ -141,3 +141,29 @@ def test_undecorated_coroutine_yield(dut):
 
     yield example()
     assert ran
+
+
+# these tests should run in definition order, not lexicographic order
+last_ordered_test = None
+
+
+@cocotb.test()
+async def test_ordering_3(dut):
+    global last_ordered_test
+    val, last_ordered_test = last_ordered_test, 3
+    assert val is None
+
+
+@cocotb.test()
+async def test_ordering_2(dut):
+    global last_ordered_test
+    val, last_ordered_test = last_ordered_test, 2
+    assert val == 3
+
+
+@cocotb.test()
+async def test_ordering_1(dut):
+    global last_ordered_test
+    val, last_ordered_test = last_ordered_test, 1
+    assert val == 2
+


### PR DESCRIPTION
Previously, tests ran according to their names in lexical order. Now they run in order of their definition in a test module top-to-bottom. When specifying multiple test modules they are evaluated in the order they are listed.