### PR TITLE
Cleanup and fix tcl sources paths on Windows

### DIFF
--- a/cocotb/share/makefiles/Makefile.pylib.Msys
+++ b/cocotb/share/makefiles/Makefile.pylib.Msys
@@ -48,7 +48,7 @@ endif
 
 PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_inc() )')
 
-# For tcl scripts purpose source files paths in form of C:/User/..
+# For Tcl script purposes, generate source file paths in the form of C:/User/...
 ifneq ($(VERILOG_SOURCES),)
     VERILOG_SOURCES := $(shell cygpath -m $(VERILOG_SOURCES))
 endif

--- a/cocotb/share/makefiles/Makefile.pylib.Msys
+++ b/cocotb/share/makefiles/Makefile.pylib.Msys
@@ -47,3 +47,11 @@ ifeq ($(PYTHON_LIBDIR),None)
 endif
 
 PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_inc() )')
+
+# For tcl scripts purpose source files paths in form of C:/User/..
+ifneq ($(VERILOG_SOURCES),)
+    VERILOG_SOURCES := $(shell cygpath -m $(VERILOG_SOURCES))
+endif
+ifneq ($(VHDL_SOURCES),)
+    VHDL_SOURCES := $(shell cygpath -m $(VHDL_SOURCES))
+endif

--- a/examples/adder/tests/Makefile
+++ b/examples/adder/tests/Makefile
@@ -31,18 +31,12 @@ TOPLEVEL_LANG ?= verilog
 
 PWD=$(shell pwd)
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
 PYTHONPATH := $(PWD)/../model:$(PYTHONPATH)
 
 ifeq ($(TOPLEVEL_LANG),verilog)
-    VERILOG_SOURCES = $(WPWD)/../hdl/adder.v
+    VERILOG_SOURCES = $(PWD)/../hdl/adder.v
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    VHDL_SOURCES = $(WPWD)/../hdl/adder.vhdl
+    VHDL_SOURCES = $(PWD)/../hdl/adder.vhdl
 else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif

--- a/examples/endian_swapper/tests/Makefile
+++ b/examples/endian_swapper/tests/Makefile
@@ -30,22 +30,20 @@
 # Default to verilog
 TOPLEVEL_LANG ?= verilog
 
-WPWD=$(shell sh -c 'pwd -W')
 PWD=$(shell pwd)
 
 ifeq ($(OS),Msys)
 WPWD=$(shell sh -c 'pwd -W')
-PYTHONPATH := $(PWD)/../cosim;$(PYTHONPATH)
+PYTHONPATH := $(WPWD)/../cosim;$(PYTHONPATH)
 else
-WPWD=$(shell pwd)
 PYTHONPATH := $(PWD)/../cosim:$(PYTHONPATH)
 endif
 
 ifeq ($(TOPLEVEL_LANG),verilog)
-    VERILOG_SOURCES = $(WPWD)/../hdl/endian_swapper.sv
+    VERILOG_SOURCES = $(PWD)/../hdl/endian_swapper.sv
     TOPLEVEL = endian_swapper_sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    VHDL_SOURCES = $(WPWD)/../hdl/endian_swapper.vhdl
+    VHDL_SOURCES = $(PWD)/../hdl/endian_swapper.vhdl
     TOPLEVEL = endian_swapper_vhdl
     ifneq ($(filter $(SIM),ius xcelium),)
         SIM_ARGS += -v93

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -13,14 +13,8 @@ TOPLEVEL := mean_sv
 
 PWD=$(shell pwd)
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
-VHDL_SOURCES = $(WPWD)/../hdl/mean_pkg.vhd
-VHDL_SOURCES += $(WPWD)/../hdl/mean.vhd
+VHDL_SOURCES = $(PWD)/../hdl/mean_pkg.vhd
+VHDL_SOURCES += $(PWD)/../hdl/mean.vhd
 
 ifeq ($(SIM),questa)
 COMPILE_ARGS = -mixedsvvh

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -15,14 +15,8 @@ TOPLEVEL = endian_swapper_mixed
 
 PWD=$(shell pwd)
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
-VERILOG_SOURCES = $(WPWD)/../../endian_swapper/hdl/endian_swapper.sv
-VHDL_SOURCES    = $(WPWD)/../../endian_swapper/hdl/endian_swapper.vhdl
+VERILOG_SOURCES = $(PWD)/../../endian_swapper/hdl/endian_swapper.sv
+VHDL_SOURCES    = $(PWD)/../../endian_swapper/hdl/endian_swapper.vhdl
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES += $(WPWD)/../hdl/toplevel.sv

