### PR TITLE
Allow setting array values with lists.

### DIFF
--- a/documentation/source/newsfragments/1507.bugfix.rst
+++ b/documentation/source/newsfragments/1507.bugfix.rst
@@ -1,0 +1,1 @@
+Getting and setting the value of an :class:`~cocotb.handle.NonHierarchyIndexableObject` now iterates through the correct range of the simulation object, so arrays that do not start/end at index 0 are supported.

--- a/documentation/source/newsfragments/1507.bugfix.rst
+++ b/documentation/source/newsfragments/1507.bugfix.rst
@@ -1,1 +1,1 @@
-Getting and setting the value of an :class:`~cocotb.handle.NonHierarchyIndexableObject` now iterates through the correct range of the simulation object, so arrays that do not start/end at index 0 are supported.
+Getting and setting the value of a :class:`~cocotb.handle.NonHierarchyIndexableObject` now iterates through the correct range of the simulation object, so arrays that do not start/end at index 0 are supported.

--- a/documentation/source/newsfragments/1507.change.rst
+++ b/documentation/source/newsfragments/1507.change.rst
@@ -1,0 +1,2 @@
+:attr:`cocotb.handle.NonHierarchyIndexableObject.value` is now a list in left-to-right range order of the underlying simulation object.
+Previously the list was always ordered low-to-high.

--- a/documentation/source/newsfragments/1507.feature.rst
+++ b/documentation/source/newsfragments/1507.feature.rst
@@ -1,0 +1,13 @@
+New methods for setting the value of an :class:`~cocotb.handle.NonHierarchyIndexableObject` (HDL arrays). (:pr:`1507`)
+
+.. code-block:: python3
+
+    # Now supported
+    dut.some_array <= [0xAA, 0xBB, 0xCC]
+    dut.some_array.value = [0xAA, 0xBB, 0xCC]
+
+    # For simulators that support n-dimensional arrays
+    dut.some_2d_array <= [[0xAA, 0xBB], [0xCC, 0xDD]]
+    dut.some_2d_array.value = [[0xAA, 0xBB], [0xCC, 0xDD]]
+
+.. consume the towncrier issue number on this line.

--- a/documentation/source/newsfragments/1507.feature.rst
+++ b/documentation/source/newsfragments/1507.feature.rst
@@ -1,4 +1,4 @@
-New methods for setting the value of an :class:`~cocotb.handle.NonHierarchyIndexableObject` (HDL arrays). (:pr:`1507`)
+New methods for setting the value of a :class:`~cocotb.handle.NonHierarchyIndexableObject` (HDL arrays). (:pr:`1507`)
 
 .. code-block:: python3
 

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -117,6 +117,21 @@ always @(posedge clk) begin
     register_array[0] <= 0;
 end
 
+//For testing arrays
+reg [7:0]  array_7_downto_4[7:4];
+reg [7:0]  array_4_to_7[4:7];
+reg [7:0]  array_3_downto_0[3:0];
+reg [7:0]  array_0_to_3[0:3];
+reg [7:0]  array_2d[0:1][31:28];
+always @(posedge stream_in_valid) begin
+    // Ensure internal array is not optimized out
+    array_7_downto_4[4] <= 0;
+    array_4_to_7[7] <= 0;
+    array_3_downto_0[0] <= 0;
+    array_0_to_3[3] <= 0;
+    array_2d[1][28] <= 0;
+end
+
 //For testing type assigned to logic
 logic logic_a, logic_b, logic_c;
 assign logic_a = stream_in_valid;

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -98,6 +98,15 @@ end afunc;
   signal cosLut1, sinLut1 : lutType;
   signal cosLut,  sinLut  : lutType;
 
+  type unsignedArrayType is array (natural range <>) of unsigned(7 downto 0);
+  signal array_7_downto_4 : unsignedArrayType(7 downto 4);
+  signal array_4_to_7     : unsignedArrayType(4 to 7);
+  signal array_3_downto_0 : unsignedArrayType(3 downto 0);
+  signal array_0_to_3     : unsignedArrayType(0 to 3);
+
+  type twoDimArrayType is array (natural range <>) of unsignedArrayType(31 downto 28);
+  signal array_2d         : twoDimArrayType(0 to 1);
+
 begin
 
 process (clk) begin
@@ -126,6 +135,5 @@ isample_module1 : component sample_module_1
   stream_out_data_registered => open,
   stream_out_data_valid => open
   );
