### PR TITLE
Make `BinaryValue.buff` bytes not str.

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -675,7 +675,7 @@ class AvalonSTPkts(ValidatedBusDriver):
     @coroutine
     def _send_string(self, string, sync=True, channel=None):
         """Args:
-            string (str): A string of bytes to send over the bus.
+            string (bytes): A string of bytes to send over the bus.
             channel (int): Channel to send the data on.
         """
         # Avoid spurious object creation by recycling
@@ -747,7 +747,7 @@ class AvalonSTPkts(ValidatedBusDriver):
                 self.bus.endofpacket <= 1
                 if self.use_empty:
                     self.bus.empty <= bus_width - len(string)
-                string = ""
+                string = b""
             else:
                 string = string[bus_width:]
 
@@ -831,11 +831,13 @@ class AvalonSTPkts(ValidatedBusDriver):
         """
 
         # Avoid spurious object creation by recycling
-        if isinstance(pkt, str):
+        if isinstance(pkt, bytes):
             self.log.debug("Sending packet of length %d bytes", len(pkt))
             self.log.debug(hexdump(pkt))
             yield self._send_string(pkt, sync=sync, channel=channel)
             self.log.debug("Successfully sent packet of length %d bytes", len(pkt))
+        elif isinstance(pkt, str):
+            raise TypeError("pkt must be a bytestring, not a unicode string")
         else:
             if channel is not None:
                 self.log.warning("%s is ignoring channel=%d because pkt is an iterable", self.name, channel)

--- a/cocotb/generators/byte.py
+++ b/cocotb/generators/byte.py
@@ -30,40 +30,48 @@
 
 """
     Collection of generators for creating byte streams
+
+    Note that on Python 3, individual bytes are represented with integers.
 """
 import random
+import itertools
 from cocotb.decorators import public
+from typing import Iterator
 
 
 @public
-def get_bytes(nbytes, generator):
-    """Get nbytes from generator"""
-    result = ""
-    for i in range(nbytes):
-        result += next(generator)
-    return result
+def get_bytes(nbytes: int, generator: Iterator[int]) -> bytes:
+    """Get nbytes from generator
+
+    .. versionchanged:: 1.4.0
+        This now returns :type:`bytes` not :type:`str`. """
+    return bytes(next(generator) for i in range(nbytes))
 
 
 @public
-def random_data():
-    """Random bytes"""
+def random_data() -> Iterator[int]:
+    r"""Random bytes
+
+    .. versionchanged:: 1.4.0
+        This now returns integers not single-character :type:`str`\ s. """
     while True:
-        yield chr(random.randint(0, 255))
+        yield random.randrange(256)
 
 
 @public
-def incrementing_data(increment=1):
-    """Incrementing bytes"""
+def incrementing_data(increment=1) -> Iterator[int]:
+    r"""Incrementing bytes
+
+    .. versionchanged:: 1.4.0
+        This now returns integers not single-character :type:`str`\ s. """
     val = 0
     while True:
-        yield chr(val)
+        yield val
         val += increment
         val = val & 0xFF
 
 
 @public
-def repeating_bytes(pattern="\x00"):
+def repeating_bytes(pattern : bytes = b"\x00") -> Iterator[int]:
     """Repeat a pattern of bytes"""
-    while True:
-        for byte in pattern:
-            yield byte
+    return itertools.cycle(pattern)

--- a/cocotb/monitors/avalon.py
+++ b/cocotb/monitors/avalon.py
@@ -153,7 +153,7 @@ class AvalonSTPkts(BusMonitor):
         # Avoid spurious object creation by recycling
         clkedge = RisingEdge(self.clock)
         rdonly = ReadOnly()
-        pkt = ""
+        pkt = b""
         in_pkt = False
         invalid_cyclecount = 0
         channel = None
@@ -177,7 +177,7 @@ class AvalonSTPkts(BusMonitor):
                     if pkt:
                         raise AvalonProtocolError("Duplicate start-of-packet received on %s" %
                                                   str(self.bus.startofpacket))
-                    pkt = ""
+                    pkt = b""
                     in_pkt = True
 
                 if not in_pkt:
@@ -222,7 +222,7 @@ class AvalonSTPkts(BusMonitor):
                         self._recv({"data": pkt, "channel": channel})
                     else:
                         self._recv(pkt)
-                    pkt = ""
+                    pkt = b""
                     in_pkt = False
                     channel = None
             else:

--- a/documentation/source/newsfragments/1514.change.rst
+++ b/documentation/source/newsfragments/1514.change.rst
@@ -1,0 +1,7 @@
+Various binary representations have changed type from :class:`str` to :class:`bytes`. These include:
+
+* :attr:`cocotb.binary.BinaryValue.buff`, which as a consequence means :meth:`cocotb.binary.BinaryValue.assign` no longer accepts malformed ``10xz``-style :class:`str`\ s (which were treated as binary).
+* The packets produced by the :class:`~cocotb.drivers.avalon.AvalonSTPkts`.
+
+Code working with these objects may find it needs to switch from creating :class:`str` objects like ``"this"`` to :class:`bytes` objects like ``b"this"``.
+This change is a consequence of the move to Python 3.

--- a/documentation/source/newsfragments/1514.change.rst
+++ b/documentation/source/newsfragments/1514.change.rst
@@ -1,6 +1,7 @@
 Various binary representations have changed type from :class:`str` to :class:`bytes`. These include:
 
 * :attr:`cocotb.binary.BinaryValue.buff`, which as a consequence means :meth:`cocotb.binary.BinaryValue.assign` no longer accepts malformed ``10xz``-style :class:`str`\ s (which were treated as binary).
+* The objects produced by :mod:`cocotb.generators.byte`, which means that single bytes are represented by :class:`int` instead of 1-character :class:`str`\ s.
 * The packets produced by the :class:`~cocotb.drivers.avalon.AvalonSTPkts`.
 
 Code working with these objects may find it needs to switch from creating :class:`str` objects like ``"this"`` to :class:`bytes` objects like ``b"this"``.

--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -94,11 +94,9 @@ def test_init_little_endian_twos_comp():
     temp_bin = BinaryValue(value="11111111111111111111110000101100", bigEndian=False,
                            binaryRepresentation=BinaryRepresentation.UNSIGNED)
 
-    # Silently fails to set value when another BinaryValue object is passed in
-    bin6 = BinaryValue(value=temp_bin, n_bits=32, binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
-    assert bin6._str == ""
-    assert bin6.binstr == ""
-    assert bin6.n_bits == 32
+    # Illegal to construct from another BinaryValue (used to silently fail)
+    with pytest.raises(TypeError):
+        BinaryValue(value=temp_bin, n_bits=32, binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
 
     bin7 = BinaryValue(value=temp_bin.binstr, n_bits=32,
                        bigEndian=False, binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)

--- a/tests/test_cases/test_avalon_stream/test_avalon_stream.py
+++ b/tests/test_cases/test_avalon_stream/test_avalon_stream.py
@@ -43,7 +43,6 @@ class AvalonSTTB(object):
     @cocotb.coroutine
     def send_data(self, data):
         exp_data = struct.pack("B",data)
-        exp_data = exp_data.decode('ascii')
         self.expected_output.append(exp_data)
         yield self.stream_in.send(data)
 


### PR DESCRIPTION
This makes the behavior consistent with python 2, where the two types were equivalent.

`str` is not appropriate for storing binary data.

Also adjusts the docstring to pass.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

probably relates to #1381

Milestoned as 1.4 since this is part of #1289