### PR TITLE
Guard against user setting vars we append to

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -54,11 +54,20 @@ endif
 
 BUILD_VPI=1
 
-COMPILE_ARGS += -g2012 # Default to latest SystemVerilog standard
+# Do not directly append to COMPILE_ARGS, SIM_ARGS, EXTRA_ARGS etc.,
+# because if a user sets these variables on the make command line,
+# only the user's variable values will be seen.
+# Instead, append to local variables.
+_COMPILE_ARGS += $(COMPILE_ARGS)
+_SIM_ARGS     += $(SIM_ARGS)
+_EXTRA_ARGS   += $(EXTRA_ARGS)
+_PLUSARGS     += $(PLUSARGS)
+
+_COMPILE_ARGS += -g2012 # Default to latest SystemVerilog standard
 
 # Compilation phase
 $(SIM_BUILD)/sim.vvp: $(SIM_BUILD) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS)
-	$(CMD) -o $(SIM_BUILD)/sim.vvp -D COCOTB_SIM=1 -s $(TOPLEVEL) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+	$(CMD) -o $(SIM_BUILD)/sim.vvp -D COCOTB_SIM=1 -s $(TOPLEVEL) $(_COMPILE_ARGS) $(_EXTRA_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 
@@ -78,7 +87,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $
 
 	PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
-        $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
+        $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi $(_SIM_ARGS) $(_EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(_PLUSARGS)
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)
@@ -88,7 +97,7 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
 
 	PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
-        gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
+        gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi $(_SIM_ARGS) $(_EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(_PLUSARGS)
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -45,25 +45,32 @@ else
     export IUS_BIN_DIR
 endif
 
-EXTRA_ARGS += $(COMPILE_ARGS)
-EXTRA_ARGS += $(SIM_ARGS)
-EXTRA_ARGS += -licqueue
+# Do not directly append to COMPILE_ARGS, SIM_ARGS, EXTRA_ARGS etc.,
+# because if a user sets these variables on the make command line,
+# only the user's variable values will be seen.
+# Instead, append to local variables.
+_IRUN_ARGS += $(COMPILE_ARGS)
+_IRUN_ARGS += $(SIM_ARGS)
+_IRUN_ARGS += $(EXTRA_ARGS)
+_IRUN_ARGS += $(PLUSARGS)
+
+_IRUN_ARGS += -licqueue
 
 ifneq ($(ARCH),i686)
-EXTRA_ARGS += -64
+_IRUN_ARGS += -64
 endif
 
-EXTRA_ARGS += -nclibdirpath $(SIM_BUILD)
-EXTRA_ARGS += -plinowarn
+_IRUN_ARGS += -nclibdirpath $(SIM_BUILD)
+_IRUN_ARGS += -plinowarn
 
 ifeq ($(GUI),1)
-    EXTRA_ARGS += -gui
+    _IRUN_ARGS += -gui
 else
-    EXTRA_ARGS +=
+    _IRUN_ARGS +=
 endif
 
 # IUS errors out if multiple timescales are specified on the command line.
-ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
+ifneq (,$(findstring timescale,$(_IRUN_ARGS)))
     $(error "Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.")
 endif
 
@@ -74,7 +81,7 @@ endif
 GPI_ARGS = -loadvpi $(LIB_DIR)/libcocotbvpi:vlog_startup_routines_bootstrap
 
 ifeq ($(TOPLEVEL_LANG),verilog)
-    EXTRA_ARGS += -v93
+    _IRUN_ARGS += -v93
     HDL_SOURCES = $(VERILOG_SOURCES)
     ROOT_LEVEL = $(TOPLEVEL)
 ifneq ($(VHDL_SOURCES),)
@@ -83,8 +90,8 @@ ifneq ($(VHDL_SOURCES),)
 endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     GPI_EXTRA = cocotbvhpi
-    EXTRA_ARGS += -v93
-    EXTRA_ARGS += -top $(TOPLEVEL)
+    _IRUN_ARGS += -v93
+    _IRUN_ARGS += -top $(TOPLEVEL)
     RTL_LIBRARY ?= $(TOPLEVEL)
     MAKE_LIB = -makelib $(RTL_LIBRARY)
     HDL_SOURCES = $(VHDL_SOURCES)
@@ -106,7 +113,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD) $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUS
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	\
 	$(CMD) -timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) $(GPI_ARGS) +access+rwc $(MAKE_LIB) $(HDL_SOURCES) $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
+	$(_IRUN_ARGS) $(GPI_ARGS) +access+rwc $(MAKE_LIB) $(HDL_SOURCES) 2>&1 | tee $(SIM_BUILD)/sim.log
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -51,12 +51,21 @@ else
      export VCS_BIN_DIR
 endif
 
