### PR TITLE
Update VHPI callbacks

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -919,14 +919,14 @@ int VhpiTimedCbHdl::cleanup_callback()
 VhpiReadwriteCbHdl::VhpiReadwriteCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                                                  VhpiCbHdl(impl)
 {
-    cb_data.reason = vhpiCbRepEndOfProcesses;
+    cb_data.reason = vhpiCbRepLastKnownDeltaCycle;
     cb_data.time = &vhpi_time;
 }
 
 VhpiReadOnlyCbHdl::VhpiReadOnlyCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                                                VhpiCbHdl(impl)
 {
-    cb_data.reason = vhpiCbRepLastKnownDeltaCycle;
+    cb_data.reason = vhpiCbRepEndOfTimeStep;
     cb_data.time = &vhpi_time;
 }
 


### PR DESCRIPTION
**PR for testing simulators that support VHPI**
Closes #1061
Closes #1880 

The current use of the `vhpiCbRepEndOfProcesses` callback for `ReadWrite`
triggers can cause subtle issues in simulation. Signal values can take
multiple delta cycles to propogate through designs, and
`vhpiCbRepEndOfProcesses` is called at the end of the current delta cycle.
This means that depending on when signal values are cached when using
the `<=` operator, signal values may be set at the wrong time relative
to other signals.

Changing `ReadWrite` to `vhpiCbRepLastKnownDeltaCycle` and `ReadOnly`
to `vhpiCbRepEndOfTimeStep` brings VHPI behavior more in-line with VPI.

See the following references for further details:
IEEE Std 1076-2008 VHDL Language Ref Manual Section 14.7.5 and 21.3.6.1
IEEE Std 1364-2001 Verilog Hardware Description Language Section 27.33.2
