### PR TITLE
Ensure simulators are launched in 32-bit mode with 32-bit python

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -36,9 +36,6 @@ COCOTB_PY_DIR := $(realpath $(shell cocotb-config --prefix))
 # simulations: Makefile fragments, and the simulator libraries.
 COCOTB_SHARE_DIR := $(COCOTB_PY_DIR)/cocotb/share
 
-ARCH?=$(shell uname -m)
-export ARCH
-
 OS=$(shell uname)
 ifneq (, $(findstring MINGW, $(OS)))
 OS=Msys
@@ -75,6 +72,11 @@ ifeq ($(OS),Msys)
 LIB_EXT    := dll
 else
 LIB_EXT    := so
+endif
+
+PYTHON_ARCH := $(shell $(PYTHON_BIN) -c 'from platform import architecture; print(architecture()[0])')
+ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)
+    $(error Unknown Python architecture: $(PYTHON_ARCH))
 endif
 
 # Set PYTHONHOME to properly populate sys.path in embedded python interpreter

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -49,8 +49,8 @@ EXTRA_ARGS += $(COMPILE_ARGS)
 EXTRA_ARGS += $(SIM_ARGS)
 EXTRA_ARGS += -licqueue
 
-ifneq ($(ARCH),i686)
-EXTRA_ARGS += -64
+ifeq ($(PYTHON_ARCH),64bit)
+    EXTRA_ARGS += -64
 endif
 
 EXTRA_ARGS += -nclibdirpath $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -114,8 +114,8 @@ else
 	@echo "quit" >> $@
 endif
 
-ifneq ($(ARCH),i686)
-CMD += -64
+ifeq ($(PYTHON_ARCH),64bit)
+    CMD += -64
 endif
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -51,7 +51,7 @@ else
      export VCS_BIN_DIR
 endif
 
-ifeq ($(ARCH),x86_64)
+ifeq ($(PYTHON_ARCH),64bit)
     EXTRA_ARGS += -full64
 endif
 

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -49,7 +49,7 @@ EXTRA_ARGS += $(COMPILE_ARGS)
 EXTRA_ARGS += $(SIM_ARGS)
 EXTRA_ARGS += -licqueue
 
-ifneq ($(ARCH),i686)
+ifeq ($(PYTHON_ARCH),64bit)
     EXTRA_ARGS += -64
 endif
 


### PR DESCRIPTION
Change `ARCH` to `PYTHON_ARCH` (32bit/64bit) and use Python binary version to decide about simulator options.

"If you've installed cocotb into a 32-bit python, then you'll only be able to run it with 32-bit simulators."

Closes #1600