+# Do not directly append to COMPILE_ARGS, SIM_ARGS, EXTRA_ARGS etc.,
+# because if a user sets these variables on the make command line,
+# only the user's variable values will be seen.
+# Instead, append to local variables.
+_COMPILE_ARGS += $(COMPILE_ARGS)
+_SIM_ARGS     += $(SIM_ARGS)
+_EXTRA_ARGS   += $(EXTRA_ARGS)
+_PLUSARGS     += $(PLUSARGS)
+
 ifeq ($(ARCH),x86_64)
-    EXTRA_ARGS += -full64
+    _EXTRA_ARGS += -full64
 endif
 
 ifeq ($(GUI),1)
-    EXTRA_ARGS += -gui
+    _EXTRA_ARGS += -gui
 endif
 
 # TODO:
@@ -73,7 +82,7 @@ $(SIM_BUILD)/simv: $(SIM_BUILD) $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(COCOTB
 	LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) TOPLEVEL=$(TOPLEVEL) \
 	$(CMD) -top $(TOPLEVEL) $(PLUSARGS) +acc+1 +vpi -P pli.tab +define+COCOTB_SIM=1 -sverilog \
 	-timescale=$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) -debug -load $(LIB_DIR)/libcocotbvpi.so $(COMPILE_ARGS) $(VERILOG_SOURCES)
+	$(_EXTRA_ARGS) -debug -load $(LIB_DIR)/libcocotbvpi.so $(_COMPILE_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(PYTHON_FILES) $(CUSTOM_SIM_DEPS)
@@ -83,7 +92,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(PYTHON_FILES) $(CUSTOM_SIM_DEPS)
 	LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 \
 	TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(SIM_BUILD)/simv +define+COCOTB_SIM=1 $(SIM_ARGS) $(EXTRA_ARGS)
+	$(SIM_BUILD)/simv +define+COCOTB_SIM=1 $(_SIM_ARGS) $(_EXTRA_ARGS)
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -18,14 +18,23 @@ ifeq ($(shell which $(CMD) 2>/dev/null),)
 $(error Cannot find verilator.)
 endif
 
+# Do not directly append to COMPILE_ARGS, SIM_ARGS, EXTRA_ARGS etc.,
+# because if a user sets these variables on the make command line,
+# only the user's variable values will be seen.
+# Instead, append to local variables.
+_COMPILE_ARGS += $(COMPILE_ARGS)
+_SIM_ARGS     += $(SIM_ARGS)
+_EXTRA_ARGS   += $(EXTRA_ARGS)
+_PLUSARGS     += $(PLUSARGS)
+
 ifeq ($(VERILATOR_SIM_DEBUG), 1)
-  COMPILE_ARGS += --debug
-  PLUSARGS += +verilator+debug
+  _COMPILE_ARGS += --debug
+  _PLUSARGS += +verilator+debug
   SIM_BUILD_FLAGS += -DVL_DEBUG
 endif
 
 ifeq ($(VERILATOR_TRACE),1)
-  EXTRA_ARGS += --trace --trace-structs
+  _EXTRA_ARGS += --trace --trace-structs
 endif
 
 ifdef COCOTB_HDL_TIMEPRECISION
@@ -34,10 +43,10 @@ endif
 
 SIM_BUILD_FLAGS += -std=c++11
 
-COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-L$(LIB_DIR) -lcocotbvpi -lgpi -lcocotb -lgpilog -lcocotbutils"
+_COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-L$(LIB_DIR) -lcocotbvpi -lgpi -lcocotb -lgpilog -lcocotbutils"
 
 $(SIM_BUILD)/Vtop.mk: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp
-	$(CMD) -cc --exe -Mdir $(SIM_BUILD) -DCOCOTB_SIM=1 --top-module $(TOPLEVEL) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp
+	$(CMD) -cc --exe -Mdir $(SIM_BUILD) -DCOCOTB_SIM=1 --top-module $(TOPLEVEL) $(_COMPILE_ARGS) $(_EXTRA_ARGS) $(VERILOG_SOURCES) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp
 
 # Compilation phase
 $(SIM_BUILD)/$(TOPLEVEL): $(SIM_BUILD)/Vtop.mk $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
@@ -59,7 +68,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS) $(COCOTB_LIB
 
 	PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR) $(LIB_LOAD) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
-        $< $(PLUSARGS)
+        $< $(_PLUSARGS) $(_SIM_ARGS)
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)
@@ -69,7 +78,7 @@ debug: $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_L
 
 	PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR) $(LIB_LOAD) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
