### PR TITLE
Remove BinaryValue.__cmp__

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -443,12 +443,6 @@ class BinaryValue(object):
             other = other.value
         return self.value != other
 
-    def __cmp__(self, other):
-        """Comparison against other values"""
-        if isinstance(other, BinaryValue):
-            other = other.value
-        return self.value.__cmp__(other)
-
     def __int__(self):
         return self.integer
 


### PR DESCRIPTION
The __cmp__ magic method is meaningless in python 3.
The equivalent is the set of `__eq__`, `__ne__`, `__lt__`, `__le__`, `__gt__`, `__ge__`.
Furthermore, an explicit call to this method would just fail because `int.__cmp__` is missing.

We already implement `__eq__` and `__ne__`, and overload `__le__` to mean `.assign` - implementing the other operators would be unwise.