### PR TITLE
Revert "Implemented PLUSARGS for FLI"

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -148,7 +148,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(INT_LIBS)
 
 	set -o pipefail; $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 \
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) \
-	$(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
+	$(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do 2>&1 | tee $(SIM_BUILD)/sim.log
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/documentation/source/newsfragments/1256.feature.rst
+++ b/documentation/source/newsfragments/1256.feature.rst
@@ -1,1 +1,0 @@
-Questa now supports :envvar:`PLUSARGS`. This requires that ``tcl.h`` be present on the system. This is likely included in your installation of Questa. Otherwise, specify ``CXXFLAGS=-I/path/to/tcl/includedir``.


### PR DESCRIPTION
This reverts commit b283b48368a3a7f507110c6699db3a6c7ce01677.

The Questa-shipped TCL interface changed from TCL 8.5 to 8.6 in newer
versions, which is incompatible with this change.

See #1404