### PR TITLE
Store the simulator time in the log record, rather than retrieving it when printing

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -50,7 +50,7 @@ extensions = [
     'sphinxarg.ext',
     ]
 
-intersphinx_mapping = {'https://docs.python.org/3': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # Github repo
 issues_github_path = "cocotb/cocotb"

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -169,6 +169,20 @@ Logging
     :show-inheritance:
     :no-members:
 
+.. autoclass:: SimTimeContextFilter
+    :show-inheritance:
+    :no-members:
+
+.. currentmodule:: None
+
+.. attribute:: logging.LogRecord.created_sim_time
+
+    The result of :func:`get_sim_time` at the point the log was created
+    (in simulator units). The formatter is responsible for converting this
+    to something like nanoseconds via :func:`~cocotb.utils.get_time_from_sim_steps`.
+
+    This is added by :class:`cocotb.log.SimTimeContextFilter`.
+
 
 Simulation Object Handles
 =========================

--- a/documentation/source/newsfragments/1411.feature.rst
+++ b/documentation/source/newsfragments/1411.feature.rst
@@ -1,0 +1,4 @@
+Custom logging handlers can now access the simulator time using
+:attr:`logging.LogRecord.created_sim_time`, provided the
+:class:`~cocotb.log.SimTimeContextFilter` filter added by
+:func:`~cocotb.log.default_config` is not removed from the logger instance.


### PR DESCRIPTION
Without this change, it was possible that records had incorrect timestamps - if someone attached a handlers that put the records in a list, and formatted them only at shutdown, they'd find that all their log messages had the same timestamp.

This also fixes a crash if `get_sim_time` tries to log. (#1320)

https://external-builds.readthedocs.io/html/cocotb/1411/library_reference.html#cocotb.log.SimTimeContextFilter