### PR TITLE
Add FOSSi Foundation to Contributors section

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -69,7 +69,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'cocotb'
-copyright = '2014-{0}, PotentialVentures'.format(datetime.datetime.now().year)
+copyright = '2014-{0}, cocotb contributors'.format(datetime.datetime.now().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -242,7 +242,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'cocotb.tex', 'cocotb Documentation',
-   'PotentialVentures', 'manual'),
+   'cocotb contributors', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -272,7 +272,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'cocotb', 'cocotb Documentation',
-     ['PotentialVentures'], 1)
+     ['cocotb contributors'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -286,7 +286,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'cocotb', 'cocotb Documentation',
-   'PotentialVentures', 'cocotb', 'Coroutine Cosimulation TestBench \
+   'cocotb contributors', 'cocotb', 'Coroutine Cosimulation TestBench \
      environment for efficient verification of RTL using Python.',
    'Miscellaneous'),
 ]

--- a/documentation/source/contributors.rst
+++ b/documentation/source/contributors.rst
@@ -6,7 +6,14 @@ Contributors
    McGregor
    Grimwood
 
-cocotb was developed by `Potential Ventures <https://potential.ventures>`_ with the support of
-`Solarflare Communications Ltd <https://www.solarflare.com/>`_
-and contributions from Gordon McGregor and Finn Grimwood
-(see `contributors <https://github.com/cocotb/cocotb/graphs/contributors>`_ for the full list of contributions).
+cocotb is developed and maintained by an active community.
+Our GitHub repository contains a list of all `contributors <https://github.com/cocotb/cocotb/graphs/contributors>`_.
+
+Since mid-2018 cocotb is an independent project under the umbrella of the
+`Free and Open Source Silicon Foundation <https://www.fossi-foundation.org>`_.
+The FOSSi Foundation provides the cocotb project with financial,
+legal and administrative support, and holds cocotb assets.
+
+cocotb was originally developed by Stuart Hodgson and Chris Higgs of Potential Ventures
+with the support of Solarflare Communications Ltd.
+and contributions from Gordon McGregor and Finn Grimwood.


### PR DESCRIPTION
Replace "PotentialVentures" with "cocotb Contributors"  in Sphinx output.

Closes #1625