### PR TITLE
Update Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,26 +27,29 @@ jobs:
       script: flake8
 
     - stage: SimTests
-      os: linux
       python: 3.5
-      before_install: &docker_prep
-        - docker build -t cocotb .
-        - docker images -a
-        - docker run -d --name cocotb cocotb tail -f /dev/null
-        - docker ps -a
-      script:
-        - echo 'Running cocotb tests with Python 3.5 ...' && echo -en 'travis_fold:start:cocotb_py35'
-        - docker exec -it -e TRAVIS=true cocotb bash -lc 'pip3 install tox; cd /src; tox -e py35'
-        - echo 'travis_fold:end:cocotb_py35'
-
-    - stage: SimTests
-      python: 3.7
       before_install: &travis_linx_prep
         - sudo apt-get -y install gperf swig
         - if [[ ! -e "./iverilog/README.txt" ]]; then rm -rf iverilog; git clone https://github.com/steveicarus/iverilog.git --depth=1 --branch v10_2; fi
         - cd iverilog && autoconf && ./configure && make -j2 && sudo make install && cd ..
         - pip install tox
         - pyenv global system $TRAVIS_PYTHON_VERSION
+      script:
+        - echo 'Running cocotb tests with Python 3.5 ...' && echo -en 'travis_fold:start:cocotb_py35'
+        - tox -e py35
+        - echo 'travis_fold:end:cocotb_py35'
+
+    - stage: SimTests
+      python: 3.6.7
+      before_install: *travis_linx_prep
+      script:
+        - echo 'Running cocotb tests with Python 3.6.7 ...' && echo -en 'travis_fold:start:cocotb_py36'
+        - tox -e py36
+        - echo 'travis_fold:end:cocotb_py36'
+
+    - stage: SimTests
+      python: 3.7
+      before_install: *travis_linx_prep
       script:
         - echo 'Running cocotb tests with Python 3.7 ...' && echo -en 'travis_fold:start:cocotb_py37'
         - tox -e py37
@@ -59,14 +62,6 @@ jobs:
         - echo 'Running cocotb tests with Python 3.8 ...' && echo -en 'travis_fold:start:cocotb_py38'
         - tox -e py38
         - echo 'travis_fold:end:cocotb_py38'
-
-    - stage: SimTests
-      python: 3.6.7
-      before_install: *travis_linx_prep
-      script:
-        - echo 'Running cocotb tests with Python 3.6.7 ...' && echo -en 'travis_fold:start:cocotb_py36'
-        - tox -e py36
-        - echo 'travis_fold:end:cocotb_py36'
 
     - stage: SimTests
       python: 3.7


### PR DESCRIPTION
We should have the following matrix of tests in CI:

Python version
 - 3.5
 - 3.6
 - 3.7
 - 3.8

OS
 - Ubuntu 16.04
 - Ubuntu 18.04
 - CentOS 6
 - CentOS 7
 - Windows 10 + mingw-w64
 - OSX?

Simulators
 - Icarus
 - GHDL

Additionally we should have targets for warnings compliance with additional warning flags enabled building for all supported compilers: GCC, Clang. And linting tests: Python, C++, whitespace, maybe more...