### PR TITLE
Remove the use of `ReturnValue` internally

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -146,8 +146,7 @@ class RunningTask(object):
             self._outcome = outcomes.Value(e.retval)
             raise CoroutineComplete()
         except StopIteration as e:
-            retval = getattr(e, 'value', None)  # for python >=3.3
-            self._outcome = outcomes.Value(retval)
+            self._outcome = outcomes.Value(e.value)
             raise CoroutineComplete()
         except BaseException as e:
             self._outcome = outcomes.Error(remove_traceback_frames(e, ['_advance', 'send']))
@@ -475,7 +474,7 @@ class test(coroutine, metaclass=_decorator_helper):
                     running_co.kill()
                     raise
                 else:
-                    raise ReturnValue(res)
+                    return res
 
         super(test, self).__init__(f)
 

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -29,7 +29,6 @@
 import cocotb
 from cocotb.triggers import RisingEdge, ReadOnly, Lock
 from cocotb.drivers import BusDriver
-from cocotb.result import ReturnValue
 from cocotb.binary import BinaryValue
 
 import array
@@ -158,7 +157,7 @@ class AXI4LiteMaster(BusDriver):
             raise AXIProtocolError("Write to address 0x%08x failed with BRESP: %d"
                                % (address, int(result)))
 
-        raise ReturnValue(result)
+        return result
 
     @cocotb.coroutine
     def read(self, address, sync=True):
@@ -202,7 +201,7 @@ class AXI4LiteMaster(BusDriver):
             raise AXIProtocolError("Read address 0x%08x failed with RRESP: %d" %
                                (address, int(result)))
 
-        raise ReturnValue(data)
+        return data
 
     def __len__(self):
         return 2**len(self.bus.ARADDR)

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -40,7 +40,7 @@ from cocotb.triggers import RisingEdge, FallingEdge, ReadOnly, NextTimeStep, Eve
 from cocotb.drivers import BusDriver, ValidatedBusDriver
 from cocotb.utils import hexdump
 from cocotb.binary import BinaryValue
-from cocotb.result import ReturnValue, TestError
+from cocotb.result import TestError
 
 
 class AvalonMM(BusDriver):
@@ -180,7 +180,7 @@ class AvalonMaster(AvalonMM):
         data = self.bus.readdata.value
 
         self._release_lock()
-        raise ReturnValue(data)
+        return data
 
     @coroutine
     def write(self, address, value):

--- a/cocotb/drivers/opb.py
+++ b/cocotb/drivers/opb.py
@@ -33,7 +33,6 @@ NOTE: Currently we only support a very small subset of functionality.
 import cocotb
 from cocotb.triggers import RisingEdge, ReadOnly, Event
 from cocotb.drivers import BusDriver
-from cocotb.result import ReturnValue
 
 
 class OPBException(Exception):
@@ -108,7 +107,7 @@ class OPBMaster(BusDriver):
         self.bus.select <= 0
         self._release_lock()
         self.log.info("Read of address 0x%x returned 0x%08x" % (address, data))
-        raise ReturnValue(data)
+        return data
 
     @cocotb.coroutine
     def write(self, address, value, sync=True):

--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -39,7 +39,6 @@ import cocotb
 from cocotb.bus import Bus
 from cocotb.decorators import coroutine
 from cocotb.log import SimLog
-from cocotb.result import ReturnValue
 from cocotb.triggers import Event, Timer
 
 
@@ -129,12 +128,11 @@ class Monitor(object):
             t = Timer(timeout)
             fired = yield [self._wait_event.wait(), t]
             if fired is t:
-                raise ReturnValue(None)
+                return None
         else:
             yield self._wait_event.wait()
 
-        pkt = self._wait_event.data
-        raise ReturnValue(pkt)
+        return self._wait_event.data
 
     @coroutine
     def _monitor_recv(self):

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -60,7 +60,7 @@ import cocotb.decorators
 from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly,
                              NextTimeStep, ReadWrite, Event, Join, NullTrigger)
 from cocotb.log import SimLog
-from cocotb.result import TestComplete, ReturnValue
+from cocotb.result import TestComplete
 from cocotb.utils import remove_traceback_frames
 from cocotb import _py_compat
 
@@ -627,8 +627,7 @@ class Scheduler(object):
 
             yield waiter.event.wait()
 
-            ret = waiter.result  # raises if there was an exception
-            raise ReturnValue(ret)
+            return waiter.result  # raises if there was an exception
 
         return wrapper()
 

--- a/documentation/source/hal_cosimulation.rst
+++ b/documentation/source/hal_cosimulation.rst
@@ -131,7 +131,7 @@ These are then passed to the `IO Module`_:
         master.log.debug("External source: reading address 0x%08X" % address)
         value = yield master.read(address)
         master.log.debug("Reading complete: got value 0x%08x" % value)
-        raise ReturnValue(value)
+        return value
 
     @cocotb.function
     def write(address, value):


### PR DESCRIPTION
Now that all supported python versions are newer than 3.3, `return` works natively in coroutines
This may give a marginal performance improvement.

For now, we leave behind the `ReturnValue`s in our tests.

xref #1289 