### PR TITLE
Change string type of handles to bytes

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -802,15 +802,28 @@ class StringObject(ModifiableObject):
         object, e.g. net, signal or variable.
 
         Args:
-            value (str): The value to drive onto the simulator object.
+            value (bytes): The value to drive onto the simulator object.
 
         Raises:
             TypeError: If target has an unsupported type for
                  string value assignment.
+
+        .. versionchanged:: 1.4
+            Takes :class:`bytes` instead of :class:`str`.
+            Users are now expected to choose an encoding when using these objects.
+            As a convenience, when assigning :class:`str` values, ASCII encoding will be used as a safe default.
+
         """
         value, set_action = self._check_for_set_action(value)
 
-        if not isinstance(value, str):
+        if isinstance(value, str):
+            warnings.warn(
+                "Handles on string objects will soon not accept `str` objects. "
+                "Please use a bytes object by encoding the string as you see fit. "
+                "`str.encode('ascii')` is typically sufficient.", DeprecationWarning, stacklevel=2)
+            value = value.encode('ascii')  # may throw UnicodeEncodeError
+
+        if not isinstance(value, bytes):
             self._log.critical("Unsupported type for string value assignment: %s (%s)", type(value), repr(value))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -626,7 +626,7 @@ static PyObject *get_signal_val_str(PyObject *self, PyObject *args)
     }
 
     result = gpi_get_signal_value_str(hdl);
-    retstr = Py_BuildValue("s", result);
+    retstr = PyBytes_FromString(result);
 
     return retstr;
 }
@@ -688,7 +688,7 @@ static PyObject *set_signal_val_str(PyObject *self, PyObject *args)
     gpi_set_action_t action;
     const char *str;
 
-    if (!PyArg_ParseTuple(args, "O&is", gpi_sim_hdl_converter, &hdl, &action, &str)) {
+    if (!PyArg_ParseTuple(args, "O&iy", gpi_sim_hdl_converter, &hdl, &action, &str)) {
         return NULL;
     }
 

--- a/documentation/source/newsfragments/1381.removal.rst
+++ b/documentation/source/newsfragments/1381.removal.rst
@@ -1,0 +1,1 @@
+The value of :class:`cocotb.handle.StringObject`\ s is now of type :class:`bytes`, instead of  :class:`str` with an implied ASCII encoding scheme.

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -1436,3 +1436,13 @@ async def test_except_lock(dut):
         pass
     async with lock:
         pass
+
+
+# strings are not supported on Icarus
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
+async def test_string_handle_takes_bytes(dut):
+    dut.string_input_port.value = b"bytes"
+    await cocotb.triggers.Timer(10, 'ns')
+    val = dut.string_input_port.value
+    assert isinstance(val, bytes)
+    assert val == b"bytes"

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -1,19 +1,38 @@
 import cocotb
 import warnings
+from contextlib import contextmanager
+
+
+@contextmanager
+def assert_deprecated():
+    warns = []
+    try:
+        with warnings.catch_warnings(record=True) as warns:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            yield warns  # note: not a cocotb yield, but a contextlib one!
+    finally:
+        assert len(warns) == 1
+        assert issubclass(warns[0].category, DeprecationWarning)
 
 
 @cocotb.test()
 async def test_returnvalue_deprecated(dut):
+
     @cocotb.coroutine
     def get_value():
         yield cocotb.triggers.Timer(1, units='ns')
         raise cocotb.result.ReturnValue(42)
 
-    with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
-        warnings.simplefilter("always")
+    with assert_deprecated() as warns:
         val = await get_value()
     assert val == 42
-    assert len(w) == 1
-    assert issubclass(w[-1].category, DeprecationWarning)
-    assert "return statement instead" in str(w[-1].message)
+    assert "return statement instead" in str(warns[0].message)
+
+
+# strings are not supported on Icarus
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
+async def test_unicode_handle_assignment_deprecated(dut):
+    with assert_deprecated() as warns:
+        dut.string_input_port <= "Bad idea"
+    assert "bytes" in str(warns[0].message)

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -285,14 +285,14 @@ def access_const_string_verilog(dut):
     tlog.info("%r is %s" % (string_const, str(string_const)))
     if not isinstance(string_const, StringObject):
         raise TestFailure("STRING_CONST was not StringObject")
-    if string_const != "TESTING_CONST":
+    if string_const != b"TESTING_CONST":
         raise TestFailure("STRING_CONST was not == \'TESTING_CONST\'")
 
     tlog.info("Modifying const string")
-    string_const <= "MODIFIED"
+    string_const <= b"MODIFIED"
     yield Timer(10)
     string_const = dut.STRING_CONST;
-    if string_const != "TESTING_CONST":
+    if string_const != b"TESTING_CONST":
         raise TestFailure("STRING_CONST was not still \'TESTING_CONST\'")
 
 
@@ -307,14 +307,14 @@ def access_var_string_verilog(dut):
     tlog.info("%r is %s" % (string_var, str(string_var)))
     if not isinstance(string_var, StringObject):
         raise TestFailure("STRING_VAR was not StringObject")
-    if string_var != "TESTING_VAR":
+    if string_var != b"TESTING_VAR":
         raise TestFailure("STRING_VAR was not == \'TESTING_VAR\'")
 
     tlog.info("Modifying var string")
-    string_var <= "MODIFIED"
+    string_var <= b"MODIFIED"
     yield Timer(10)
     string_var = dut.STRING_VAR;
-    if string_var != "MODIFIED":
+    if string_var != b"MODIFIED":
         raise TestFailure("STRING_VAR was not == \'MODIFIED\'")
 
 


### PR DESCRIPTION
The simulator interfaces only deal in bytes, however the current implementation will take any string object including unicode sequences, which it will encode using UTF-8 (default) before writing it to the
simulator interface. Instead, string encoding/decoding should be lifted into userspace to offer more control.

`simulator.set_signal_value_str` and `simulator.get_signal_value` now expect and return a bytes object. `StringObject` handles now expect and return `bytes`.

Handles some issues in #1374.