-
 
 end architecture;

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -40,6 +40,12 @@ def _check_real(tlog, hdl, expected):
     else:
         tlog.info("   Found {0!r} ({1}) with value={2}".format(hdl, hdl._type, float(hdl)))
 
+def _check_value(tlog, hdl, expected):
+    if hdl.value != expected:
+        raise TestFailure("{2!r}: Expected >{0}< but got >{1}<".format(expected, hdl.value, hdl))
+    else:
+        tlog.info("   Found {0!r} ({1}) with value={2}".format(hdl, hdl._type, hdl.value))
+
 # NOTE: simulator-specific handling is done in this test itself, not via expect_error in the decorator
 @cocotb.test()
 def test_read_write(dut):
@@ -107,6 +113,14 @@ def test_read_write(dut):
     tlog.info("Writing the signals!!!")
     dut.sig_logic         = 1
     dut.sig_logic_vec     = 0xCC
+    dut.sig_t2 = [0xCC, 0xDD, 0xEE, 0xFF]
+    dut.sig_t4 = [
+        [0x00, 0x11, 0x22, 0x33],
+        [0x44, 0x55, 0x66, 0x77],
+        [0x88, 0x99, 0xAA, 0xBB],
+        [0xCC, 0xDD, 0xEE, 0xFF]
+    ]
+
     if cocotb.LANGUAGE in ["vhdl"]:
         dut.sig_bool          = 1
         dut.sig_int           = 5000
@@ -131,6 +145,11 @@ def test_read_write(dut):
     tlog.info("Checking writes:")
     _check_logic(tlog, dut.port_logic_out    , 1)
     _check_logic(tlog, dut.port_logic_vec_out, 0xCC)
+    _check_value(tlog, dut.sig_t2, [0xCC, 0xDD, 0xEE, 0xFF])
+    _check_logic(tlog, dut.sig_t2[7], 0xCC)
+    _check_logic(tlog, dut.sig_t2[4], 0xFF)
+    _check_logic(tlog, dut.sig_t4[1][5], 0x66)
+    _check_logic(tlog, dut.sig_t4[3][7], 0xCC)
 
     if cocotb.LANGUAGE in ["vhdl"]:
         _check_int (tlog, dut.port_bool_out, 1)

