### PR TITLE
Build docs against installed cocotb

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,11 @@
 version: 2
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: documentation/requirements.txt
+    - method: pip
+      path: .
 
 sphinx:
   configuration: documentation/source/conf.py

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -12,10 +12,6 @@ import os
 import subprocess
 import sys
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../..'))
 
 # Add in-tree extensions to path
 sys.path.insert(0, os.path.abspath('../sphinxext'))


### PR DESCRIPTION
This seems more common in packages I've looked at before.

CI almost certainly fails due to #1569 
