### PR TITLE
Fix undefined reference in documentation

### DIFF
--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -198,7 +198,8 @@ Simulation Object Handles
     :show-inheritance:
     :synopsis: Classes for simulation objects.
 
-.. assigment-methods-section
+
+.. _assignment-methods:
 
 Assignment Methods
 ------------------
@@ -212,6 +213,7 @@ Assignment Methods
 .. autoclass:: Freeze
 
 .. autoclass:: Release
+
 
 Implemented Testbench Structures
 ================================

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -252,7 +252,7 @@ Use ``sig.setimmediatevalue(new_val)`` to set a new value immediately
 
 In addition to regular value assignments (deposits), signals can be forced
 to a predetermined value or frozen at their current value. To achieve this,
-the various actions described in :ref:`assignment-methods-section` can be used.
+the various actions described in :ref:`Assignment Methods <assignment-methods>` can be used.
 
 .. code-block:: python3
 


### PR DESCRIPTION
Note that the first method of referencing described in
https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref
only applies to *sections*, but not e.g. *sub*sections like we have here,
so we have to provide the explicit title.

The now-fixed reference is in
https://cocotb--1467.org.readthedocs.build/en/1467/quickstart.html#assigning-values-to-signals