### PR TITLE
Fix missing function arguments in FLI after #1403

### DIFF
--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -353,7 +353,7 @@ public:
     long get_signal_value_long() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value) override;
+    int set_signal_value(long value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
 };


### PR DESCRIPTION
We, unfortunately, we cannot build FLI in CI and `gpi_set_action_t action` was missing in #1403 .