### PR TITLE
Add a missing `static` on a private function

### DIFF
--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -205,7 +205,7 @@ extern "C" void embed_sim_cleanup(void)
  * Loads the Python module called cocotb and calls the _initialise_testbench function
  */
 
-int get_module_ref(const char *modname, PyObject **mod)
+static int get_module_ref(const char *modname, PyObject **mod)
 {
     PyObject *pModule = PyImport_ImportModule(modname);
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
