### PR TITLE
Cleanup and fix tcl sources paths on Windows

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -91,7 +91,10 @@ ifeq ($(OS),Msys)
     # On Windows there is no support for @rpath/LD_LIBRARY_PATH so we need to set PATH to find cocotb libraries
     # https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order?redirectedfrom=MSDN#standard-search-order-for-desktop-applications
     export PATH := $(LIB_DIR):$(PATH)
+endif
 
-    # For tcl scripts the path to dll has to be in form of C:/User/..
-    LIB_DIR := $(shell cygpath -m '$(LIB_DIR)')
+ifeq ($(OS),Msys)
+    to_tcl_path = $(shell cygpath -m $(1) )
+else
+    to_tcl_path = $(1)
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -84,13 +84,13 @@ endif
 
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
-    GPI_ARGS = -pli $(LIB_DIR)/libcocotbvpi_aldec
+    GPI_ARGS = -pli $(call to_tcl_path,$(LIB_DIR))/libcocotbvpi_aldec
 ifneq ($(VHDL_SOURCES),)
     GPI_EXTRA = cocotbvhpi_aldec:cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_ARGS = -loadvhpi $(LIB_DIR)/libcocotbvhpi_aldec:vhpi_startup_routines_bootstrap
+    GPI_ARGS = -loadvhpi $(call to_tcl_path,$(LIB_DIR))/libcocotbvhpi_aldec:vhpi_startup_routines_bootstrap
 ifneq ($(VERILOG_SOURCES),)
     GPI_EXTRA = cocotbvpi_aldec:cocotbvpi_entry_point
 endif
@@ -111,10 +111,10 @@ $(SIM_BUILD)/runsim.tcl : $(VERILOG_SOURCES) $(VHDL_SOURCES) $(SIM_BUILD)
 	@echo "alib $(RTL_LIBRARY)" >> $@
 	@echo "set worklib $(RTL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)
-	@echo "acom $(ACOM_ARGS) $(VHDL_SOURCES)" >> $@
+	@echo "acom $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif
 ifneq ($(VERILOG_SOURCES),)
-	@echo "alog $(ALOG_ARGS) $(VERILOG_SOURCES)" >> $@
+	@echo "alog $(ALOG_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
 endif
 ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -84,7 +84,7 @@ endif
 
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
-    GPI_ARGS = -pli $(call to_tcl_path,$(LIB_DIR))/libcocotbvpi_aldec
+    GPI_ARGS = -pli $(call to_tcl_path,$(LIB_DIR)/libcocotbvpi_aldec)
 ifneq ($(VHDL_SOURCES),)
     GPI_EXTRA = cocotbvhpi_aldec:cocotbvhpi_entry_point
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -90,7 +90,7 @@ ifneq ($(VHDL_SOURCES),)
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_ARGS = -loadvhpi $(call to_tcl_path,$(LIB_DIR))/libcocotbvhpi_aldec:vhpi_startup_routines_bootstrap
+    GPI_ARGS = -loadvhpi $(call to_tcl_path,$(LIB_DIR)/libcocotbvhpi_aldec):vhpi_startup_routines_bootstrap
 ifneq ($(VERILOG_SOURCES),)
     GPI_EXTRA = cocotbvpi_aldec:cocotbvpi_entry_point
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -69,13 +69,13 @@ endif
 
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),vhdl)
-    VSIM_ARGS += -foreign \"cocotb_init $(LIB_DIR)/libcocotbfli_modelsim.$(LIB_EXT)\"
+    VSIM_ARGS += -foreign \"cocotb_init $(call to_tcl_path,$(LIB_DIR))/libcocotbfli_modelsim.$(LIB_EXT)\"
 ifneq ($(VERILOG_SOURCES),)
     GPI_EXTRA = cocotbvpi_modelsim:cocotbvpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),verilog)