--- a/examples/ping_tun_tap/tests/Makefile
+++ b/examples/ping_tun_tap/tests/Makefile
@@ -38,12 +38,6 @@ else
 
 TOPLEVEL = icmp_reply
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
 PWD=$(shell pwd)
 
 VERILOG_SOURCES = $(PWD)/../hdl/icmp_reply.sv

--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -31,13 +31,9 @@ TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL := array_module
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/array_module/array_module.sv

--- a/tests/designs/avalon_module/Makefile
+++ b/tests/designs/avalon_module/Makefile
@@ -39,13 +39,7 @@ else
 
 TOPLEVEL := burst_read_master
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_module/burst_read_master.v
 

--- a/tests/designs/avalon_streaming_module/Makefile
+++ b/tests/designs/avalon_streaming_module/Makefile
@@ -10,13 +10,9 @@ else
 
 TOPLEVEL := avalon_streaming
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_streaming_module/avalon_streaming.sv
 

--- a/tests/designs/basic_hierarchy_module/Makefile
+++ b/tests/designs/basic_hierarchy_module/Makefile
@@ -14,13 +14,9 @@ else
 
 TOPLEVEL := basic_hierarchy_module
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/basic_hierarchy_module/basic_hierarchy_module.v
 

--- a/tests/designs/close_module/Makefile
+++ b/tests/designs/close_module/Makefile
@@ -39,13 +39,9 @@ else
 
 TOPLEVEL = close_module
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/close_module/close_module.v
 

--- a/tests/designs/multi_dimension_array/Makefile
+++ b/tests/designs/multi_dimension_array/Makefile
@@ -39,13 +39,9 @@ clean::
 
 else
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/multi_dimension_array/cocotb_array_pkg.sv \
                   $(COCOTB)/tests/designs/multi_dimension_array/cocotb_array.sv

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -31,13 +31,9 @@ TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL := tb_top
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/plusargs_module/tb_top.v

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -31,13 +31,9 @@ TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL := sample_module
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/sample_module/sample_module.sv

--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -8,13 +8,9 @@ clean::
 
 else
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 SRC_BASE = $(COCOTB)/tests/designs/uart2bus
 

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -16,13 +16,9 @@ else
 
 TOPLEVEL = testbench
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VHDL_SOURCES = $(COCOTB)/tests/designs/vhdl_configurations/dut.vhd
 ifeq ($(TOPLEVEL_LANG),verilog)

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -37,13 +37,9 @@ else
 
 TOPLEVEL = dec_viterbi_ent
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 SRC_BASE = $(COCOTB)/tests/designs/viterbi_decoder_axi4s
 

--- a/tests/test_cases/test_iteration_verilog/Makefile
+++ b/tests/test_cases/test_iteration_verilog/Makefile
@@ -35,13 +35,9 @@ clean::
 
 else
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/examples/endian_swapper/hdl/endian_swapper.sv
 TOPLEVEL = endian_swapper_sv


### PR DESCRIPTION
This PR introduced sources paths formatting on Windows using `cygpath` in `Makefile.pylib.Msys`

- It fixes sources paths format in tcl scripts (questa and aldec) 
- Simplifies the multi-OS support in Makefiles (not required special Windows path construction)
- Cleanup test and examples from unused code

It is a subset of #1462. Hope this makes it easier to review.

