### PR TITLE
Fix doctests in cocotb.binary, and run them as part of the regression test

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -328,7 +328,7 @@ class BinaryValue(object):
     def buff(self):
         """Attribute :attr:`buff` represents the value as a binary string buffer.
 
-        >>> "0100000100101111".buff == "\x41\x2F"
+        >>> BinaryValue("0100000100101111").buff == "\x41\x2F"
         True
         """
         bits = resolve(self._str)

--- a/tests/test_cases/test_cocotb/Makefile
+++ b/tests/test_cases/test_cocotb/Makefile
@@ -29,7 +29,7 @@
 
 include ../../designs/sample_module/Makefile
 
-MODULE := test_cocotb,test_deprecated
+MODULE := test_cocotb,test_deprecated,test_doctests
 
 ifeq ($(shell python -c "import sys; print(sys.version_info >= (3, 6))"), "True")
 MODULE += ,test_async_generators

--- a/tests/test_cases/test_cocotb/test_doctests.py
+++ b/tests/test_cases/test_cocotb/test_doctests.py
@@ -1,0 +1,18 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+import doctest
+
+import cocotb
+
+
+@cocotb.test()
+async def test_utils(dut):
+    failures, n = doctest.testmod(cocotb.utils, verbose=True)
+    assert failures == 0
+
+
+@cocotb.test()
+async def test_binary(dut):
+    failures, n = doctest.testmod(cocotb.binary, verbose=True)
+    assert failures == 0


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