-        gdb --args $< $(PLUSARGS)
+        gdb --args $< $(_PLUSARGS) $(_SIM_ARGS)
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -45,33 +45,40 @@ else
     export XCELIUM_BIN_DIR
 endif
 
-EXTRA_ARGS += $(COMPILE_ARGS)
-EXTRA_ARGS += $(SIM_ARGS)
-EXTRA_ARGS += -licqueue
+# Do not directly append to COMPILE_ARGS, SIM_ARGS, EXTRA_ARGS etc.,
+# because if a user sets these variables on the make command line,
+# only the user's variable values will be seen.
+# Instead, append to local variables.
+_XRUN_ARGS += $(COMPILE_ARGS)
+_XRUN_ARGS += $(SIM_ARGS)
+_XRUN_ARGS += $(EXTRA_ARGS)
+_XRUN_ARGS += $(PLUSARGS)
+
+#_XRUN_ARGS += -licqueue
 
 ifneq ($(ARCH),i686)
-    EXTRA_ARGS += -64
+    _XRUN_ARGS += -64
 endif
 
-EXTRA_ARGS += -xmlibdirpath $(SIM_BUILD)
+_XRUN_ARGS += -xmlibdirpath $(SIM_BUILD)
 ifeq ($(DEBUG),1)
-    EXTRA_ARGS += -pliverbose
-    EXTRA_ARGS += -messages
-    EXTRA_ARGS += -plidebug             # Enhance the profile output with PLI info
-    EXTRA_ARGS += -plierr_verbose       # Expand handle info in PLI/VPI/VHPI messages
-    EXTRA_ARGS += -vpicompat 1800v2005  #  <1364v1995|1364v2001|1364v2005|1800v2005> Specify the IEEE VPI
+    _XRUN_ARGS += -pliverbose
+    _XRUN_ARGS += -messages
+    _XRUN_ARGS += -plidebug             # Enhance the profile output with PLI info
+    _XRUN_ARGS += -plierr_verbose       # Expand handle info in PLI/VPI/VHPI messages
+    _XRUN_ARGS += -vpicompat 1800v2005  #  <1364v1995|1364v2001|1364v2005|1800v2005> Specify the IEEE VPI
 else
-    EXTRA_ARGS += -plinowarn
+    _XRUN_ARGS += -plinowarn
 endif
 
 ifeq ($(GUI),1)
-    EXTRA_ARGS += -gui
+    _XRUN_ARGS += -gui
 else
-    EXTRA_ARGS +=
+    _XRUN_ARGS +=
 endif
 
 # Xcelium errors out if multiple timescales are specified on the command line.
-ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
+ifneq (,$(findstring timescale,$(_XRUN_ARGS)))
     $(error "Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.")
 endif
 
@@ -83,7 +90,7 @@ GPI_ARGS = -loadvpi $(LIB_DIR)/libcocotbvpi:vlog_startup_routines_bootstrap
 ifeq ($(TOPLEVEL_LANG),verilog)
     HDL_SOURCES = $(VERILOG_SOURCES)
     ROOT_LEVEL = $(TOPLEVEL)
-    EXTRA_ARGS += -top $(TOPLEVEL)
+    _XRUN_ARGS += -top $(TOPLEVEL)
     ifneq ($(VHDL_SOURCES),)
         HDL_SOURCES += $(VHDL_SOURCES)
         GPI_EXTRA = cocotbvhpi
@@ -91,7 +98,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     # GPI_EXTRA will internally be extended to lib<GPI_EXTRA>.so
     GPI_EXTRA = cocotbvhpi
-    EXTRA_ARGS += -top $(TOPLEVEL)
+    _XRUN_ARGS += -top $(TOPLEVEL)
     RTL_LIBRARY ?= $(TOPLEVEL)
     MAKE_LIB = -makelib $(RTL_LIBRARY)
     HDL_SOURCES = $(VHDL_SOURCES)
@@ -113,7 +120,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD) $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUS
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	\
 	$(CMD) -timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) $(GPI_ARGS) $(INCDIRS) -access +rwc -createdebugdb $(MAKE_LIB) $(HDL_SOURCES) $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
+	$(_XRUN_ARGS) $(GPI_ARGS) $(INCDIRS) -access +rwc -createdebugdb $(MAKE_LIB) $(HDL_SOURCES) 2>&1 | tee $(SIM_BUILD)/sim.log
 
 	# check that the file was actually created, since we can't set an exit code from cocotb
 	test -f $(COCOTB_RESULTS_FILE)


### PR DESCRIPTION
Do not directly append to ``COMPILE_ARGS``, ``SIM_ARGS``, ``EXTRA_ARGS`` etc., because if a user sets these variables on the make command line, only the user's variable values will be seen.
Instead, append to local variables.

Fixes #1552
