### PR TITLE
Remove dependency on Makfiles in endian_swapper

### DIFF
--- a/examples/endian_swapper/cosim/Makefile
+++ b/examples/endian_swapper/cosim/Makefile
@@ -1,30 +1,34 @@
-include $(shell cocotb-config --makefiles)/Makefile.inc
-include $(shell cocotb-config --makefiles)/Makefile.pylib
+PYTHON_BIN ?= $(realpath $(shell cocotb-config --python-bin))
 
-PYTHON_LIBDIR ?= /usr/lib64
-SWIG ?= swig
-CC=gcc
-ifeq ($(ARCH),i686)
-	CC += -m32
+PYTHON_LIBDIR := $(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; print( sysconfig.get_config_var("LIBDIR") )')
+ifeq ($(PYTHON_LIBDIR),None)
+    PYTHON_LIBDIR := $(shell dirname $(PYTHON_BIN))/libs
 endif
 
+PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_inc() )')
+
+SWIG ?= swig
+CC ?= gcc
+
+OS := $(shell uname)
+
 ifeq ($(OS),Darwin)
-PYTHON_LD_FLAGS += -undefined dynamic_lookup
+    CFLAGS += -undefined dynamic_lookup
 endif
 
 .PHONY: all
 all: io_module.so _hal.so
 
 io_module.o: io.c io_module.h io.h
-	$(CC) $(GCC_FLAGS) -fPIC -pthread -fno-strict-aliasing -O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 \
+	$(CC) $(CFLAGS) -fPIC -pthread -fno-strict-aliasing -O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 \
 	-fexceptions --param=ssp-buffer-size=4 -D_GNU_SOURCE \
 	-fwrapv -DNDEBUG -I$(PYTHON_INCLUDEDIR) -c $< -o $@
 
 io_module.so: io_module.o
-	$(CC) -pthread -shared  $< -L$(PYTHON_LIBDIR) $(PYTHON_LD_FLAGS) -o $@
+	$(CC) $(CFLAGS) -pthread -shared  $< -L$(PYTHON_LIBDIR)  -o $@
 
 _hal.so: ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so
-	$(CC) -g -ldl -shared -fPIC -I$(shell pwd) $(PYTHON_LD_FLAGS) -I$(PYTHON_INCLUDEDIR) -I../hal ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so -o $@
+	$(CC) $(CFLAGS) -g -ldl -shared -fPIC -I$(shell pwd) -I$(PYTHON_INCLUDEDIR) -I../hal ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so -o $@
 	if [ $(OS) = Darwin ]; then \
 		install_name_tool -change io_module.so $(shell pwd)/io_module.so $@; \
 	fi


### PR DESCRIPTION
Gives the ability to simplify Makefiles (remove pylib Makefiles).

Remove dependency on cocotb Makefiles in endian_swapper (test_endian_swapper_hal) example.
Cleanup.