### PR TITLE
Fix Sphinx warnings

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -95,7 +95,14 @@ autoclass_content = "both"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = [
+    # these are compiled into a single file at build-time,
+    # so there is no need to build them separately:
+    "newsfragments/*.rst",
+    # unused outputs from breathe:
+    "generated/namespacelist.rst",
+    "generated/namespace/*.rst",
+    ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'breathe',
     'sphinx_issues',
     'sphinxarg.ext',
+    'sphinxcontrib.spelling',
     ]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
@@ -315,12 +316,6 @@ breathe_domain_by_extension = {
 breathe_show_define_initializer = True
 
 # -- Extra setup for spelling check --------------------------------------------
-
-# Spelling check needs an additional module that is not installed by default.
-# Add it only if spelling check is requested so docs can be generated without it.
-
-if 'spelling' in sys.argv:
-    extensions.append("sphinxcontrib.spelling")
 
 # Spelling language.
 spelling_lang = 'en_US'


### PR DESCRIPTION
* Always include sphinxcontrib.spelling
* Add files not directly included to exclude_patterns