### PR TITLE
Revert "remove PY_SO_LIB and do not try to load python dynamically"

### DIFF
--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -148,6 +148,16 @@ def _get_python_lib_link():
     return python_lib_link
 
 
+def _get_python_lib():
+    """ Get the library for embedded the python interpreter """
+
+    if os.name == "nt":
+        python_lib = _get_python_lib_link() + "." + _get_lib_ext_name()
+    else:
+        python_lib = "lib" + _get_python_lib_link() + "." + _get_lib_ext_name()
+
+    return python_lib
+
 # TODO [gh-1372]: make this work for MSVC which has a different flag syntax
 _base_warns = ["-Wall", "-Wextra", "-Wcast-qual", "-Wwrite-strings", "-Wconversion"]
 _cc_warns = _base_warns + ["-Wstrict-prototypes", "-Waggregate-return"]
@@ -197,6 +207,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir, sim_define):
     #
     libcocotb = Extension(
         os.path.join("cocotb", "libs", sim_define.lower(), "libcocotb"),
+        define_macros=[("PYTHON_SO_LIB", _get_python_lib())],
         include_dirs=[include_dir],
         libraries=[_get_python_lib_link(), "gpilog", "cocotbutils"],
         library_dirs=python_lib_dirs,

--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -112,9 +112,20 @@ void embed_init_python(void)
 {
     FENTER;
 
+#ifndef PYTHON_SO_LIB
+#error "Python version needs passing in with -DPYTHON_SO_VERSION=libpython<ver>.so"
+#else
+#define PY_SO_LIB xstr(PYTHON_SO_LIB)
+#endif
+
     // Don't initialize Python if already running
     if (gtstate)
         return;
+
+    void * lib_handle = utils_dyn_open(PY_SO_LIB);
+    if (!lib_handle) {
+        LOG_ERROR("Failed to find Python shared library\n");
+    }
 
     to_python();
     set_program_name_in_venv();


### PR DESCRIPTION
Reverts cocotb/cocotb#1416

It is needed for commercial simulators.