--- a/tests/test_cases/test_array_simple/Makefile
+++ b/tests/test_cases/test_array_simple/Makefile
@@ -1,0 +1,3 @@
+include ../../designs/sample_module/Makefile
+
+MODULE = test_array_simple

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -1,0 +1,197 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test getting and setting values of arrays"""
+import contextlib
+import logging
+
+import cocotb
+from cocotb.binary import BinaryValue
+from cocotb.clock import Clock
+from cocotb.result import TestFailure
+from cocotb.triggers import Timer
+
+tlog = logging.getLogger("cocotb.test")
+
+def _check_value(tlog, hdl, expected):
+    if hdl.value != expected:
+        raise TestFailure("{2!r}: Expected >{0}< but got >{1}<".format(expected, hdl.value, hdl))
+    else:
+        tlog.info("   Found {0!r} ({1}) with value={2}".format(hdl, hdl._type, hdl.value))
+
+
+@cocotb.test()
+async def test_1dim_array_handles(dut):
+    """Test getting and setting array values using the handle of the full array."""
+
+    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+
+    # Set values with '<=' operator
+    dut.array_7_downto_4 <= [0xF0, 0xE0, 0xD0, 0xC0]
+    dut.array_4_to_7     <= [0xB0, 0xA0, 0x90, 0x80]
+    dut.array_3_downto_0 <= [0x70, 0x60, 0x50, 0x40]
+    dut.array_0_to_3     <= [0x30, 0x20, 0x10, 0x00]
+
+    await Timer(1000, 'ns')
+
+    _check_value(tlog, dut.array_7_downto_4, [0xF0, 0xE0, 0xD0, 0xC0])
+    _check_value(tlog, dut.array_4_to_7    , [0xB0, 0xA0, 0x90, 0x80])
+    _check_value(tlog, dut.array_3_downto_0, [0x70, 0x60, 0x50, 0x40])
+    _check_value(tlog, dut.array_0_to_3    , [0x30, 0x20, 0x10, 0x00])
+
+    # Set values through HierarchyObject.__setattr__ method on 'dut' handle
+    dut.array_7_downto_4 = [0x00, 0x11, 0x22, 0x33]
+    dut.array_4_to_7     = [0x44, 0x55, 0x66, 0x77]
+    dut.array_3_downto_0 = [0x88, 0x99, 0xAA, 0xBB]
+    dut.array_0_to_3     = [0xCC, 0xDD, 0xEE, 0xFF]
+
+    await Timer(1000, 'ns')
+
+    _check_value(tlog, dut.array_7_downto_4, [0x00, 0x11, 0x22, 0x33])
+    _check_value(tlog, dut.array_4_to_7    , [0x44, 0x55, 0x66, 0x77])
+    _check_value(tlog, dut.array_3_downto_0, [0x88, 0x99, 0xAA, 0xBB])
+    _check_value(tlog, dut.array_0_to_3    , [0xCC, 0xDD, 0xEE, 0xFF])
+
+
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")))
+async def test_ndim_array_handles(dut):
+    """Test getting and setting multi-dimensional array values using the handle of the full array."""
+
+    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+
+    # Set values with '<=' operator
+    dut.array_2d <= [
+        [0xF0, 0xE0, 0xD0, 0xC0],
+        [0xB0, 0xA0, 0x90, 0x80]
+    ]
+
+    await Timer(1000, 'ns')
+
+    _check_value(tlog, dut.array_2d, [[0xF0, 0xE0, 0xD0, 0xC0], [0xB0, 0xA0, 0x90, 0x80]])
+
+    # Set values through HierarchyObject.__setattr__ method on 'dut' handle
+    dut.array_2d = [
+        [0x00, 0x11, 0x22, 0x33],
+        [0x44, 0x55, 0x66, 0x77]
+    ]
+
+    await Timer(1000, 'ns')
+
+    _check_value(tlog, dut.array_2d, [[0x00, 0x11, 0x22, 0x33], [0x44, 0x55, 0x66, 0x77]])
+
+
+@cocotb.test()
+async def test_1dim_array_indexes(dut):
+    """Test getting and setting values of array indexes."""
+
+    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+
+    dut.array_7_downto_4 <= [0xF0, 0xE0, 0xD0, 0xC0]
+    dut.array_4_to_7     <= [0xB0, 0xA0, 0x90, 0x80]
+    dut.array_3_downto_0 <= [0x70, 0x60, 0x50, 0x40]
+    dut.array_0_to_3     <= [0x30, 0x20, 0x10, 0x00]
+
+    await Timer(1000, 'ns')
+
+    # Check indices
+    _check_value(tlog, dut.array_7_downto_4[7], 0xF0)
+    _check_value(tlog, dut.array_7_downto_4[4], 0xC0)
+    _check_value(tlog, dut.array_4_to_7[4]    , 0xB0)
+    _check_value(tlog, dut.array_4_to_7[7]    , 0x80)
+    _check_value(tlog, dut.array_3_downto_0[3], 0x70)
+    _check_value(tlog, dut.array_3_downto_0[0], 0x40)
+    _check_value(tlog, dut.array_0_to_3[0]    , 0x30)
+    _check_value(tlog, dut.array_0_to_3[3]    , 0x00)
+    _check_value(tlog, dut.array_0_to_3[1]    , 0x20)
+
+    # Get sub-handles through NonHierarchyIndexableObject.__getitem__
+    dut.array_7_downto_4[7] <= 0xDE
+    dut.array_4_to_7[4]     <= 0xFC
+    dut.array_3_downto_0[0] <= 0xAB
+    dut.array_0_to_3[1]     <= 0x7A
+    dut.array_0_to_3[3]     <= 0x42
+
+    await Timer(1000, 'ns')
+
+    _check_value(tlog, dut.array_7_downto_4[7], 0xDE)
+    _check_value(tlog, dut.array_4_to_7[4]    , 0xFC)
+    _check_value(tlog, dut.array_3_downto_0[0], 0xAB)
+    _check_value(tlog, dut.array_0_to_3[1]    , 0x7A)
+    _check_value(tlog, dut.array_0_to_3[3]    , 0x42)
+
+    # Set sub-handle values through NonHierarchyIndexableObject.__setitem__
+    dut.array_7_downto_4[7] = 0x77
+    dut.array_4_to_7[4]     = 0x44
+    dut.array_3_downto_0[0] = 0x00
+    dut.array_0_to_3[1]     = 0x11
+    dut.array_0_to_3[3]     = 0x33
+
+    await Timer(1000, 'ns')
+
+    _check_value(tlog, dut.array_7_downto_4[7], 0x77)
+    _check_value(tlog, dut.array_4_to_7[4]    , 0x44)
+    _check_value(tlog, dut.array_3_downto_0[0], 0x00)
+    _check_value(tlog, dut.array_0_to_3[1]    , 0x11)
+    _check_value(tlog, dut.array_0_to_3[3]    , 0x33)
+
+
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")))
+async def test_ndim_array_indexes(dut):
+    """Test getting and setting values of multi-dimensional array indexes."""
+
+    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+
+    dut.array_2d <= [
+        [0xF0, 0xE0, 0xD0, 0xC0],
+        [0xB0, 0xA0, 0x90, 0x80]
+    ]
+
+    await Timer(1000, 'ns')
+
+    # Check indices
+    _check_value(tlog, dut.array_2d[1]    , [0xB0, 0xA0, 0x90, 0x80])
+    _check_value(tlog, dut.array_2d[0][31], 0xF0)
+    _check_value(tlog, dut.array_2d[1][29], 0x90)
+    _check_value(tlog, dut.array_2d[1][28], 0x80)
+
+    # Get sub-handles through NonHierarchyIndexableObject.__getitem__
+    dut.array_2d[1]     <= [0xDE, 0xAD, 0xBE, 0xEF]
+    dut.array_2d[0][31] <= 0x0F
+
+    await Timer(1000, 'ns')
+
+    _check_value(tlog, dut.array_2d[0][31], 0x0F)
+    _check_value(tlog, dut.array_2d[0][29], 0xD0)
+    _check_value(tlog, dut.array_2d[1][30], 0xAD)
+    _check_value(tlog, dut.array_2d[1][28], 0xEF)
+
+    # Set sub-handle values through NonHierarchyIndexableObject.__setitem__
+    dut.array_2d[0]     = [0xBA, 0xBE, 0xCA, 0xFE]
+    dut.array_2d[1][29] = 0x12
+
+    await Timer(1000, 'ns')
+
+    _check_value(tlog, dut.array_2d[0][31], 0xBA)
+    _check_value(tlog, dut.array_2d[0][30], 0xBE)
+    _check_value(tlog, dut.array_2d[1]    , [0xDE, 0xAD, 0x12, 0xEF])
+
+@contextlib.contextmanager
+def assert_raises(exc_type):
+    try:
+        yield
+    except exc_type as exc:
+        tlog.info("   {} raised as expected: {}".format(exc_type.__name__, exc))
+    else:
+        raise AssertionError("{} was not raised".format(exc_type.__name__))
+
+@cocotb.test()
+async def test_exceptions(dut):
+    """Test that correct Exceptions are raised."""
+    with assert_raises(TypeError):
+        dut.array_7_downto_4 <= (0xF0, 0xE0, 0xD0, 0xC0)
+    with assert_raises(TypeError):
+        dut.array_4_to_7      = Exception("Exception Object")
+    with assert_raises(ValueError):
+        dut.array_3_downto_0 <= [0x70, 0x60, 0x50]
+    with assert_raises(ValueError):
+        dut.array_0_to_3     <= [0x40, 0x30, 0x20, 0x10, 0x00]


### PR DESCRIPTION
This change allows setting the value of a NonHierarchyIndexableObject
handle with a Python list. The values of the list indexes will be
assigned to the sub-handles in range order from left to right. Supports
multi-dimensional arrays.

Fix value getter for NonHierarchyIndexableObject. Now supports arrays
that don't start at index 0, and gives value in range order left to right.

Added a test for this because `test_array` is skipped by iverilog.

When adding support for arrays that don't start at index 0, I opted to go with mapping index `0` of the python list to `range'left` and the last index to `range'right`. I'm not sure if this is better than using `range'low` to `range'high`, but matches how we assign `binstr` values.

Also I'm not sure if this would go under `bugfix` or `feature`.

- [x] Document **left-to-right** assignment in NonHierarchyIndexableObject.value docstring
    - [sphinx preview here](https://cocotb--1507.org.readthedocs.build/en/1507/library_reference.html#cocotb.handle.NonHierarchyIndexableObject)
- [x] Release note regarding change of behavior, bugfix, additional feature