### PR TITLE
Unpin Sphinx and breathe

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies to build the documentation
 
-Sphinx ~= 3
+Sphinx ~= 3.0
 breathe
 sphinx-rtd-theme
 cairosvg

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,14 +1,7 @@
 # Python dependencies to build the documentation
 
-# Pinned below 3 until https://github.com/sphinx-contrib/domaintools/pull/9 is
-# merged and released.
-Sphinx~=2.1
-
-# 4.15 depends on sphinx 3.0.0, but for some reason ReadTheDocs tries to install
-# it anyway.
-breathe < 4.15
-
-# other dependencies
+Sphinx
+breathe
 sphinx-rtd-theme
 cairosvg
 sphinxcontrib-makedomain

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies to build the documentation
 
-Sphinx
+Sphinx ~= 3
 breathe
 sphinx-rtd-theme
 cairosvg


### PR DESCRIPTION
The upstream bug in sphinxcontrib-domaintools has been fixed and released in 0.3, so we should be able to unpin these again.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
