### PR TITLE
Pin sphinx before version 3, until an upstream bug is fixed.

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,5 +1,10 @@
 # Python dependencies to build the documentation
-Sphinx>=2.1
+
+# Pinned below 3 until https://github.com/sphinx-contrib/domaintools/pull/9 is
+# merged and released.
+Sphinx~=2.1
+
+# other dependencies
 sphinx-rtd-theme
 cairosvg
 breathe


### PR DESCRIPTION
If docs CI passes, then this PR should be good.

Upstream patch is https://github.com/sphinx-contrib/domaintools/pull/9.