### PR TITLE
Use extension types for handles instead of integers

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -94,7 +94,7 @@ class SimHandleBase:
         return self._def_file
 
     def __hash__(self):
-        return self._handle
+        return hash(self._handle)
 
     def __len__(self):
         """Returns the 'length' of the underlying object.

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -176,8 +176,9 @@ typedef enum gpi_set_action_e {
 // Functions for iterating over entries of a handle
 // Returns an iterator handle which can then be used in gpi_next calls
 //
-// NB the iterator handle may be NULL if no objects of the requested type are
-// found
+// Unlike `vpi_iterate` the iterator handle may only be NULL if the `type` is
+// not supported, If no objects of the requested type are found, an empty
+// iterator is returned.
 gpi_iterator_hdl gpi_iterate(gpi_sim_hdl base, gpi_iterator_sel_t type);
 
 // Returns NULL when there are no more objects

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -643,13 +643,6 @@ static PyObject *next(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    // TODO:eric-wieser: It's valid for iterate to return a NULL handle, to make the Python
-    // intuitive we simply raise StopIteration on the first iteration
-    // if (!hdl) {
-    //     PyErr_SetNone(PyExc_StopIteration);
-    //     return NULL;
-    // }
-
     result = gpi_next(hdl_obj->hdl);
 
     // Raise StopIteration when we're done

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -148,13 +148,13 @@ class GPITrigger(Trigger):
         # if simulator is not None:
         #    self.cbhdl = simulator.create_callback(self)
         # else:
-        self.cbhdl = 0
+        self.cbhdl = None
 
     def unprime(self):
         """Disable a primed trigger, can be re-primed."""
-        if self.cbhdl != 0:
+        if self.cbhdl is not None:
             simulator.deregister_callback(self.cbhdl)
-        self.cbhdl = 0
+        self.cbhdl = None
         Trigger.unprime(self)
 
 
@@ -203,10 +203,10 @@ class Timer(GPITrigger):
 
     def prime(self, callback):
         """Register for a timed callback."""
-        if self.cbhdl == 0:
+        if self.cbhdl is None:
             self.cbhdl = simulator.register_timed_callback(self.sim_steps,
                                                            callback, self)
-            if self.cbhdl == 0:
+            if self.cbhdl is None:
                 raise TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger.prime(self, callback)
 
@@ -242,9 +242,9 @@ class ReadOnly(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         GPITrigger.__init__(self)
 
     def prime(self, callback):
-        if self.cbhdl == 0:
+        if self.cbhdl is None:
             self.cbhdl = simulator.register_readonly_callback(callback, self)
-            if self.cbhdl == 0:
+            if self.cbhdl is None:
                 raise TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger.prime(self, callback)
 
@@ -264,11 +264,11 @@ class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         GPITrigger.__init__(self)
 
     def prime(self, callback):
-        if self.cbhdl == 0:
+        if self.cbhdl is None:
             # import pdb
             # pdb.set_trace()
             self.cbhdl = simulator.register_rwsynch_callback(callback, self)
-            if self.cbhdl == 0:
+            if self.cbhdl is None:
                 raise TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger.prime(self, callback)
 
@@ -288,9 +288,9 @@ class NextTimeStep(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         GPITrigger.__init__(self)
 
     def prime(self, callback):
-        if self.cbhdl == 0:
+        if self.cbhdl is None:
             self.cbhdl = simulator.register_nextstep_callback(callback, self)
-            if self.cbhdl == 0:
+            if self.cbhdl is None:
                 raise TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger.prime(self, callback)
 
@@ -318,11 +318,11 @@ class _EdgeBase(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
 
     def prime(self, callback):
         """Register notification of a value change via a callback"""
-        if self.cbhdl == 0:
+        if self.cbhdl is None:
             self.cbhdl = simulator.register_value_change_callback(
                 self.signal._handle, callback, type(self)._edge_type, self
             )
-            if self.cbhdl == 0:
+            if self.cbhdl is None:
                 raise TriggerException("Unable set up %s Trigger" % (str(self)))
         super(_EdgeBase, self).prime(callback)
 


### PR DESCRIPTION
This means that:
* Passing handles back and forth should be faster, as there is no need to convert back and forth between big integers and pointers
* The simulator module becomes more type safe, and does not allow passing objects of one type to functions expecting a different type
* It is no longer possible to pass arbitrary integers in that don't correspond to actual handles
* Instead of returning `0`, failure is indicated by returning `None`. This results in a `TypeError` rather than a segfault if used again unchecked.

There is one behavior change here, in that `simulator.next(simulator.iterate(not_iterable))` no longer raises StopIteration.
If you are seeing this in the commit history, then this change didn't manifest in any regression tests.

---

This follows on from #1427.
