### PR TITLE
Better back compatibility and use cocotb-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,6 @@
 .PHONY: all
 all: test
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 .PHONY: clean
 clean:
 	-@rm -rf $(BUILD_DIR)

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -29,20 +29,12 @@
 
 # Common makefile included by everything
 
-# Directory containing the cocotb Python module
-ifeq ($(COCOTB_PY_DIR),)
-export COCOTB_PY_DIR:=$(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../../..)
-endif
+# Directory containing the cocotb Python module (realpath for Windows compatibility)
+COCOTB_PY_DIR := $(realpath $(shell cocotb-config --prefix))
 
 # Directory containing all support files required to build cocotb-based
 # simulations: Makefile fragments, and the simulator libraries.
-ifeq ($(COCOTB_SHARE_DIR),)
-export COCOTB_SHARE_DIR:=$(realpath $(dir $(lastword $(MAKEFILE_LIST)))/..)
-endif
-
-ifeq ($(COCOTB_PY_DIR),$(COCOTB_SHARE_DIR))
-$(warning 'Deprecated cocotb file structure detected. Please use "include $$(shell cocotb-config --makefile)/Makefile.inc" in Makefiles')
-endif
+COCOTB_SHARE_DIR := $(COCOTB_PY_DIR)/cocotb/share
 
 ifeq ($(USER_DIR),)
 export USER_DIR:=$(realpath $(dir $(firstword $(MAKEFILE_LIST))))

--- a/documentation/source/newsfragments/1445.change.rst
+++ b/documentation/source/newsfragments/1445.change.rst
@@ -1,0 +1,1 @@
+Cocotb must now be :ref:`installed <installation_via_pip>` before it can be used.

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -18,6 +18,8 @@ Cocotb has the following requirements:
 
 .. versionchanged:: 1.4 Dropped Python 2 support
 
+.. _installation_via_pip:
+
 Installation via PIP
 --------------------
 

--- a/examples/endian_swapper/cosim/Makefile
+++ b/examples/endian_swapper/cosim/Makefile
@@ -1,5 +1,5 @@
-include $(COCOTB_SHARE_DIR)/makefiles/Makefile.pylib
-include $(COCOTB_SHARE_DIR)/makefiles/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.pylib
 
 PYTHON_LIBDIR ?= /usr/lib64
 SWIG ?= swig

--- a/makefiles/Makefile.inc
+++ b/makefiles/Makefile.inc
@@ -27,10 +27,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ##############################################################################
 
-# Backwards-compatibility wrapper for people using
-# "include $COCOTB/makefiles/Makefile.inc" in their Makefile.
-COCOTB_INSTALL_METHOD = srctree
-export COCOTB_INSTALL_METHOD
+COCOTB_CONFIG_CMD := $(shell :; command -v cocotb-config)
+ifeq ($(COCOTB_CONFIG_CMD),)
+    $(error 'Cocotb is not installed (cocotb-config not found). \
+             Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#installing-cocotb \
+             for installation instructions.')
+endif
 
-_NEW_SHARE_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/../cocotb/share
-include $(_NEW_SHARE_DIR)/makefiles/Makefile.inc
+$(error 'Deprecated cocotb file structure detected. \
+         Use "include $$(shell cocotb-config --makefile)/Makefile.inc" instead. \
+         Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#creating-a-makefile \
+         for instructions.')

--- a/makefiles/Makefile.sim
+++ b/makefiles/Makefile.sim
@@ -27,13 +27,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ##############################################################################
 
-# Backwards-compatibility wrapper for people using
-# "include $COCOTB/makefiles/Makefile.sim" in their Makefile.
+COCOTB_CONFIG_CMD := $(shell :; command -v cocotb-config)
+ifeq ($(COCOTB_CONFIG_CMD),)
+    $(error 'Cocotb is not installed (cocotb-config not found). \
+             Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#installing-cocotb \
+             for installation instructions.')
+endif
 
-# COCOTB_INSTALL_METHOD should already have been set in Makefile.inc, but
-# better be safe than sorry to cover unusual ways of people using cocotb.
-COCOTB_INSTALL_METHOD = srctree
-export COCOTB_INSTALL_METHOD
-
-_NEW_SHARE_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/../cocotb/share
-include $(_NEW_SHARE_DIR)/makefiles/Makefile.sim
+$(error 'Deprecated cocotb file structure detected. \
+         Use "include $$(shell cocotb-config --makefile)/Makefile.sim" instead. \
+         Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#creating-a-makefile \
+         for instructions.')

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,8 +25,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-include ../makefiles/Makefile.inc
-
 # distutils warnings are caused by an old version of virtualenv in travis
 export PYTHONWARNINGS = error,ignore::DeprecationWarning:distutils
 


### PR DESCRIPTION
Prior #1304 it was possible to use "previous file structure" without installation now it is not possible. 

This PR:
 - add a warning message about deprecated file structure
 - add error message if cocotb is not installed 
 - use cocotb-config instead of MAKEFILE_LIST so "previous file structure" still works better (independent of makefile structure)  and for (future) better multi-os support