### PR TITLE
Deprecate hexdump and hexdiffs on str arguments

### DIFF
--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -202,42 +202,59 @@ def unpack(ctypes_obj, string, bytes=None):
 import cocotb.ANSI as ANSI
 
 
-def _sane_color(x):
+# A note on the use of latin1 in the deprecations below:
+# Latin1 is the only encoding `e` that satisfies
+# `all(chr(x).encode(e) == bytes([x]) for x in range(255))`
+# Our use of `ord` and `chr` throughout other bits of code make this the most
+# compatible choice of encoding. Under this convention, old code can be upgraded
+# by changing "binary" strings from `"\x12\x34"` to `b"\x12\x34"`.
+
+
+def _sane_color(x: bytes) -> str:
     r = ""
-    for i in x:
-        j = ord(i)
+    for j in x:
         if (j < 32) or (j >= 127):
             r += "."
         else:
-            r += i
+            r += chr(j)
     return r
 
 
-def hexdump(x):
+def hexdump(x: bytes) -> str:
     """Hexdump a buffer.
 
     Args:
-        x: Object that supports conversion via the ``str`` built-in.
+        x: Object that supports conversion to :class:`bytes`.
 
     Returns:
         A string containing the hexdump.
 
+    .. deprecated:: 1.4
+        Passing a :class:`str` to this function is deprecated, as it
+        is not an appropriate type for binary data. Doing so anyway
+        will encode the string to latin1.
+
     Example:
-        >>> print(hexdump('this somewhat long string'))
+        >>> print(hexdump(b'this somewhat long string'))
         0000   74 68 69 73 20 73 6F 6D 65 77 68 61 74 20 6C 6F   this somewhat lo
         0010   6E 67 20 73 74 72 69 6E 67                        ng string
         <BLANKLINE>
     """
     # adapted from scapy.utils.hexdump
     rs = ""
-    x = str(x)
+    if isinstance(x, str):
+        warnings.warn(
+            "Passing a string to hexdump is deprecated, pass bytes instead",
+            DeprecationWarning, stacklevel=2)
+        x = x.encode('latin1')
+    x = b"%b" % x
     l = len(x)
     i = 0
     while i < l:
         rs += "%04x   " % i
         for j in range(16):
             if i + j < l:
-                rs += "%02X " % ord(x[i + j])
+                rs += "%02X " % x[i + j]
             else:
                 rs += "   "
             if j % 16 == 7:
@@ -248,40 +265,40 @@ def hexdump(x):
     return rs
 
 
-def hexdiffs(x, y):
-    """Return a diff string showing differences between two binary strings.
+def hexdiffs(x: bytes, y: bytes) -> str:
+    r"""Return a diff string showing differences between two binary strings.
 
     Args:
-        x: Object that supports conversion via the ``str`` built-in.
-        y: Object that supports conversion via the ``str`` built-in.
+        x: Object that supports conversion to :class:`bytes`.
+        y: Object that supports conversion to :class:`bytes`.
+
+    .. deprecated:: 1.4
+        Passing :class:`str`\ s to this function is deprecated, as it
+        is not an appropriate type for binary data. Doing so anyway
+        will encode the string to latin1.
 
     Example:
-        >>> print(hexdiffs(0, 1))
-        0000      30                                               0
-             0000 31                                               1
-        <BLANKLINE>
-        >>> print(hexdiffs('a', 'b'))
+        >>> print(hexdiffs(b'a', b'b'))
         0000      61                                               a
              0000 62                                               b
         <BLANKLINE>