-    VSIM_ARGS += -pli $(LIB_DIR)/libcocotbvpi_modelsim.$(LIB_EXT)
+    VSIM_ARGS += -pli $(call to_tcl_path,$(LIB_DIR))/libcocotbvpi_modelsim.$(LIB_EXT)
 ifneq ($(VHDL_SOURCES),)
     GPI_EXTRA = cocotbfli_modelsim:cocotbfli_entry_point
 endif
@@ -94,10 +94,10 @@ $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEP
 	@echo "vmap -c" >> $@
 	@echo "vmap $(RTL_LIBRARY) $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)
-	@echo "vcom -work $(RTL_LIBRARY) $(VCOM_ARGS) $(VHDL_SOURCES)" >> $@
+	@echo "vcom -work $(RTL_LIBRARY) $(VCOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif
 ifneq ($(VERILOG_SOURCES),)
-	@echo "vlog -work $(RTL_LIBRARY) +define+COCOTB_SIM -sv $(VLOG_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)" >> $@
+	@echo "vlog -work $(RTL_LIBRARY) +define+COCOTB_SIM -sv $(VLOG_ARGS) $(EXTRA_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
 endif
 ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -69,7 +69,7 @@ endif
 
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),vhdl)
-    VSIM_ARGS += -foreign \"cocotb_init $(call to_tcl_path,$(LIB_DIR))/libcocotbfli_modelsim.$(LIB_EXT)\"
+    VSIM_ARGS += -foreign \"cocotb_init $(call to_tcl_path,$(LIB_DIR)/libcocotbfli_modelsim.$(LIB_EXT))\"
 ifneq ($(VERILOG_SOURCES),)
     GPI_EXTRA = cocotbvpi_modelsim:cocotbvpi_entry_point
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -75,7 +75,7 @@ ifneq ($(VERILOG_SOURCES),)
 endif
 
 else ifeq ($(TOPLEVEL_LANG),verilog)
-    VSIM_ARGS += -pli $(call to_tcl_path,$(LIB_DIR))/libcocotbvpi_modelsim.$(LIB_EXT)
+    VSIM_ARGS += -pli $(call to_tcl_path,$(LIB_DIR)/libcocotbvpi_modelsim.$(LIB_EXT))
 ifneq ($(VHDL_SOURCES),)
     GPI_EXTRA = cocotbfli_modelsim:cocotbfli_entry_point
 endif

--- a/examples/adder/tests/Makefile
+++ b/examples/adder/tests/Makefile
@@ -31,18 +31,12 @@ TOPLEVEL_LANG ?= verilog
 
 PWD=$(shell pwd)
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
 export PYTHONPATH := $(PWD)/../model:$(PYTHONPATH)
 
 ifeq ($(TOPLEVEL_LANG),verilog)
-    VERILOG_SOURCES = $(WPWD)/../hdl/adder.v
+    VERILOG_SOURCES = $(PWD)/../hdl/adder.v
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    VHDL_SOURCES = $(WPWD)/../hdl/adder.vhdl
+    VHDL_SOURCES = $(PWD)/../hdl/adder.vhdl
 else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -13,14 +13,8 @@ TOPLEVEL := mean_sv
 
 PWD=$(shell pwd)
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
-VHDL_SOURCES = $(WPWD)/../hdl/mean_pkg.vhd
-VHDL_SOURCES += $(WPWD)/../hdl/mean.vhd
+VHDL_SOURCES = $(PWD)/../hdl/mean_pkg.vhd
+VHDL_SOURCES += $(PWD)/../hdl/mean.vhd
 
 ifeq ($(SIM),questa)
 COMPILE_ARGS = -mixedsvvh

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -15,14 +15,8 @@ TOPLEVEL = endian_swapper_mixed
 
 PWD=$(shell pwd)
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
-VERILOG_SOURCES = $(WPWD)/../../endian_swapper/hdl/endian_swapper.sv
-VHDL_SOURCES    = $(WPWD)/../../endian_swapper/hdl/endian_swapper.vhdl
+VERILOG_SOURCES = $(PWD)/../../endian_swapper/hdl/endian_swapper.sv
+VHDL_SOURCES    = $(PWD)/../../endian_swapper/hdl/endian_swapper.vhdl
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES += $(WPWD)/../hdl/toplevel.sv

