### PR TITLE
Cleanup of several Python 2 legacy code styles

### DIFF
--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -32,7 +32,7 @@ import sys
 
 
 # backport of Python 3.7's contextlib.nullcontext
-class nullcontext(object):
+class nullcontext:
     """Context manager that does no additional processing.
     Used as a stand-in for a normal context manager, when a particular
     block of code is only sometimes used with a normal context manager:

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -383,7 +383,7 @@ class BinaryValue:
         for char in string:
             if char not in BinaryValue._permitted_chars:
                 raise ValueError("Attempting to assign character %s to a %s" %
-                                 (char, self.__class__.__name__))
+                                 (char, type(self).__name__))
         self._str = string
         self._adjust()
 

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -61,13 +61,13 @@ def _clog2(val):
         exp += 1
 
 
-class BinaryRepresentation():  # noqa
+class BinaryRepresentation:  # noqa
     UNSIGNED         = 0  #: Unsigned format
     SIGNED_MAGNITUDE = 1  #: Sign and magnitude format
     TWOS_COMPLEMENT  = 2  #: Two's complement format
 
 
-class BinaryValue(object):
+class BinaryValue:
     """Representation of values in binary format.
 
     The underlying value can be set or accessed using these aliasing attributes:

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -411,9 +411,6 @@ class BinaryValue:
         return self.__str__()
 
     def __bool__(self):
-        return self.__nonzero__()
-
-    def __nonzero__(self):
         """Provide boolean testing of a :attr:`binstr`.
 
         >>> val = BinaryValue("0000")

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -27,8 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-
 import os
 import random
 import warnings

--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -124,7 +124,7 @@ class Bus:
                     msg = ("Unable to drive onto {0}.{1} because {2} is missing "
                            "attribute {3}".format(self._entity._name,
                                                   self._name,
-                                                  obj.__class__.__name__,
+                                                  type(obj).__name__,
                                                   attr_name))
                     raise AttributeError(msg)
                 else:
@@ -178,7 +178,7 @@ class Bus:
                     msg = ("Unable to sample from {0}.{1} because {2} is missing "
                            "attribute {3}".format(self._entity._name,
                                                   self._name,
-                                                  obj.__class__.__name__,
+                                                  type(obj).__name__,
                                                   attr_name))
                     raise AttributeError(msg)
                 else:

--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -39,7 +39,7 @@ def _build_sig_attr_dict(signals):
         return {sig: sig for sig in signals}
 
 
-class Bus(object):
+class Bus:
     """Wraps up a collection of signals.
 
     Assumes we have a set of signals/nets named ``entity.<bus_name><separator><signal>``.

--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -34,7 +34,7 @@ from cocotb.triggers import Timer
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps, lazy_property
 
 
-class BaseClock(object):
+class BaseClock:
     """Base class to derive from."""
     def __init__(self, signal):
         self.signal = signal

--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -42,7 +42,7 @@ class BaseClock:
     @lazy_property
     def log(self):
         return SimLog("cocotb.%s.%s" % (
-            self.__class__.__name__, self.signal._name
+            type(self).__name__, self.signal._name
         ))
 
 
@@ -152,4 +152,4 @@ class Clock(BaseClock):
                 await t
 
     def __str__(self):
-        return self.__class__.__name__ + "(%3.1f MHz)" % self.frequency
+        return type(self).__name__ + "(%3.1f MHz)" % self.frequency

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -305,10 +305,10 @@ class coroutine:
     def __call__(self, *args, **kwargs):
         return RunningCoroutine(self._func(*args, **kwargs), self)
 
-    def __get__(self, obj, type=None):
+    def __get__(self, obj, owner=None):
         """Permit the decorator to be used on class methods
             and standalone functions"""
-        return self.__class__(self._func.__get__(obj, type))
+        return type(self)(self._func.__get__(obj, owner))
 
     def __iter__(self):
         return self
@@ -336,10 +336,10 @@ class function:
     def __call__(self, *args, **kwargs):
         return cocotb.scheduler.queue_function(self._coro(*args, **kwargs))
 
