### PR TITLE
Make the gpi C types stricter

### DIFF
--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -85,8 +85,10 @@ we have to create a process with the signal on the sensitivity list to imitate a
      * incomplete types, as this avoids the need for any casting in GpiCommon.cpp.
      */
     class GpiObjHdl;
+    class GpiCbHdl;
     class GpiIterator;
     typedef GpiObjHdl *gpi_sim_hdl;
+    typedef GpiCbHdl *gpi_cb_hdl;
     typedef GpiIterator *gpi_iterator_hdl;
 #else
     /* In C, we declare some incomplete struct types that we never complete.
@@ -94,8 +96,10 @@ we have to create a process with the signal on the sensitivity list to imitate a
      * names.
      */
     struct GpiObjHdl;
+    struct GpiCbHdl;
     struct GpiIterator;
     typedef struct GpiObjHdl *gpi_sim_hdl;
+    typedef struct GpiCbHdl *gpi_cb_hdl;
     typedef struct GpiIterator *gpi_iterator_hdl;
 #endif
 
@@ -224,19 +228,19 @@ typedef enum gpi_edge {
 } gpi_edge_e;
 
 // The callback registering functions
-gpi_sim_hdl gpi_register_timed_callback                  (int (*gpi_function)(const void *), void *gpi_cb_data, uint64_t time_ps);
-gpi_sim_hdl gpi_register_value_change_callback           (int (*gpi_function)(const void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl, int edge);
-gpi_sim_hdl gpi_register_readonly_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
-gpi_sim_hdl gpi_register_nexttime_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
-gpi_sim_hdl gpi_register_readwrite_callback              (int (*gpi_function)(const void *), void *gpi_cb_data);
+gpi_cb_hdl gpi_register_timed_callback                  (int (*gpi_function)(const void *), void *gpi_cb_data, uint64_t time_ps);
+gpi_cb_hdl gpi_register_value_change_callback           (int (*gpi_function)(const void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl, int edge);
+gpi_cb_hdl gpi_register_readonly_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
+gpi_cb_hdl gpi_register_nexttime_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
+gpi_cb_hdl gpi_register_readwrite_callback              (int (*gpi_function)(const void *), void *gpi_cb_data);
 
 // Calling convention is that 0 = success and negative numbers a failure
 // For implementers of GPI the provided macro GPI_RET(x) is provided
-void gpi_deregister_callback(gpi_sim_hdl gpi_hdl);
+void gpi_deregister_callback(gpi_cb_hdl gpi_hdl);
 
 // Because the internal structures may be different for different implementations
 // of GPI we provide a convenience function to extract the callback data
-void *gpi_get_callback_data(gpi_sim_hdl gpi_hdl);
+void *gpi_get_callback_data(gpi_cb_hdl gpi_hdl);
 
 // Print out what implementations are registered. Python needs to be loaded for this,
 // Returns the number of libs

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -72,7 +72,32 @@ we have to create a process with the signal on the sensitivity list to imitate a
 # define __attribute__(x)
 #endif
 
-
+/*
+ * Declare the handle types.
+ *
+ * We want these handles to be opaque pointers, since their layout is not
+ * exposed to C. We do this by using incomplete types. The assumption being
+ * made here is that `sizeof(some_cpp_class*) == sizeof(some_c_struct*)`, which
+ * is true on all reasonable platforms.
+ */
+#ifdef __cplusplus
+    /* In C++, we use forward-declarations of the types in gpi_priv.h as our
+     * incomplete types, as this avoids the need for any casting in GpiCommon.cpp.
+     */
+    class GpiObjHdl;
+    class GpiIterator;
+    typedef GpiObjHdl *gpi_sim_hdl;
+    typedef GpiIterator *gpi_iterator_hdl;
+#else
+    /* In C, we declare some incomplete struct types that we never complete.
+     * The names of these are irrelevant, but for simplicity they match the C++
+     * names.
+     */
+    struct GpiObjHdl;
+    struct GpiIterator;
+    typedef struct GpiObjHdl *gpi_sim_hdl;
+    typedef struct GpiIterator *gpi_iterator_hdl;
+#endif
 
 EXTERN_C_START
 
@@ -90,12 +115,6 @@ typedef struct gpi_sim_info_s
     char      *version;
     int32_t   *reserved[4];
 } gpi_sim_info_t;
-
-// Define a type for our simulation handle.
-typedef void * gpi_sim_hdl;
-
-// Define a handle type for iterators
-typedef void * gpi_iterator_hdl;
 
 // Functions for controlling/querying the simulation state
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -355,10 +355,9 @@ static GpiObjHdl* __gpi_get_handle_by_raw(GpiObjHdl *parent,
     }
 }
 
