### PR TITLE
Better error messages when accidentally using yield in coroutines

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -85,12 +85,18 @@ class RunningTask(object):
         task.kill() will destroy a coroutine instance (and cause any Join
         triggers to fire.
     """
+
     def __init__(self, inst):
 
         if inspect.iscoroutine(inst):
             self._natively_awaitable = True
         elif inspect.isgenerator(inst):
             self._natively_awaitable = False
+        elif sys.version_info >= (3, 6) and inspect.isasyncgen(inst):
+            raise TypeError(
+                "{} is an async generator, not a coroutine. "
+                "You likely used the yield keyword instead of await.".format(
+                    inst.__qualname__))
         else:
             raise TypeError(
                 "%s isn't a valid coroutine! Did you forget to use the yield keyword?" % inst)

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -34,6 +34,7 @@ also have pending writes we have to schedule the ReadWrite callback before
 the ReadOnly (and this is invalid, at least in Modelsim).
 """
 import os
+import sys
 import logging
 import threading
 import inspect
@@ -648,6 +649,12 @@ class Scheduler(object):
         if inspect.iscoroutine(coroutine):
             return self.add(cocotb.decorators.RunningTask(coroutine))
 
+        elif sys.version_info >= (3, 6) and inspect.isasyncgen(coroutine):
+            raise TypeError(
+                "{} is an async generator, not a coroutine. "
+                "You likely used the yield keyword instead of await.".format(
+                    coroutine.__qualname__))
+
         elif not isinstance(coroutine, cocotb.decorators.RunningTask):
             raise TypeError(
                 "Attempt to add a object of type {} to the scheduler, which "
@@ -720,6 +727,12 @@ class Scheduler(object):
 
         if isinstance(result, cocotb.triggers.Waitable):
             return self._trigger_from_waitable(result)
+
+        if sys.version_info >= (3, 6) and inspect.isasyncgen(result):
+            raise TypeError(
+                "{} is an async generator, not a coroutine. "
+                "You likely used the yield keyword instead of await.".format(
+                    result.__qualname__))
 
         raise TypeError(
             "Coroutine yielded an object of type {}, which the scheduler can't "

--- a/tests/test_cases/test_cocotb/Makefile
+++ b/tests/test_cases/test_cocotb/Makefile
@@ -29,4 +29,8 @@
 
 include ../../designs/sample_module/Makefile
 
-MODULE = test_cocotb,test_deprecated
+MODULE := test_cocotb,test_deprecated
+
+ifeq ($(shell python -c "import sys; print(sys.version_info >= (3, 6))"), "True")
+MODULE += ,test_async_generators
+endif

--- a/tests/test_cases/test_cocotb/test_async_generators.py
+++ b/tests/test_cases/test_cocotb/test_async_generators.py
@@ -1,0 +1,42 @@
+import cocotb
+
+
+async def whoops_async_generator():
+    # the user should have used `await` here, but they wrote `yield` by accident.
+    yield cocotb.triggers.Timer(1)
+
+
+@cocotb.test()
+def test_yielding_accidental_async_generator(dut):
+    # this test deliberately does not use `async def`, as we are testing the behavior of `yield`
+    try:
+        yield whoops_async_generator()
+    except TypeError as e:
+        assert "async generator" in str(e)
+    else:
+        assert False, "should have thrown"
+
+
+@cocotb.test()
+async def test_forking_accidental_async_generator(dut):
+    try:
+        cocotb.fork(whoops_async_generator())
+    except TypeError as e:
+        assert "async generator" in str(e)
+    else:
+        assert False, "should have thrown"
+
+
+@cocotb.coroutine
+async def whoops_async_generator_decorated():
+    yield cocotb.triggers.Timer(1)
+
+
+@cocotb.test()
+async def test_decorating_accidental_async_generator(dut):
+    try:
+        await whoops_async_generator_decorated()
+    except TypeError as e:
+        assert "async generator" in str(e)
+    else:
+        assert False, "should have thrown"


### PR DESCRIPTION
Fixes #1512. There are a few points where we expect coroutines, so each place got a warning.