-    def __get__(self, obj, type=None):
+    def __get__(self, obj, owner=None):
         """Permit the decorator to be used on class methods
             and standalone functions"""
-        return self.__class__(self._coro._func.__get__(obj, type))
+        return type(self)(self._coro._func.__get__(obj, owner))
 
 @public
 class external:
@@ -357,10 +357,10 @@ class external:
     def __call__(self, *args, **kwargs):
         return cocotb.scheduler.run_in_executor(self._func, *args, **kwargs)
 
-    def __get__(self, obj, type=None):
+    def __get__(self, obj, owner=None):
         """Permit the decorator to be used on class methods
             and standalone functions"""
-        return self.__class__(self._func.__get__(obj, type))
+        return type(self)(self._func.__get__(obj, owner))
 
 
 class _decorator_helper(type):

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -184,7 +184,7 @@ class RunningTask:
     def has_started(self):
         return self._started
 
-    def __nonzero__(self):
+    def __bool__(self):
         """Provide boolean testing
             if the coroutine has finished return false
             otherwise return true"""
@@ -200,8 +200,6 @@ class RunningTask:
 
         # Hand the coroutine back to the scheduler trampoline.
         return (yield self)
-
-    __bool__ = __nonzero__
 
 
 class RunningCoroutine(RunningTask):

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -25,7 +25,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
 import sys
 import time
 import logging

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -73,7 +73,7 @@ class CoroutineComplete(Exception):
         Exception.__init__(self, text)
 
 
-class RunningTask(object):
+class RunningTask:
     """Per instance wrapper around a running generator.
 
     Provides the following:
@@ -285,7 +285,7 @@ class RunningTest(RunningCoroutine):
             return "%s.%d.%s" % (self.module, self.stage, self.funcname)
 
 
-class coroutine(object):
+class coroutine:
     """Decorator class that allows us to provide common coroutine mechanisms:
 
     ``log`` methods will log to ``cocotb.coroutine.name``.
@@ -320,7 +320,7 @@ class coroutine(object):
 
 
 @public
-class function(object):
+class function:
     """Decorator class that allows a function to block.
 
     This allows a coroutine that consumes simulation time
@@ -344,7 +344,7 @@ class function(object):
         return self.__class__(self._coro._func.__get__(obj, type))
 
 @public
-class external(object):
+class external:
     """Decorator to apply to an external function to enable calling from cocotb.
 
     This turns a normal function that isn't a coroutine into a blocking coroutine.

--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -102,7 +102,7 @@ class Driver:
 
         # Sub-classes may already set up logging
         if not hasattr(self, "log"):
-            self.log = SimLog("cocotb.driver.%s" % (self.__class__.__name__))
+            self.log = SimLog("cocotb.driver.%s" % (type(self).__name__))
 
         # Create an independent coroutine which can send stuff
         self._thread = cocotb.scheduler.add(self._send_thread())

--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -39,7 +39,7 @@ from cocotb.bus import Bus
 from cocotb.log import SimLog
 
 
-class BitDriver(object):
+class BitDriver:
     """Drives a signal onto a single bit.
 
     Useful for exercising ready/valid flags.
@@ -89,7 +89,7 @@ class BitDriver(object):
                 yield edge
 
 
-class Driver(object):
+class Driver:
     """Class defining the standard interface for a driver within a testbench.
 
     The driver is responsible for serializing transactions onto the physical

--- a/cocotb/drivers/xgmii.py
+++ b/cocotb/drivers/xgmii.py
@@ -44,7 +44,7 @@ _XGMII_TERMINATE = 0xFD  # noqa
 _PREAMBLE_SFD = b"\x55\x55\x55\x55\x55\x55\xD5"
 
 
-class _XGMIIBus(object):
+class _XGMIIBus:
     r"""Helper object for abstracting the underlying bus format.
 
     Index bytes directly on this object, pass a tuple of ``(value, ctrl)`` to

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -49,7 +49,7 @@ from cocotb.result import TestError
 _deprecation_warned = set()
 
 
-class SimHandleBase(object):
+class SimHandleBase:
     """Base class for all simulation objects.
 
     We maintain a handle which we can use for GPI calls.
