### PR TITLE
Fix weird indentationn in sample_module

### DIFF
--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -93,8 +93,8 @@ test_if struct_var;
 and test_and_gate(and_output, stream_in_ready, stream_in_valid);
 
 initial begin
-     $dumpfile("waveform.vcd");
-     $dumpvars(0,sample_module);
+    $dumpfile("waveform.vcd");
+    $dumpvars(0,sample_module);
 
 //   TODO: Move into a separate test
 //     #500000 $fail_test("Test timed out, failing...");
@@ -104,11 +104,11 @@ reg[3:0] temp;
 parameter NUM_OF_MODULES = 4;
 genvar idx;
 generate
-for (idx = 0; idx < NUM_OF_MODULES; idx=idx+1) begin
-    always @(posedge clk) begin
-        temp[idx] <= 1'b0;
+    for (idx = 0; idx < NUM_OF_MODULES; idx=idx+1) begin
+        always @(posedge clk) begin
+            temp[idx] <= 1'b0;
+        end
     end
-end
 endgenerate
 
 reg [7:0] register_array [1:0];

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -66,74 +66,74 @@ end;
 
 architecture impl of sample_module is
 
-  component sample_module_1 is
-  generic (
-    EXAMPLE_STRING      : string;
-    EXAMPLE_BOOL        : boolean;
-    EXAMPLE_WIDTH       : integer
-    );
-    port (
-        clk                             : in    std_ulogic;
-        stream_in_data                  : in    std_ulogic_vector(EXAMPLE_WIDTH downto 0);
-        stream_out_data_registered      : buffer   std_ulogic_vector(EXAMPLE_WIDTH downto 0);
-        stream_out_data_valid           : out   std_ulogic
-    );
-end component sample_module_1;
+    component sample_module_1 is
+        generic (
+            EXAMPLE_STRING      : string;
+            EXAMPLE_BOOL        : boolean;
+            EXAMPLE_WIDTH       : integer
+        );
+        port (
+            clk                             : in    std_ulogic;
+            stream_in_data                  : in    std_ulogic_vector(EXAMPLE_WIDTH downto 0);
+            stream_out_data_registered      : buffer   std_ulogic_vector(EXAMPLE_WIDTH downto 0);
+            stream_out_data_valid           : out   std_ulogic
+        );
+    end component sample_module_1;
 
-  type lutType is array (0 to 3, 0 to 6) of signed(10 downto 0);
+    type lutType is array (0 to 3, 0 to 6) of signed(10 downto 0);
 
-function afunc(value : std_ulogic_vector) return std_ulogic_vector is
-    variable i: integer;
-    variable rv: std_ulogic_vector(7 downto 0);
+    function afunc(value : std_ulogic_vector) return std_ulogic_vector is
+        variable i: integer;
+        variable rv: std_ulogic_vector(7 downto 0);
+    begin
+        i := 0;
+        while i <= 7 loop
+            rv(i) := value(7-i);
+            i := i + 1;
+        end loop;
+        return rv;
+    end afunc;
+
+    signal cosLut0, sinLut0 : lutType;
+    signal cosLut1, sinLut1 : lutType;
+    signal cosLut,  sinLut  : lutType;
+
+    type unsignedArrayType is array (natural range <>) of unsigned(7 downto 0);
+    signal array_7_downto_4 : unsignedArrayType(7 downto 4);
+    signal array_4_to_7     : unsignedArrayType(4 to 7);
+    signal array_3_downto_0 : unsignedArrayType(3 downto 0);
+    signal array_0_to_3     : unsignedArrayType(0 to 3);
+
+    type twoDimArrayType is array (natural range <>) of unsignedArrayType(31 downto 28);
+    signal array_2d         : twoDimArrayType(0 to 1);
+
 begin
-    i := 0;
-    while i <= 7 loop
-        rv(i) := value(7-i);
-        i := i + 1;
-    end loop;
-    return rv;
-end afunc;
 
-  signal cosLut0, sinLut0 : lutType;
-  signal cosLut1, sinLut1 : lutType;
-  signal cosLut,  sinLut  : lutType;
+    process (clk) begin
+        if rising_edge(clk) then
+            stream_out_data_registered <= stream_in_data;
+        end if;
+    end process;
 
