### PR TITLE
use pip3 to install tox on travis and Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
         - docker ps -a
       script:
         - echo 'Running cocotb tests with Python 3.5 ...' && echo -en 'travis_fold:start:cocotb_py35'
-        - docker exec -it -e TRAVIS=true cocotb bash -lc 'pip install tox; cd /src; tox -e py35'
+        - docker exec -it -e TRAVIS=true cocotb bash -lc 'pip3 install tox; cd /src; tox -e py35'
         - echo 'travis_fold:end:cocotb_py35'
 
     - stage: SimTests
@@ -94,7 +94,7 @@ jobs:
       before_install: &osx_prep
         - brew update-reset
         - brew install icarus-verilog
-        - pip install tox
+        - pip3 install tox
       script:
         - tox -e py37
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,16 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends \
        g++ \
        flex \
        bison \
-       python2.7-dev python3-dev\
-       python-pip \
-       python-setuptools \
+       python3-dev\
+       python3-pip \
+       python3-setuptools \
        python3 \
        virtualenv \
        python3-venv \
        swig \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
-    && pip install --upgrade pip \
+    && pip3 install --upgrade pip \
     && g++ --version
 
 # Icarus Verilog


### PR DESCRIPTION
Since on setup, we will use python3 syntax (#1306) need to install tox with `pip3`.

Python 2 is end of support.