@@ -352,7 +352,7 @@ class HierarchyArrayObject(RegionObject):
         raise TypeError("Not permissible to set %s at index %d" % (self._name, index))
 
 
-class _AssignmentResult(object):
+class _AssignmentResult:
     """
     An object that exists solely to provide an error message if the caller
     is not aware of cocotb's meaning of ``<=``.

--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -42,14 +42,14 @@ from cocotb.log import SimLog
 from cocotb.triggers import Event, Timer
 
 
-class MonitorStatistics(object):
+class MonitorStatistics:
     """Wrapper class for storing Monitor statistics"""
 
     def __init__(self):
         self.received_transactions = 0
 
 
-class Monitor(object):
+class Monitor:
     """Base class for Monitor objects.
 
     Monitors are passive 'listening' objects that monitor pins going in or out of a DUT.

--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -82,7 +82,7 @@ class Monitor:
 
         # Sub-classes may already set up logging
         if not hasattr(self, "log"):
-            self.log = SimLog("cocotb.monitor.%s" % (self.__class__.__name__))
+            self.log = SimLog("cocotb.monitor.%s" % (type(self).__name__))
 
         if callback is not None:
             self.add_callback(callback)
@@ -194,4 +194,4 @@ class BusMonitor(Monitor):
         return False
 
     def __str__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.name)
+        return "%s(%s)" % (type(self).__name__, self.name)

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -72,7 +72,7 @@ def _my_import(name):
     return mod
 
 
-class RegressionManager(object):
+class RegressionManager:
     """Encapsulates all regression capability into a single place"""
 
     def __init__(self, root_name, modules, tests=None, seed=None, hooks=[]):
@@ -534,7 +534,7 @@ def _create_test(function, name, documentation, mod, *args, **kwargs):
     return cocotb.test()(_my_test)
 
 
-class TestFactory(object):
+class TestFactory:
     """Factory to automatically generate tests.
 
     Args:

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -341,7 +341,7 @@ class RegressionManager:
         # Helper for logging result
         def _result_was():
             result_was = ("{} (result was {})".format
-                          (test.__name__, result.__class__.__name__))
+                          (test.__name__, type(result).__name__))
             return result_was
 
         # scoring outcomes

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -71,7 +71,7 @@ class InternalError(RuntimeError):
     pass
 
 
-class profiling_context(object):
+class profiling_context:
     """ Context manager that profiles its contents """
     def __enter__(self):
         _profile.enable()
@@ -82,14 +82,14 @@ class profiling_context(object):
 
 from cocotb import outcomes
 
-class external_state(object):
+class external_state:
     INIT = 0
     RUNNING = 1
     PAUSED = 2
     EXITED = 3
 
 @cocotb.decorators.public
-class external_waiter(object):
+class external_waiter:
 
     def __init__(self):
         self._outcome = None
@@ -150,7 +150,7 @@ class external_waiter(object):
 
         return self.state
 
-class Scheduler(object):
+class Scheduler:
     """The main scheduler.
 
     Here we accept callbacks from the simulator and schedule the appropriate

--- a/cocotb/scoreboard.py
+++ b/cocotb/scoreboard.py
@@ -204,7 +204,7 @@ class Scoreboard:
         # Enforce some type checking as we only work with a real monitor
         if not isinstance(monitor, Monitor):
             raise TypeError("Expected monitor on the interface but got %s" %
-                            (monitor.__class__.__name__))
+                            (type(monitor).__name__))
 
         if compare_fn is not None:
             if callable(compare_fn):
@@ -222,7 +222,7 @@ class Scoreboard:
             if monitor.name:
                 log_name = self.log.name + '.' + monitor.name
             else:
-                log_name = self.log.name + '.' + monitor.__class__.__name__
+                log_name = self.log.name + '.' + type(monitor).__name__
 
             log = logging.getLogger(log_name)
 

