### PR TITLE
Set PYTHON_BIN using cocotb-config

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -54,6 +54,9 @@ OS=Msys
 endif
 export OS
 
+# this ensures we use the same python as the one cocotb was installed into
+PYTHON_BIN ?= $(shell cocotb-config --python-bin)
+
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.deprecations
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.pylib
 

--- a/cocotb/share/makefiles/Makefile.pylib.Darwin
+++ b/cocotb/share/makefiles/Makefile.pylib.Darwin
@@ -29,13 +29,6 @@
 
 # All common python related rules
 
-ifneq ($(COCOTB_PYTHON_DEBUG),)
-	DBG_PYTHON_VERSION=$(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')
-	PYTHON_BIN?=python$(DBG_PYTHON_VERSION)-dbg
-else
-	PYTHON_BIN?=python
-endif
-
 PYTHON_LIBDIR:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')
 
 # Nasty hack but there's no way in Python properly get the directories for 32-bit Python on a 64-bit system

--- a/cocotb/share/makefiles/Makefile.pylib.Linux
+++ b/cocotb/share/makefiles/Makefile.pylib.Linux
@@ -29,13 +29,6 @@
 
 # All common python related rules
 
-ifneq ($(COCOTB_PYTHON_DEBUG),)
-    DBG_PYTHON_VERSION=$(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')
-    PYTHON_BIN?=python$(DBG_PYTHON_VERSION)-dbg
-else
-    PYTHON_BIN?=python
-endif
-
 PYTHON_LIBDIR:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')
 
 # Nasty hack but there's no way in Python properly get the directories for 32-bit Python on a 64-bit system

--- a/cocotb/share/makefiles/Makefile.pylib.Msys
+++ b/cocotb/share/makefiles/Makefile.pylib.Msys
@@ -29,21 +29,9 @@
 
 # All common python related rules
 
-# if not explicitly set, auto-detect python dir from system path
-ifeq ($(PYTHON_DIR),)
-    PYTHON_DIR ?= $(shell dirname $(shell :; command -v python))
-endif
-
-# make sure python dir was set properly
-ifeq ($(PYTHON_DIR),)
-    $(error "Path to Python directory must be included in system path or defined in PYTHON_DIR environment variable")
-endif
-
-PYTHON_BIN?=$(PYTHON_DIR)/python.exe
-
 PYTHON_LIBDIR:=$(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; print( sysconfig.get_config_var("LIBDIR") )')
 ifeq ($(PYTHON_LIBDIR),None)
-    PYTHON_LIBDIR=$(PYTHON_DIR)/libs
+    PYTHON_LIBDIR=$(shell dirname $(PYTHON_BIN))/libs
 endif
 
 PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_inc() )')

--- a/documentation/source/newsfragments/1574.change.rst
+++ b/documentation/source/newsfragments/1574.change.rst
@@ -1,0 +1,1 @@
+There's no longer any need to set the ``PYTHON_BIN`` makefile variable, the Python executable automatically matches the one cocotb was installed into.


### PR DESCRIPTION
Mentioned here: https://github.com/cocotb/cocotb/pull/1462#discussion_r403546411

Use `cocotb-config` to resolve python executable that cocotb was installed with.
Remove `COCOTB_PYTHON_DEBUG` (undocumented) still `PYTHON_BIN` can be overwritten if needed.

It will help in many cases like #1539 and for multi-os support.



