### PR TITLE
Add a test to prove that coroutines keep running when passed to First

### DIFF
--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -1169,6 +1169,30 @@ def test_nested_first(dut):
 
 
 @cocotb.test()
+async def test_first_does_not_kill(dut):
+    """ Test that `First` does not kill coroutines that did not finish first """
+    ran = False
+
+    # decorating `async def` is required to use `First`
+    @cocotb.coroutine
+    async def coro():
+        nonlocal ran
+        await Timer(2, units='ns')
+        ran = True
+
+    # Coroutine runs for 2ns, so we expect the timer to fire first
+    timer = Timer(1, units='ns')
+    t = await First(timer, coro())
+    assert t is timer
+    assert not ran
+
+    # the background routine is still running, but should finish after 1ns
+    await Timer(2, units='ns')
+
+    assert ran
+
+
+@cocotb.test()
 def test_readwrite(dut):
     """ Test that ReadWrite can be waited on """
     # gh-759


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

This spun out of a discussion with @ktbarrett  reviewing #1523.