--- a/cocotb/scoreboard.py
+++ b/cocotb/scoreboard.py
@@ -37,7 +37,7 @@ from cocotb.monitors import Monitor
 from cocotb.result import TestFailure, TestSuccess
 
 
-class Scoreboard(object):
+class Scoreboard:
     """Generic scoreboarding class.
 
     We can add interfaces by providing a monitor and an expected output queue.

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -373,7 +373,7 @@ class _Event(PythonTrigger):
         return "<{!r}.wait() at {}>".format(self.parent, _pointer_str(self))
 
 
-class Event(object):
+class Event:
     """Event to permit synchronization between two coroutines.
 
     Awaiting :meth:`wait()` from one coroutine will block the coroutine until
@@ -453,7 +453,7 @@ class _Lock(PythonTrigger):
         return "<{!r}.acquire() at {}>".format(self.parent, _pointer_str(self))
 
 
-class Lock(object):
+class Lock:
     """Lock primitive (not re-entrant).
 
     This can be used as::

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -78,7 +78,7 @@ class Trigger(Awaitable):
 
     @lazy_property
     def log(self):
-        return SimLog("cocotb.%s" % (self.__class__.__name__), id(self))
+        return SimLog("cocotb.%s" % (type(self).__name__), id(self))
 
     @abc.abstractmethod
     def prime(self, callback):

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -520,11 +520,9 @@ class Lock:
             _pointer_str(self)
         )
 
-    def __nonzero__(self):
+    def __bool__(self):
         """Provide boolean of a Lock"""
         return self.locked
-
-    __bool__ = __nonzero__
 
     async def __aenter__(self):
         return await self.acquire()

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -493,7 +493,7 @@ def reject_remaining_kwargs(name, kwargs):
         )
 
 
-class lazy_property(object):
+class lazy_property:
     """
     A property that is executed the first time, then cached forever.
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 # Copyright (c) 2013 Potential Ventures Ltd
 # Copyright (c) 2013 SolarFlare Communications Inc
 # All rights reserved.

--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -31,7 +31,7 @@ from cocotb.bus import Bus
 from cocotb.triggers import RisingEdge, ReadOnly
 
 
-class Wavedrom(object):
+class Wavedrom:
     """Base class for a WaveDrom compatible tracer."""
     def __init__(self, obj):
 
@@ -113,7 +113,7 @@ class Wavedrom(object):
         return siglist
 
 
