### PR TITLE
Implemented PLUSARGS for FLI

### DIFF
--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -59,12 +59,6 @@ we have to create a process with the signal on the sensitivity list to imitate a
 
 #include <gpi_logging.h>
 
-#if defined(__MINGW32__) || defined (__CYGWIN32__)
-#  define DLLEXPORT __declspec(dllexport)
-#else
-#  define DLLEXPORT
-#endif
-
 #ifdef __cplusplus
 # define EXTERN_C_START extern "C" {
 # define EXTERN_C_END }

--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -26,6 +26,9 @@
 ******************************************************************************/
 
 #include "FliImpl.h"
+#include "mti.h"
+#include "tcl.h"
+#include <limits>
 
 /**
  * @name    cleanup callback
@@ -140,6 +143,53 @@ int FliStartupCbHdl::arm_callback()
     return 0;
 }
 
+
+static std::vector<std::string> get_argv()
+{
+    /*  Necessary to implement PLUSARGS
+        There is no function available on the FLI to obtain argc+argv directly from the
+        simulator. To work around this we use the TCL interpreter that ships with Questa,
+        some TCL commands, and the TCL variable `argv` to obtain the simulator argc+argv.
+    */
+    std::vector<std::string> argv;
+
+    // obtain a reference to TCL interpreter
+    Tcl_Interp* interp = reinterpret_cast<Tcl_Interp*>(mti_Interp());
+
+    // get argv TCL variable
+    if (mti_Cmd("return -level 0 $argv") != TCL_OK) {
+        const char* errmsg = Tcl_GetStringResult(interp);
+        LOG_WARN("Failed to get reference to argv: %s", errmsg);
+        Tcl_ResetResult(interp);
+        return argv;
+    }
+    Tcl_Obj* result = Tcl_GetObjResult(interp);
+    Tcl_IncrRefCount(result);
+    Tcl_ResetResult(interp);
+
+    // split TCL list into length and element array
+    int argc;
+    Tcl_Obj** tcl_argv;
+    if (Tcl_ListObjGetElements(interp, result, &argc, &tcl_argv) != TCL_OK) {
+        const char* errmsg = Tcl_GetStringResult(interp);
+        LOG_WARN("Failed to get argv elements: %s", errmsg);
+        Tcl_DecrRefCount(result);
+        Tcl_ResetResult(interp);
+        return argv;
+    }
+    Tcl_ResetResult(interp);
+
+    // get each argv arg and copy into internal storage
+    for (int i = 0; i < argc; i++) {
+        const char* arg = Tcl_GetString(tcl_argv[i]);
+        argv.push_back(arg);
+    }
+    Tcl_DecrRefCount(result);
+
+    return argv;
+}
+
+
 int FliStartupCbHdl::run_callback()
 {
     gpi_sim_info_t sim_info;
@@ -166,12 +216,16 @@ int FliStartupCbHdl::run_callback()
     product.push_back('\0');
     version.push_back('\0');
 
-
-    // copy in sim_info.product
-    sim_info.argc = 0;
-    sim_info.argv = NULL;
     sim_info.product = &product[0];
     sim_info.version = &version[0];
+
+    std::vector<std::string> argv = get_argv();
+    std::vector<char*> argv_cstr;
+    for (const auto& arg : argv) {
+        argv_cstr.push_back(const_cast<char*>(arg.c_str()));
+    }
+    sim_info.argc = static_cast<int>(argv.size());
+    sim_info.argv = argv_cstr.data();
 
     gpi_embed_init(&sim_info);
 

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -146,7 +146,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(INT_LIBS)
 
 	set -o pipefail; $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 \
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) \
-	$(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do 2>&1 | tee $(SIM_BUILD)/sim.log
+	$(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/documentation/source/newsfragments/1424.feature.rst
+++ b/documentation/source/newsfragments/1424.feature.rst
@@ -1,0 +1,3 @@
+Questa now supports :envvar:`PLUSARGS`.
+This requires that ``tcl.h`` be present on the system.
+This is likely included in your installation of Questa, otherwise, specify ``CFLAGS=-I/path/to/tcl/includedir``.


### PR DESCRIPTION
Fixed version of b283b48368a3a7f507110c6699db3a6c7ce01677. Uses `Tcl_GetStringResult` instead of accessing the internal `result` field, this works on TCL 8.5 and 8.6. Fixes #1404.

Finally got 2019.1 setup and tested this PR against it as well as 10.5c and 10.7c.

I tried using `Tcl_GetVar2Ex` to grab a reference to `argv`, then do processing on it, but there is something weird about how Questa maintains its TCL interpreter because it returns a message that the variable isn't defined. `mti_Cmd` seems to work.