-gpi_sim_hdl gpi_get_handle_by_name(gpi_sim_hdl parent, const char *name)
+gpi_sim_hdl gpi_get_handle_by_name(gpi_sim_hdl base, const char *name)
 {
     std::string s_name = name;
-    GpiObjHdl *base = sim_to_hdl<GpiObjHdl*>(parent);
     GpiObjHdl *hdl = __gpi_get_handle_by_name(base, s_name, NULL);
     if (!hdl) {
         LOG_DEBUG("Failed to find a handle named %s via any registered implementation",
@@ -367,10 +366,9 @@ gpi_sim_hdl gpi_get_handle_by_name(gpi_sim_hdl parent, const char *name)
     return hdl;
 }
 
-gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl parent, int32_t index)
+gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl base, int32_t index)
 {
     GpiObjHdl *hdl         = NULL;
-    GpiObjHdl *base        = sim_to_hdl<GpiObjHdl*>(parent);
     GpiImplInterface *intf = base->m_impl;
 
     /* Shouldn't need to iterate over interfaces because indexing into a handle shouldn't
@@ -390,20 +388,18 @@ gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl parent, int32_t index)
     }
 }
 
-gpi_iterator_hdl gpi_iterate(gpi_sim_hdl base, gpi_iterator_sel_t type)
+gpi_iterator_hdl gpi_iterate(gpi_sim_hdl obj_hdl, gpi_iterator_sel_t type)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(base);
     GpiIterator *iter = obj_hdl->m_impl->iterate_handle(obj_hdl, type);
     if (!iter) {
         return NULL;
     }
-    return (gpi_iterator_hdl)iter;
+    return iter;
 }
 
-gpi_sim_hdl gpi_next(gpi_iterator_hdl iterator)
+gpi_sim_hdl gpi_next(gpi_iterator_hdl iter)
 {
     std::string name;
-    GpiIterator *iter = sim_to_hdl<GpiIterator*>(iterator);
     GpiObjHdl *parent = iter->get_parent();
 
     while (true) {
@@ -441,71 +437,65 @@ gpi_sim_hdl gpi_next(gpi_iterator_hdl iterator)
     }
 }
 
-const char* gpi_get_definition_name(gpi_sim_hdl sig_hdl)
+const char* gpi_get_definition_name(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     return obj_hdl->get_definition_name();
 }
 
-const char* gpi_get_definition_file(gpi_sim_hdl sig_hdl)
+const char* gpi_get_definition_file(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     return obj_hdl->get_definition_file();
 }
 
 const char *gpi_get_signal_value_binstr(gpi_sim_hdl sig_hdl)
 {
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
     return obj_hdl->get_signal_value_binstr();
 }
 
 const char *gpi_get_signal_value_str(gpi_sim_hdl sig_hdl)
 {
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
     return obj_hdl->get_signal_value_str();
 }
 
 double gpi_get_signal_value_real(gpi_sim_hdl sig_hdl)
 {
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
     return obj_hdl->get_signal_value_real();
 }
 
 long gpi_get_signal_value_long(gpi_sim_hdl sig_hdl)
 {
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
     return obj_hdl->get_signal_value_long();
 }
 
 const char *gpi_get_signal_name_str(gpi_sim_hdl sig_hdl)
 {
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
     return obj_hdl->get_name_str();
 }
 
-const char *gpi_get_signal_type_str(gpi_sim_hdl sig_hdl)
+const char *gpi_get_signal_type_str(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     return obj_hdl->get_type_str();
 }
 
-gpi_objtype_t gpi_get_object_type(gpi_sim_hdl sig_hdl)
+gpi_objtype_t gpi_get_object_type(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     return obj_hdl->get_type();
 }
 
-int gpi_is_constant(gpi_sim_hdl sig_hdl)
+int gpi_is_constant(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     if (obj_hdl->get_const())
         return 1;
     return 0;
 }
 
-int gpi_is_indexable(gpi_sim_hdl sig_hdl)
+int gpi_is_indexable(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     if (obj_hdl->get_indexable())
         return 1;
     return 0;
@@ -513,7 +503,7 @@ int gpi_is_indexable(gpi_sim_hdl sig_hdl)
 
 void gpi_set_signal_value_long(gpi_sim_hdl sig_hdl, long value, gpi_set_action_t action)
 {
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
 
     obj_hdl->set_signal_value(value, action);
 }
@@ -521,38 +511,35 @@ void gpi_set_signal_value_long(gpi_sim_hdl sig_hdl, long value, gpi_set_action_t
 void gpi_set_signal_value_binstr(gpi_sim_hdl sig_hdl, const char *binstr, gpi_set_action_t action)
 {
     std::string value = binstr;
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
     obj_hdl->set_signal_value_binstr(value, action);
 }
 
 void gpi_set_signal_value_str(gpi_sim_hdl sig_hdl, const char *str, gpi_set_action_t action)
 {
     std::string value = str;
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
     obj_hdl->set_signal_value_str(value, action);
 }
 
 void gpi_set_signal_value_real(gpi_sim_hdl sig_hdl, double value, gpi_set_action_t action)
 {
-    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
     obj_hdl->set_signal_value(value, action);
 }
 
-int gpi_get_num_elems(gpi_sim_hdl sig_hdl)
+int gpi_get_num_elems(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     return obj_hdl->get_num_elems();
 }
 
-int gpi_get_range_left(gpi_sim_hdl sig_hdl)
+int gpi_get_range_left(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     return obj_hdl->get_range_left();
 }
 
-int gpi_get_range_right(gpi_sim_hdl sig_hdl)
+int gpi_get_range_right(gpi_sim_hdl obj_hdl)
 {
-    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
     return obj_hdl->get_range_right();
 }
 
@@ -562,7 +549,7 @@ gpi_sim_hdl gpi_register_value_change_callback(int (*gpi_function)(const void *)
                                                int edge)
 {
 
-    GpiSignalObjHdl *signal_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    GpiSignalObjHdl *signal_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
 
     /* Do something based on int & GPI_RISING | GPI_FALLING */
     GpiCbHdl *gpi_hdl = signal_hdl->value_change_cb(edge);
@@ -637,7 +624,8 @@ gpi_sim_hdl gpi_register_readwrite_callback(int (*gpi_function)(const void *),
 
 void gpi_deregister_callback(gpi_sim_hdl hdl)
 {
-    GpiCbHdl *cb_hdl = sim_to_hdl<GpiCbHdl*>(hdl);
+    // TODO: Why are we pretending this is one type when it is another?
+    GpiCbHdl *cb_hdl = reinterpret_cast<GpiCbHdl*>(hdl);
     cb_hdl->m_impl->deregister_callback(cb_hdl);
 }
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -543,7 +543,7 @@ int gpi_get_range_right(gpi_sim_hdl obj_hdl)
     return obj_hdl->get_range_right();
 }
 
-gpi_sim_hdl gpi_register_value_change_callback(int (*gpi_function)(const void *),
+gpi_cb_hdl gpi_register_value_change_callback(int (*gpi_function)(const void *),
                                                void *gpi_cb_data,
                                                gpi_sim_hdl sig_hdl,
                                                int edge)
@@ -559,12 +559,12 @@ gpi_sim_hdl gpi_register_value_change_callback(int (*gpi_function)(const void *)
     }
 
     gpi_hdl->set_user_data(gpi_function, gpi_cb_data);
-    return (gpi_sim_hdl)gpi_hdl;
+    return gpi_hdl;
 }
 
 /* It should not matter which implementation we use for this so just pick the first
    one */
-gpi_sim_hdl gpi_register_timed_callback(int (*gpi_function)(const void *),
+gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(const void *),
                                         void *gpi_cb_data, uint64_t time_ps)
 {
     GpiCbHdl *gpi_hdl = registered_impls[0]->register_timed_callback(time_ps);
@@ -574,13 +574,13 @@ gpi_sim_hdl gpi_register_timed_callback(int (*gpi_function)(const void *),
     }
 
     gpi_hdl->set_user_data(gpi_function, gpi_cb_data);
-    return (gpi_sim_hdl)gpi_hdl;
+    return gpi_hdl;
 }
 
 /* It should not matter which implementation we use for this so just pick the first
    one
 */
-gpi_sim_hdl gpi_register_readonly_callback(int (*gpi_function)(const void *),
+gpi_cb_hdl gpi_register_readonly_callback(int (*gpi_function)(const void *),
                                            void *gpi_cb_data)
 {
     GpiCbHdl *gpi_hdl = registered_impls[0]->register_readonly_callback();
@@ -590,10 +590,10 @@ gpi_sim_hdl gpi_register_readonly_callback(int (*gpi_function)(const void *),
     }
 
     gpi_hdl->set_user_data(gpi_function, gpi_cb_data);
-    return (gpi_sim_hdl)gpi_hdl;
+    return gpi_hdl;
 }
 
-gpi_sim_hdl gpi_register_nexttime_callback(int (*gpi_function)(const void *),
+gpi_cb_hdl gpi_register_nexttime_callback(int (*gpi_function)(const void *),
                                            void *gpi_cb_data)
 {
     GpiCbHdl *gpi_hdl = registered_impls[0]->register_nexttime_callback();
@@ -603,13 +603,13 @@ gpi_sim_hdl gpi_register_nexttime_callback(int (*gpi_function)(const void *),
     }
 
     gpi_hdl->set_user_data(gpi_function, gpi_cb_data);
-    return (gpi_sim_hdl)gpi_hdl;
+    return gpi_hdl;
 }
 
 /* It should not matter which implementation we use for this so just pick the first
    one
 */
-gpi_sim_hdl gpi_register_readwrite_callback(int (*gpi_function)(const void *),
+gpi_cb_hdl gpi_register_readwrite_callback(int (*gpi_function)(const void *),
                                             void *gpi_cb_data)
 {
     GpiCbHdl *gpi_hdl = registered_impls[0] ->register_readwrite_callback();
@@ -619,13 +619,11 @@ gpi_sim_hdl gpi_register_readwrite_callback(int (*gpi_function)(const void *),
     }
 
     gpi_hdl->set_user_data(gpi_function, gpi_cb_data);
-    return (gpi_sim_hdl)gpi_hdl;
+    return gpi_hdl;
 }
 
-void gpi_deregister_callback(gpi_sim_hdl hdl)
+void gpi_deregister_callback(gpi_cb_hdl cb_hdl)
 {
-    // TODO: Why are we pretending this is one type when it is another?
-    GpiCbHdl *cb_hdl = reinterpret_cast<GpiCbHdl*>(hdl);
     cb_hdl->m_impl->deregister_callback(cb_hdl);
 }
 

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -49,17 +49,6 @@ class GpiImplInterface;
 class GpiIterator;
 class GpiCbHdl;
 
-template<class To>
-inline To sim_to_hdl(gpi_sim_hdl input)
-{
-    To result = static_cast<To>(input);
-    if (!result) {
-        LOG_CRITICAL("GPI: Handle passed down is not valid gpi_sim_hdl");
-    }
-
-    return result;
-}
-
 /* Base GPI class others are derived from */
 class GpiHdl {
 public:

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -86,6 +86,22 @@ static int gpi_sim_hdl_converter(PyObject *o, gpi_sim_hdl *data)
     return 1;
 }
 
+// Same as above, for a callback handle.
+static int gpi_cb_hdl_converter(PyObject *o, gpi_cb_hdl *data)
+{
+    void *p = PyLong_AsVoidPtr(o);
+    if ((p == NULL) && PyErr_Occurred()) {
+        return 0;
+    }
+    if (p == NULL) {
+        PyErr_SetString(PyExc_ValueError, "handle cannot be 0");
+        return 0;
+    }
+    *data = (gpi_cb_hdl)p;
+    return 1;
+}
+
+
 // Same as above, for an iterator handle.
 static int gpi_iterator_hdl_converter(PyObject *o, gpi_iterator_hdl *data)
 {
@@ -230,7 +246,7 @@ static PyObject *register_readonly_callback(PyObject *self, PyObject *args)
 
     PyObject *fArgs;
     PyObject *function;
-    gpi_sim_hdl hdl;
+    gpi_cb_hdl hdl;
 
     p_callback_data callback_data_p;
 
@@ -283,7 +299,7 @@ static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args)
 
     PyObject *fArgs;
     PyObject *function;
-    gpi_sim_hdl hdl;
+    gpi_cb_hdl hdl;
 
     p_callback_data callback_data_p;
 
@@ -336,7 +352,7 @@ static PyObject *register_nextstep_callback(PyObject *self, PyObject *args)
 
     PyObject *fArgs;
     PyObject *function;
-    gpi_sim_hdl hdl;
+    gpi_cb_hdl hdl;
 
     p_callback_data callback_data_p;
 
@@ -393,7 +409,7 @@ static PyObject *register_timed_callback(PyObject *self, PyObject *args)
 
     PyObject *fArgs;
     PyObject *function;
-    gpi_sim_hdl hdl;
+    gpi_cb_hdl hdl;
     uint64_t time_ps;
 
     p_callback_data callback_data_p;
@@ -466,7 +482,7 @@ static PyObject *register_value_change_callback(PyObject *self, PyObject *args) 
     PyObject *fArgs;
     PyObject *function;
     gpi_sim_hdl sig_hdl;
-    gpi_sim_hdl hdl;
+    gpi_cb_hdl hdl;
     int edge;
 
     p_callback_data callback_data_p;
@@ -959,11 +975,11 @@ static PyObject *stop_simulator(PyObject *self, PyObject *args)
 static PyObject *deregister_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
-    gpi_sim_hdl hdl;
+    gpi_cb_hdl hdl;
 
     FENTER
 
-    if (!PyArg_ParseTuple(args, "O&", gpi_sim_hdl_converter, &hdl)) {
+    if (!PyArg_ParseTuple(args, "O&", gpi_cb_hdl_converter, &hdl)) {
         return NULL;
     }
 


### PR DESCRIPTION
This means it is no longer legal to accidentally pass an arbitrary void pointer to gpi functions.
This turned segfaults into compilations errors for me, while working on some other changes.

This also eliminates the need for a lot of internal casting, as the types being cast from and to are already identical.

Making this change exposes some dubious uses of the type system internally - for now, these are plastered over with a TODO comment and a reinterpret_cast.

---

Some discussion about the merits of a similar approach here: https://softwareengineering.stackexchange.com/q/294761/205