### PR TITLE
Align Aldec simulators with others based on #1063

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,11 @@ tests/test_cases/*/transcript
 examples/*/tests/modelsim.ini
 examples/*/tests/transcript
 *.wlf
+
+# Riviera
+tests/test_cases/*/library.cfg
+tests/test_cases/*/dataset.asdb
+tests/test_cases/*/compile
+examples/*/tests/library.cfg
+examples/*/tests/dataset.asdb
+examples/*/tests/compile

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -63,7 +63,7 @@ ASIM_ARGS += $(SIM_ARGS)
 # Plusargs need to be passed to ASIM command not vsimsa
 ASIM_ARGS += $(PLUSARGS)
 
-RTL_LIBRARY ?= work
+RTL_LIBRARY ?= $(SIM_BUILD)/work
 ALOG_ARGS += +define+COCOTB_SIM -dbg -pli libgpi
 ACOM_ARGS += -dbg
 
@@ -143,10 +143,13 @@ endif
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(COCOTB_LIBS) $(COCOTB_VHPI_LIB) $(COCOTB_VPI_LIB) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
-	set -o pipefail; cd $(SIM_BUILD) && GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 $(CMD) $(RUN_ARGS) -do runsim.tcl | tee sim.log
+	set -o pipefail; GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
+	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.tcl | tee $(SIM_BUILD)/sim.log
 
 	$(call check_for_results_file)
 
 clean::
 	@rm -rf $(SIM_BUILD)
+	@rm -rf compile
+	@rm -rf library.cfg
+	@rm -rf dataset.asdb


### PR DESCRIPTION
Align based on the discussion in #1063

It is failing at the moment because of the wrong locations of `results.xml` and https://github.com/cocotb/cocotb/pull/1595

Other simulators will follow ...