### PR TITLE
Fixup compilation with Conda GCC

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -28,6 +28,8 @@
 #ifndef COCOTB_VHPI_IMPL_H_
 #define COCOTB_VHPI_IMPL_H_
 
+// Ensure that format macros are provided
+#define __STDC_FORMAT_MACROS
 #include "../gpi/gpi_priv.h"
 #include <vhpi_user.h>
 #include <vector>


### PR DESCRIPTION
This PR ensures the standard format macros (eg PRIu32) are defined when C++ code is compiled with a newer GCC (eg 7.3.0 from Conda).

This PR addresses #1451.