### PR TITLE
Update modelsim.def to fix compilation errors

### DIFF
--- a/cocotb/share/def/.gitignore
+++ b/cocotb/share/def/.gitignore
@@ -1,0 +1,2 @@
+# Generated import libraries on Windows
+*.a

--- a/cocotb/share/def/modelsim.def
+++ b/cocotb/share/def/modelsim.def
@@ -100,3 +100,16 @@ mti_TickLeft
 mti_TickLength
 mti_TickRight
 mti_VsimFree
+mti_Interp
+mti_Cmd
+Tcl_GetStringResult
+Tcl_ResetResult
+Tcl_GetObjResult
+Tcl_ResetResult
+Tcl_ListObjGetElements
+Tcl_GetStringResult
+TclFreeObj
+Tcl_ResetResult
+Tcl_ResetResult
+Tcl_GetString
+TclFreeObj


### PR DESCRIPTION
Some function definitions ware missing from https://github.com/cocotb/cocotb/pull/1424 that was casing FLI compilation error on Windows.
