### PR TITLE
remove unused EXTRA_LIBS and EXTRA_LIBDIRS vars

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -154,18 +154,10 @@ ifeq ($(OS),Msys)
 
 MINGW_BIN_DIR = $(shell dirname $(shell :; command -v gcc))
 
-EXTRA_LIBS := -laldecpli
-EXTRA_LIBDIRS := -L$(ALDEC_BIN_DIR)
 OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
 LIB_LOAD = PATH=$(MINGW_BIN_DIR):$(OLD_PATH):$(LIB_DIR)
 NEW_PYTHONPATH := $(shell echo "$(PYTHONPATH)" | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):\//\/\1\//g' -e 's/;/:/g')
 else
-EXTRA_LIBS = -laldecpli
-ifeq ($(ARCH),i686)
-EXTRA_LIBDIRS = -L$(ALDEC_BIN_DIR)/Linux
-else
-EXTRA_LIBDIRS = -L$(ALDEC_BIN_DIR)/Linux64
-endif
 LIB_LOAD := LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)
 NEW_PYTHONPATH := $(PYTHONPATH)
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -64,8 +64,6 @@ $(SIM_BUILD)/sim.vvp: $(SIM_BUILD) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS)
 
 ifeq ($(OS),Msys)
 
-EXTRA_LIBS := -lvpi
-EXTRA_LIBDIRS := -L$(ICARUS_BIN_DIR)/../lib
 OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
 LIB_LOAD = PATH=$(OLD_PATH):$(LIB_DIR)
 NEW_PYTHONPATH:=$(shell python -c "import sys, os; print(':'.join(['/'+dir.replace(os.sep,'/').replace(':','') for dir in sys.path]))")

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -124,8 +124,6 @@ ifeq ($(OS),Msys)
 
 MINGW_BIN_DIR = $(shell dirname $(shell :; command -v gcc))
 
-EXTRA_LIBS := -lmtipli
-EXTRA_LIBDIRS := -L$(MODELSIM_BIN_DIR)
 OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
 
 LIB_LOAD := PATH=$(MINGW_BIN_DIR):$(OLD_PATH):$(LIB_DIR)


### PR DESCRIPTION
cleanup after #1306

Linking is handled now in `_build_libs.py` during setup using def files. No need to specify this in simulator makefiles.
