### PR TITLE
Remove unnecessary __await__ call when creating async-based coroutines

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -89,13 +89,12 @@ class RunningTask(object):
 
         if inspect.iscoroutine(inst):
             self._natively_awaitable = True
-            self._coro = inst.__await__()
         elif inspect.isgenerator(inst):
             self._natively_awaitable = False
-            self._coro = inst
         else:
             raise TypeError(
                 "%s isn't a valid coroutine! Did you forget to use the yield keyword?" % inst)
+        self._coro = inst
         self.__name__ = "%s" % inst.__name__
         self._started = False
         self._callbacks = []


### PR DESCRIPTION
The call to `__await__()` on coroutines when we created `RunningTask`s offer nothing and prevents introspection.