### PR TITLE
Cleanup code with "Python 2" comments

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -257,19 +257,6 @@ class RunningTest(RunningCoroutine):
             self.started = True
         return super(RunningTest, self)._advance(outcome)
 
-    def _force_outcome(self, outcome):
-        """
-        This method exists as a workaround for preserving tracebacks on
-        python 2, and is called in unschedule. Once Python 2 is dropped, this
-        should be inlined into `abort` below, and the call in `unschedule`
-        replaced with `abort(outcome.error)`.
-        """
-        assert self._outcome is None
-        if _debug:
-            self.log.debug("outcome forced to {}".format(outcome))
-        self._outcome = outcome
-        cocotb.scheduler.unschedule(self)
-
     # like RunningTask.kill(), but with a way to inject a failure
     def abort(self, exc):
         """Force this test to end early, without executing any cleanup.
@@ -281,7 +268,12 @@ class RunningTest(RunningCoroutine):
         `exc` is the exception that the test should report as its reason for
         aborting.
         """
-        return self._force_outcome(outcomes.Error(exc))
+        assert self._outcome is None
+        outcome = outcomes.Error(exc)
+        if _debug:
+            self.log.debug("outcome forced to {}".format(outcome))
+        self._outcome = outcome
+        cocotb.scheduler.unschedule(self)
 
     def sort_name(self):
         if self.stage is None:

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -381,9 +381,6 @@ class _AssignmentResult(object):
             .format(self)
         )
 
-    # Python 2
-    __nonzero__ = __bool__
-
 
 class NonHierarchyObject(SimHandleBase):
     """Common base class for all non-hierarchy objects."""

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -496,12 +496,12 @@ class Scheduler(object):
                 coro._outcome.get()
             except (TestComplete, AssertionError) as e:
                 coro.log.info("Test stopped by this forked coroutine")
-                outcome = outcomes.Error(remove_traceback_frames(e, ['unschedule', 'get']))
-                self._test._force_outcome(outcome)
+                e = remove_traceback_frames(e, ['unschedule', 'get'])
+                self._test.abort(e)
             except Exception as e:
                 coro.log.error("Exception raised by this forked coroutine")
-                outcome = outcomes.Error(remove_traceback_frames(e, ['unschedule', 'get']))
-                self._test._force_outcome(outcome)
+                e = remove_traceback_frames(e, ['unschedule', 'get'])
+                self._test.abort(e)
 
     def save_write(self, handle, value):
         if self._mode == Scheduler._MODE_READONLY:

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -426,8 +426,7 @@ class ParametrizedSingleton(type):
         """Convert the construction arguments into a normalized representation that
         uniquely identifies this singleton.
         """
-        # Once we drop Python 2, we can implement a default like the following,
-        # which will work in 99% of cases:
+        # Could default to something like this, but it would be slow
         # return tuple(inspect.Signature(cls).bind(*args, **kwargs).arguments.items())
         raise NotImplementedError
 


### PR DESCRIPTION
This performs the suggested changes in comments saying "when we drop python 2..."

xref #1289 