### PR TITLE
Ensure source files are read as utf8, rather than a system-specific encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ from io import StringIO
 from cocotb._build_libs import get_ext, build_ext
 
 def read_file(fname):
-    return open(path.join(path.dirname(__file__), fname)).read()
+    with open(path.join(path.dirname(__file__), fname), encoding='utf8') as f:
+        return f.read()
 
 def package_files(directory):
     paths = []


### PR DESCRIPTION
We authored the files being read here, so we know their encoding in advance.
This fixes a CI failure in Python 3.5.

Also switch to use a `with` statement to ensure the file is closed a little sooner.

Fixes the underlying issue worked around in gh-1556.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
