### PR TITLE
Update docs for async/await syntax

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -724,7 +724,7 @@ class First(_AggregateWaitable):
             t_ret = await First(t1, t2)
 
     .. note::
-        When using the old-style :keyword:`yield`-based coroutines, ``t = yield [a, b]`` was another spelling of
+        In the old-style :ref:`generator-based coroutines <yield-syntax>`, ``t = yield [a, b]`` was another spelling of
         ``t = yield First(a, b)``. This spelling is no longer available when using :keyword:`await`-based
         coroutines.
     """

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -5,80 +5,50 @@ Coroutines
 **********
 
 Testbenches built using cocotb use coroutines. While the coroutine is executing
-the simulation is paused. The coroutine uses the :keyword:`yield` keyword to
-pass control of execution back to the simulator and simulation time can advance
-again.
+the simulation is paused. The coroutine uses the :keyword:`await` keyword to
+block on another coroutine's execution or pass control of execution back to the
+simulator, allowing simulation time to advance.
 
-Typically coroutines :keyword:`yield` a :any:`Trigger` object which
+Typically coroutines :keyword:`await` a :class:`~cocotb.triggers.Trigger` object which
 indicates to the simulator some event which will cause the coroutine to be woken
 when it occurs.  For example:
 
 .. code-block:: python3
 
-    @cocotb.coroutine
-    def wait_10ns():
+    async def wait_10ns():
         cocotb.log.info("About to wait for 10 ns")
-        yield Timer(10, units='ns')
+        await Timer(10, units='ns')
         cocotb.log.info("Simulation time has advanced by 10 ns")
 
-Coroutines may also yield other coroutines:
+Coroutines may also :keyword:`await` on other coroutines:
 
 .. code-block:: python3
 
-    @cocotb.coroutine
-    def wait_100ns():
+    async def wait_100ns():
         for i in range(10):
-            yield wait_10ns()
+            await wait_10ns()
 
-Coroutines can return a value, so that they can be used by other coroutines.
+Coroutines can :keyword:`return` a value, so that they can be used by other coroutines.
 
 .. code-block:: python3
 
-    @cocotb.coroutine
-    def get_signal(clk, signal):
-        yield RisingEdge(clk)
+    async def get_signal(clk, signal):
+        await RisingEdge(clk)
         return signal.value
 
-    @cocotb.coroutine
-    def check_signal_changes(dut):
-        first = yield get_signal(dut.clk, dut.signal)
-        second = yield get_signal(dut.clk, dut.signal)
+    async def check_signal_changes(dut):
+        first = await get_signal(dut.clk, dut.signal)
+        second = await get_signal(dut.clk, dut.signal)
         if first == second:
             raise TestFailure("Signal did not change")
 
 
-Coroutines may also yield a list of triggers and coroutines to indicate that
-execution should resume if *any* of them fires:
-
-.. code-block:: python3
-
-    @cocotb.coroutine
-    def packet_with_timeout(monitor, timeout):
-        """Wait for a packet but time out if nothing arrives"""
-        yield [Timer(timeout, units='ns'), RisingEdge(dut.ready)]
-
-
-The trigger that caused execution to resume is passed back to the coroutine,
-allowing them to distinguish which trigger fired:
-
-.. code-block:: python3
-
-    @cocotb.coroutine
-    def packet_with_timeout(monitor, timeout):
-        """Wait for a packet but time out if nothing arrives"""
-        tout_trigger = Timer(timeout, units='ns')
-        result = yield [tout_trigger, RisingEdge(dut.ready)]
-        if result is tout_trigger:
-            raise TestFailure("Timed out waiting for packet")
-
-
-Coroutines can be forked for parallel operation within a function of that code and
-the forked code.
+Coroutines can be used with :func:`~cocotb.fork` for concurrent operation.
 
 .. code-block:: python3
 
     @cocotb.test()
-    def test_act_during_reset(dut):
+    async def test_act_during_reset(dut):
         """While reset is active, toggle signals"""
         tb = uart_tb(dut)
         # "Clock" is a built in class for toggling a clock signal
@@ -87,28 +57,28 @@ the forked code.
         # part of the user-generated "uart_tb" class
         cocotb.fork(tb.reset_dut(dut.rstn, 20))
 
-        yield Timer(10, units='ns')
+        await Timer(10, units='ns')
         print("Reset is still active: %d" % dut.rstn)
-        yield Timer(15, units='ns')
-        print("Reset has gone inactive: %d" % dut.rstn)
+        await Timer(15, units='ns')
+        await("Reset has gone inactive: %d" % dut.rstn)
 
 
-Coroutines can be joined to end parallel operation within a function.
+Forked coroutines can be used in an :keyword:`await` statement to block until the forked coroutine finishes.
 
 .. code-block:: python3
 
     @cocotb.test()
-    def test_count_edge_cycles(dut, period=1, clocks=6):
-        cocotb.fork(Clock(dut.clk, period, units='ns').start())
-        yield RisingEdge(dut.clk)
+    async def test_count_edge_cycles(dut, period_ns=1, clocks=6):
+        cocotb.fork(Clock(dut.clk, period_ns, units='ns').start())
+        await RisingEdge(dut.clk)
 
-        timer = Timer(period + 10)
+        timer = Timer(period_ns + 10, 'ns')
         task = cocotb.fork(count_edges_cycles(dut.clk, clocks))
         count = 0
         expect = clocks - 1
 
         while True:
-            result = yield [timer, task.join()]
+            result = await First(timer, task)
             if count > expect:
                 raise TestFailure("Task didn't complete in expected time")
             if result is timer:
@@ -117,71 +87,42 @@ Coroutines can be joined to end parallel operation within a function.
             else:
                 break
 
-Coroutines can be killed before they complete, forcing their completion before
+Forked coroutines can be killed before they complete, forcing their completion before
 they'd naturally end.
 
 .. code-block:: python3
 
     @cocotb.test()
-    def test_different_clocks(dut):
+    async def test_different_clocks(dut):
         clk_1mhz   = Clock(dut.clk, 1.0, units='us')
         clk_250mhz = Clock(dut.clk, 4.0, units='ns')
 
         clk_gen = cocotb.fork(clk_1mhz.start())
         start_time_ns = get_sim_time(units='ns')
-        yield Timer(1, units='ns')
-        yield RisingEdge(dut.clk)
+        await Timer(1, units='ns')
+        await RisingEdge(dut.clk)
         edge_time_ns = get_sim_time(units='ns')
-        # NOTE: isclose is a Python 3.5+ feature
         if not isclose(edge_time_ns, start_time_ns + 1000.0):
             raise TestFailure("Expected a period of 1 us")
 
-        clk_gen.kill()
+        clk_gen.kill()  # kill clock coroutine here
 
         clk_gen = cocotb.fork(clk_250mhz.start())
         start_time_ns = get_sim_time(units='ns')
-        yield Timer(1, units='ns')
-        yield RisingEdge(dut.clk)
+        await Timer(1, units='ns')
+        await RisingEdge(dut.clk)
         edge_time_ns = get_sim_time(units='ns')
-        # NOTE: isclose is a Python 3.5+ feature
         if not isclose(edge_time_ns, start_time_ns + 4.0):
             raise TestFailure("Expected a period of 4 ns")
 
-.. _async_functions:
 
-Async functions
-===============
-
-Python 3.5 introduces :keyword:`async` functions, which provide an alternative
-syntax. For example:
-
-.. code-block:: python3
-
-    @cocotb.coroutine
-    async def wait_10ns():
-        cocotb.log.info("About to wait for 10 ns")
-        await Timer(10, units='ns')
-        cocotb.log.info("Simulation time has advanced by 10 ns")
-
-To wait on a trigger or a nested coroutine, these use :keyword:`await` instead
-of :keyword:`yield`. Provided they are decorated with ``@cocotb.coroutine``,
-``async def`` functions using :keyword:`await` and regular functions using
-:keyword:`yield` can be used interchangeable - the appropriate keyword to use
-is determined by which type of function it appears in, not by the
-sub-coroutine being called.
-
-.. versionadded:: 1.4
+.. versionchanged:: 1.4
     The :any:`cocotb.coroutine` decorator is no longer necessary for ``async def`` coroutines.
     ``async def`` coroutines can be used, without the ``@cocotb.coroutine`` decorator, wherever decorated coroutines are accepted,
     including :keyword:`yield` statements and :any:`cocotb.fork`.
 
-.. note::
-    It is not legal to ``await`` a list of triggers as can be done in
-    ``yield``-based coroutine with ``yield [trig1, trig2]``. Use
-    ``await First(trig1, trig2)`` instead.
-
 Async generators
-----------------
+================
 
 In Python 3.6, a ``yield`` statement within an ``async`` function has a new
 meaning (rather than being a ``SyntaxError``) which matches the typical meaning
@@ -202,3 +143,90 @@ type of generator function that can be iterated with ``async for``:
 
 More details on this type of generator can be found in :pep:`525`.
 
+
+.. _yield-syntax:
+
+Generator-based coroutines
+==========================
+
+.. note:: This style is no longer recommended and support may someday be removed.
+
+Prior to Python 3.5, and the introduction of :keyword:`async` and :keyword:`await`, coroutines were implemented as wrappers around generators.
+Coroutine functions would be decorated with :class:`~cocotb.decorators.coroutine` and would use :keyword:`yield` to block on other coroutines or triggers.
+You may see existing code that uses this syntax for coroutines, but do not worry, it is compatible with async coroutines.
+
+Any object that can be used in an :keyword:`await` statement can also be used in a :keyword:`yield` statement while in a generator-based coroutine;
+including triggers like :class:`~cocotb.triggers.Timer`.
+
+.. code-block:: python3
+
+    @cocotb.coroutine
+    def simple_clock(signal, half_period, half_period_units):
+        signal <= 0
+        while True:
+            # in generator-based coroutines triggers are yielded
+            yield Timer(half_period, half_period_units)
+            signal <= ~signal
+
+Likewise, any place that will accept async coroutines will also accept generator-based coroutines;
+including :func:`~cocotb.fork`.
+
+.. code-block:: python3
+
+    @cocotb.coroutine
+    def start_clock(clk):
+        # generator-based coroutines can still be forked
+        cocotb.fork(simple_clock(clk, 5, units='ns'))
+        yield RisingEdge(clk)
+
+Async coroutines can be yielded in generator-based coroutines.
+
+.. code-block:: python3
+
+    async def detect_transaction(clk, valid):
+        await RisingEdge(clk)
+        while not valid.value:
+            await RisingEdge(clk)
+
+    @cocotb.coroutine
+    def monitor(clk, valid, data):
+        # async coroutines can be yielded
+        yield detect_transaction(clk, valid)
+        return data.value
+
+Generator-based coroutines can also be awaited in async coroutines.
+
+.. code-block:: python3
+
+    async def check_incrementing(clk, valid, data):
+        # generator-based coroutines can be awaited
+        prev_count = await monitor()
+        while True:
+            count = await monitor()
+            assert count == (prev_count + 1)
+            prev_count = count
+
+You may also see syntax like ``yield [trigger_a, trigger_b, ...]``, which is syntactic sugar for :class:`~cocotb.triggers.First`.
+
+.. code-block:: python3
+
+    @cocotb.coroutine
+    def run_for(coro, time, units):
+        timeout = Timer(time, units='ps')
+        # block until first trigger fires
+        yield [timeout, coro]
+
+Tests can also be generator-based coroutines.
+Tests are not required to be decorated with :class:`~cocotb.decorators.coroutine` as the :class:`~cocotb.decorators.test` decorator will handle this case automatically.
+
+.. code-block:: python3
+
+    # just need the test decorator
+    @cocotb.test()
+    def run_test(dut):
+        yield start_clock(dut.clk)
+        checker = check_incrementing(
+            clk=dut.clk,
+            valid=dut.valid,
+            data=dut.cnt)
+        yield run_for(checker, 1, 'us')

--- a/documentation/source/triggers.rst
+++ b/documentation/source/triggers.rst
@@ -3,21 +3,12 @@ Triggers
 ********
 
 Triggers are used to indicate when the cocotb scheduler should resume coroutine execution.
-To use a trigger, a coroutine should :keyword:`await` or :keyword:`yield` it.
+To use a trigger, a coroutine should :keyword:`await` it.
 This will cause execution of the current coroutine to pause.
 When the trigger fires, execution of the paused coroutine will resume::
 
-    @cocotb.coroutine
-    def coro():
-        print("Some time before the edge")
-        yield RisingEdge(clk)
-        print("Immediately after the edge")
-
-Or using the syntax in Python 3.5 onwards:
-
 .. code-block:: python3
 
-    @cocotb.coroutine
     async def coro():
         print("Some time before the edge")
         await RisingEdge(clk)


### PR DESCRIPTION
This updates the documentation on coroutines and triggers in the documentation to use `async`/`await`. What was previously the `Async Syntax` section now describes the old generator-based approach and mentions it's compatibility with new-style coroutines.