### PR TITLE
Update release notes for cocotb 1.3.1

### DIFF
--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -8,6 +8,16 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 
 .. towncrier release notes start
 
+cocotb 1.3.1
+============
+
+Released on 15 March 2020
+
+Notable changes and bug fixes
+-----------------------------
+- The Makefiles for the Aldec Riviera and Cadence Incisive simulators have been fixed to use the correct name of the VHPI library (``libcocotbvhpi``).
+  This bug prevented VHDL designs from being simulated, and was a regression in 1.3.0. (:pr:`1472`)
+
 cocotb 1.3.0
 ============
 


### PR DESCRIPTION
Backport of the 1.3.1 release notes for master. I'm not sure if we want to do that; it's probably helpful, as the main entry point to the documentation wouldn't have this information otherwise.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->