### PR TITLE
Do not ignore fail in hal target

### DIFF
--- a/examples/endian_swapper/tests/Makefile
+++ b/examples/endian_swapper/tests/Makefile
@@ -69,7 +69,7 @@ include $(shell cocotb-config --makefiles)/Makefile.sim
 ifeq ($(OS),Linux)
 .PHONY: hal
 hal:
-	-cd ../cosim && make
+	cd ../cosim && make
 
 clean::
 	-cd ../cosim && make clean


### PR DESCRIPTION
This is to "fail early" and prevents a more obscure fail later in the run.
Fixes #1539.