### PR TITLE
Add a pull request template for GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--
+
+Thanks for improving cocotb! Here are some points to make this as smooth as possible.
+Not all of them may be applicable.
+
+Most important: please explain *why* you are proposing this change.
+
+* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
+* Extend or add a test under `tests/test_cases/`.
+* Add documentation under `documentation/source/`,
+  docstrings in Python code, or Doxygen markup in C/C++ code.
+  Use ``versionadded``/``versionchanged``/``deprecated``.
+* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
+* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).
+
+-->


### PR DESCRIPTION
When merged, this is acting as a reminder when opening a pull request.
It started out as several paragraphs with explanatory links etc.,
but now I think succinct is better.