### PR TITLE
remove cocotb python files from CUSTOM_SIM_DEPS

### DIFF
--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -112,10 +112,6 @@ ifeq ($(HAVE_SIMULATOR),0)
     $(error "Couldn't find makefile for simulator: "$(SIM_LOWERCASE)"! Available simulators: $(AVAILABLE_SIMULATORS)")
 endif
 
-# Depend on all Python from the cocotb package. This triggers a
-# recompilation of the simulation if cocotb is updated.
-CUSTOM_SIM_DEPS += $(shell find $(COCOTB_PY_DIR)/cocotb/ -name "*.py")
-
 PWD := $(shell pwd)
 
 #include $(COCOTB_SHARE_DIR)/lib/Makefile


### PR DESCRIPTION
There is no reason for simulation compilation to depend on cocotb python files