### PR TITLE
 Updated tests and examples to use installed makefiles, not the ones pointed to by $COCOTB

### DIFF
--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -54,5 +54,5 @@ else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/avalon_module/Makefile
+++ b/tests/designs/avalon_module/Makefile
@@ -49,7 +49,7 @@ COCOTB?=$(WPWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_module/burst_read_master.v
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/avalon_streaming_module/Makefile
+++ b/tests/designs/avalon_streaming_module/Makefile
@@ -20,7 +20,7 @@ COCOTB?=$(WPWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_streaming_module/avalon_streaming.sv
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/basic_hierarchy_module/Makefile
+++ b/tests/designs/basic_hierarchy_module/Makefile
@@ -24,7 +24,7 @@ COCOTB?=$(WPWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/basic_hierarchy_module/basic_hierarchy_module.v
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/close_module/Makefile
+++ b/tests/designs/close_module/Makefile
@@ -50,8 +50,8 @@ COCOTB?=$(WPWD)/../../..
 VERILOG_SOURCES = $(COCOTB)/tests/designs/close_module/close_module.v
 
 ifneq ($(SIM),vcs)
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 else
 all:
 	@echo "Skipping test as system call overrides seqfault VCS"

--- a/tests/designs/multi_dimension_array/Makefile
+++ b/tests/designs/multi_dimension_array/Makefile
@@ -50,7 +50,7 @@ COCOTB?=$(WPWD)/../../..
 VERILOG_SOURCES = $(COCOTB)/tests/designs/multi_dimension_array/cocotb_array_pkg.sv \
                   $(COCOTB)/tests/designs/multi_dimension_array/cocotb_array.sv
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -51,5 +51,5 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -51,5 +51,5 @@ else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -40,7 +40,7 @@ ifeq ($(SIM),$(filter $(SIM),ius xcelium))
     SIM_ARGS += -v93
 endif
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -38,7 +38,7 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -69,7 +69,7 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/test_cases/test_iteration_verilog/Makefile
+++ b/tests/test_cases/test_iteration_verilog/Makefile
@@ -48,7 +48,7 @@ TOPLEVEL = endian_swapper_sv
 
 MODULE = test_iteration_es
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif


### PR DESCRIPTION
Tests previously depended upon the `COCOTB` environment variable to obtain a reference to the standard makefile includes. This was deprecated recently (link); tests should instead use `cocotb-config --makefiles` to obtain a reference to the makefiles in the package installation directory.

The included regression tests were previously not updated, they required a compatibility layer that the regression scripts sourced. This meant that the existing regressions could not be run independently unless the user manually set the `COCOTB` variable. This PR fixes that issue by updating all the designs to use the new recommended method.

This changed slowed down the regressions notably (20s on master, 50s after change). So a new variable that caches the result of the shell out is used to avoid repeated shelling. After the fix, regressions are now faster (15s) due to the same change being made to the examples.