### PR TITLE
Expose force/release to cocotb

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -577,6 +577,35 @@ class NonConstantObject(NonHierarchyIndexableObject):
         """An iterator for gathering all loads on a signal."""
         return _SimIterator(self._handle, simulator.LOADS)
 
+class _SetAction:
+    """Base class representing the type of action used while write-accessing a handle."""
+    pass
+
+class _SetValueAction(_SetAction):
+    __slots__ = ("value",)
+    """Base class representing the type of action used while write-accessing a handle with a value."""
+    def __init__(self, value):
+        self.value = value
+
+class Deposit(_SetValueAction):
+    """Action used for placing a value into a given handle."""
+    def _as_gpi_args_for(self, hdl):
+        return self.value, 0  # GPI_DEPOSIT
+
+class Force(_SetValueAction):
+    """Action used to force a handle to a given value until a release is applied."""
+    def _as_gpi_args_for(self, hdl):
+        return self.value, 1  # GPI_FORCE
+
+class Freeze(_SetAction):
+    """Action used to make a handle keep its current value until a release is used."""
+    def _as_gpi_args_for(self, hdl):
+        return hdl.value, 1  # GPI_FORCE
+
+class Release(_SetAction):
+    """Action used to stop the effects of a previously applied force/freeze action."""
+    def _as_gpi_args_for(self, hdl):
+        return 0, 2  # GPI_RELEASE
 
 class ModifiableObject(NonConstantObject):
     """Base class for simulator objects whose values can be modified."""
@@ -598,10 +627,11 @@ class ModifiableObject(NonConstantObject):
             TypeError: If target is not wide enough or has an unsupported type
                  for value assignment.
         """
-        if isinstance(value, _py_compat.integer_types) and value < 0x7fffffff and len(self) <= 32:
-            simulator.set_signal_val_long(self._handle, value)
-            return
+        value, set_action = self._check_for_set_action(value)
 
+        if isinstance(value, _py_compat.integer_types) and value < 0x7fffffff and len(self) <= 32:
+            simulator.set_signal_val_long(self._handle, set_action, value)
+            return
         if isinstance(value, ctypes.Structure):
             value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
         elif isinstance(value, _py_compat.integer_types):
@@ -625,7 +655,12 @@ class ModifiableObject(NonConstantObject):
             self._log.critical("Unsupported type for value assignment: %s (%s)", type(value), repr(value))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
-        simulator.set_signal_val_binstr(self._handle, value.binstr)
+        simulator.set_signal_val_binstr(self._handle, set_action, value.binstr)
+
+    def _check_for_set_action(self, value):
+        if not isinstance(value, _SetAction):
+            return value, 0  # GPI_DEPOSIT
+        return value._as_gpi_args_for(self)
 
     @NonConstantObject.value.getter
     def value(self):
@@ -666,6 +701,8 @@ class RealObject(ModifiableObject):
             TypeError: If target has an unsupported type for
                 real value assignment.
         """
+        value, set_action = self._check_for_set_action(value)
+
         try:
             value = float(value)
         except ValueError:
@@ -673,7 +710,7 @@ class RealObject(ModifiableObject):
                                (type(value), repr(value)))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
-        simulator.set_signal_val_real(self._handle, value)
+        simulator.set_signal_val_real(self._handle, set_action, value)
 
     @ModifiableObject.value.getter
     def value(self):
@@ -699,13 +736,15 @@ class EnumObject(ModifiableObject):
             TypeError: If target has an unsupported type for
                  integer value assignment.
         """
+        value, set_action = self._check_for_set_action(value)
+
         if isinstance(value, BinaryValue):
             value = int(value)
         elif not isinstance(value, _py_compat.integer_types):
             self._log.critical("Unsupported type for integer value assignment: %s (%s)", type(value), repr(value))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
-        simulator.set_signal_val_long(self._handle, value)
+        simulator.set_signal_val_long(self._handle, set_action, value)
 
     @ModifiableObject.value.getter
     def value(self):
@@ -728,13 +767,15 @@ class IntegerObject(ModifiableObject):
             TypeError: If target has an unsupported type for
                  integer value assignment.
         """
