### PR TITLE
Advertise user survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+**Your input is needed!** Please help out by taking 10 minutes to fill out this year’s cocotb user survey. This survey gives the development community important feedback to steer the future of cocotb into the right direction for your use case.
+[**Take the cocotb user survey now**](https://docs.google.com/forms/d/e/1FAIpQLSfD36PldzszbuZjysss3AMvxkf6XCtSbDTVh9qVNNYDaHTZ_w/viewform).
+
+---
+
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 
 [![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=latest)](http://cocotb.readthedocs.org/en/latest/)

--- a/documentation/source/_templates/layout.html
+++ b/documentation/source/_templates/layout.html
@@ -1,0 +1,14 @@
+{% extends "!layout.html" %}
+
+{% block document %}
+
+<div class="admonition info">
+  <p>The cocotb user survey 2020 is awaiting your answers.
+  Please take 10 minutes to <strong>help cocotb developers understand your use of cocotb better, and influence the direction of the project.</strong></p>
+  <div class="wy-text-right">
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSfD36PldzszbuZjysss3AMvxkf6XCtSbDTVh9qVNNYDaHTZ_w/viewform" class="btn btn-success">Take the survey now!</a>
+  </div>
+</div>
+
+{{ super() }}
+{% endblock %}


### PR DESCRIPTION
We are having our user survey. Advertise it as widely as we can to make
users aware of it. The project relies on getting enough answers to steer
development efforts into the right directions.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->