### PR TITLE
Add matrix_multiplier to examples.

### DIFF
--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -35,6 +35,47 @@ to start and stop generation of input data.
 A :class:`.TestFactory` is used to generate the random tests.
 
 
+.. _matrix_multiplier:
+
+Matrix Multiplier
+=================
+
+The directory :file:`cocotb/examples/matrix_multiplier`
+contains a module for multiplying two matrices together,
+implemented in both **VHDL** and **SystemVerilog**.
+
+The module takes two matrices ``a_i`` and ``b_i`` as inputs
+and provides the resulting matrix ``c_o`` as an output.
+On each rising clock edge,
+``c_o`` is calculated and output.
+When input ``valid_i`` is high
+and ``c_o`` is calculated,
+``valid_o`` goes high to signal a valid output value.
+
+The testbench defines ``MatrixInMonitor`` and ``MatrixOutMonitor``
+(both sub-classes of :class:`.BusMonitor`)
+and a test case ``test_multiply``.
+
+``MatrixInMonitor`` watches for valid input matrices,
+then does the multiplication in Python
+and stores the result as the expected output matrix.
+
+``MatrixOutMonitor`` watches for valid output matrices
+and compares the result to the expected value.
+
+The testbench makes use of :class:`.TestFactory`
+and random data generators
+to test many sets of matrices,
+and :class:`.Scoreboard` to compare expected and actual results.
+
+The number of data bits for each entry in the matrices,
+as well as the row and column counts for each matrix,
+are configurable in the Makefile.
+
+.. note::
+    The example module uses one-dimensional arrays in the port definition to represent the matrices.
+
+
 Mean
 ====
 

--- a/documentation/source/newsfragments/1502.doc.rst
+++ b/documentation/source/newsfragments/1502.doc.rst
@@ -1,0 +1,1 @@
+New example :ref:`matrix_multiplier`.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -32,6 +32,7 @@ EXAMPLES := adder/tests \
             dff/tests \
             simple_dff \
             endian_swapper/tests \
+            matrix_multiplier/tests \
             mean/tests \
             mixed_language/tests
 # requires root permissions: ping_tun_tap/tests

--- a/examples/matrix_multiplier/hdl/matrix_multiplier.sv
+++ b/examples/matrix_multiplier/hdl/matrix_multiplier.sv
@@ -1,0 +1,78 @@
+// This file is public domain, it can be freely copied without restrictions.
+// SPDX-License-Identifier: CC0-1.0
+
+// Matrix Multiplier DUT
+`timescale 1ns/1ps
+
+module matrix_multiplier #(
+  parameter int DATA_WIDTH = 8,
+  parameter int A_ROWS = 8,
+  parameter int B_COLUMNS = 5,
+  parameter int A_COLUMNS_B_ROWS = 4,
+  parameter int C_DATA_WIDTH = (2 * DATA_WIDTH) + $clog2(A_COLUMNS_B_ROWS)
+) (
+  input                           clk_i,
+  input                           reset_i,
+  input                           valid_i,
+  output logic                    valid_o,
+  input        [DATA_WIDTH-1:0]   a_i[A_ROWS * A_COLUMNS_B_ROWS],
+  input        [DATA_WIDTH-1:0]   b_i[A_COLUMNS_B_ROWS * B_COLUMNS],
+  output logic [C_DATA_WIDTH-1:0] c_o[A_ROWS * B_COLUMNS]
+);
+
+  logic [C_DATA_WIDTH-1:0] c_calc[A_ROWS * B_COLUMNS];
+
+  always @(*) begin
+    logic [C_DATA_WIDTH-1:0] c_element;
+    for (int i = 0; i < A_ROWS; i = i + 1) begin
+      for (int j = 0; j < B_COLUMNS; j = j + 1) begin
+        c_element = 0;
+        for (int k = 0; k < A_COLUMNS_B_ROWS; k = k + 1) begin
+          c_element = c_element + (a_i[(i * A_COLUMNS_B_ROWS) + k] * b_i[(k * B_COLUMNS) + j]);
+        end
+        c_calc[(i * B_COLUMNS) + j] = c_element;
+      end
+    end
+  end
+
+  always @(posedge clk_i) begin
+    if (reset_i) begin
+      valid_o <= 1'b0;
+
+      for (int idx = 0; idx < (A_ROWS * B_COLUMNS); idx++) begin
+        c_o[idx] <= '0;
+      end
+    end else begin
+      valid_o <= valid_i;
+
+      for (int idx = 0; idx < (A_ROWS * B_COLUMNS); idx++) begin
+        c_o[idx] <= c_calc[idx];
+      end
+    end
+  end
+
+  // Dump waves
+`ifndef VERILATOR
+  initial begin
+    integer idx;
+    $dumpfile("dump.vcd");
+    $dumpvars(1, matrix_multiplier);
+  `ifdef __ICARUS__
+      for (idx = 0; idx < (A_ROWS * A_COLUMNS_B_ROWS); idx++) begin
+        $dumpvars(1, a_i[idx]);
+      end
+      for (idx = 0; idx < (A_COLUMNS_B_ROWS * B_COLUMNS); idx++) begin
+        $dumpvars(1, b_i[idx]);
+      end
+      for (idx = 0; idx < (A_ROWS * B_COLUMNS); idx++) begin
+        $dumpvars(1, c_o[idx]);
+      end
+  `else
+    $dumpvars(1, a_i);
+    $dumpvars(1, b_i);
+    $dumpvars(1, c_o);
+  `endif
+  end
+`endif
+
+endmodule

