### PR TITLE
Do not add -v93 to SIM_ARGS when SIM not set

### DIFF
--- a/examples/dff/tests/Makefile
+++ b/examples/dff/tests/Makefile
@@ -26,7 +26,7 @@ ifeq ($(SIM),questa)
     SIM_ARGS=-t 1ps
 endif
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 

--- a/examples/endian_swapper/tests/Makefile
+++ b/examples/endian_swapper/tests/Makefile
@@ -47,7 +47,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES = $(WPWD)/../hdl/endian_swapper.vhdl
     TOPLEVEL = endian_swapper_vhdl
-    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+    ifneq ($(filter $(SIM),ius xcelium),)
         SIM_ARGS += -v93
     endif
 else

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -30,8 +30,8 @@ VERILOG_SOURCES = $(WPWD)/../hdl/mean_sv.sv
 
 MODULE := test_mean
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-   SIM_ARGS += -v93
+ifneq ($(filter $(SIM),ius xcelium),)
+    SIM_ARGS += -v93
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.inc

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -36,8 +36,8 @@ endif
 
 MODULE=test_mixed_language
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-   SIM_ARGS += -v93
+ifneq ($(filter $(SIM),ius xcelium),)
+    SIM_ARGS += -v93
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.inc

--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -42,7 +42,7 @@ COCOTB?=$(WPWD)/../../..
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/array_module/array_module.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+    ifneq ($(filter $(SIM),ius xcelium),)
         SIM_ARGS += -v93
     endif
 ifeq ($(shell echo $(SIM) | tr A-Z a-z),aldec)

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -47,7 +47,7 @@ else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -44,7 +44,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES =  $(COCOTB)/tests/designs/sample_module/sample_module_pack.vhdl $(COCOTB)/tests/designs/sample_module/sample_module_1.vhdl $(COCOTB)/tests/designs/sample_module/sample_module.vhdl
 
-    ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+    ifneq ($(filter $(SIM),ius xcelium),)
         SIM_ARGS += -v93
     endif
 else

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -34,7 +34,7 @@ else
 endif
 VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/configurations.vhd
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -65,7 +65,7 @@ VHDL_SOURCES = $(SRC_BASE)/packages/pkg_helper.vhd \
 	       $(SRC_BASE)/src/recursion.vhd \
 	       $(SRC_BASE)/src/dec_viterbi.vhd
 
-ifeq ($(SIM),$(filter $(SIM),ius xcelium))
+ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 

--- a/tests/test_cases/test_iteration_vhdl/Makefile
+++ b/tests/test_cases/test_iteration_vhdl/Makefile
@@ -28,10 +28,10 @@
 include ../../designs/viterbi_decoder_axi4s/Makefile
 MODULE = test_iteration
 
-ifeq ($(SIM),$(filter $(SIM), ius xcelium))
+ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -notimezeroasrtmsg
 endif
 
-ifeq ($(SIM),$(filter $(SIM), ghdl))
+ifeq ($(SIM),ghdl)
     SIM_ARGS += --ieee-asserts=disable-at-0
 endif


### PR DESCRIPTION
In many places `-v93` is add `SIM_ARGS` if `SIM` is not set. This causes errors if one corrects the order of  `SIM_ARGS` for Icarus #1447. 

This PR corrects this situation. Based on @eric-wieser suggestion https://github.com/cocotb/cocotb/pull/1447#discussion_r383220980