### PR TITLE
Minor cleanups to the amba driver

### DIFF
--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -303,7 +303,7 @@ class AXI4Slave(BusDriver):
                     _burst_diff = burst_length - burst_count
                     _st = _awaddr + (_burst_diff * bytes_in_beat)  # start
                     _end = _awaddr + ((_burst_diff + 1) * bytes_in_beat)  # end
-                    self._memory[_st:_end] = array.array('B', word.get_buff())
+                    self._memory[_st:_end] = array.array('B', word.buff)
                     burst_count -= 1
                     if burst_count == 0:
                         break

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -352,7 +352,7 @@ class AXI4Slave(BusDriver):
                     _burst_diff = burst_length - burst_count
                     _st = _araddr + (_burst_diff * bytes_in_beat)
                     _end = _araddr + ((_burst_diff + 1) * bytes_in_beat)
-                    word.buff = self._memory[_st:_end].tostring()
+                    word.buff = self._memory[_st:_end].tobytes()
                     self.bus.RDATA <= word
                     if burst_count == 1:
                         self.bus.RLAST <= 1


### PR DESCRIPTION
See commit messages for the explanation for each one-line change.

No change in behavior in either, other than avoiding a warning.

Split from #1514, since it does not depend on it.