### PR TITLE
Clean up leftover uses of WPWD

### DIFF
--- a/examples/endian_swapper/tests/Makefile
+++ b/examples/endian_swapper/tests/Makefile
@@ -32,19 +32,13 @@ TOPLEVEL_LANG ?= verilog
 
 PWD=$(shell pwd)
 
-ifeq ($(OS),Msys)
-    WPWD=$(shell cygpath -m "$(PWD)")
-else
-    WPWD=$(PWD)
-endif
-
 export PYTHONPATH := $(PWD)/../cosim:$(PYTHONPATH)
 
 ifeq ($(TOPLEVEL_LANG),verilog)
-    VERILOG_SOURCES = $(WPWD)/../hdl/endian_swapper.sv
+    VERILOG_SOURCES = $(PWD)/../hdl/endian_swapper.sv
     TOPLEVEL = endian_swapper_sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    VHDL_SOURCES = $(WPWD)/../hdl/endian_swapper.vhdl
+    VHDL_SOURCES = $(PWD)/../hdl/endian_swapper.vhdl
     TOPLEVEL = endian_swapper_vhdl
     ifneq ($(filter $(SIM),ius xcelium),)
         SIM_ARGS += -v93

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -20,7 +20,7 @@ ifeq ($(SIM),questa)
 COMPILE_ARGS = -mixedsvvh
 endif
 
-VERILOG_SOURCES = $(WPWD)/../hdl/mean_sv.sv
+VERILOG_SOURCES = $(PWD)/../hdl/mean_sv.sv
 
 MODULE := test_mean
 

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -19,10 +19,10 @@ VERILOG_SOURCES = $(PWD)/../../endian_swapper/hdl/endian_swapper.sv
 VHDL_SOURCES    = $(PWD)/../../endian_swapper/hdl/endian_swapper.vhdl
 
 ifeq ($(TOPLEVEL_LANG),verilog)
-    VERILOG_SOURCES += $(WPWD)/../hdl/toplevel.sv
+    VERILOG_SOURCES += $(PWD)/../hdl/toplevel.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     $(error "VHDL toplevel not yet implemented")
-    VHDL_SOURCES += $(WPWD)/../hdl/toplevel.vhdl
+    VHDL_SOURCES += $(PWD)/../hdl/toplevel.vhdl
 else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif


### PR DESCRIPTION
These were missed in #1596, but for some reason CI didn't care.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
