### PR TITLE
Deprecate COCOTB_NVC_TRACE, with doc reference

### DIFF
--- a/cocotb/share/makefiles/Makefile.deprecations
+++ b/cocotb/share/makefiles/Makefile.deprecations
@@ -1,0 +1,7 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+ifdef COCOTB_NVC_TRACE
+   $(warning COCOTB_NVC_TRACE is deprecated, see the "Simulator Support" section in the documentation.)
+endif

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -62,6 +62,7 @@ OS=Msys
 endif
 export OS
 
+include $(COCOTB_SHARE_DIR)/makefiles/Makefile.deprecations
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.pylib
 
 # Default to Icarus if no simulator is defined

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -59,7 +59,6 @@ COCOTB_HDL_TIMEUNIT       Default time unit for simulation
 COCOTB_HDL_TIMEPRECISION  Default time precision for simulation
 CUSTOM_COMPILE_DEPS       Add additional dependencies to the compilation target
 CUSTOM_SIM_DEPS           Add additional dependencies to the simulation target
-COCOTB_NVC_TRACE          Set this to 1 to enable display of VHPI traces for NVC
 SIM_BUILD                 Define a scratch directory for use by the simulator
 
 Environment Variables

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -132,6 +132,10 @@ and
 
       Set this to 1 to enable display of VHPI traces when using the NVC VHDL simulator.
 
+      .. deprecated:: 1.4
+
+         Replaced by the instructions in :ref:`sim-nvc`.
+
 .. make:var:: SIM_BUILD
 
       Use to define a scratch directory for use by the simulator. The path is relative to the Makefile location.

--- a/documentation/source/newsfragments/1495.removal.rst
+++ b/documentation/source/newsfragments/1495.removal.rst
@@ -1,0 +1,5 @@
+The makefile variable
+:make:var:`COCOTB_NVC_TRACE`
+that was not supported for all simulators has been deprecated.
+Using it prints a deprecation warning and points to documentation (:ref:`simulator-support`)
+explaining how to replace it by other means.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -140,3 +140,10 @@ GHDL
 
 Support is preliminary.
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the VPI interface.
+
+.. _sim-nvc:
+
+NVC
+===
+
+To enable display of VHPI traces, use ``SIM_ARGS=--vhpi-trace make ...``.


### PR DESCRIPTION
Introduce a new ``Makefile.deprecations`` to collect make variable
deprecation warnings in a central place.

More deprecations to come via #1495, but this PR creates the "infrastructure" these will base on,  so it should go in first.