### PR TITLE
Add documentation for test ordering change

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -421,6 +421,8 @@ class test(_py_compat.with_metaclass(_decorator_helper, coroutine)):
     some common reporting etc., a test timeout and allows
     us to mark tests as expected failures.
 
+    Tests are evaluated in the order they are defined in a test module.
+
     Used as ``@cocotb.test(...)``.
 
     Args:

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -176,7 +176,9 @@ Environment Variables
 
 .. envvar:: MODULE
 
-    The name of the module(s) to search for test functions.  Multiple modules can be specified using a comma-separated list.
+    The name of the module(s) to search for test functions.
+    Multiple modules can be specified using a comma-separated list.
+    All tests will be run from each specified module in order of the module's appearance in this list.
 
 .. envvar:: TESTCASE
 

--- a/documentation/source/newsfragments/1380.change.rst
+++ b/documentation/source/newsfragments/1380.change.rst
@@ -1,0 +1,1 @@
+Tests are now evaluated in order of their appearance in the :envvar:`MODULE` environment variable, their stage, and the order of invocation of the :class:`cocotb.test` decorator within a module.


### PR DESCRIPTION
Per https://github.com/cocotb/cocotb/pull/1380#issuecomment-586724801 adding a newsfragment and documentation of how tests are ordered. Fixes #1395.

Not entirely sure where to stick the documentation besides on the decorator itself.