--- a/examples/matrix_multiplier/hdl/matrix_multiplier.vhd
+++ b/examples/matrix_multiplier/hdl/matrix_multiplier.vhd
@@ -1,0 +1,75 @@
+-- This file is public domain, it can be freely copied without restrictions.
+-- SPDX-License-Identifier: CC0-1.0
+
+-- Matrix Multiplier DUT
+library ieee ;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.matrix_multiplier_pkg.all;
+use work.mean_pkg.clog2;
+
+entity matrix_multiplier is
+  generic (
+    DATA_WIDTH : positive := 8;
+    A_ROWS : positive := 8;
+    B_COLUMNS : positive := 5;
+    A_COLUMNS_B_ROWS : positive := 4
+  );
+  port (
+    clk_i   : in    std_logic;
+    reset_i : in    std_logic;
+    valid_i : in    std_logic;
+    valid_o : out   std_logic;
+    a_i     : in    flat_matrix_type(0 to (A_ROWS * A_COLUMNS_B_ROWS) - 1)(DATA_WIDTH - 1 downto 0);
+    b_i     : in    flat_matrix_type(0 to (A_COLUMNS_B_ROWS * B_COLUMNS) - 1)(DATA_WIDTH - 1 downto 0);
+    c_o     : out   flat_matrix_type(0 to (A_ROWS * B_COLUMNS) - 1)((2 * DATA_WIDTH) + clog2(A_COLUMNS_B_ROWS) - 1 downto 0)
+  );
+end entity matrix_multiplier;
+
+architecture rtl of matrix_multiplier is
+
+  signal c_calc : flat_matrix_type(c_o'RANGE)(c_o(0)'RANGE);
+
+begin
+
+  multiply : process (all) is
+
+    variable c_var : flat_matrix_type(c_o'RANGE)(c_o(0)'RANGE);
+
+  begin
+
+    c_var := (others => (others => '0'));
+
+    C_ROWS : for i in 0 to A_ROWS-1 loop
+      C_COLUMNS : for j in 0 to B_COLUMNS-1 loop
+        DOT_PRODUCT : for k in 0 to A_COLUMNS_B_ROWS-1 loop
+          c_var((i * B_COLUMNS) + j) := c_var((i * B_COLUMNS) + j) + (a_i((i * A_COLUMNS_B_ROWS) + k) * b_i((k * B_COLUMNS) + j));
+        end loop;
+      end loop;
+    end loop;
+
+    c_calc <= c_var;
+
+  end process multiply;
+
+  proc_reg : process (clk_i) is
+  begin
+
+    if (rising_edge(clk_i)) then
+      if (reset_i) then
+        valid_o <= '0';
+        c_o <= (others => (others => '0'));
+      else
+        valid_o <= valid_i;
+
+        if (valid_i) then
+          c_o <= c_calc;
+        else
+          c_o <= (others => (others => 'X'));
+        end if;
+      end if;
+    end if;
+
+  end process proc_reg;
+
+end architecture rtl;

--- a/examples/matrix_multiplier/hdl/matrix_multiplier_pkg.vhd
+++ b/examples/matrix_multiplier/hdl/matrix_multiplier_pkg.vhd
@@ -1,0 +1,13 @@
+-- This file is public domain, it can be freely copied without restrictions.
+-- SPDX-License-Identifier: CC0-1.0
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package matrix_multiplier_pkg is
+
+    -- VHDL-2008 required for unconstrained array types
+    type flat_matrix_type is array (integer range <>) of unsigned;
+
+end package;

