### PR TITLE
Remove HierarchyObject.__hasattr__

### DIFF
--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -95,9 +95,7 @@ class Bus(object):
                 signame += "[{:d}]".format(array_idx)
 
             self._entity._log.debug("Signal name {}".format(signame))
-            # Attempts to access a signal that doesn't exist will print a
-            # backtrace so we 'peek' first, slightly un-pythonic
-            if entity.__hasattr__(signame):
+            if hasattr(entity, signame):
                 self._add_signal(attr_name, signame)
             else:
                 self._entity._log.debug("Ignoring optional missing signal "


### PR DESCRIPTION
This was introduced in 7ce68f1 as a hack because `__getattr__` contained log statements.
This is not a real magic method, and now that we do not log in `__getattr__` there is no need to have a "peek" accessor.

(note: this PR has had most of its contents moved to other PRs)