-        >>> print(hexdiffs('this short thing', 'this also short'))
+        >>> print(hexdiffs(b'this short thing', b'this also short'))
         0000      746869732073686F 7274207468696E67 this short thing
              0000 7468697320616C73 6F  2073686F7274 this also  short
         <BLANKLINE>
     """
     # adapted from scapy.utils.hexdiff
 
-    def sane(x):
+    def sane(x: bytes) -> str:
         r = ""
-        for i in x:
-            j = ord(i)
+        for j in x:
             if (j < 32) or (j >= 127):
                 r = r + "."
             else:
-                r = r + i
+                r = r + chr(j)
         return r
 
-    def highlight(string, colour=ANSI.COLOR_HILITE_HEXDIFF_DEFAULT):
+    def highlight(string: str, colour=ANSI.COLOR_HILITE_HEXDIFF_DEFAULT) -> str:
         """Highlight with ANSI colors if possible/requested and not running in GUI."""
 
         if want_color_output():
@@ -289,10 +306,22 @@ def hexdiffs(x, y):
         else:
             return string
 
+
+    x_is_str = isinstance(x, str)
+    y_is_str = isinstance(y, str)
+    if x_is_str or y_is_str:
+        warnings.warn(
+            "Passing strings to hexdiffs is deprecated, pass bytes instead",
+            DeprecationWarning, stacklevel=2)
+    if x_is_str:
+        x = x.encode('latin1')
+    if y_is_str:
+        y = y.encode('latin1')
+
     rs = ""
 
-    x = str(x)[::-1]
-    y = str(y)[::-1]
+    x = (b'%b' % x)[::-1]
+    y = (b'%b' % y)[::-1]
     SUBST = 1
     INSERT = 1
     d = {}
@@ -373,11 +402,12 @@ def hexdiffs(x, y):
         for j in range(16):
             if i + j < l:
                 if line[j]:
+                    char_j, = line[j]
                     if linex[j] != liney[j]:
-                        rs += highlight("%02X" % ord(line[j]),
+                        rs += highlight("%02X" % char_j,
                                         colour=ANSI.COLOR_HILITE_HEXDIFF_2)
                     else:
-                        rs += "%02X" % ord(line[j])
+                        rs += "%02X" % char_j
                     if linex[j] == liney[j]:
                         cl += highlight(_sane_color(line[j]),
                                         colour=ANSI.COLOR_HILITE_HEXDIFF_3)

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -210,7 +210,7 @@ import cocotb.ANSI as ANSI
 # by changing "binary" strings from `"\x12\x34"` to `b"\x12\x34"`.
 
 
-def _sane_color(x: bytes) -> str:
+def _sane(x: bytes) -> str:
     r = ""
     for j in x:
         if (j < 32) or (j >= 127):
@@ -260,7 +260,7 @@ def hexdump(x: bytes) -> str:
             if j % 16 == 7:
                 rs += ""
         rs += "  "
-        rs += _sane_color(x[i:i + 16]) + "\n"
+        rs += _sane(x[i:i + 16]) + "\n"
         i += 16
     return rs
 
@@ -288,15 +288,6 @@ def hexdiffs(x: bytes, y: bytes) -> str:
         <BLANKLINE>
     """
     # adapted from scapy.utils.hexdiff
-
-    def sane(x: bytes) -> str:
-        r = ""
-        for j in x:
-            if (j < 32) or (j >= 127):
-                r = r + "."
-            else:
-                r = r + chr(j)
-        return r
 
     def highlight(string: str, colour=ANSI.COLOR_HILITE_HEXDIFF_DEFAULT) -> str:
         """Highlight with ANSI colors if possible/requested and not running in GUI."""
@@ -409,10 +400,10 @@ def hexdiffs(x: bytes, y: bytes) -> str:
                     else:
                         rs += "%02X" % char_j
                     if linex[j] == liney[j]:
-                        cl += highlight(_sane_color(line[j]),
+                        cl += highlight(_sane(line[j]),
                                         colour=ANSI.COLOR_HILITE_HEXDIFF_3)
                     else:
-                        cl += highlight(sane(line[j]),
+                        cl += highlight(_sane(line[j]),
                                         colour=ANSI.COLOR_HILITE_HEXDIFF_4)
                 else:
                     rs += "  "

--- a/documentation/source/newsfragments/1519.removal.rst
+++ b/documentation/source/newsfragments/1519.removal.rst
@@ -1,0 +1,1 @@
+Passing :type:`str` instances to :func:`cocotb.utils.hexdump` and :func:`cocotb.utils.hexdiffs` is deprecated. :class:`bytes` objects should be passed instead.

--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -1,3 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 import pytest
 
 import cocotb

--- a/tests/pytest/test_utils.py
+++ b/tests/pytest/test_utils.py
@@ -1,0 +1,38 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+import pytest
+
+import cocotb.utils
+
+
+class TestHexDump:
+    def test_int_illegal(dut):
+        # this used to be legal, but deliberately is no longer
+        with pytest.raises(TypeError):
+            cocotb.utils.hexdump(1)
+
+    def test_str_deprecated(dut):
+        with pytest.warns(DeprecationWarning) as w:
+            dump_str = cocotb.utils.hexdump('\x20\x65\x00\xff')
+        assert "str" in str(w[-1].message)
+        assert "bytes instead" in str(w[-1].message)
+
+        dump_bytes = cocotb.utils.hexdump(b'\x20\x65\x00\xff')
+        assert dump_bytes == dump_str
+
+
+class TestHexDiffs:
+    def test_int_illegal(dut):
+        # this used to be legal, but deliberately is no longer
+        with pytest.raises(TypeError):
+            cocotb.utils.hexdiffs(0, 1)
+
+    def test_str_deprecated(dut):
+        with pytest.warns(DeprecationWarning) as w:
+            diff_str = cocotb.utils.hexdiffs('\x20\x65\x00\xff', '\x20\x00\x65')
+        assert "str" in str(w[-1].message)
+        assert "bytes instead" in str(w[-1].message)
+
+        diff_bytes = cocotb.utils.hexdiffs(b'\x20\x65\x00\xff', b'\x20\x00\x65')
+        assert diff_bytes == diff_str


### PR DESCRIPTION
This function should accept bytes, not str.
Indeed, the upstream `scapy.utils.hexdump` this is derived from already behaves in this way.

Adds some annotations while we're here.

It would make sense to merge #1518 first, since those tests will verify this change.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
