### PR TITLE
Better error message when missing COCOTB_RESULTS_FILE and cleaner log

### DIFF
--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -131,6 +131,11 @@ PWD := $(shell pwd)
 
 include $(COCOTB_SHARE_DIR)/makefiles/simulators/Makefile.$(SIM_LOWERCASE)
 
+# Check that the COCOTB_RESULTS_FILE was created, since we can't set an exit code from cocotb.
+define check_for_results_file
+    @test -f $(COCOTB_RESULTS_FILE) || (echo "ERROR: $(COCOTB_RESULTS_FILE) was not written by the simulation!" >&2 && exit 1)
+endef
+
 # Append directory containing the cocotb Python package to PYTHONPATH
 # XXX: This is only needed if cocotb is not installed into the default
 # Python search path.

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -171,8 +171,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(COCOTB_LIBS) $(COCOTB_VHPI_LIB
 	set -o pipefail; cd $(SIM_BUILD) && PYTHONPATH=$(PWD):$(NEW_PYTHONPATH) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 $(CMD) $(RUN_ARGS) -do runsim.tcl | tee sim.log
 
-	# check that the file was actually created
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 clean::
 	@rm -rf $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -72,8 +72,7 @@ $(COCOTB_RESULTS_FILE): analyse  $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
 	$(CMD) -r $(GHDL_ARGS) --work=$(RTL_LIBRARY) $(TOPLEVEL) --vpi=$(LIB_DIR)/libcocotbvpi_ghdl.$(LIB_EXT) $(SIM_ARGS) $(PLUSARGS)
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 clean::
 	-@rm -rf $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -78,8 +78,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
         $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
@@ -88,8 +87,7 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
         gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 clean::
 	-@rm -rf $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -108,8 +108,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD) $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUS
 	$(CMD) -timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
 	$(EXTRA_ARGS) $(GPI_ARGS) +access+rwc $(MAKE_LIB) $(HDL_SOURCES) $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 clean::
 	@rm -rf $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -46,8 +46,7 @@ $(COCOTB_RESULTS_FILE): analyse $(COCOTB_LIBS) $(COCOTB_VHPI_LIB)
 		TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
 		$(CMD) $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS) --work=$(RTL_LIBRARY) -r --load $(LIB_DIR)/libcocotbvhpi_ius.$(LIB_EXT) $(TRACE) $(TOPLEVEL)
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 clean::
 	-@rm -rf $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -148,8 +148,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(INT_LIBS)
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) PYTHONPATH=$(PWD):$(NEW_PYTHONPATH) \
 	$(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 # Potential fix for buffered stdout, YMMV
 # STDOUT=$(SIM_BUILD)/sim.log stdbuf --output=0 $(CMD) -do runsim.do 2>&1 && stdbuf --output=0 --input=0 tail -f sim.log && exit $${PIPESTATUS[0]}

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -84,8 +84,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(PYTHON_FILES) $(CUSTOM_SIM_DEPS)
 	TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(SIM_BUILD)/simv +define+COCOTB_SIM=1 $(SIM_ARGS) $(EXTRA_ARGS)
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 .PHONY: clean
 clean::

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -61,8 +61,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS) $(COCOTB_LIB
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
         $< $(PLUSARGS)
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 debug: $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	-@rm -f $(COCOTB_RESULTS_FILE)
@@ -71,8 +70,7 @@ debug: $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_L
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
         gdb --args $< $(PLUSARGS)
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 clean::
 	@rm -rf $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -115,8 +115,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD) $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUS
 	$(CMD) -timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
 	$(EXTRA_ARGS) $(GPI_ARGS) $(INCDIRS) -access +rwc -createdebugdb $(MAKE_LIB) $(HDL_SOURCES) $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
 
-	# check that the file was actually created, since we can't set an exit code from cocotb
-	test -f $(COCOTB_RESULTS_FILE)
+	$(call check_for_results_file)
 
 clean::
 	@rm -rf $(SIM_BUILD)


### PR DESCRIPTION
Better error message when missing `COCOTB_RESULTS_FILE` and cleaner log
