### PR TITLE
Simplify `cocotb.generators` to use builtins where possible

### DIFF
--- a/cocotb/generators/__init__.py
+++ b/cocotb/generators/__init__.py
@@ -44,7 +44,10 @@ def repeat(obj, nrepeat=None):
     Kwargs:
         nrepeat (int): The number of times to repeatedly yield obj
     """
-    return itertools.repeat(obj, times=nrepeat)
+    if nrepeat is None:
+        return itertools.repeat(obj)
+    else:
+        return itertools.repeat(obj, times=nrepeat)
 
 
 @public

--- a/cocotb/generators/__init__.py
+++ b/cocotb/generators/__init__.py
@@ -30,6 +30,7 @@
 """
 import math
 import random
+import itertools
 from cocotb.decorators import public
 
 
@@ -43,12 +44,7 @@ def repeat(obj, nrepeat=None):
     Kwargs:
         nrepeat (int): The number of times to repeatedly yield obj
     """
-    if nrepeat is None:
-        while True:
-            yield obj
-    else:
-        for i in range(nrepeat):
-            yield obj
+    return itertools.repeat(obj, times=nrepeat)
 
 
 @public
@@ -59,9 +55,7 @@ def combine(generators):
     Args:
         generators (iterable): Generators to combine together
     """
-    for gen in generators:
-        for item in gen:
-            yield item
+    return itertools.chain.from_iterable(generators)
 
 
 @public


### PR DESCRIPTION
~Also fix `cocotb.generators.byte` to produce bytes and not unicode in Python 3.
Without this change, the generators in `cocotb.generators.packet` produces UTF-8 encoded latin1 (so never actually emits 0xFF, for instance!).~~

---

~~Alternatively...~~ In a future PR should we just remove this submodule?
* It's not documented
* It's somewhat duplicated by the standard library
* ~~`generator.byte` doesn't produce bytes at all on python 3~~
* `generators.packet` has dependencies on `scapy`.