--- a/examples/matrix_multiplier/tests/Makefile
+++ b/examples/matrix_multiplier/tests/Makefile
@@ -1,0 +1,82 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+TOPLEVEL_LANG ?= verilog
+SIM ?= icarus
+
+PWD=$(shell pwd)
+
+# Matrix parameters
+DATA_WIDTH ?= 32
+A_ROWS ?= 10
+B_COLUMNS ?= 4
+A_COLUMNS_B_ROWS ?= 6
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+    VERILOG_SOURCES = $(PWD)/../hdl/matrix_multiplier.sv
+
+    # Set module parameters
+    ifeq ($(SIM),icarus)
+        COMPILE_ARGS += -Pmatrix_multiplier.DATA_WIDTH=$(DATA_WIDTH) -Pmatrix_multiplier.A_ROWS=$(A_ROWS) -Pmatrix_multiplier.B_COLUMNS=$(B_COLUMNS) -Pmatrix_multiplier.A_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
+    else ifneq ($(filter $(SIM),questa modelsim riviera activehdl),)
+        SIM_ARGS += -gDATA_WIDTH=$(DATA_WIDTH) -gA_ROWS=$(A_ROWS) -gB_COLUMNS=$(B_COLUMNS) -gA_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
+    else ifeq ($(SIM),vcs)
+        COMPILE_ARGS += -pvalue+matrix_multiplier/DATA_WIDTH=$(DATA_WIDTH) -pvalue+matrix_multiplier/A_ROWS=$(A_ROWS) -pvalue+matrix_multiplier/B_COLUMNS=$(B_COLUMNS) -pvalue+matrix_multiplier/A_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
+    else ifeq ($(SIM),verilator)
+        COMPILE_ARGS += -GDATA_WIDTH=$(DATA_WIDTH) -GA_ROWS=$(A_ROWS) -GB_COLUMNS=$(B_COLUMNS) -GA_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
+    else ifneq ($(filter $(SIM),ius xcelium),)
+        EXTRA_ARGS += -defparam "matrix_multiplier.DATA_WIDTH=$(DATA_WIDTH)" -defparam "matrix_multiplier.A_ROWS=$(A_ROWS)" -defparam "matrix_multiplier.B_COLUMNS=$(B_COLUMNS)" -defparam "matrix_multiplier.A_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)"
+    endif
+
+    ifneq ($(filter $(SIM),riviera activehdl),)
+        COMPILE_ARGS += -sv2k12
+    endif
+
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+    VHDL_SOURCES = $(PWD)/../../mean/hdl/mean_pkg.vhd $(PWD)/../hdl/matrix_multiplier_pkg.vhd $(PWD)/../hdl/matrix_multiplier.vhd
+
+    ifneq ($(filter $(SIM),ghdl questa modelsim riviera activehdl),)
+        # ghdl, questa, and aldec all use SIM_ARGS with '-g' for setting generics
+        SIM_ARGS += -gDATA_WIDTH=$(DATA_WIDTH) -gA_ROWS=$(A_ROWS) -gB_COLUMNS=$(B_COLUMNS) -gA_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
+    else ifneq ($(filter $(SIM),ius xcelium),)
+        SIM_ARGS += -generic "matrix_multiplier:DATA_WIDTH=>$(DATA_WIDTH)" -generic "matrix_multiplier:A_ROWS=>$(A_ROWS)" -generic "matrix_multiplier:B_COLUMNS=>$(B_COLUMNS)" -generic "matrix_multiplier:A_COLUMNS_B_ROWS=>$(A_COLUMNS_B_ROWS)"
+    endif
+
+    ifeq ($(SIM),ghdl)
+        EXTRA_ARGS += --std=08
+        SIM_ARGS += --wave=wave.ghw
+    else ifneq ($(filter $(SIM),questa modelsim riviera activehdl),)
+        COMPILE_ARGS += -2008
+    endif
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
+
+# Fix the seed to ensure deterministic tests
+export RANDOM_SEED := 123456789
+
+# Export generics to test
+# Can't use plusargs since they aren't supported by ghdl
+export DATA_WIDTH
+export A_ROWS
+export B_COLUMNS
+export A_COLUMNS_B_ROWS
+
+TOPLEVEL    := matrix_multiplier
+MODULE      := test_matrix_multiplier
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+
+# Profiling
+
+DOT_BINARY ?= dot
+
+test_profile.pstat: sim
+
+callgraph.svg: test_profile.pstat
+	$(shell cocotb-config --python-bin) -m gprof2dot -f pstats ./$< | $(DOT_BINARY) -Tsvg -o $@
+
+.PHONY: profile
+profile:
+	COCOTB_ENABLE_PROFILING=1 $(MAKE) callgraph.svg

