### PR TITLE
Mention proper way of setting make vars

### DIFF
--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -1,3 +1,5 @@
+.. _building:
+
 ***************************************
 Build options and Environment Variables
 ***************************************
@@ -73,9 +75,19 @@ and
 
       Any arguments or flags to pass to the compile stage of the simulation.
 
+   .. note::
+      For use on the command line, set this as an environment variable:
+      ``COMPILE_ARGS="..." make`` (for fish and csh: ``env COMPILE_ARGS="..." make``).
+      See :ref:`troubleshooting-make-vars` for details.
+
 .. make:var:: SIM_ARGS
 
       Any arguments or flags to pass to the execution of the compiled simulation.
+
+   .. note::
+      For use on the command line, set this as an environment variable:
+      ``SIM_ARGS="..." make`` (for fish and csh: ``env SIM_ARGS="..." make``).
+      See :ref:`troubleshooting-make-vars` for details.
 
 .. make:var:: RUN_ARGS
 
@@ -85,7 +97,13 @@ and
 
 .. make:var:: EXTRA_ARGS
 
-      Passed to both the compile and execute phases of simulators with two rules, or passed to the single compile and run command for simulators which don't have a distinct compilation stage.
+      Passed to both the compile and execute phases of simulators with two rules,
+      or passed to the single compile and run command for simulators which don't have a distinct compilation stage.
+
+   .. note::
+      For use on the command line, set this as an environment variable:
+      ``EXTRA_ARGS="..." make`` (for fish and csh: ``env EXTRA_ARGS="..." make``).
+      See :ref:`troubleshooting-make-vars` for details.
 
 .. make:var:: PLUSARGS
 
@@ -97,6 +115,11 @@ and
       The special plusargs ``+ntb_random_seed`` and ``+seed``, if present, are evaluated
       to set the random seed value if :envvar:`RANDOM_SEED` is not set.
       If both ``+ntb_random_seed`` and ``+seed`` are set, ``+ntb_random_seed`` is used.
+
+   .. note::
+      For use on the command line, set this as an environment variable:
+      ``PLUSARGS="..." make`` (for fish and csh: ``env PLUSARGS="..." make``).
+      See :ref:`troubleshooting-make-vars` for details.
 
 .. make:var:: COCOTB_HDL_TIMEUNIT
 

--- a/documentation/source/troubleshooting.rst
+++ b/documentation/source/troubleshooting.rst
@@ -80,3 +80,24 @@ A prebuilt test is included to easily launch an IPython shell in an existing des
 To embed a shell within an existing test, where it can inspect local variables, the :func:`embed` function can be used.
 
 .. autofunction:: embed
+
+
+.. _troubleshooting-make-vars:
+
+Setting make variables on the command line
+==========================================
+
+When trying to set one of the make variables listed in :ref:`building` from the command line,
+it is strongly recommended to use an environment variable, i.e.
+``EXTRA_ARGS="..." make`` (for the fish and csh shells: ``env EXTRA_ARGS="..." make``)
+and *not* ``make EXTRA_ARGS=...``.
+
+This is because in the case of the disrecommended ``make EXTRA_ARGS=...``,
+if one of the involved Makefiles contains lines to assign (``=``) or append (``+=``) to ``EXTRA_ARGS`` internally,
+such lines will be ignored.
+These lines are needed for the operation of cocotb however,
+and having them ignored is likely to lead to strange errors.
+
+As a side note,
+when you need to *clear* a Makefile variable from the command line,
+use the syntax ``make EXTRA_ARGS=``.


### PR DESCRIPTION
Document that users should use the syntax ``EXTRA_ARGS=... make`` instead of ``make  EXTRA_ARGS=...`` because some Makefiles append to these variables internally, and the second syntax would break them.

Closes #1552