### PR TITLE
Updated core libraries to use async/await

### DIFF
--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -29,7 +29,6 @@
 
 import itertools
 
-import cocotb
 from cocotb.log import SimLog
 from cocotb.triggers import Timer
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps, lazy_property
@@ -76,17 +75,16 @@ class Clock(BaseClock):
 
     .. code-block:: python
 
-        @cocotb.coroutine
-        def custom_clock():
+        async def custom_clock():
             # pre-construct triggers for performance
             high_time = Timer(high_delay, units="ns")
             low_time = Timer(low_delay, units="ns")
-            yield Timer(initial_delay, units="ns")
+            await Timer(initial_delay, units="ns")
             while True:
                 dut.clk <= 1
-                yield high_time
+                await high_time
                 dut.clk <= 0
-                yield low_time
+                await low_time
 
     If you also want to change the timing during simulation,
     use this slightly more inefficient example instead where
@@ -95,19 +93,18 @@ class Clock(BaseClock):
 
     .. code-block:: python
 
-        @cocotb.coroutine
-        def custom_clock():
+        async def custom_clock():
             while True:
                 dut.clk <= 1
-                yield Timer(high_delay, units="ns")
+                await Timer(high_delay, units="ns")
                 dut.clk <= 0
-                yield Timer(low_delay, units="ns")
+                await Timer(low_delay, units="ns")
 
         high_delay = low_delay = 100
         cocotb.fork(custom_clock())
-        yield Timer(1000, units="ns")
+        await Timer(1000, units="ns")
         high_delay = low_delay = 10  # change the clock speed
-        yield Timer(1000, units="ns")
+        await Timer(1000, units="ns")
     """
 
     def __init__(self, signal, period, units=None):
@@ -120,8 +117,7 @@ class Clock(BaseClock):
         self.coro = None
         self.mcoro = None
 
-    @cocotb.coroutine
-    def start(self, cycles=None, start_high=True):
+    async def start(self, cycles=None, start_high=True):
         r"""Clocking coroutine.  Start driving your clock by :func:`fork`\ ing a
         call to this.
 
@@ -145,15 +141,15 @@ class Clock(BaseClock):
         if start_high:
             for _ in it:
                 self.signal <= 1
-                yield t
+                await t
                 self.signal <= 0
-                yield t
+                await t
         else:
             for _ in it:
                 self.signal <= 0
-                yield t
+                await t
                 self.signal <= 1
-                yield t
+                await t
 
     def __str__(self):
         return self.__class__.__name__ + "(%3.1f MHz)" % self.frequency

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -434,9 +434,9 @@ class test(coroutine, metaclass=_decorator_helper):
             Users are encouraged to use the following idiom instead::
 
                 @cocotb.test()
-                def my_test(dut):
+                async def my_test(dut):
                     try:
-                        yield thing_that_should_fail()
+                        await thing_that_should_fail()
                     except ExceptionIExpect:
                         pass
                     else:
@@ -463,10 +463,11 @@ class test(coroutine, metaclass=_decorator_helper):
             co = coroutine(f)
 
             @functools.wraps(f)
-            def f(*args, **kwargs):
+            async def f(*args, **kwargs):
                 running_co = co(*args, **kwargs)
+
                 try:
-                    res = yield cocotb.triggers.with_timeout(running_co, self.timeout_time, self.timeout_unit)
+                    res = await cocotb.triggers.with_timeout(running_co, self.timeout_time, self.timeout_unit)
                 except cocotb.result.SimTimeoutError:
                     running_co.kill()
                     raise

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -525,8 +525,8 @@ def _create_test(function, name, documentation, mod, *args, **kwargs):
     Returns:
         Decorated test function
     """
-    def _my_test(dut):
-        yield function(dut, *args, **kwargs)
+    async def _my_test(dut):
+        await function(dut, *args, **kwargs)
 
     _my_test.__name__ = name
     _my_test.__doc__ = documentation

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -25,10 +25,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""A collections of triggers which a testbench can yield."""
+"""A collections of triggers which a testbench can await."""
 
 import os
 import abc
+from collections.abc import Awaitable
 
 if "COCOTB_SIM" in os.environ:
     import simulator
