### PR TITLE
Use docs.cocotb.org for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 
-[![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=latest)](http://cocotb.readthedocs.org/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=latest)](https://docs.cocotb.org/en/latest/)
 [![Build Status](https://travis-ci.org/cocotb/cocotb.svg?branch=master)](https://travis-ci.org/cocotb/cocotb)
 [![PyPI](https://img.shields.io/pypi/dm/cocotb.svg?label=PyPI%20downloads)](https://pypi.org/project/cocotb/)
 
-* Read the [documentation](http://cocotb.readthedocs.org)
+* Read the [documentation](https://docs.cocotb.org)
 * Get involved:
   * [Raise a bug / request an enhancement](https://github.com/cocotb/cocotb/issues/new) (Requires a GitHub account)
   * [Join the mailing list](https://lists.librecores.org/listinfo/cocotb)
@@ -40,6 +40,6 @@ Cocotb can be installed by running `pip install cocotb`.
 
 ## Tutorials and examples
 
-* [Endian Swapper tutorial](https://cocotb.readthedocs.org/en/latest/endian_swapper.html)
-* [Ping using TUN/TAP tutorial](https://cocotb.readthedocs.org/en/latest/ping_tun_tap.html)
+* [Endian Swapper tutorial](https://docs.cocotb.org/en/latest/endian_swapper.html)
+* [Ping using TUN/TAP tutorial](https://docs.cocotb.org/en/latest/ping_tun_tap.html)
 * [OpenCores JPEG Encoder example](https://github.com/chiggs/oc_jpegencode/)

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -28,7 +28,7 @@
 """
 Cocotb is a coroutine, cosimulation framework for writing testbenches in Python.
 
-See http://cocotb.readthedocs.org for full documentation
+See https://docs.cocotb.org for full documentation
 """
 import os
 import sys


### PR DESCRIPTION
Use docs.cocotb.org as entry point for our documentation (it continues
to be hosted by readthedocs).

Also ensure that we use HTTPS links.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->