### PR TITLE
Fix libraries runpath on newer Debian

### DIFF
--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -144,10 +144,12 @@ def _extra_link_args(lib_name=None, rpath=None):
     On Linux use`rpath`
     """
 
+    args = []
     if sys.platform == "darwin" and lib_name is not None:
-        return ["-Wl,-install_name,@rpath/%s.so" % lib_name]
-    elif sys.platform == "linux" and rpath is not None:
-        return ["-Wl,-rpath,%s" % rpath]
+        args += ["-Wl,-install_name,@rpath/%s.so" % lib_name]
+    if rpath is not None:
+        args += ["-Wl,-rpath,%s" % rpath]
+    return args
     else:
         return []
 

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -137,14 +137,17 @@ class build_ext(_build_ext):
                 )
 
 
-def _extra_link_args(lib_name):
+def _extra_link_args(lib_name=None, rpath=None):
     """
-    Add linker `install_name` argument on osx to load dependencies from the directory
-    where vpi/vhpi/fli library is located
+    Add linker argument to load dependencies from the directory where vpi/vhpi/fli library is located
+    On osx use`install_name`
+    On Linux use`rpath`
     """
 
-    if sys.platform == "darwin":
+    if sys.platform == "darwin" and lib_name is not None:
         return ["-Wl,-install_name,@rpath/%s.so" % lib_name]
+    elif sys.platform == "linux" and rpath is not None:
+        return ["-Wl,-rpath,%s" % rpath]
     else:
         return []
 
@@ -201,7 +204,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         os.path.join("cocotb", "libs", "libcocotbutils"),
         include_dirs=[include_dir],
         sources=[os.path.join(share_lib_dir, "utils", "cocotb_utils.cpp")],
-        extra_link_args=_extra_link_args("libcocotbutils"),
+        extra_link_args=_extra_link_args(lib_name="libcocotbutils", rpath="$ORIGIN"),
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -218,7 +221,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         libraries=["cocotbutils"],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "gpi_log", "gpi_logging.cpp")],
-        extra_link_args=_extra_link_args("libgpilog"),
+        extra_link_args=_extra_link_args(lib_name="libgpilog", rpath="$ORIGIN"),
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -232,7 +235,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         libraries=[_get_python_lib_link(), "gpilog", "cocotbutils"],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "embed", "gpi_embed.cpp")],
-        extra_link_args=_extra_link_args("libcocotb"),
+        extra_link_args=_extra_link_args(lib_name="libcocotb", rpath="$ORIGIN"),
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -248,7 +251,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
             os.path.join(share_lib_dir, "gpi", "GpiCbHdl.cpp"),
             os.path.join(share_lib_dir, "gpi", "GpiCommon.cpp"),
         ],
-        extra_link_args=_extra_link_args("libgpi"),
+        extra_link_args=_extra_link_args(lib_name="libgpi", rpath="$ORIGIN"),
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -262,7 +265,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "simulator", "simulatormodule.cpp")],
         extra_compile_args=_extra_cxx_compile_args,
-        extra_link_args=["-Wl,-rpath,$ORIGIN/libs"],
+        extra_link_args=_extra_link_args(rpath="$ORIGIN/libs"),
     )
 
     return [libcocotbutils, libgpilog, libcocotb, libgpi, libsim]
@@ -281,7 +284,7 @@ def _get_vpi_lib_ext(
             os.path.join(share_lib_dir, "vpi", "VpiImpl.cpp"),
             os.path.join(share_lib_dir, "vpi", "VpiCbHdl.cpp"),
         ],
-        extra_link_args=["-Wl,-rpath,$ORIGIN"],
+        extra_link_args=_extra_link_args(rpath="$ORIGIN"),
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -301,7 +304,7 @@ def _get_vhpi_lib_ext(
             os.path.join(share_lib_dir, "vhpi", "VhpiImpl.cpp"),
             os.path.join(share_lib_dir, "vhpi", "VhpiCbHdl.cpp"),
         ],
-        extra_link_args=["-Wl,-rpath,$ORIGIN"],
+        extra_link_args=_extra_link_args(rpath="$ORIGIN"),
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -383,7 +386,7 @@ def get_ext():
                     os.path.join(share_lib_dir, "fli", "FliCbHdl.cpp"),
                     os.path.join(share_lib_dir, "fli", "FliObjHdl.cpp"),
                 ],
-                extra_link_args=["-Wl,-rpath,$ORIGIN"],
+                extra_link_args=_extra_link_args(rpath="$ORIGIN"),
                 extra_compile_args=_extra_cxx_compile_args,
             )
 

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -150,8 +150,6 @@ def _extra_link_args(lib_name=None, rpath=None):
     if rpath is not None:
         args += ["-Wl,-rpath,%s" % rpath]
     return args
-    else:
-        return []
 
 
 def _get_python_lib_link():

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -140,7 +140,7 @@ class build_ext(_build_ext):
 def _extra_link_args(lib_name=None, rpath=None):
     """
     Add linker argument to load dependencies from the directory where vpi/vhpi/fli library is located
-    On osx use`install_name`
+    On osx use `install_name`.
     On Linux use`rpath`
     """
 

--- a/cocotb/_build_libs.py
+++ b/cocotb/_build_libs.py
@@ -141,7 +141,7 @@ def _extra_link_args(lib_name=None, rpath=None):
     """
     Add linker argument to load dependencies from the directory where vpi/vhpi/fli library is located
     On osx use `install_name`.
-    On Linux use`rpath`
+    Use `rpath` on all platforms
     """
 
     args = []


### PR DESCRIPTION
Due to changes in Debian (default `--enable-new-dtagshas`), `rpath` has to be set on dependent libraries.
See: https://stackoverflow.com/questions/52018092/how-to-set-rpath-and-runpath-with-gcc-ld
