### PR TITLE
Remove flake8 ignores on blank lines

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,4 @@ ignore =
     F403  # 'from ... import *' used; unable to detect
     F405  # ... may be undefined, or defined from star
     F841  # local variable ... is assigned to but never used
-    W291  # trailing whitespace
-    W293  # blank line contains whitespace
     W504  # line break after binary operator


### PR DESCRIPTION
This should give better error messages than our whitespace linter, but won't touch all files.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

xref #1281, cc @ktbarrett 