@@ -40,7 +41,6 @@ from cocotb.utils import (
     get_sim_steps, get_time_from_sim_steps, ParametrizedSingleton,
     lazy_property, remove_traceback_frames,
 )
-from cocotb import decorators
 from cocotb import outcomes
 import cocotb
 
@@ -59,7 +59,7 @@ def _pointer_str(obj):
 class TriggerException(Exception):
     pass
 
-class Trigger(metaclass=abc.ABCMeta):
+class Trigger(Awaitable):
     """Base class to derive from."""
 
     # __dict__ is needed here for the `.log` lazy_property below to work.
@@ -115,7 +115,7 @@ class Trigger(metaclass=abc.ABCMeta):
 
     @property
     def _outcome(self):
-        """The result that `yield this_trigger` produces in a coroutine.
+        """The result that `await this_trigger` produces in a coroutine.
 
         The default is to produce the trigger itself, which is done for
         ease of use with :class:`~cocotb.triggers.First`.
@@ -173,24 +173,24 @@ class Timer(GPITrigger):
 
         Examples:
 
-            >>> yield Timer(100, units='ps')
+            >>> await Timer(100, units='ps')
 
             The time can also be a ``float``:
 
-            >>> yield Timer(100e-9, units='sec')
+            >>> await Timer(100e-9, units='sec')
 
             which is particularly convenient when working with frequencies:
 
             >>> freq = 10e6  # 10 MHz
-            >>> yield Timer(1 / freq, units='sec')
+            >>> await Timer(1 / freq, units='sec')
 
             Other builtin exact numeric types can be used too:
 
             >>> from fractions import Fraction
-            >>> yield Timer(Fraction(1, 10), units='ns')
+            >>> await Timer(Fraction(1, 10), units='ns')
 
             >>> from decimal import Decimal
-            >>> yield Timer(Decimal('100e-9'), units='sec')
+            >>> await Timer(Decimal('100e-9'), units='sec')
 
             These are most useful when using computed durations while
             avoiding floating point inaccuracies.
@@ -376,7 +376,7 @@ class _Event(PythonTrigger):
 class Event(object):
     """Event to permit synchronization between two coroutines.
 
-    Yielding :meth:`wait()` from one coroutine will block the coroutine until
+    Awaiting :meth:`wait()` from one coroutine will block the coroutine until
     :meth:`set()` is called somewhere else.
     """
 
@@ -458,7 +458,7 @@ class Lock(object):
 
     This should be used as::
 
-        yield lock.acquire()
+        await lock.acquire()
         try:
             # do some stuff
         finally:
@@ -553,20 +553,6 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
     The result of blocking on the trigger can be used to get the coroutine
     result::
 
-        @cocotb.coroutine()
-        def coro_inner():
-            yield Timer(1, units='ns')
-            return "Hello world"
-
-        task = cocotb.fork(coro_inner())
-        result = yield Join(task)
-        assert result == "Hello world"
-
-    Or using the syntax in Python 3.5 onwards:
-
-    .. code-block:: python3
-
-        @cocotb.coroutine()
         async def coro_inner():
             await Timer(1, units='ns')
             return "Hello world"
@@ -575,8 +561,7 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
         result = await Join(task)
         assert result == "Hello world"
 
-    If the coroutine threw an exception, the :keyword:`await` or :keyword:`yield`
-    will re-raise it.
+    If the coroutine threw an exception, the :keyword:`await` will re-raise it.
 
     """
     __slots__ = ('_coroutine',)
@@ -603,13 +588,13 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
 
                 forked = cocotb.fork(mycoro())
                 j = Join(forked)
-                yield j
+                await j
                 result = j.retval
 
             ::
 
                 forked = cocotb.fork(mycoro())
-                result = yield Join(forked)
+                result = await Join(forked)
         """
         return self._coroutine.retval
 
@@ -623,24 +608,20 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
         return "{}({!r})".format(type(self).__name__, self._coroutine)
 
 
-class Waitable(object):
+class Waitable(Awaitable):
     """
-    Compatibility layer that emulates `collections.abc.Awaitable`.
+    Base class for trigger-like objects implemented using coroutines.
 
-    This converts a `_wait` abstract method into a suitable `__await__` on
-    supporting Python versions (>=3.3).
+    This converts a `_wait` abstract method into a suitable `__await__`.
     """
     __slots__ = ()
