### PR TITLE
Fix handling of escaped identifiers containing dots

### DIFF
--- a/docs/source/newsfragments/1610.bugfix.rst
+++ b/docs/source/newsfragments/1610.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes handling of escaped identifiers containing characters that are special in regular expressions (e.g. dots).

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -477,7 +477,7 @@ class HierarchyObject(HierarchyObjectBase[str]):
         return f"{self._path}{delimiter}{name}"
 
     def _sub_handle_key(self, name: str) -> str:
-        return name.rsplit(".", 1)[-1]
+        return name
 
     def _get_handle_by_key(self, key: str) -> Optional[simulator.gpi_sim_hdl]:
         return self._handle.get_handle_by_name(key)
@@ -529,11 +529,13 @@ class HierarchyArrayObject(HierarchyObjectBase[int], RangeableObjectMixin):
         # FLI and VHPI:       _name(X) where X is the index
         # VHPI(ALDEC):        _name__X where X is the index
         # VPI:                _name[X] where X is the index
-        result = re.match(rf"{self._name}__(?P<index>\d+)$", name)
+        result = re.match(rf"{re.escape(self._name)}__(?P<index>\d+)$", name)
         if not result:
-            result = re.match(rf"{self._name}\((?P<index>\d+)\)$", name, re.IGNORECASE)
+            result = re.match(
+                rf"{re.escape(self._name)}\((?P<index>\d+)\)$", name, re.IGNORECASE
+            )
         if not result:
-            result = re.match(rf"{self._name}\[(?P<index>\d+)\]$", name)
+            result = re.match(rf"{re.escape(self._name)}\[(?P<index>\d+)\]$", name)
 
         if result:
             return int(result.group("index"))

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -248,4 +248,12 @@ always @(mybits_uninitialized) begin
     $display("%m: mybits_uninitialized has been updated, new value is %b", mybits_uninitialized);
 end
 
+// for testing weird signal names
+reg [3:0] \weird.signal[1] = 0;
+reg [3:0] \weird.signal[2] = 0;
+reg [3:0] \(.*|this_looks_like_a_regex) = 0;
+
+// just to check that extended identifiers are the same as non-extended ones
+always@* \weird.signal[1] [0] = \stream_in_valid ;
+
 endmodule

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -103,6 +103,11 @@ architecture impl of sample_module is
 
     signal stream_in_string_asciival_sum : natural;
 
+    -- for testing weird signal names
+    signal \weird.signal(1)\              : std_ulogic_vector(3 downto 0);
+    signal \weird.signal(2)\              : std_ulogic_vector(3 downto 0);
+    signal \(.*|this looks like a regex)\ : std_ulogic_vector(3 downto 0);
+
 begin
 
     genblk1: for i in NUM_OF_MODULES - 1 downto 0 generate

--- a/tests/test_cases/issue_2255/test_issue2255.py
+++ b/tests/test_cases/issue_2255/test_issue2255.py
@@ -2,8 +2,6 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import logging
-
 import cocotb
 
 
@@ -20,13 +18,5 @@ import cocotb
     else ()
 )
 async def test_distinct_generates(dut):
-    tlog = logging.getLogger("cocotb.test")
-
-    foobar = dut.foobar
-    foo = dut.foo
-
-    tlog.info("Length of foobar is %d", len(foobar))
-    tlog.info("Length of foo is %d", len(foo))
-
-    assert len(foobar) == 10
-    assert len(foo) == 6
+    assert len(dut.foobar) == 10
+    assert len(dut.foo) == 6

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -302,7 +302,7 @@ async def test_discover_all(dut):
         pass_total = 180
     elif LANGUAGE in ["verilog"] and "vcs" in SIM_NAME:
         # VCS is unable to access signals in generate loops through VPI (#4328).
-        pass_total = 142
+        pass_total = 172
     elif LANGUAGE in ["vhdl"]:
         pass_total = 244
     else:


### PR DESCRIPTION
Needs tests.

Fixes #1548, probably.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