--- a/examples/ping_tun_tap/tests/Makefile
+++ b/examples/ping_tun_tap/tests/Makefile
@@ -38,12 +38,6 @@ else
 
 TOPLEVEL = icmp_reply
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
 PWD=$(shell pwd)
 
 VERILOG_SOURCES = $(PWD)/../hdl/icmp_reply.sv

--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -31,13 +31,9 @@ TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL := array_module
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/array_module/array_module.sv

--- a/tests/designs/avalon_module/Makefile
+++ b/tests/designs/avalon_module/Makefile
@@ -39,13 +39,7 @@ else
 
 TOPLEVEL := burst_read_master
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
-
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_module/burst_read_master.v
 

--- a/tests/designs/avalon_streaming_module/Makefile
+++ b/tests/designs/avalon_streaming_module/Makefile
@@ -10,13 +10,9 @@ else
 
 TOPLEVEL := avalon_streaming
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_streaming_module/avalon_streaming.sv
 

--- a/tests/designs/basic_hierarchy_module/Makefile
+++ b/tests/designs/basic_hierarchy_module/Makefile
@@ -14,13 +14,9 @@ else
 
 TOPLEVEL := basic_hierarchy_module
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/basic_hierarchy_module/basic_hierarchy_module.v
 

--- a/tests/designs/close_module/Makefile
+++ b/tests/designs/close_module/Makefile
@@ -39,13 +39,9 @@ else
 
 TOPLEVEL = close_module
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/close_module/close_module.v
 

--- a/tests/designs/multi_dimension_array/Makefile
+++ b/tests/designs/multi_dimension_array/Makefile
@@ -39,13 +39,9 @@ clean::
 
 else
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/multi_dimension_array/cocotb_array_pkg.sv \
                   $(COCOTB)/tests/designs/multi_dimension_array/cocotb_array.sv

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -31,13 +31,9 @@ TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL := tb_top
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/plusargs_module/tb_top.v

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -31,13 +31,9 @@ TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL := sample_module
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/sample_module/sample_module.sv

--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -8,13 +8,9 @@ clean::
 
 else
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 SRC_BASE = $(COCOTB)/tests/designs/uart2bus
 

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -16,13 +16,9 @@ else
 
 TOPLEVEL = testbench
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VHDL_SOURCES = $(COCOTB)/tests/designs/vhdl_configurations/dut.vhd
 ifeq ($(TOPLEVEL_LANG),verilog)

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -37,13 +37,9 @@ else
 
 TOPLEVEL = dec_viterbi_ent
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 SRC_BASE = $(COCOTB)/tests/designs/viterbi_decoder_axi4s
 

--- a/tests/test_cases/test_iteration_verilog/Makefile
+++ b/tests/test_cases/test_iteration_verilog/Makefile
@@ -35,13 +35,9 @@ clean::
 
 else
 
-ifeq ($(OS),Msys)
-WPWD=$(shell sh -c 'pwd -W')
-else
-WPWD=$(shell pwd)
-endif
+PWD=$(shell pwd)
 
-COCOTB?=$(WPWD)/../../..
+COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/examples/endian_swapper/hdl/endian_swapper.sv
 TOPLEVEL = endian_swapper_sv


### PR DESCRIPTION
This PR introduced source paths formatting in Tcl scripts on Windows using `cygpath` 

- It fixes sources paths format in Tcl scripts (questa and aldec) 
- Simplifies the multi-OS support in Makefiles (not required special Windows path construction)
- Cleanup test and examples from unused code
