### PR TITLE
Do not manually link libraries against CPython

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  version: 3.7
+  install:
+    - requirements: documentation/requirements.txt
+    - method: pip
+      path: .
+
+sphinx:
+  configuration: documentation/source/conf.py

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -212,7 +212,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     libgpilog = Extension(
         os.path.join("cocotb", "libs", "libgpilog"),
         include_dirs=[include_dir],
-        libraries=[_get_python_lib_link(), "cocotbutils"],
+        libraries=["cocotbutils"],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "gpi_log", "gpi_logging.cpp")],
         extra_link_args=_extra_link_args("libgpilog"),
@@ -222,6 +222,8 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     #
     #  libcocotb
     #
+    # this is the top-level python entry point, so embeds python
+    python_link_args = sysconfig.get_config_var("LINKFORSHARED").split(' ')
     libcocotb = Extension(
         os.path.join("cocotb", "libs", "libcocotb"),
         define_macros=[("PYTHON_SO_LIB", _get_python_lib())],
@@ -229,7 +231,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         libraries=[_get_python_lib_link(), "gpilog", "cocotbutils"],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "embed", "gpi_embed.cpp")],
-        extra_link_args=_extra_link_args("libcocotb"),
+        extra_link_args=_extra_link_args("libcocotb") + python_link_args,
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -255,7 +257,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     libsim = Extension(
         os.path.join("cocotb", "simulator"),
         include_dirs=[include_dir],
-        libraries=[_get_python_lib_link(), "cocotbutils", "gpilog", "gpi"],
+        libraries=["cocotbutils", "gpilog", "gpi"],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "simulator", "simulatormodule.cpp")],
         extra_compile_args=_extra_cxx_compile_args,

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,12 @@ log = logging.getLogger("cocotb._build_libs")
 log.setLevel(logging.INFO)
 log.addHandler(handler)
 
+import os
+import pprint
+pprint.pprint(os.listdir("/home/docs/.pyenv/versions/3.7.3/lib"))
+pprint.pprint(os.listdir("/home/docs/.pyenv/versions/3.7.3/lib/python3.7"))
+os.system('tree /home/docs/.pyenv/versions/3.7.3/lib')
+
 setup(
     name='cocotb',
     cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
Apparently this is done automatically for us.
This will hopefully fix #1569.

To test this, I've added a ReadTheDocs configuration file to turn on installation during doc builds.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
