### PR TITLE
Rearrange Makefiles

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -29,6 +29,19 @@
 
 # Common makefile included by everything
 
+ifndef COCOTB_MAKEFILE_INC_INCLUDED # Protect against multiple includes
+COCOTB_MAKEFILE_INC_INCLUDED = 1
+
+# Default sim rule will force a re-run of the simulation (though the cocotb library
+# and RTL compilation phases are still evaluated by makefile dependencies)
+.PHONY: sim
+sim:
+	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(MAKE) $(COCOTB_RESULTS_FILE)
+
+# Make sure to use bash for the pipefail option used in many simulator Makefiles
+SHELL := bash
+
 # Directory containing the cocotb Python module (realpath for Windows compatibility)
 COCOTB_PY_DIR := $(realpath $(shell cocotb-config --prefix))
 
@@ -38,9 +51,9 @@ COCOTB_SHARE_DIR := $(COCOTB_PY_DIR)/cocotb/share
 
 OS=$(shell uname)
 ifneq (, $(findstring MINGW, $(OS)))
-OS=Msys
+    OS := Msys
 else ifneq (, $(findstring MSYS, $(OS)))
-OS=Msys
+    OS := Msys
 endif
 export OS
 
@@ -50,27 +63,12 @@ PYTHON_BIN ?= $(realpath $(shell cocotb-config --python-bin))
 
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.deprecations
 
-# Default to Icarus if no simulator is defined
-SIM ?= icarus
-
-SIM_DEFINE := $(shell echo $(SIM) | tr a-z A-Z)
-
-# Use a common define for Questa and Modelsim and cvc
-ifeq ($(SIM_DEFINE),$(filter $(SIM_DEFINE),QUESTA CVC))
-SIM_DEFINE = MODELSIM
-endif
-
-# Use a common define for Xcelium and IUS
-ifeq ($(SIM_DEFINE),XCELIUM)
-SIM_DEFINE = IUS
-endif
-
 LIB_DIR=$(COCOTB_PY_DIR)/cocotb/libs
 
 ifeq ($(OS),Msys)
-LIB_EXT    := dll
+    LIB_EXT := dll
 else
-LIB_EXT    := so
+    LIB_EXT := so
 endif
 
 PYTHON_ARCH := $(shell $(PYTHON_BIN) -c 'from platform import architecture; print(architecture()[0])')
@@ -92,3 +90,33 @@ ifeq ($(OS),Msys)
 else
     to_tcl_path = $(1)
 endif
+
+# Check that the COCOTB_RESULTS_FILE was created, since we can't set an exit code from cocotb.
+define check_for_results_file
+    @test -f $(COCOTB_RESULTS_FILE) || (echo "ERROR: $(COCOTB_RESULTS_FILE) was not written by the simulation!" >&2 && exit 1)
+endef
+
+SIM_BUILD ?= sim_build
+export SIM_BUILD
+
+COCOTB_RESULTS_FILE ?= results.xml
+COCOTB_HDL_TIMEUNIT ?= 1ns
+COCOTB_HDL_TIMEPRECISION ?= 1ps
+
+# Depend on all Python from the cocotb package. This triggers a
+# recompilation of the simulation if cocotb is updated.
+CUSTOM_SIM_DEPS += $(shell find $(COCOTB_PY_DIR)/cocotb/ -name "*.py")
+
+# This triggers a recompilation of the simulation if cocotb library is updated.
+CUSTOM_SIM_DEPS += $(shell find $(LIB_DIR)/ -name "*")
+
+$(SIM_BUILD):
+	mkdir -p $@
+
+# Regression rule uses Make dependencies to determine whether to run the simulation
+.PHONY: regression
+regression: $(COCOTB_RESULTS_FILE)
+
+else
+    $(warning "Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.")
+endif # COCOTB_MAKEFILE_INC_INCLUDED

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -27,11 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-# This is a simple wrapper Makefile to pull in the appropriate Makefile for
-# the desired simulator and set up common paths for the sims to use to build with
-
-# Make sure to use bash for the pipefail option used in many simulator Makefiles
-SHELL := bash
+# This file includes an appropriate makefile depending on the SIM variable.
 
 .PHONY: all
 all: sim
@@ -94,59 +90,46 @@ endef
 
 # this cannot be a regular target because of the way Makefile.$(SIM) is included
 ifeq ($(MAKECMDGOALS),help)
-_VERSION := $(shell cocotb-config -v)
-# for non-intuitive use of ifneq see https://www.gnu.org/software/make/manual/make.html#Testing-Flags
-ifneq (,$(findstring dev,$(_VERSION)))
-DOCLINK := https://cocotb.readthedocs.io/en/latest/building.html
-else
-DOCLINK := https://cocotb.readthedocs.io/en/v$(_VERSION)/building.html
-endif
-$(info $(helpmsg))
-# is there a cleaner way to exit here?
-$(error "Stopping after printing help")
+    _VERSION := $(shell cocotb-config -v)
+    # for non-intuitive use of ifneq see https://www.gnu.org/software/make/manual/make.html#Testing-Flags
+    ifneq (,$(findstring dev,$(_VERSION)))
+        DOCLINK := https://cocotb.readthedocs.io/en/latest/building.html
+    else
+        DOCLINK := https://cocotb.readthedocs.io/en/v$(_VERSION)/building.html
+    endif
+    $(info $(helpmsg))
+    # is there a cleaner way to exit here?
+    $(error "Stopping after printing help")
 endif
 
-SIM_BUILD ?= sim_build
-export SIM_BUILD
+# Default to Icarus if no simulator is defined
+SIM ?= icarus
 
