### PR TITLE
Doc build: Fix call to towncrier through Makefile

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -40,4 +40,4 @@ distclean:
 # We hack around that by calling the target explicitly.
 	make .venv
 
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	source .venv/bin/activate; $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
The "towncrier" binary is installed into a venv when using the
documentation build makefile. To make Sphinx find the binary, we need to
adjust the PATH. The easiest and most future-proof option is to source
the shell activation code provided by venv.

Error message without this fix when running `make html`:

```
Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/philipp/src/cocotb/documentation/.venv/lib64/python3.7/site-packages/sphinx/config.py", line 348, in eval_config_file
    execfile_(filename, namespace)
  File "/home/philipp/src/cocotb/documentation/.venv/lib64/python3.7/site-packages/sphinx/util/pycompat.py", line 81, in execfile_
    exec(code, _globals)
  File "/home/philipp/src/cocotb/documentation/source/conf.py", line 346, in <module>
    universal_newlines=True)
  File "/usr/lib64/python3.7/subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "/usr/lib64/python3.7/subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib64/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/usr/lib64/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] Datei oder Verzeichnis nicht gefunden: 'towncrier': 'towncrier'
```