### PR TITLE
Add tests for getting and setting `BinaryValue.buff`

### DIFF
--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -256,7 +256,7 @@ def test_buff_big_endian():
     assert v.buff == orig_bytes
     assert v.binstr == orig_str
 
-    # extra bits are stripped
+    # extra bits are stripped because they don't fit into the 12 bits
     v.buff = b'\xF6\xC9'
     assert v.buff == orig_bytes
     assert v.binstr == orig_str
@@ -274,7 +274,7 @@ def test_buff_little_endian():
     assert v.buff == orig_bytes
     assert v.binstr == orig_str
 
-    # extra bits are stripped
+# extra bits are stripped because they don't fit into the 12 bits
     v.buff = b'\xC9\xF6'
     assert v.buff == orig_bytes
     assert v.binstr == orig_str

--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -242,3 +242,39 @@ def test_backwards_compatibility():
 
     with pytest.raises(TypeError):
         BinaryValue(value=0, bits=16, n_bits=17)
+
+
+def test_buff_big_endian():
+    orig_str = "011011001001"
+    orig_bytes = b'\x06\xC9'  # padding is the high bits of the first byte
+
+    v = BinaryValue(value=orig_str, n_bits=12, bigEndian=True)
+    assert v.buff == orig_bytes
+
+    # should be unchanged
+    v.buff = orig_bytes
+    assert v.buff == orig_bytes
+    assert v.binstr == orig_str
+
+    # extra bits are stripped
+    v.buff = b'\xF6\xC9'
+    assert v.buff == orig_bytes
+    assert v.binstr == orig_str
+
+
+def test_buff_little_endian():
+    orig_str = "011011001001"
+    orig_bytes = b'\xC9\x06'  # padding is the high bits of the last byte
+
+    v = BinaryValue(value=orig_str, n_bits=12, bigEndian=False)
+    assert v.buff == orig_bytes
+
+    # should be unchanged
+    v.buff = orig_bytes
+    assert v.buff == orig_bytes
+    assert v.binstr == orig_str
+
+    # extra bits are stripped
+    v.buff = b'\xC9\xF6'
+    assert v.buff == orig_bytes
+    assert v.binstr == orig_str


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
