### PR TITLE
Only link libcocotb against libpython

### DIFF
--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -212,7 +212,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     libgpilog = Extension(
         os.path.join("cocotb", "libs", "libgpilog"),
         include_dirs=[include_dir],
-        libraries=[_get_python_lib_link(), "cocotbutils"],
+        libraries=["cocotbutils"],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "gpi_log", "gpi_logging.cpp")],
         extra_link_args=_extra_link_args("libgpilog"),
@@ -255,7 +255,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     libsim = Extension(
         os.path.join("cocotb", "simulator"),
         include_dirs=[include_dir],
-        libraries=[_get_python_lib_link(), "cocotbutils", "gpilog", "gpi"],
+        libraries=["cocotbutils", "gpilog", "gpi"],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "simulator", "simulatormodule.cpp")],
         extra_compile_args=_extra_cxx_compile_args,


### PR DESCRIPTION
libcocotb is the library that actually _embeds_ python, so therefore must be linked against it.
All the other modules are loaded within python or libcocotb, so do not need to link against this library.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
