### PR TITLE
Tidy vlog_startup_routines_bootstrap a little

### DIFF
--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -705,7 +705,7 @@ void (*vlog_startup_routines[])() = {
 // For non-VPI compliant applications that cannot find vlog_startup_routines symbol
 void vlog_startup_routines_bootstrap() {
     // call each routine in turn like VPI would
-    for (auto it = &log_startup_routines[0]; *it != nullptr; it++) {
+    for (auto it = &vlog_startup_routines[0]; *it != nullptr; it++) {
         auto routine = *it;
         routine();
     }

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -698,18 +698,15 @@ void (*vlog_startup_routines[])() = {
     register_system_functions,
     register_initial_callback,
     register_final_callback,
-    0
+    nullptr
 };
 
 
 // For non-VPI compliant applications that cannot find vlog_startup_routines symbol
 void vlog_startup_routines_bootstrap() {
-    void (*routine)();
-    int i;
-    routine = vlog_startup_routines[0];
-    for (i = 0, routine = vlog_startup_routines[i];
-         routine;
-         routine = vlog_startup_routines[++i]) {
+    // call each routine in turn like VPI would
+    for (auto it = &log_startup_routines[0]; *it != nullptr; it++) {
+        auto routine = *it;
         routine();
     }
 }


### PR DESCRIPTION
No functional change here, just eliminating a lot of noise.
`it` is a pretty standard variable name for a C++ iterator.