### PR TITLE
Convert all existing C files to C++ files

### DIFF
--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -200,9 +200,9 @@ def _get_common_lib_ext(include_dir, share_lib_dir, sim_define):
         include_dirs=[include_dir],
         libraries=[_get_python_lib_link(), "cocotbutils"],
         library_dirs=python_lib_dirs,
-        sources=[os.path.join(share_lib_dir, "gpi_log", "gpi_logging.c")],
+        sources=[os.path.join(share_lib_dir, "gpi_log", "gpi_logging.cpp")],
         extra_link_args=_extra_link_args("libgpilog"),
-        extra_compile_args=_extra_cc_compile_args,
+        extra_compile_args=_extra_cxx_compile_args,
     )
 
     #

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -160,10 +160,7 @@ def _get_python_lib():
 
 # TODO [gh-1372]: make this work for MSVC which has a different flag syntax
 _base_warns = ["-Wall", "-Wextra", "-Wcast-qual", "-Wwrite-strings", "-Wconversion"]
-_cc_warns = _base_warns + ["-Wstrict-prototypes", "-Waggregate-return"]
 _ccx_warns = _base_warns + ["-Wnon-virtual-dtor", "-Woverloaded-virtual"]
-
-_extra_cc_compile_args = ["-std=gnu99"] + _cc_warns
 _extra_cxx_compile_args = ["-std=c++11"] + _ccx_warns
 
 # Make PRI* format macros available with C++11 compiler but older libc, e.g. on RHEL6.

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -214,9 +214,9 @@ def _get_common_lib_ext(include_dir, share_lib_dir, sim_define):
         include_dirs=[include_dir],
         libraries=[_get_python_lib_link(), "gpilog", "cocotbutils"],
         library_dirs=python_lib_dirs,
-        sources=[os.path.join(share_lib_dir, "embed", "gpi_embed.c")],
+        sources=[os.path.join(share_lib_dir, "embed", "gpi_embed.cpp")],
         extra_link_args=_extra_link_args("libcocotb"),
-        extra_compile_args=_extra_cc_compile_args,
+        extra_compile_args=_extra_cxx_compile_args,
     )
 
     #

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -183,9 +183,9 @@ def _get_common_lib_ext(include_dir, share_lib_dir, sim_define):
     libcocotbutils = Extension(
         os.path.join("cocotb", "libs", sim_define.lower(), "libcocotbutils"),
         include_dirs=[include_dir],
-        sources=[os.path.join(share_lib_dir, "utils", "cocotb_utils.c")],
+        sources=[os.path.join(share_lib_dir, "utils", "cocotb_utils.cpp")],
         extra_link_args=_extra_link_args("libcocotbutils"),
-        extra_compile_args=_extra_cc_compile_args,
+        extra_compile_args=_extra_cxx_compile_args,
     )
 
     #

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -243,8 +243,8 @@ def _get_common_lib_ext(include_dir, share_lib_dir, sim_define):
         include_dirs=[include_dir],
         libraries=[_get_python_lib_link(), "cocotbutils", "gpilog", "gpi"],
         library_dirs=python_lib_dirs,
-        sources=[os.path.join(share_lib_dir, "simulator", "simulatormodule.c")],
-        extra_compile_args=_extra_cc_compile_args,
+        sources=[os.path.join(share_lib_dir, "simulator", "simulatormodule.cpp")],
+        extra_compile_args=_extra_cxx_compile_args,
     )
 
     return [libcocotbutils, libgpilog, libcocotb, libgpi, libsim]

--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -68,7 +68,6 @@ enum gpi_log_levels {
 
 void set_log_handler(void *handler);
 void clear_log_handler(void);
-void set_make_record(void *makerecord);
 void set_log_filter(void *filter);
 void clear_log_filter(void);
 void set_log_level(enum gpi_log_levels new_level);

--- a/cocotb/share/lib/utils/cocotb_utils.cpp
+++ b/cocotb/share/lib/utils/cocotb_utils.cpp
@@ -40,7 +40,7 @@
 // Tracks if we are in the context of Python or Simulator
 int is_python_context = 0;
 
-void to_python(void) {
+extern "C" void to_python(void) {
     if (is_python_context) {
         fprintf(stderr, "FATAL: We are calling up again\n");
         exit(1);
@@ -49,7 +49,7 @@ void to_python(void) {
     //fprintf(stderr, "INFO: Calling up to python %d\n", is_python_context);
 }
 
-void to_simulator(void) {
+extern "C" void to_simulator(void) {
     if (!is_python_context) {
         fprintf(stderr, "FATAL: We have returned twice from python\n");
         exit(1);
@@ -59,12 +59,12 @@ void to_simulator(void) {
     //fprintf(stderr, "INFO: Returning back to simulator %d\n", is_python_context);
 }
 
-void* utils_dyn_open(const char* lib_name)
+extern "C" void* utils_dyn_open(const char* lib_name)
 {
     void *ret = NULL;
 #if ! defined(__linux__) && ! defined(__APPLE__)
     SetErrorMode(0);
-    ret = LoadLibrary(lib_name);
+    ret = static_cast<void*>(LoadLibrary(lib_name));
     if (!ret) {
         printf("Unable to open lib %s", lib_name);
         LPSTR msg_ptr;
@@ -91,11 +91,11 @@ void* utils_dyn_open(const char* lib_name)
     return ret;
 }
 
-void* utils_dyn_sym(void *handle, const char* sym_name)
+extern "C" void* utils_dyn_sym(void *handle, const char* sym_name)
 {
     void *entry_point;
 #if ! defined(__linux__) && ! defined(__APPLE__)
-    entry_point = GetProcAddress(handle, sym_name);
+    entry_point = reinterpret_cast<void*>(GetProcAddress(static_cast<HMODULE>(handle), sym_name));
     if (!entry_point) {
         printf("Unable to find symbol %s", sym_name);
         LPSTR msg_ptr;


### PR DESCRIPTION
This will allow us to use the extra features that C++ offers through the entire code base.

Moving the compilation standard from gnu99 to c++11 was mostly painless, there were a few cases of gotos jumping over variable initialization.