### PR TITLE
Enable SV assertion in Makefile.verilator

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -34,7 +34,7 @@ endif
 
 SIM_BUILD_FLAGS += -std=c++11
 
-COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-L$(LIB_DIR) -lcocotbvpi -lgpi -lcocotb -lgpilog -lcocotbutils"
+COMPILE_ARGS += --vpi --public-flat-rw --assert --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-L$(LIB_DIR) -lcocotbvpi -lgpi -lcocotb -lgpilog -lcocotbutils"
 
 $(SIM_BUILD)/Vtop.mk: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp
 	$(CMD) -cc --exe -Mdir $(SIM_BUILD) -DCOCOTB_SIM=1 --top-module $(TOPLEVEL) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp


### PR DESCRIPTION
SV assertions are disabled by default. Adding `--assert` to make it consistent with commercial simulators
