### PR TITLE
Fix the XGMII monitor to work correctly on raw bytes

### DIFF
--- a/cocotb/drivers/xgmii.py
+++ b/cocotb/drivers/xgmii.py
@@ -34,9 +34,9 @@ from cocotb.drivers import Driver
 from cocotb.utils import hexdump
 from cocotb.binary import BinaryValue
 
-_XGMII_IDLE      = b"\x07"  # noqa
-_XGMII_START     = b"\xFB"  # noqa
-_XGMII_TERMINATE = b"\xFD"  # noqa
+_XGMII_IDLE      = 0x07  # noqa
+_XGMII_START     = 0xFB  # noqa
+_XGMII_TERMINATE = 0xFD  # noqa
 
 # Preamble is technically supposed to be 7 bytes of 0x55 but it seems that it's
 # permissible for the start byte to replace one of the preamble bytes

--- a/documentation/source/newsfragments/1545.bugfix.rst
+++ b/documentation/source/newsfragments/1545.bugfix.rst
@@ -1,0 +1,1 @@
+The :class:`~cocotb.monitors.xgmii.XGMII` monitor no longer crashes on Python 3, and now assembles packets as :class:`bytes` not :class:`str`. The :class:`~cocotb.drivers.xgmii.XGMII` driver has expected :class:`bytes` since cocotb 1.2.0.

--- a/documentation/source/newsfragments/1545.bugfix.rst
+++ b/documentation/source/newsfragments/1545.bugfix.rst
@@ -1,1 +1,1 @@
-The :class:`~cocotb.monitors.xgmii.XGMII` monitor no longer crashes on Python 3, and now assembles packets as :class:`bytes` not :class:`str`. The :class:`~cocotb.drivers.xgmii.XGMII` driver has expected :class:`bytes` since cocotb 1.2.0.
+The :class:`~cocotb.monitors.xgmii.XGMII` monitor no longer crashes on Python 3, and now assembles packets as :class:`bytes` instead of :class:`str`. The :class:`~cocotb.drivers.xgmii.XGMII` driver has expected :class:`bytes` since cocotb 1.2.0.


### PR DESCRIPTION
This was already fixed for the driver in 11356124bbe5bd8b928ac1cf2b63d7dc12ecc6e2 (part of #1011).
Without this change, the calls to `hexdump` give a DeprecationWarning.

The change to the driver files is just for consistency, and should not affect behavior.

Not tested unfortunately, but hopefully more correct.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
