### PR TITLE
Add fork-like interface that propagates exceptions

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -490,3 +490,39 @@ class test(coroutine, metaclass=_decorator_helper):
 
     def __call__(self, *args, **kwargs):
         return RunningTest(self._func(*args, **kwargs), self)
+
+
+def make_task(coro):
+    """
+    Turn the given object into a task.
+
+    Perform type checking, convert compatible types into :class:`~cocotb.decorators.RunningTask`,
+    and report common gotchas.
+
+    .. versionadded:: 1.4
+    """
+
+    if isinstance(coro, RunningTask):
+        return coro
+
+    if inspect.iscoroutine(coro):
+        return RunningTask(coro)
+
+    if isinstance(coro, coroutine):
+        raise TypeError(
+            "Attempt to convert a cocotb.coroutine object ({}) into a task.\n"
+            "Did you forget to call the cocotb.coroutine-decorated function?"
+            .format(coro)
+        )
+
+    if sys.version_info >= (3, 6) and inspect.isasyncgen(coro):
+        raise TypeError(
+            "{} is an async generator, not a coroutine. "
+            "You likely used the yield keyword instead of await.".format(
+                coro.__qualname__))
+
+    raise TypeError(
+        "Attempt to convert an incompatible object of type {} into a task: {!r}\n"
+        "Did you forget to use the @cocotb.coroutine decorator, or async/await?"
+        .format(type(coro), coro)
+    )

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -638,30 +638,7 @@ class Scheduler(object):
         Just a wrapper around self.schedule which provides some debug and
         useful error messages in the event of common gotchas.
         """
-        if isinstance(coroutine, cocotb.decorators.coroutine):
-            raise TypeError(
-                "Attempt to schedule a coroutine that hasn't started: {}.\n"
-                "Did you forget to add parentheses to the @cocotb.test() "
-                "decorator?"
-                .format(coroutine)
-            )
-
-        if inspect.iscoroutine(coroutine):
-            return self.add(cocotb.decorators.RunningTask(coroutine))
-
-        elif sys.version_info >= (3, 6) and inspect.isasyncgen(coroutine):
-            raise TypeError(
-                "{} is an async generator, not a coroutine. "
-                "You likely used the yield keyword instead of await.".format(
-                    coroutine.__qualname__))
-
-        elif not isinstance(coroutine, cocotb.decorators.RunningTask):
-            raise TypeError(
-                "Attempt to add a object of type {} to the scheduler, which "
-                "isn't a coroutine: {!r}\n"
-                "Did you forget to use the @cocotb.coroutine decorator?"
-                .format(type(coroutine), coroutine)
-            )
+        coroutine = cocotb.decorators.make_task(coroutine)
 
         if _debug:
             self.log.debug("Adding new coroutine %s" % coroutine.__name__)

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -61,8 +61,6 @@ import cocotb.decorators
 from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly,
                              NextTimeStep, ReadWrite, Event, Join, NullTrigger)
 from cocotb.log import SimLog
-from cocotb.result import TestComplete
-from cocotb.utils import remove_traceback_frames
 from cocotb import _py_compat
 
 
@@ -461,7 +459,6 @@ class Scheduler(object):
                 self.log.debug("All coroutines scheduled, handing control back"
                                " to simulator")
 
-
     def unschedule(self, coro):
         """Unschedule a coroutine.  Unprime any pending triggers"""
 
@@ -490,19 +487,6 @@ class Scheduler(object):
 
         elif Join(coro) in self._trigger2coros:
             self.react(Join(coro))
-        else:
-            try:
-                # throws an error if the background coroutine errored
-                # and no one was monitoring it
-                coro._outcome.get()
-            except (TestComplete, AssertionError) as e:
-                coro.log.info("Test stopped by this forked coroutine")
-                e = remove_traceback_frames(e, ['unschedule', 'get'])
-                self._test.abort(e)
-            except Exception as e:
-                coro.log.error("Exception raised by this forked coroutine")
-                e = remove_traceback_frames(e, ['unschedule', 'get'])
-                self._test.abort(e)
 
     def save_write(self, handle, value):
         if self._mode == Scheduler._MODE_READONLY:

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -50,6 +50,10 @@ Interacting with the Simulator
 
 .. autoclass:: cocotb.clock.Clock
 
+.. autofunction:: cocotb.run_task
+
+.. autofunction:: cocotb.fire_and_forget
+
 .. autofunction:: cocotb.fork
 
 .. autofunction:: cocotb.decorators.RunningTask.join

--- a/documentation/source/newsfragments/1526.feature.rst
+++ b/documentation/source/newsfragments/1526.feature.rst
@@ -1,0 +1,2 @@
+Added new :function:`~cocotb.run_task` and :function:`~cocotb.fire_and_forget` functions that run coroutines concurrently.
+The intent is to replicate :function:`~cocotb.fork`'s functionality with new interfaces that have easier to reason about semantics.

--- a/tests/test_cases/test_cocotb/Makefile
+++ b/tests/test_cases/test_cocotb/Makefile
@@ -29,7 +29,7 @@
 
 include ../../designs/sample_module/Makefile
 
-MODULE := test_cocotb,test_deprecated,test_doctests
+MODULE := test_cocotb,test_deprecated,test_doctests,test_concurrency
 
 ifeq ($(shell python -c "import sys; print(sys.version_info >= (3, 6))"), "True")
 MODULE += ,test_async_generators

--- a/tests/test_cases/test_cocotb/test_async_generators.py
+++ b/tests/test_cases/test_cocotb/test_async_generators.py
@@ -18,6 +18,26 @@ def test_yielding_accidental_async_generator(dut):
 
 
 @cocotb.test()
+async def test_run_task_accidental_async_generator(dut):
+    try:
+        cocotb.run_task(whoops_async_generator())
+    except TypeError as e:
+        assert "async generator" in str(e)
+    else:
+        assert False, "should have thrown"
+
+
+@cocotb.test()
+async def test_fire_and_forget_accidental_async_generator(dut):
+    try:
+        cocotb.fire_and_forget(whoops_async_generator())
+    except TypeError as e:
+        assert "async generator" in str(e)
+    else:
+        assert False, "should have thrown"
+
+
+@cocotb.test()
 async def test_forking_accidental_async_generator(dut):
     try:
         cocotb.fork(whoops_async_generator())

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -129,7 +129,7 @@ def test_function_not_decorated_fork(dut):
     try:
         cocotb.fork(normal_function(dut))
     except TypeError as exc:
-        assert "isn't a coroutine" in str(exc)
+        assert "@cocotb.coroutine" in str(exc)
     else:
         raise TestFailure()
 
@@ -202,7 +202,7 @@ def test_adding_a_coroutine_without_starting(dut):
     try:
         forked = cocotb.fork(clock_gen)
     except TypeError as exc:
-        assert "a coroutine that hasn't started" in str(exc)
+        assert "forget to call" in str(exc)
     else:
         raise TestFailure
 

--- a/tests/test_cases/test_cocotb/test_concurrency.py
+++ b/tests/test_cases/test_cocotb/test_concurrency.py
@@ -1,0 +1,107 @@
+import cocotb
+
+
+class ExampleException(Exception):
+    """Used by a few tests"""
+
+
+async def test_concurrency_types(func):
+
+    async def coro():
+        return 1
+
+    func(coro()).kill()
+
+    @cocotb.coroutine
+    def old_coro():
+        yield cocotb.triggers.NullTrigger()
+        return 1
+
+    func(coro()).kill()
+
+    # accidental async generator test in test_async_generators.py
+
+    def whoops_no_decorator():
+        yield cocotb.triggers.NullTrigger()
+        return 1
+
+    try:
+        func(whoops_no_decorator())
+    except TypeError as e:
+        assert "@cocotb.coroutine" in str(e)
+
+    try:
+        func(old_coro)  # unstarted decorated coroutine
+    except TypeError as e:
+        assert "forget to call" in str(e)
+
+
+@cocotb.test()
+async def test_run_task_types(dut):
+    await test_concurrency_types(cocotb.run_task)
+
+
+@cocotb.test()
+async def test_fire_and_forget_types(dut):
+    await test_concurrency_types(cocotb.fire_and_forget)
+
+
+@cocotb.test()
+async def test_fork_types(dut):
+    await test_concurrency_types(cocotb.fork)
+
+
+@cocotb.test()
+async def test_run_task_value(dut):
+
+    async def example():
+        await cocotb.triggers.Timer(10, 'ns')
+        return 42
+
+    future = cocotb.run_task(example())
+    await cocotb.triggers.Timer(1, 'ns')
+    res = await future
+    assert res == 42
+
+
+@cocotb.test()
+async def test_run_task_exception(dut):
+
+    async def example():
+        await cocotb.triggers.Timer(10, 'ns')
+        raise ExampleException
+
+    future = cocotb.run_task(example())
+    await cocotb.triggers.Timer(1, 'ns')
+    try:
+        await future
+    except ExampleException:
+        pass
+    else:
+        assert False, "should have thrown"
+
+
+@cocotb.test(expect_error=ExampleException)
+async def test_fire_and_forget_exception(dut):
+
+    async def example():
+        await cocotb.triggers.Timer(1, 'ns')
+        raise ExampleException
+
+    cocotb.fire_and_forget(example())
+
+    await cocotb.triggers.Timer(10, 'ns')
+
+
+@cocotb.test()
+async def test_fire_and_forget_exception_cancelled(dut):
+
+    async def example():
+        await cocotb.triggers.Timer(2, 'ns')
+        raise ExampleException
+
+    thread = cocotb.fire_and_forget(example())
+
+    await cocotb.triggers.Timer(1, 'ns')
+    thread.kill()
+    await cocotb.triggers.Timer(2, 'ns')


### PR DESCRIPTION
## Issue

`fork` is the primary mechanism to run coroutines concurrently in cocotb, however, it has a major flaw. When `fork`ing a coroutine, if a `Join` trigger is not created or the forked coroutine is not `await`ed nor `yield`ed (which creates a `Join`) *before* the coroutine finishes with an exception, the test is killed.

xref #922.

For example, the following causes a test end rather than throwing `NameError` when the forked coroutine is awaited on.

```python
async def name_error():
    await does_not_exist()
    #  ... other stuff

task = cocotb.fork(name_error())
await Timer(100)
await task  # should throw NameError here, but the test dies before it gets here
```

But this works.

```python
async def name_error():
    await Timer(100)
    await does_not_exist()
    #  ... other stuff

task = cocotb.fork(name_error())
await Timer(10)
await task  # throws NameError here because we start waiting *before* name_error throws
```

While the above behavior is bad and unexpected (and depending upon the code, non-deterministic!), the test-killing behavior is leveraged in many tests and is useful. For instance, monitors use this to end tests when the monitoring "thread" fails, which might otherwise allow the test to run in an invalid state.

## Proposal
* change the scheduler to not kill tests in these cases and always hold exceptions until awaited on
* add a new interface that uses the newer cleaner semantics
* re-implement fork to obtain the legacy behavior using the new interface

## Alternative Proposals

2. Just change fork to never kill the test
   * users will have to update tests
   * the behavior is deterministic
   * should add warnings for un-joined coroutines much like asyncio does with un-awaited tasks
3. Add new interface and leave fork, but make fork *always* kill the test
   * users will have to update tests
   * the behavior is deterministic
   * still useful for many cases