+        value, set_action = self._check_for_set_action(value)
+
         if isinstance(value, BinaryValue):
             value = int(value)
         elif not isinstance(value, _py_compat.integer_types):
             self._log.critical("Unsupported type for integer value assignment: %s (%s)", type(value), repr(value))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
-        simulator.set_signal_val_long(self._handle, value)
+        simulator.set_signal_val_long(self._handle, set_action, value)
 
     @ModifiableObject.value.getter
     def value(self):
@@ -757,11 +798,13 @@ class StringObject(ModifiableObject):
             TypeError: If target has an unsupported type for
                  string value assignment.
         """
+        value, set_action = self._check_for_set_action(value)
+
         if not isinstance(value, str):
             self._log.critical("Unsupported type for string value assignment: %s (%s)", type(value), repr(value))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
-        simulator.set_signal_val_str(self._handle, value)
+        simulator.set_signal_val_str(self._handle, set_action, value)
 
     @ModifiableObject.value.getter
     def value(self):

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -150,6 +150,11 @@ typedef enum gpi_iterator_sel_e {
     GPI_LOADS = 3,
 } gpi_iterator_sel_t;
 
+typedef enum gpi_set_action_e {
+    GPI_DEPOSIT = 0,
+    GPI_FORCE = 1,
+    GPI_RELEASE = 2,
+} gpi_set_action_t;
 
 // Functions for iterating over entries of a handle
 // Returns an iterator handle which can then be used in gpi_next calls
@@ -195,10 +200,10 @@ int gpi_is_constant(gpi_sim_hdl gpi_hdl);
 int gpi_is_indexable(gpi_sim_hdl gpi_hdl);
 
 // Functions for setting the properties of a handle
-void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value);
-void gpi_set_signal_value_long(gpi_sim_hdl gpi_hdl, long value);
-void gpi_set_signal_value_binstr(gpi_sim_hdl gpi_hdl, const char *str); // String of binary char(s) [1, 0, x, z]
-void gpi_set_signal_value_str(gpi_sim_hdl gpi_hdl, const char *str);    // String of ASCII char(s)
+void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value, gpi_set_action_t action);
+void gpi_set_signal_value_long(gpi_sim_hdl gpi_hdl, long value, gpi_set_action_t action);
+void gpi_set_signal_value_binstr(gpi_sim_hdl gpi_hdl, const char *str, gpi_set_action_t action); // String of binary char(s) [1, 0, x, z]
+void gpi_set_signal_value_str(gpi_sim_hdl gpi_hdl, const char *str, gpi_set_action_t action);    // String of ASCII char(s)
 
 typedef enum gpi_edge {
     GPI_RISING = 1,

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -241,10 +241,10 @@ public:
     double get_signal_value_real() override;
     long get_signal_value_long() override;
 
-    int set_signal_value(long value) override;
-    int set_signal_value(double value) override;
-    int set_signal_value_binstr(std::string &value) override;
-    int set_signal_value_str(std::string &value) override;
+    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value(double value, gpi_set_action_t action) override;
+    int set_signal_value_str(std::string &value, gpi_set_action_t action) override;
+    int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
 
     void *get_sub_hdl(int index);
 
@@ -280,7 +280,7 @@ public:
     long get_signal_value_long() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value) override;
+    int set_signal_value(long value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
 
@@ -322,8 +322,8 @@ public:
     const char* get_signal_value_binstr() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value) override;
-    int set_signal_value_binstr(std::string &value) override;
+    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
 
@@ -380,7 +380,7 @@ public:
     double get_signal_value_real() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(double value) override;
+    int set_signal_value(double value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
 
@@ -410,7 +410,7 @@ public:
     const char* get_signal_value_str() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value_str(std::string &value) override;
+    int set_signal_value_str(std::string &value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
 

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -140,30 +140,34 @@ long FliValueObjHdl::get_signal_value_long()
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value(long value)
+int FliValueObjHdl::set_signal_value(long value, gpi_set_action_t action)
 {
     COCOTB_UNUSED(value);
+    COCOTB_UNUSED(action);
     LOG_ERROR("Setting signal/variable value via long not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value_binstr(std::string &value)
+int FliValueObjHdl::set_signal_value_binstr(std::string &value, gpi_set_action_t action)
 {
     COCOTB_UNUSED(value);
+    COCOTB_UNUSED(action);
     LOG_ERROR("Setting signal/variable value via string not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value_str(std::string &value)
+int FliValueObjHdl::set_signal_value_str(std::string &value, gpi_set_action_t action)
 {
     COCOTB_UNUSED(value);
+    COCOTB_UNUSED(action);
     LOG_ERROR("Setting signal/variable value via string not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value(double value)
+int FliValueObjHdl::set_signal_value(double value, gpi_set_action_t action)
 {
     COCOTB_UNUSED(value);
+    COCOTB_UNUSED(action);
     LOG_ERROR("Setting signal/variable value via double not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }
@@ -221,8 +225,13 @@ long FliEnumObjHdl::get_signal_value_long()
     }
 }
 
-int FliEnumObjHdl::set_signal_value(const long value)
+int FliEnumObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
 {
+    if (action != GPI_DEPOSIT) {
+        LOG_CRITICAL("Force or release action not supported for FLI.");
+        return -1;
+    }
+
     if (value > m_num_enum || value < 0) {
         LOG_ERROR("Attempted to set a enum with range [0,%d] with invalid value %d!\n", m_num_enum, value);
         return -1;
@@ -313,8 +322,13 @@ const char* FliLogicObjHdl::get_signal_value_binstr()
     return m_val_buff;
 }
 
-int FliLogicObjHdl::set_signal_value(const long value)
+int FliLogicObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
 {
+    if (action != GPI_DEPOSIT) {
+        LOG_CRITICAL("Force or release action not supported for FLI.");
+        return -1;
+    }
+
     if (m_fli_type == MTI_TYPE_ENUM) {
         mtiInt32T enumVal = value ? m_enum_map['1'] : m_enum_map['0'];
 
@@ -341,8 +355,13 @@ int FliLogicObjHdl::set_signal_value(const long value)
     return 0;
 }
 
-int FliLogicObjHdl::set_signal_value_binstr(std::string &value)
+int FliLogicObjHdl::set_signal_value_binstr(std::string &value, const gpi_set_action_t action)
 {
+    if (action != GPI_DEPOSIT) {
+        LOG_CRITICAL("Force or release action not supported for FLI.");
+        return -1;
+    }
+
     if (m_fli_type == MTI_TYPE_ENUM) {
         mtiInt32T enumVal = m_enum_map[value.c_str()[0]];
 
@@ -424,8 +443,13 @@ long FliIntObjHdl::get_signal_value_long()
     return (long)value;
 }
 
-int FliIntObjHdl::set_signal_value(const long value)
+int FliIntObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
 {
+    if (action != GPI_DEPOSIT) {
+        LOG_CRITICAL("Force or release action not supported for FLI.");
+        return -1;
+    }
+
     if (m_is_var) {
         mti_SetVarValue(get_handle<mtiVariableIdT>(), value);
     } else {
@@ -462,8 +486,13 @@ double FliRealObjHdl::get_signal_value_real()
     return m_mti_buff[0];
 }
 
-int FliRealObjHdl::set_signal_value(const double value)
+int FliRealObjHdl::set_signal_value(const double value, const gpi_set_action_t action)
 {
+    if (action != GPI_DEPOSIT) {
+        LOG_CRITICAL("Force or release action not supported for FLI.");
+        return -1;
+    }
+
     m_mti_buff[0] = value;
 
     if (m_is_var) {
@@ -513,8 +542,13 @@ const char* FliStringObjHdl::get_signal_value_str()
     return m_val_buff;
 }
 
-int FliStringObjHdl::set_signal_value_str(std::string &value)
+int FliStringObjHdl::set_signal_value_str(std::string &value, const gpi_set_action_t action)
 {
+    if (action != GPI_DEPOSIT) {
+        LOG_CRITICAL("Force or release action not supported for FLI.");
+        return -1;
+    }
+
     strncpy(m_mti_buff, value.c_str(), static_cast<size_t>(m_num_elems));
 
     if (m_is_var) {

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -493,30 +493,31 @@ int gpi_is_indexable(gpi_sim_hdl sig_hdl)
     return 0;
 }
 
-void gpi_set_signal_value_long(gpi_sim_hdl sig_hdl, long value)
+void gpi_set_signal_value_long(gpi_sim_hdl sig_hdl, long value, gpi_set_action_t action)
 {
     GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
-    obj_hdl->set_signal_value(value);
+
+    obj_hdl->set_signal_value(value, action);
 }
 
-void gpi_set_signal_value_binstr(gpi_sim_hdl sig_hdl, const char *binstr)
+void gpi_set_signal_value_binstr(gpi_sim_hdl sig_hdl, const char *binstr, gpi_set_action_t action)
 {
     std::string value = binstr;
     GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
-    obj_hdl->set_signal_value_binstr(value);
+    obj_hdl->set_signal_value_binstr(value, action);
 }
 
-void gpi_set_signal_value_str(gpi_sim_hdl sig_hdl, const char *str)
+void gpi_set_signal_value_str(gpi_sim_hdl sig_hdl, const char *str, gpi_set_action_t action)
 {
     std::string value = str;
     GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
-    obj_hdl->set_signal_value_str(value);
+    obj_hdl->set_signal_value_str(value, action);
 }
 
-void gpi_set_signal_value_real(gpi_sim_hdl sig_hdl, double value)
+void gpi_set_signal_value_real(gpi_sim_hdl sig_hdl, double value, gpi_set_action_t action)
 {
     GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
-    obj_hdl->set_signal_value(value);
+    obj_hdl->set_signal_value(value, action);
 }
 
 int gpi_get_num_elems(gpi_sim_hdl sig_hdl)

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -175,10 +175,10 @@ public:
 
     int m_length;
 
-    virtual int set_signal_value(const long value) = 0;
-    virtual int set_signal_value(const double value) = 0;
-    virtual int set_signal_value_str(std::string &value) = 0;
-    virtual int set_signal_value_binstr(std::string &value) = 0;
+    virtual int set_signal_value(const long value, gpi_set_action_t action) = 0;
+    virtual int set_signal_value(const double value, gpi_set_action_t action) = 0;
+    virtual int set_signal_value_str(std::string &value, gpi_set_action_t action) = 0;
+    virtual int set_signal_value_binstr(std::string &value, gpi_set_action_t action) = 0;
     //virtual GpiCbHdl monitor_value(bool rising_edge) = 0; this was for the triggers
     // but the explicit ones are probably better
 

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -653,12 +653,13 @@ static PyObject *set_signal_val_binstr(PyObject *self, PyObject *args)
     COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     const char *binstr;
+    gpi_set_action_t action;
 
-    if (!PyArg_ParseTuple(args, "O&s", gpi_sim_hdl_converter, &hdl, &binstr)) {
+    if (!PyArg_ParseTuple(args, "O&is", gpi_sim_hdl_converter, &hdl, &action, &binstr)) {
         return NULL;
     }
 
-    gpi_set_signal_value_binstr(hdl, binstr);
+    gpi_set_signal_value_binstr(hdl, binstr, action);
     Py_RETURN_NONE;
 }
 
@@ -666,13 +667,14 @@ static PyObject *set_signal_val_str(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
+    gpi_set_action_t action;
     const char *str;
 
-    if (!PyArg_ParseTuple(args, "O&s", gpi_sim_hdl_converter, &hdl, &str)) {
+    if (!PyArg_ParseTuple(args, "O&is", gpi_sim_hdl_converter, &hdl, &action, &str)) {
         return NULL;
     }
 
-    gpi_set_signal_value_str(hdl, str);
+    gpi_set_signal_value_str(hdl, str, action);
     Py_RETURN_NONE;
 }
 
@@ -681,12 +683,13 @@ static PyObject *set_signal_val_real(PyObject *self, PyObject *args)
     COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     double value;
+    gpi_set_action_t action;
 
-    if (!PyArg_ParseTuple(args, "O&d", gpi_sim_hdl_converter, &hdl, &value)) {
+    if (!PyArg_ParseTuple(args, "O&id", gpi_sim_hdl_converter, &hdl, &action, &value)) {
         return NULL;
     }
 
-    gpi_set_signal_value_real(hdl, value);
+    gpi_set_signal_value_real(hdl, value, action);
     Py_RETURN_NONE;
 }
 
@@ -695,12 +698,13 @@ static PyObject *set_signal_val_long(PyObject *self, PyObject *args)
     COCOTB_UNUSED(self);
     gpi_sim_hdl hdl;
     long value;
+    gpi_set_action_t action;
 
-    if (!PyArg_ParseTuple(args, "O&l", gpi_sim_hdl_converter, &hdl, &value)) {
+    if (!PyArg_ParseTuple(args, "O&il", gpi_sim_hdl_converter, &hdl, &action, &value)) {
         return NULL;
     }
 
-    gpi_set_signal_value_long(hdl, value);
+    gpi_set_signal_value_long(hdl, value, action);
     Py_RETURN_NONE;
 }
 

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -151,6 +151,24 @@ bool get_range(vhpiHandleT hdl, vhpiIntT dim, int *left, int *right) {
 
 }
 
+vhpiPutValueModeT map_put_value_mode(gpi_set_action_t action) {
+    vhpiPutValueModeT put_value_mode = vhpiDeposit;
+    switch (action) {
+        case GPI_DEPOSIT:
+            put_value_mode = vhpiDepositPropagate;
+            break;
+        case GPI_FORCE:
+            put_value_mode = vhpiForcePropagate;
+            break;
+        case GPI_RELEASE:
+            put_value_mode = vhpiRelease;
+            break;
+        default:
+            assert(0);
+    }
+    return put_value_mode;
+}
+
 int VhpiArrayObjHdl::initialise(std::string &name, std::string &fq_name) {
     vhpiHandleT handle = GpiObjHdl::get_handle<vhpiHandleT>();
 
@@ -474,7 +492,7 @@ vhpiEnumT VhpiSignalObjHdl::chr2vhpi(const char value)
 }
 
 // Value related functions
-int VhpiLogicSignalObjHdl::set_signal_value(long value)
+int VhpiLogicSignalObjHdl::set_signal_value(long value, gpi_set_action_t action)
 {
     switch (m_value.format) {
         case vhpiEnumVal:
@@ -499,7 +517,7 @@ int VhpiLogicSignalObjHdl::set_signal_value(long value)
         }
     }
 
-    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, vhpiDepositPropagate)) {
+    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, map_put_value_mode(action))) {
         check_vhpi_error();
         return -1;
     }
@@ -507,7 +525,7 @@ int VhpiLogicSignalObjHdl::set_signal_value(long value)
     return 0;
 }
 
-int VhpiLogicSignalObjHdl::set_signal_value_binstr(std::string &value)
+int VhpiLogicSignalObjHdl::set_signal_value_binstr(std::string &value, gpi_set_action_t action)
 {
     switch (m_value.format) {
         case vhpiEnumVal:
@@ -544,7 +562,7 @@ int VhpiLogicSignalObjHdl::set_signal_value_binstr(std::string &value)
         }
     }
 
-    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, vhpiDepositPropagate)) {
+    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, map_put_value_mode(action))) {
         check_vhpi_error();
         return -1;
     }
@@ -553,7 +571,7 @@ int VhpiLogicSignalObjHdl::set_signal_value_binstr(std::string &value)
 }
 
 // Value related functions
-int VhpiSignalObjHdl::set_signal_value(long value)
+int VhpiSignalObjHdl::set_signal_value(long value, gpi_set_action_t action)
 {
     switch (m_value.format) {
         case vhpiEnumVecVal:
@@ -606,7 +624,7 @@ int VhpiSignalObjHdl::set_signal_value(long value)
             return -1;
         }
     }
-    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, vhpiDepositPropagate)) {
+    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, map_put_value_mode(action))) {
         check_vhpi_error();
         return -1;
     }
@@ -614,7 +632,7 @@ int VhpiSignalObjHdl::set_signal_value(long value)
     return 0;
 }
 
-int VhpiSignalObjHdl::set_signal_value(double value)
+int VhpiSignalObjHdl::set_signal_value(double value, gpi_set_action_t action)
 {
     switch (m_value.format) {
         case vhpiRealVal:
@@ -631,7 +649,7 @@ int VhpiSignalObjHdl::set_signal_value(double value)
 
     }
 
-    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, vhpiDepositPropagate)) {
+    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, map_put_value_mode(action))) {
         check_vhpi_error();
         return -1;
     }
@@ -639,7 +657,7 @@ int VhpiSignalObjHdl::set_signal_value(double value)
     return 0;
 }
 
-int VhpiSignalObjHdl::set_signal_value_binstr(std::string &value)
+int VhpiSignalObjHdl::set_signal_value_binstr(std::string &value, gpi_set_action_t action)
 {
     switch (m_value.format) {
         case vhpiEnumVal:
@@ -677,7 +695,7 @@ int VhpiSignalObjHdl::set_signal_value_binstr(std::string &value)
         }
     }
 
-    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, vhpiDepositPropagate)) {
+    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, map_put_value_mode(action))) {
         check_vhpi_error();
         return -1;
     }
@@ -685,7 +703,7 @@ int VhpiSignalObjHdl::set_signal_value_binstr(std::string &value)
     return 0;
 }
 
-int VhpiSignalObjHdl::set_signal_value_str(std::string &value)
+int VhpiSignalObjHdl::set_signal_value_str(std::string &value, gpi_set_action_t action)
 {
     switch (m_value.format) {
 
@@ -704,7 +722,7 @@ int VhpiSignalObjHdl::set_signal_value_str(std::string &value)
         }
     }
 
-    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, vhpiDepositPropagate)) {
+    if (vhpi_put_value(GpiObjHdl::get_handle<vhpiHandleT>(), &m_value, map_put_value_mode(action))) {
         check_vhpi_error();
         return -1;
     }

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -187,10 +187,10 @@ public:
     long get_signal_value_long() override;
 
     using GpiSignalObjHdl::set_signal_value;
-    int set_signal_value(long value) override;
-    int set_signal_value(double value) override;
-    int set_signal_value_binstr(std::string &value) override;
-    int set_signal_value_str(std::string &value) override;
+    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value(double value, gpi_set_action_t action) override;
+    int set_signal_value_str(std::string &value, gpi_set_action_t action) override;
+    int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(int edge) override;
@@ -214,8 +214,8 @@ public:
 
 
     using GpiSignalObjHdl::set_signal_value;
-    int set_signal_value(long value) override;
-    int set_signal_value_binstr(std::string &value) override;
+    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
 };

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -173,17 +173,17 @@ public:
     double get_signal_value_real() override;
     long get_signal_value_long() override;
 
-    int set_signal_value(const long value) override;
-    int set_signal_value(const double value) override;
-    int set_signal_value_binstr(std::string &value) override;
-    int set_signal_value_str(std::string &value) override;
+    int set_signal_value(const long value, gpi_set_action_t action) override;
+    int set_signal_value(const double value, gpi_set_action_t action) override;
+    int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
+    int set_signal_value_str(std::string &value, gpi_set_action_t action) override;
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(int edge) override;
     int initialise(std::string &name, std::string &fq_name) override;
 
 private:
-    int set_signal_value(s_vpi_value value);
+    int set_signal_value(s_vpi_value value, gpi_set_action_t action);
 
     VpiValueCbHdl m_rising_cb;
     VpiValueCbHdl m_falling_cb;

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -198,6 +198,21 @@ Simulation Object Handles
     :show-inheritance:
     :synopsis: Classes for simulation objects.
 
+.. assigment-methods-section
+
+Assignment Methods
+------------------
+
+.. currentmodule:: cocotb.handle
+
+.. autoclass:: Deposit
+
+.. autoclass:: Force
+
+.. autoclass:: Freeze
+
+.. autoclass:: Release
+
 Implemented Testbench Structures
 ================================
 

--- a/documentation/source/newsfragments/1403.feature.rst
+++ b/documentation/source/newsfragments/1403.feature.rst
@@ -1,0 +1,15 @@
+Cocotb now supports deposit/force/release/freeze actions on simulator handles, exposing functionality similar to the respective Verilog/VHDL assignments.
+
+.. code-block:: python3
+
+   from cocotb.handle import Deposit, Force, Release, Freeze
+
+   dut.q <= 1            # A regular value deposit
+   dut.q <= Deposit(1)   # The same, higher verbosity
+   dut.q <= Force(1)     # Force value of q to 1
+   dut.q <= Release()    # Release q from a Force
+   dut.q <= Freeze()     # Freeze the current value of q
+
+..
+   towncrier will append the issue number taken from the file name here:
+Issue

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -250,6 +250,24 @@ writes are not applied immediately, but delayed until the next write cycle.
 Use ``sig.setimmediatevalue(new_val)`` to set a new value immediately
 (see :meth:`~cocotb.handle.ModifiableObject.setimmediatevalue`).
 
+In addition to regular value assignments (deposits), signals can be forced
+to a predetermined value or frozen at their current value. To achieve this,
+the various actions described in :ref:`assignment-methods-section` can be used.
+
+.. code-block:: python3
+
+    # Deposit action
+    dut.my_signal <= 12
+    dut.my_signal <= Deposit(12)  # equivalent syntax
+
+    # Force action
+    dut.my_signal <= Force(12)    # my_signal stays 12 until released
+
+    # Release action
+    dut.my_signal <= Release()    # Reverts any force/freeze assignments
+
+    # Freeze action
+    dut.my_signal <= Freeze()     # my_signal stays at current value until released
 
 
 Reading values from signals

--- a/tests/test_cases/test_force_release/Makefile
+++ b/tests/test_cases/test_force_release/Makefile
@@ -1,0 +1,7 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+include ../../designs/sample_module/Makefile
+
+MODULE ?= test_force_release

--- a/tests/test_cases/test_force_release/test_force_release.py
+++ b/tests/test_cases/test_force_release/test_force_release.py
@@ -1,0 +1,34 @@
+import logging
+
+import cocotb
+from cocotb.triggers import Timer
+from cocotb.result import TestFailure
+from cocotb.handle import Force, Release
+
+
+@cocotb.test(expect_fail=cocotb.SIM_NAME in ["GHDL"])
+async def test_force_release(dut):
+    """
+    Test force and release on simulation handles
+    """
+    log = logging.getLogger("cocotb.test")
+    await Timer(10, "ns")
+    dut.stream_in_data = 4
+    dut.stream_out_data_comb = Force(5)
+    await Timer(10, "ns")
+    got_in = int(dut.stream_in_data)
+    got_out = int(dut.stream_out_data_comb)
+    log.info("dut.stream_in_data = %d" % got_in)
+    log.info("dut.stream_out_data_comb = %d" % got_out)
+    if got_in == got_out:
+        raise TestFailure("stream_in_data and stream_out_data_comb should not match when force is active!")
+
+    dut.stream_out_data_comb = Release()
+    dut.stream_in_data = 3
+    await Timer(10, "ns")
+    got_in = int(dut.stream_in_data)
+    got_out = int(dut.stream_out_data_comb)
+    log.info("dut.stream_in_data = %d" % got_in)
+    log.info("dut.stream_out_data_comb = %d" % got_out)
+    if got_in != got_out:
+        raise TestFailure("stream_in_data and stream_out_data_comb should match when output was released!")


### PR DESCRIPTION
I finally got around to looking at #657. I have mostly re-applied the patch prepared by @lukedarnell to current master, fixed small issues with it and gave it a test.

As it stands, a testbench running on a VPI simulator can do:
```
from cocotb.handle import Force, Release, Deposit
...
dut.q <= 0 # default action: deposit
dut.q <= Deposit(0) # does the same as above
dut.q <= Force(1) # forces the net to 1
dut.q <= Release() # releases the net
```

What's still to be done:
  - add documentation
  - implement the mechanisms also for VHPI/FLI
  - add a proper unit test/example

I'd already like to hear whether there are some thoughts on how it was implemented to figure out if any significant changes would be required in your opinion.