### PR TITLE
Pin breathe to unbreak CI

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -4,10 +4,13 @@
 # merged and released.
 Sphinx~=2.1
 
+# 4.15 depends on sphinx 3.0.0, but for some reason ReadTheDocs tries to install
+# it anyway.
+breathe < 4.15
+
 # other dependencies
 sphinx-rtd-theme
 cairosvg
-breathe
 sphinxcontrib-makedomain
 sphinxcontrib-spelling
 pyenchant


### PR DESCRIPTION
Breathe 4.15 depends on Sphinx 3.0.0, and Sphinx 3.0.0 is incompatible with sphinxcontrib-makedomain until an upstream fix is merged (#1577).

I don't know why we need to pin breathe, pip is supposed to work that out for us.
Either way, this is harmless as long as we remember to eventually unpin both.

Fixes #1603

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
