### PR TITLE
Add custom entry point to load libraries (via GPI_EXTRA)

### DIFF
--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -55,6 +55,7 @@ COMPILE_ARGS              Arguments to pass to compile stage of simulation
 SIM_ARGS                  Arguments to pass to execution of compiled simulation
 EXTRA_ARGS                Arguments for compile and execute phases
 PLUSARGS                  Plusargs to pass to the simulator
+GPI_EXTRA                 A list of extra libraries that are dynamically loaded at runtime
 COCOTB_HDL_TIMEUNIT       Default time unit for simulation
 COCOTB_HDL_TIMEPRECISION  Default time precision for simulation
 CUSTOM_COMPILE_DEPS       Add additional dependencies to the compilation target

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -273,3 +273,19 @@ Additional Environment Variables
     Path to the directory containing the cocotb Makefiles and simulator libraries in the subdirectories
     :file:`lib`, :file:`include`, and :file:`makefiles`.
     You don't normally need to modify this.
+
+.. envvar:: GPI_EXTRA
+
+    A comma-separated list of extra libraries that are dynamically loaded at runtime.
+    A function from each of these libraries will be called as an entry point prior to elaboration, allowing these libraries to register
+    system functions and callbacks. Note that HDL objects cannot be accessed at this time.
+    The function name defaults to ``{library_name}_entry_point``, but a custom name can be specified using a ``:``, which follows an existing simulator convention.
+
+    For example:
+
+    * ``GPI_EXTRA=name`` will load ``libname.so`` with default entry point ``name_entry_point``.
+    * ``GPI_EXTRA=nameA:entryA,nameB:entryB`` will first load ``libnameA.so`` with entry point ``entryA`` , then load ``libnameB.so`` with entry point ``entryB``.
+
+    .. versionchanged:: 1.4.0
+        Support for the custom entry point via ``:`` was added.
+        Previously ``:`` was used as a separator between libraries instead of ``,``.

--- a/documentation/source/newsfragments/1457.feature.rst
+++ b/documentation/source/newsfragments/1457.feature.rst
@@ -1,0 +1,2 @@
+The name of the entry point symbol for libraries in :envvar:`GPI_EXTRA` can now be customized.
+The delimiter between each library in the list has changed from ``:`` to ``,``.


### PR DESCRIPTION
Add ability to provide custom entry points for libraries in ``GPI_EXTRA``. 
Entry points can be defined after ``:`` in the format ``lib_name_X:A_entry_point,lib_name_Y:B_entry_point``.
The library delimiter between a list of libraries has changed from ``:`` to ``,``.
It follows the convention used by some simulators to load libraries.

Discussed here: https://github.com/cocotb/cocotb/pull/1425#issuecomment-588249367
Should allow keeping all compiled libraries in one directory (different name per simulator).
It could be useful for cocotb extensions that want to load code into ``GPI`` at startup.