-    @decorators.coroutine
-    def _wait(self):
-        """
-        Should be implemented by the sub-class. Called by `yield self` to
-        convert the waitable object into a coroutine.
 
-        ReturnValue can be used here.
+    async def _wait(self):
+        """
+        Should be implemented by the sub-class. Called by `await self` to
+        convert the waitable object into a coroutine.
         """
         raise NotImplementedError
-        yield
 
     def __await__(self):
         return self._wait().__await__()
@@ -656,8 +637,8 @@ class _AggregateWaitable(Waitable):
         self.triggers = tuple(triggers)
 
         # Do some basic type-checking up front, rather than waiting until we
-        # yield them.
-        allowed_types = (Trigger, Waitable, decorators.RunningTask)
+        # await them.
+        allowed_types = (Trigger, Waitable, cocotb.decorators.RunningTask)
         for trigger in self.triggers:
             if not isinstance(trigger, allowed_types):
                 raise TypeError(
@@ -673,13 +654,13 @@ class _AggregateWaitable(Waitable):
         )
 
 
-@decorators.coroutine
-def _wait_callback(trigger, callback):
+async def _wait_callback(trigger, callback):
     """
-    Wait for a trigger, and call `callback` with the outcome of the yield.
+    Wait for a trigger, and call `callback` with the outcome of the await.
     """
+    trigger = cocotb.scheduler._trigger_from_any(trigger)
     try:
-        ret = outcomes.Value((yield trigger))
+        ret = outcomes.Value(await trigger)
     except BaseException as exc:
         # hide this from the traceback
         ret = outcomes.Error(remove_traceback_frames(exc, ['_wait_callback']))
@@ -694,8 +675,7 @@ class Combine(_AggregateWaitable):
     """
     __slots__ = ()
 
-    @decorators.coroutine
-    def _wait(self):
+    async def _wait(self):
         waiters = []
         e = Event()
         triggers = list(self.triggers)
@@ -711,7 +691,7 @@ class Combine(_AggregateWaitable):
             waiters.append(cocotb.fork(_wait_callback(t, on_done)))
 
         # wait for the last waiter to complete
-        yield e.wait()
+        await e.wait()
         return self
 
 
@@ -721,10 +701,6 @@ class First(_AggregateWaitable):
 
     Returns the result of the trigger that fired.
 
-    As a shorthand, ``t = yield [a, b]`` can be used instead of
-    ``t = yield First(a, b)``. Note that this shorthand is not available when
-    using :keyword:`await`.
-
     .. note::
         The event loop is single threaded, so while events may be simultaneous
         in simulation time, they can never be simultaneous in real time.
@@ -733,12 +709,16 @@ class First(_AggregateWaitable):
 
             t1 = Timer(10, units='ps')
             t2 = Timer(10, units='ps')
-            t_ret = yield First(t1, t2)
+            t_ret = await First(t1, t2)
+
+    .. note::
+        When using the old-style :keyword:`yield`-based coroutines, ``t = yield [a, b]`` was another spelling of
+        ``t = yield First(a, b)``. This spelling is no longer available when using :keyword:`await`-based
+        coroutines.
     """
     __slots__ = ()
 
-    @decorators.coroutine
-    def _wait(self):
+    async def _wait(self):
         waiters = []
         e = Event()
         triggers = list(self.triggers)
@@ -751,7 +731,7 @@ class First(_AggregateWaitable):
             waiters.append(cocotb.fork(_wait_callback(t, on_done)))
 
         # wait for a waiter to complete
-        yield e.wait()
+        await e.wait()
 
         # kill all the other waiters
         # TODO: Should this kill the coroutines behind any Join triggers?
@@ -765,7 +745,7 @@ class First(_AggregateWaitable):
         #  - Using `NullTrigger` here instead of `result = completed[0].get()`
         #    means we avoid inserting an `outcome.get` frame in the traceback
         first_trigger = NullTrigger(outcome=completed[0])
-        return (yield first_trigger)  # the first of multiple triggers that fired
+        return await first_trigger  # the first of multiple triggers that fired
 
 
 class ClockCycles(Waitable):
@@ -785,11 +765,10 @@ class ClockCycles(Waitable):
         else:
             self._type = FallingEdge
 
-    @decorators.coroutine
-    def _wait(self):
+    async def _wait(self):
         trigger = self._type(self.signal)
         for _ in range(self.num_cycles):
-            yield trigger
+            await trigger
         return self
 
     def __repr__(self):
@@ -802,8 +781,7 @@ class ClockCycles(Waitable):
         return fmt.format(type(self).__name__, self.signal, self.num_cycles)
 
 
-@decorators.coroutine
-def with_timeout(trigger, timeout_time, timeout_unit=None):
+async def with_timeout(trigger, timeout_time, timeout_unit=None):
     """
     Waits on triggers, throws an exception if it waits longer than the given time.
 
