### PR TITLE
Fix regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ jenkins: do_tests
 # By default want the exit code to indicate the test results
 .PHONY: test
 test:
-	$(MAKE) do_tests; ret=$$?; ./bin/combine_results.py; exit $$ret
+	$(MAKE) do_tests; ret=$$?; ./bin/combine_results.py && exit $$ret
 
 .PHONY: help
 help:

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -1022,7 +1022,7 @@ def test_exceptions_first(dut):
       File ".*test_cocotb\.py", line \d+, in raise_soon
         yield cocotb\.triggers\.First\(raise_inner\(\)\)
       File ".*triggers\.py", line \d+, in _wait
-        result = yield first_trigger  # the first of multiple triggers that fired
+        return \(yield first_trigger\)[^\n]*
       File ".*test_cocotb\.py", line \d+, in raise_inner
         raise ValueError\('It is soon now'\)
     ValueError: It is soon now""").strip()


### PR DESCRIPTION
Issue in makefile caused return code of `combine_results.py` to not be taken into account. This masked a regression failure in `test_exceptions_first`.