--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -1,0 +1,148 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+import math
+import os
+from random import getrandbits
+
+import cocotb
+from cocotb.binary import BinaryValue
+from cocotb.clock import Clock
+from cocotb.monitors import BusMonitor
+from cocotb.regression import TestFactory
+from cocotb.scoreboard import Scoreboard
+from cocotb.triggers import RisingEdge, ReadOnly
+
+NUM_SAMPLES = int(os.environ.get('NUM_SAMPLES', 3000))
+DATA_WIDTH = int(os.environ['DATA_WIDTH'])
+A_ROWS = int(os.environ['A_ROWS'])
+B_COLUMNS = int(os.environ['B_COLUMNS'])
+A_COLUMNS_B_ROWS = int(os.environ['A_COLUMNS_B_ROWS'])
+
+
+class MatrixMonitor(BusMonitor):
+    """Base class for monitoring inputs/outputs of Matrix Multiplier."""
+    def __init__(self, dut, callback=None, event=None):
+        super().__init__(dut, "", dut.clk_i, callback=callback, event=event)
+
+
+class MatrixInMonitor(MatrixMonitor):
+    """Monitor inputs to Matrix Multiplier module.
+
+    Generate expected results for each multiplication operation.
+    """
+    _signals = {"A": "a_i", "B": "b_i", "valid": "valid_i"}
+
+    async def _monitor_recv(self):
+        while True:
+            await RisingEdge(self.clock)
+            await ReadOnly()
+
+            if self.bus.valid.value:
+                a_matrix = self.bus.A.value
+                b_matrix = self.bus.B.value
+
+                # Calculate the expected result of C
+                c_expected = [
+                    BinaryValue(
+                        sum(
+                            [
+                                a_matrix[(i * A_COLUMNS_B_ROWS) + n] * b_matrix[(n * B_COLUMNS) + j]
+                                for n in range(A_COLUMNS_B_ROWS)
+                            ]
+                        ),
+                        n_bits=(DATA_WIDTH * 2) + math.ceil(math.log2(A_COLUMNS_B_ROWS)),
+                        bigEndian=False
+                    )
+                    for i in range(A_ROWS)
+                    for j in range(B_COLUMNS)
+                ]
+
+                self._recv(c_expected)
+
+
+class MatrixOutMonitor(MatrixMonitor):
+    """Monitor outputs from Matrix Multiplier module.
+
+    Capture result matrix for each multiplication operation.
+    """
+    _signals = {"C": "c_o", "valid": "valid_o"}
+
+    async def _monitor_recv(self):
+        while True:
+            await RisingEdge(self.clock)
+            await ReadOnly()
+
+            if self.bus.valid.value:
+                c_actual = self.bus.C.value
+                self._recv(c_actual)
+
+
+async def test_multiply(dut, a_data, b_data):
+    """Test multiplication of many matrices."""
+
+    cocotb.fork(Clock(dut.clk_i, 10, units='ns').start())
+
+    # Configure Scoreboard to compare module results to expected
+    expected_output = []
+
+    in_monitor = MatrixInMonitor(dut, callback=expected_output.append)
+    out_monitor = MatrixOutMonitor(dut)
+
+    scoreboard = Scoreboard(dut)
+    scoreboard.add_interface(out_monitor, expected_output)
+
+    # Initial values
+    dut.valid_i <= 0
+    dut.a_i <= create_a(lambda x: 0)
+    dut.b_i <= create_b(lambda x: 0)
+
+    # Reset DUT
+    dut.reset_i <= 1
+    for _ in range(3):
+        await RisingEdge(dut.clk_i)
+    dut.reset_i <= 0
+
+    # Do multiplication operations
+    for A, B in zip(a_data(), b_data()):
+        await RisingEdge(dut.clk_i)
+        dut.a_i <= A
+        dut.b_i <= B
+        dut.valid_i <= 1
+
+        await RisingEdge(dut.clk_i)
+        dut.valid_i <= 0
+
+    await RisingEdge(dut.clk_i)
+
+    raise scoreboard.result
+
+
+def create_matrix(func, rows, cols):
+    return [func(DATA_WIDTH) for row in range(rows) for col in range(cols)]
+
+
+def create_a(func):
+    return create_matrix(func, A_ROWS, A_COLUMNS_B_ROWS)
+
+
+def create_b(func):
+    return create_matrix(func, A_COLUMNS_B_ROWS, B_COLUMNS)
+
+
+def gen_a(num_samples=NUM_SAMPLES, func=getrandbits):
+    """Generate random matrix data for A"""
+    for _ in range(num_samples):
+        yield create_a(func)
+
+
+def gen_b(num_samples=NUM_SAMPLES, func=getrandbits):
+    """Generate random matrix data for B"""
+    for _ in range(num_samples):
+        yield create_b(func)
+
+
+factory = TestFactory(test_multiply)
+factory.add_option('a_data', [gen_a])
+factory.add_option('b_data', [gen_b])
+factory.generate_tests()


### PR DESCRIPTION
Add matrix multiplication example and test. The test is heavily
weighted towards use of the BinaryValue class. By fixing the random
seed by default, it also provides a deterministic test for performance
regression.

This example and test are designed to be a testbench for various
performance enhancements, especially involving BinaryValue.

Split from gh-1286