@@ -811,13 +789,12 @@ def with_timeout(trigger, timeout_time, timeout_unit=None):
 
     .. code-block:: python
 
-        yield with_timeout(coro, 100, 'ns')
-        yield with_timeout(First(coro, event.wait()), 100, 'ns')
+        await with_timeout(coro, 100, 'ns')
+        await with_timeout(First(coro, event.wait()), 100, 'ns')
 
     Args:
         trigger (cocotb_waitable):
-            A single object that could be right of a :keyword:`yield`
-            (or :keyword:`await` in Python 3) expression in cocotb.
+            A single object that could be right of an :keyword:`await` expression in cocotb.
         timeout_time (numbers.Real or decimal.Decimal):
             Time duration.
         timeout_unit (str or None, optional):
@@ -831,8 +808,9 @@ def with_timeout(trigger, timeout_time, timeout_unit=None):
 
     .. versionadded:: 1.3
     """
+
     timeout_timer = cocotb.triggers.Timer(timeout_time, timeout_unit)
-    res = yield [timeout_timer, trigger]
+    res = await First(timeout_timer, trigger)
     if res is timeout_timer:
         raise cocotb.result.SimTimeoutError
     else:

--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -144,12 +144,11 @@ class trace(object):
         if self._clock is None:
             raise ValueError("Trace requires a clock to sample")
 
-    @cocotb.coroutine
-    def _monitor(self):
+    async def _monitor(self):
         self._clocks = 0
         while True:
-            yield RisingEdge(self._clock)
-            yield ReadOnly()
+            await RisingEdge(self._clock)
+            await ReadOnly()
             if not self._enabled:
                 continue
             self._clocks += 1

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -1169,6 +1169,30 @@ def test_nested_first(dut):
 
 
 @cocotb.test()
+async def test_first_does_not_kill(dut):
+    """ Test that `First` does not kill coroutines that did not finish first """
+    ran = False
+
+    # decorating `async def` is required to use `First`
+    @cocotb.coroutine
+    async def coro():
+        nonlocal ran
+        await Timer(2, units='ns')
+        ran = True
+
+    # Coroutine runs for 2ns, so we expect the timer to fire first
+    timer = Timer(1, units='ns')
+    t = await First(timer, coro())
+    assert t is timer
+    assert not ran
+
+    # the background routine is still running, but should finish after 1ns
+    await Timer(2, units='ns')
+
+    assert ran
+
+
+@cocotb.test()
 def test_readwrite(dut):
     """ Test that ReadWrite can be waited on """
     # gh-759

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -1015,7 +1015,11 @@ def test_exceptions_first(dut):
       File ".*test_cocotb\.py", line \d+, in raise_soon
         yield cocotb\.triggers\.First\(raise_inner\(\)\)
       File ".*triggers\.py", line \d+, in _wait
-        return \(yield first_trigger\)[^\n]*
+        return await first_trigger[^\n]*
+      File ".*triggers.py", line \d+, in __await__
+        return \(yield self\)
+      File ".*triggers.py", line \d+, in __await__
+        return \(yield self\)
       File ".*test_cocotb\.py", line \d+, in raise_inner
         raise ValueError\('It is soon now'\)
     ValueError: It is soon now""").strip()


### PR DESCRIPTION
Updated core components (things at the root directory of cocotb) to use `async`/`await` syntax over `@cocotb.coroutine` and `yield`. Docstrings and a few comments associated with those functions were also updated to remove traces of the old syntax.

Will update everything in the Python library reference in the "core components" to not reference `coroutine`/`yield`. Updating the docs to remove the old syntax will be a separate commit.