### PR TITLE
Fail other tests on SimFailure

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -206,6 +206,21 @@ class RegressionManager(object):
                         cocotb.scheduler.add(test)
 
     def tear_down(self):
+        # fail remaining tests
+        while True:
+            test = self.next_test()
+            if test is None:
+                break
+            self.xunit.add_testcase(name=test.funcname,
+                                    classname=test.module,
+                                    time=repr(0),
+                                    sim_time_ns=repr(0),
+                                    ratio_time=repr(0))
+            result_pass, _ = self._score_test(test, cocotb.outcomes.Error(SimFailure()))
+            self._store_test_result(test.__module__, test.__name__, result_pass, 0, 0, 0)
+            if not result_pass:
+                self.xunit.add_failure()
+                self.failures += 1
 
         # Write out final log messages
         if self.failures:

--- a/documentation/source/newsfragments/1279.bugfix.rst
+++ b/documentation/source/newsfragments/1279.bugfix.rst
@@ -1,0 +1,2 @@
+Tests that were not run because predecessors threw :class:`cocotb.result.SimFailure`, and caused the simulator to exit, are now recorded with an outcome of :class:`cocotb.result.SimFailure`.
+Previously, these tests were ignored.

--- a/tests/test_cases/issue_1279/issue_1279.py
+++ b/tests/test_cases/issue_1279/issue_1279.py
@@ -10,7 +10,7 @@ def test_sim_failure_a(dut):
     yield cocotb.triggers.RisingEdge(dut.clk)
 
 
-@cocotb.test(stage=2)
+@cocotb.test(expect_error=cocotb.result.SimFailure, stage=2)
 def test_sim_failure_b(dut):
     yield cocotb.triggers.NullTrigger()
     raise cocotb.result.TestFailure("This test should never run")


### PR DESCRIPTION
If a test gets a `SimFailure` or otherwise goes through `RegressionManager.tear_down`, iterate through remaining tests and score them as if the outcome was `SimFailure`, ensuring these tests get added as failures to the banner and result.xml. Previously, these tests were ignored.