### PR TITLE
Remove `BinaryValue.get_hex_buff` which is nonsense

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -332,11 +332,6 @@ class BinaryValue(object):
                 buff = chr(val) + buff
         return buff
 
-    def get_hex_buff(self):
-        bstr = self.get_buff()
-        hstr = '%0*X' % ((len(bstr) + 3) // 4, int(bstr, 2))
-        return hstr
-
     def set_buff(self, buff):
         self._str = ""
         for char in buff:

--- a/documentation/source/newsfragments/1511.removal.rst
+++ b/documentation/source/newsfragments/1511.removal.rst
@@ -1,0 +1,1 @@
+``BinaryValue.get_hex_buff`` produced nonsense and has been removed.


### PR DESCRIPTION
This was introduced in 030a25bdeae4d02db12becf461f33c5d4217c67f with no explanation or docstring. Here is a sample of its behavior:
```python
>>> BinaryValue('1111').get_hex_buff()
ValueError: invalid literal for int() with base 2: '\x0f'

# 0b00110001 is ascii 1
>>> BinaryValue('00110001').get_hex_buff()
'1'

>>> BinaryValue('00110001' + '00110000').get_hex_buff()
'2'
```

The semantics seem to be:
* Intepret the binary value as an ascii string
* ensure the only ascii characters are 0 and 1
* decode those ascii characters to a binary integer
* encode that binary integer as hex

Clearly this is nonsense. `BinaryValue.hex` produces much saner results.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
