### PR TITLE
Deprecate VERILATOR_TRACE with doc reference

### DIFF
--- a/cocotb/share/makefiles/Makefile.deprecations
+++ b/cocotb/share/makefiles/Makefile.deprecations
@@ -3,5 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 ifdef COCOTB_NVC_TRACE
-   $(warning COCOTB_NVC_TRACE is deprecated, see the "Simulator Support" section in the documentation.)
+    $(warning COCOTB_NVC_TRACE is deprecated, see the "Simulator Support" section in the documentation.)
+endif
+
+ifdef VERILATOR_TRACE
+    $(warning VERILATOR_TRACE is deprecated, see the "Simulator Support" section in the documentation.)
 endif

--- a/documentation/source/newsfragments/1495.removal.rst
+++ b/documentation/source/newsfragments/1495.removal.rst
@@ -1,5 +1,5 @@
-The makefile variable
-:make:var:`COCOTB_NVC_TRACE`
-that was not supported for all simulators has been deprecated.
-Using it prints a deprecation warning and points to documentation (:ref:`simulator-support`)
-explaining how to replace it by other means.
+The makefile variables
+:make:var:`COCOTB_NVC_TRACE`, :make:var:`VERILATOR_TRACE`
+that were not supported for all simulators have been deprecated.
+Using them prints a deprecation warning and points to the documentation section
+:ref:`simulator-support` explaining how to get the same effect by other means.


### PR DESCRIPTION
The documentation itself is handled by #1607.
Refs #1495.