### PR TITLE
Remove GpiClockHdl and its C accessor methods

### DIFF
--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -616,21 +616,6 @@ gpi_sim_hdl gpi_register_readwrite_callback(int (*gpi_function)(const void *),
     return (gpi_sim_hdl)gpi_hdl;
 }
 
-gpi_sim_hdl gpi_create_clock(gpi_sim_hdl clk_signal, const int period)
-{
-    GpiObjHdl *clk_hdl = sim_to_hdl<GpiObjHdl*>(clk_signal);
-    GpiClockHdl *clock = new GpiClockHdl(clk_hdl);
-    clock->start_clock(period);
-    return (gpi_sim_hdl)clock;
-}
-
-void gpi_stop_clock(gpi_sim_hdl clk_object)
-{
-    GpiClockHdl *clock = sim_to_hdl<GpiClockHdl*>(clk_object);
-    clock->stop_clock();
-    delete(clock);
-}
-
 void gpi_deregister_callback(gpi_sim_hdl hdl)
 {
     GpiCbHdl *cb_hdl = sim_to_hdl<GpiCbHdl*>(hdl);

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -225,16 +225,6 @@ protected:
     GpiSignalObjHdl *m_signal;
 };
 
-/* We would then have */
-class GpiClockHdl {
-public:
-    GpiClockHdl(GpiObjHdl *clk) { COCOTB_UNUSED(clk); }
-    GpiClockHdl(const char *clk) { COCOTB_UNUSED(clk); }
-    ~GpiClockHdl() { }
-    int start_clock(const int period_ps) { COCOTB_UNUSED(period_ps); return 0; } ; /* Do things with the GpiSignalObjHdl */
-    int stop_clock() { return 0; }
-};
-
 class GpiIterator : public GpiHdl {
 public:
     enum Status {


### PR DESCRIPTION
These functions had no callers, no presence in any public headers, and no interesting contents.

These were added in a63be4510d397b9350aa9e9665a91b763dd7c3cb, probably as abandoned local work that was superceded by the python-side `Clock`.