### PR TITLE
Honor NO_COLOR to disable colored output (#1309)

### DIFF
--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -524,6 +524,8 @@ def want_color_output():
     Colored output can be explicitly requested by setting :envvar:`COCOTB_ANSI_OUTPUT` to  ``1``.
     """
     want_color = sys.stdout.isatty()  # default to color for TTYs
+    if os.getenv("NO_COLOR") is not None:
+        want_color = False
     if os.getenv("COCOTB_ANSI_OUTPUT", default='0') == '1':
         want_color = True
     if os.getenv("GUI", default='0') == '1':

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -170,7 +170,6 @@ Environment Variables
     ``COCOTB_ANSI_OUTPUT=0`` suppresses the ANSI output in the log messages
 
 .. envvar:: NO_COLOR
-    
     From http://no-color.org,
 
         All command-line software which outputs text with ANSI color added should check for the presence

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -174,7 +174,7 @@ Environment Variables
     From http://no-color.org,
 
         All command-line software which outputs text with ANSI color added should check for the presence
-        of a ``NO_COLOR`` environment variable that, when present (regardless of its value), prevents the addition of ANSI color.   
+        of a ``NO_COLOR`` environment variable that, when present (regardless of its value), prevents the addition of ANSI color.
 
 .. envvar:: COCOTB_REDUCED_LOG_FMT
 

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -165,9 +165,16 @@ Environment Variables
     Use this to override the default behavior of annotating cocotb output with
     ANSI color codes if the output is a terminal (``isatty()``).
 
-    ``COCOTB_ANSI_OUTPUT=1`` forces output to be ANSI regardless of the type of ``stdout``
+    ``COCOTB_ANSI_OUTPUT=1`` forces output to be ANSI regardless of the type of ``stdout`` or the presence of :envvar:`NO_COLOR`.
 
     ``COCOTB_ANSI_OUTPUT=0`` suppresses the ANSI output in the log messages
+
+.. envvar:: NO_COLOR
+    
+    From http://no-color.org,
+
+        All command-line software which outputs text with ANSI color added should check for the presence
+        of a ``NO_COLOR`` environment variable that, when present (regardless of its value), prevents the addition of ANSI color.   
 
 .. envvar:: COCOTB_REDUCED_LOG_FMT
 

--- a/documentation/source/newsfragments/1309.feature.rst
+++ b/documentation/source/newsfragments/1309.feature.rst
@@ -1,0 +1,1 @@
+The colored output can now be disabled by the :envvar:`NO_COLOR` environment variable.


### PR DESCRIPTION
Closes #1309  The NO_COLOR environment variable is proposed as a way to disable all colored output, and more and more projects are using it now.
(https://no-color.org/)