-class trace(object):
+class trace:
     """Context manager to enable tracing of signals.
 
     Arguments are an arbitrary number of signals or buses to trace.

--- a/cocotb/xunit_reporter.py
+++ b/cocotb/xunit_reporter.py
@@ -63,7 +63,7 @@ class File(StringIO):
         return line_list[-lines_2find:]
 
 
-class XUnitReporter(object):
+class XUnitReporter:
 
     def __init__(self, filename="results.xml"):
         self.results = Element("testsuites", name="results")

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -68,8 +68,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'cocotb'
-copyright = u'2014-{0}, PotentialVentures'.format(datetime.datetime.now().year)
+project = 'cocotb'
+copyright = '2014-{0}, PotentialVentures'.format(datetime.datetime.now().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -241,8 +241,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'cocotb.tex', u'cocotb Documentation',
-   u'PotentialVentures', 'manual'),
+  ('index', 'cocotb.tex', 'cocotb Documentation',
+   'PotentialVentures', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -271,8 +271,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'cocotb', u'cocotb Documentation',
-     [u'PotentialVentures'], 1)
+    ('index', 'cocotb', 'cocotb Documentation',
+     ['PotentialVentures'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -285,8 +285,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'cocotb', u'cocotb Documentation',
-   u'PotentialVentures', 'cocotb', 'Coroutine Cosimulation TestBench \
+  ('index', 'cocotb', 'cocotb Documentation',
+   'PotentialVentures', 'cocotb', 'Coroutine Cosimulation TestBench \
      environment for efficient verification of RTL using Python.',
    'Miscellaneous'),
 ]

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -84,7 +84,7 @@ def recursive_discovery(dut):
 
     if not isinstance(dut.i_verilog.uart1.baud_gen_1.baud_freq, cocotb.handle.ModifiableObject):
         tlog.error("Expected dut.i_verilog.uart1.baud_gen_1.baud_freq to be modifiable")
-        tlog.error("but it was %s" % dut.i_verilog.uart1.baud_gen_1.baud_freq.__class__.__name__)
+        tlog.error("but it was %s" % type(dut.i_verilog.uart1.baud_gen_1.baud_freq).__name__)
         raise TestFailure()
 
 

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -84,7 +84,7 @@ def dual_iteration(dut):
 
 @cocotb.test()
 def get_clock(dut):
-    dut._log.info("dut.aclk is %s", dut.aclk.__class__.__name__)
+    dut._log.info("dut.aclk is %s", type(dut.aclk).__name__)
     dut.aclk <= 0
     yield Timer(1)
     dut.aclk <= 1

--- a/tests/test_cases/test_verilog_access/test_verilog_access.py
+++ b/tests/test_cases/test_verilog_access/test_verilog_access.py
@@ -43,9 +43,9 @@ def port_not_hierarchy(dut):
     def check_instance(obj, objtype):
         if not isinstance(obj, objtype):
             tlog.error("Expected %s to be of type %s but got %s" % (
-                obj._fullname, objtype.__name__, obj.__class__.__name__))
+                obj._fullname, objtype.__name__, type(obj).__name__))
             return 1
-        tlog.info("%s is %s" % (obj._fullname, obj.__class__.__name__))
+        tlog.info("%s is %s" % (obj._fullname, type(obj).__name__))
         return 0
 
     fails += check_instance(dut.clk, ModifiableObject)

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -53,9 +53,9 @@ def check_objects(dut):
     def check_instance(obj, objtype):
         if not isinstance(obj, objtype):
             tlog.error("Expected %s to be of type %s but got %s" % (
-                obj._fullname, objtype.__name__, obj.__class__.__name__))
+                obj._fullname, objtype.__name__, type(obj).__name__))
             return 1
-        tlog.info("%s is %s" % (obj._fullname, obj.__class__.__name__))
+        tlog.info("%s is %s" % (obj._fullname, type(obj).__name__))
         return 0
 
     # Hierarchy checks
@@ -101,12 +101,12 @@ def port_not_hierarchy(dut):
     tlog = logging.getLogger("cocotb.test")
     yield Timer(100)
     if not isinstance(dut.aclk, ModifiableObject):
-        tlog.error("dut.aclk should be ModifiableObject but got %s", dut.aclk.__class__.__name__)
+        tlog.error("dut.aclk should be ModifiableObject but got %s", type(dut.aclk).__name__)
     else:
         tlog.info("dut.aclk is ModifiableObject")
     for _ in dut:
         pass
     if not isinstance(dut.aclk, ModifiableObject):
-        tlog.error("dut.aclk should be ModifiableObject but got %s", dut.aclk.__class__.__name__)
+        tlog.error("dut.aclk should be ModifiableObject but got %s", type(dut.aclk).__name__)
     else:
         tlog.info("dut.aclk is ModifiableObject")


### PR DESCRIPTION
Solves parts of #1289, mostly the low hanging fruit. I'd like to get most of the Python 2 cleanup in before we release 1.4.

 * Remove `from __future__ import` line from Python files (but not Makefile.pylib.*)
 * Remove `(object)` from `class MyClass(object)`
 * use `type(self)` instead of `self.__class__`
 * Remove all `__nonzero__` functions which alias `__bool__`
 * make `u""` strings normal strings (e.g. in documentation/source/conf.py)

I also started making the `__name__` => `__qualname__` changes, but they will require a more deft touch due to the schizophrenic usage of `__name__` in `decorators.py` and `regression.py`.

Holding off review until CI starts passing.