-COCOTB_RESULTS_FILE ?= results.xml
-COCOTB_HDL_TIMEUNIT ?= 1ns
-COCOTB_HDL_TIMEPRECISION ?= 1ps
+SIM_DEFINE := $(shell echo $(SIM) | tr a-z A-Z)
+
+# Use a common define for Questa and Modelsim and cvc
+ifeq ($(SIM_DEFINE),$(filter $(SIM_DEFINE),QUESTA CVC))
+    SIM_DEFINE = MODELSIM
+endif
+
+# Use a common define for Xcelium and IUS
+ifeq ($(SIM_DEFINE),XCELIUM)
+    SIM_DEFINE = IUS
+endif
 
 # Maintain backwards compatibility by supporting upper and lower case SIM variable
 SIM_LOWERCASE := $(shell echo $(SIM) | tr A-Z a-z)
 
-HAVE_SIMULATOR = $(shell if [ -f $(COCOTB_SHARE_DIR)/makefiles/simulators/Makefile.$(SIM_LOWERCASE) ]; then echo 1; else echo 0; fi;)
-AVAILABLE_SIMULATORS = $(patsubst .%,%,$(suffix $(wildcard $(COCOTB_SHARE_DIR)/makefiles/simulators/Makefile.*)))
+# Directory containing the cocotb Makfiles (realpath for Windows compatibility)
+COCOTB_MAKEFILES_DIR := $(realpath $(shell cocotb-config --makefiles))
+
+include $(COCOTB_MAKEFILES_DIR)/Makefile.deprecations
+
+HAVE_SIMULATOR = $(shell if [ -f $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.$(SIM_LOWERCASE) ]; then echo 1; else echo 0; fi;)
+AVAILABLE_SIMULATORS = $(patsubst .%,%,$(suffix $(wildcard $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.*)))
 
 ifeq ($(HAVE_SIMULATOR),0)
     $(error "Couldn't find makefile for simulator: "$(SIM_LOWERCASE)"! Available simulators: $(AVAILABLE_SIMULATORS)")
 endif
 
-# Depend on all Python from the cocotb package. This triggers a
-# recompilation of the simulation if cocotb is updated.
-CUSTOM_SIM_DEPS += $(shell find $(COCOTB_PY_DIR)/cocotb/ -name "*.py")
-
-# This triggers a recompilation of the simulation if cocotb library is updated.
-CUSTOM_SIM_DEPS += $(shell find $(LIB_DIR)/ -name "*")
-
-include $(COCOTB_SHARE_DIR)/makefiles/simulators/Makefile.$(SIM_LOWERCASE)
-
-# Check that the COCOTB_RESULTS_FILE was created, since we can't set an exit code from cocotb.
-define check_for_results_file
-    @test -f $(COCOTB_RESULTS_FILE) || (echo "ERROR: $(COCOTB_RESULTS_FILE) was not written by the simulation!" >&2 && exit 1)
-endef
-
-$(SIM_BUILD):
-	mkdir -p $@
-
-# Regression rule uses Make dependencies to determine whether to run the simulation
-.PHONY: regression
-regression: $(COCOTB_RESULTS_FILE)
-
-# Default sim rule will force a re-run of the simulation (though the cocotb library
-# and RTL compilation phases are still evaluated by makefile dependencies)
-.PHONY: sim
-sim:
-	-@rm -f $(COCOTB_RESULTS_FILE)
-	$(MAKE) $(COCOTB_RESULTS_FILE)
+include $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.$(SIM_LOWERCASE)

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -4,6 +4,8 @@
 
 # Common Makefile for the Aldec Active-HDL simulator
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 CMD_BIN := vsimsa
 
 ifdef ACTIVEHDL_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -29,6 +29,8 @@
 
 # Common Makefile for Aldec Riviera-PRO simulator
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 ifeq ($(GUI),1)
     CMD_BIN := riviera
 else

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -25,6 +25,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 ifneq ($(VHDL_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -26,6 +26,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 ifneq ($(VERILOG_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -27,6 +27,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 ifneq ($(VHDL_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -29,6 +29,8 @@
 
 # Common Makefile for Cadence Incisive
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 CMD_BIN := irun
 
 ifdef IUS_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -1,5 +1,7 @@
 # -*- mode: makefile-gmake -*-
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 ifneq ($(VERILOG_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -27,6 +27,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 CMD_BIN := vsim
 
 ifdef MODELSIM_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -27,6 +27,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 ifneq ($(VHDL_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -2,6 +2,8 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 ifneq ($(VHDL_SOURCES),)
 
 results.xml:

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -27,6 +27,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+include $(shell cocotb-config --makefiles)/Makefile.inc
+
 # Common Makefile for Cadence Xcelium
 
 CMD_BIN := xrun

--- a/documentation/source/newsfragments/1629.feature.rst
+++ b/documentation/source/newsfragments/1629.feature.rst
@@ -1,0 +1,1 @@
+Including ``Makefile.inc`` from user makefiles is now a no-op and deprecated. Lines like  ``include $(shell cocotb-config --makefiles)/Makefile.inc`` can be removed from user makefiles without loss in functionality.


### PR DESCRIPTION
### Changes:
- Move all "logic" to `Makefile.inc`
- `Makefile.sim` serves only to include appropriate simulator Makefile depending on `SIM` environmental variable
- Include `Makefile.inc` in every simulator Makefile

### Consequences:
- Users need to include **ONLY** : `include $(shell cocotb-config --makefiles)/Makefile.sim`
- Users can create/copy any of simulator Makefiles, modify as needed and include instead of `Makefile.sim`. This way can easily use custom/advanced configuration/options and **cocotb does not need to support them**.
- Backward compatibility is kept.

Update of examples, tests and documentation will follow.