-  type unsignedArrayType is array (natural range <>) of unsigned(7 downto 0);
-  signal array_7_downto_4 : unsignedArrayType(7 downto 4);
-  signal array_4_to_7     : unsignedArrayType(4 to 7);
-  signal array_3_downto_0 : unsignedArrayType(3 downto 0);
-  signal array_0_to_3     : unsignedArrayType(0 to 3);
+    stream_out_data_comb <= afunc(stream_in_data) when stream_in_func_en = '0' else stream_in_data;
+    stream_in_ready      <= stream_out_ready;
+    stream_out_real      <= stream_in_real;
+    stream_out_int       <= stream_in_int;
+    stream_out_string    <= stream_in_string;
+    stream_out_bool      <= stream_in_bool;
+    stream_out_data_wide(3 downto 2) <= stream_in_data_wide(3 downto 2);
 
-  type twoDimArrayType is array (natural range <>) of unsignedArrayType(31 downto 28);
-  signal array_2d         : twoDimArrayType(0 to 1);
-
-begin
-
-process (clk) begin
-    if rising_edge(clk) then
-        stream_out_data_registered <= stream_in_data;
-    end if;
-end process;
-
-stream_out_data_comb <= afunc(stream_in_data) when stream_in_func_en = '0' else stream_in_data;
-stream_in_ready      <= stream_out_ready;
-stream_out_real      <= stream_in_real;
-stream_out_int       <= stream_in_int;
-stream_out_string    <= stream_in_string;
-stream_out_bool      <= stream_in_bool;
-stream_out_data_wide(3 downto 2) <= stream_in_data_wide(3 downto 2);
-
-isample_module1 : component sample_module_1
-      generic map (
-        EXAMPLE_STRING  => "TESTING",
-        EXAMPLE_BOOL => true,
-      	EXAMPLE_WIDTH	=> 7
+    isample_module1 : component sample_module_1
+        generic map (
+            EXAMPLE_STRING => "TESTING",
+            EXAMPLE_BOOL => true,
+            EXAMPLE_WIDTH => 7
         )
-  port map (
-  clk => clk,
-  stream_in_data => stream_in_data,
-  stream_out_data_registered => open,
-  stream_out_data_valid => open
-  );
+        port map (
+            clk => clk,
+            stream_in_data => stream_in_data,
+            stream_out_data_registered => open,
+            stream_out_data_valid => open
+        );
 
 end architecture;

--- a/tests/designs/sample_module/sample_module_1.vhdl
+++ b/tests/designs/sample_module/sample_module_1.vhdl
@@ -4,33 +4,33 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 entity sample_module_1 is
-  generic (
-    EXAMPLE_STRING      : string;
-    EXAMPLE_BOOL        : boolean;
-    EXAMPLE_WIDTH       : integer
+    generic (
+        EXAMPLE_STRING      : string;
+        EXAMPLE_BOOL        : boolean;
+        EXAMPLE_WIDTH       : integer
     );
     port (
-        clk                             : in    std_ulogic;
-        stream_in_data                  : in    std_ulogic_vector(EXAMPLE_WIDTH downto 0);
-        stream_out_data_registered      : buffer   std_ulogic_vector(EXAMPLE_WIDTH downto 0);
-        stream_out_data_valid           : out   std_ulogic
+        clk                             : in     std_ulogic;
+        stream_in_data                  : in     std_ulogic_vector(EXAMPLE_WIDTH downto 0);
+        stream_out_data_registered      : buffer std_ulogic_vector(EXAMPLE_WIDTH downto 0);
+        stream_out_data_valid           : out    std_ulogic
     );
 end;
 
 architecture impl of sample_module_1 is
 begin
-  process (clk) begin
-    if rising_edge(clk) then
-        stream_out_data_registered <= stream_in_data;
-    end if;
-  end process;
+    process (clk) begin
+        if rising_edge(clk) then
+            stream_out_data_registered <= stream_in_data;
+        end if;
+    end process;
 
-  stream_out_data_valid  <= '1' when (stream_out_data_registered(EXAMPLE_WIDTH) = '1') else '0';
+    stream_out_data_valid  <= '1' when (stream_out_data_registered(EXAMPLE_WIDTH) = '1') else '0';
 
-  SAMPLE_BLOCK : block
-    signal clk_inv : std_ulogic;
-  begin
-    clk_inv <= not clk;
-  end block;
+    SAMPLE_BLOCK : block
+        signal clk_inv : std_ulogic;
+    begin
+        clk_inv <= not clk;
+    end block;
 
 end architecture;


### PR DESCRIPTION
This was a weird mix of 2-space, 4-space, and plain nonsensical indentation.

I've basically never written any VHDL, but this formatting seems to match the semantic structure a little better.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
