### PR TITLE
Conda fixup -- Ensure format macros (PRIu32) are defined

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -29,7 +29,7 @@
 #include "VhpiImpl.h"
 #include <limits>     // numeric_limits
 #define __STDC_FORMAT_MACROS
-#include <cinttypes>  // fixed-size int types and format strings
+#include <inttypes.h>  // fixed-size int types and format strings
 
 namespace {
     using bufSize_type = decltype(vhpiValueT::bufSize);

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -28,7 +28,6 @@
 #include <assert.h>
 #include "VhpiImpl.h"
 #include <limits>     // numeric_limits
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>  // fixed-size int types and format strings
 
 namespace {

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include "VhpiImpl.h"
 #include <limits>     // numeric_limits
+#define __STDC_FORMAT_MACROS
 #include <cinttypes>  // fixed-size int types and format strings
 
 namespace {

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -28,7 +28,7 @@
 #include <assert.h>
 #include "VhpiImpl.h"
 #include <limits>     // numeric_limits
-#include <inttypes.h>  // fixed-size int types and format strings
+#include <cinttypes>  // fixed-size int types and format strings
 
 namespace {
     using bufSize_type = decltype(vhpiValueT::bufSize);

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -28,6 +28,8 @@
 #ifndef COCOTB_VHPI_IMPL_H_
 #define COCOTB_VHPI_IMPL_H_
 
+// Ensure that format macros are provided
+#define __STDC_FORMAT_MACROS
 #include "../gpi/gpi_priv.h"
 #include <vhpi_user.h>
 #include <vector>

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -78,7 +78,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $
 
 	PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
-        $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+        $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m gpivpi $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)
@@ -88,7 +88,7 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
 
 	PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
-        gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+        gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m gpivpi $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -42,8 +42,10 @@ COCOTB?=$(WPWD)/../../..
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/array_module/array_module.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-        SIM_ARGS += -v93
+    ifneq (,$(SIM))
+        ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+            SIM_ARGS += -v93
+        endif
     endif
 ifeq ($(shell echo $(SIM) | tr A-Z a-z),aldec)
     VHDL_SOURCES =  $(COCOTB)/tests/designs/array_module/array_module_pack.vhd $(COCOTB)/tests/designs/array_module/array_module_aldec.vhd

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -47,8 +47,10 @@ else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-    SIM_ARGS += -v93
+ifneq (,$(SIM))
+    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+        SIM_ARGS += -v93
+    endif
 endif
 
 include $(COCOTB)/makefiles/Makefile.inc

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -44,8 +44,10 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES =  $(COCOTB)/tests/designs/sample_module/sample_module_pack.vhdl $(COCOTB)/tests/designs/sample_module/sample_module_1.vhdl $(COCOTB)/tests/designs/sample_module/sample_module.vhdl
 
-    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-        SIM_ARGS += -v93
+    ifneq (,$(SIM))
+        ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+            SIM_ARGS += -v93
+        endif
     endif
 else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")

--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -36,8 +36,10 @@ VERILOG_SOURCES =   $(SRC_BASE)/verilog/baud_gen.v \
 VERILOG_SOURCES += $(SRC_BASE)/top/verilog_toplevel.sv
 TOPLEVEL = verilog_toplevel
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-    SIM_ARGS += -v93
+ifneq (,$(SIM))
+    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+        SIM_ARGS += -v93
+    endif
 endif
 
 include $(COCOTB)/makefiles/Makefile.inc

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -34,8 +34,10 @@ else
 endif
 VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/configurations.vhd
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-    SIM_ARGS += -v93
+ifneq (,$(SIM))
+    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+        SIM_ARGS += -v93
+    endif
 endif
 
 include $(COCOTB)/makefiles/Makefile.inc

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -65,8 +65,10 @@ VHDL_SOURCES = $(SRC_BASE)/packages/pkg_helper.vhd \
 	       $(SRC_BASE)/src/recursion.vhd \
 	       $(SRC_BASE)/src/dec_viterbi.vhd
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-    SIM_ARGS += -v93
+ifneq (,$(SIM))
+    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+        SIM_ARGS += -v93
+    endif
 endif
 
 include $(COCOTB)/makefiles/Makefile.inc


### PR DESCRIPTION
This PR ensures the standard format macros (eg PRIu32) are defined when C++ code is compiled with a newer GCC (eg 7.3.0 from Conda).

This PR addresses #1451.