### PR TITLE
Change __name__ to __qualname__ in base Python libraries

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -165,7 +165,7 @@ class BinaryValue:
         else:
             raise TypeError(
                 "value must be int, str, or bytes, not {!r}"
-                .format(type(value).__name__)
+                .format(type(value).__qualname__)
             )
 
     def _convert_to_unsigned(self, x):
@@ -396,7 +396,7 @@ class BinaryValue:
         for char in string:
             if char not in BinaryValue._permitted_chars:
                 raise ValueError("Attempting to assign character %s to a %s" %
-                                 (char, type(self).__name__))
+                                 (char, type(self).__qualname__))
         self._str = string
         self._adjust()
 

--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -122,7 +122,7 @@ class Bus:
                     msg = ("Unable to drive onto {0}.{1} because {2} is missing "
                            "attribute {3}".format(self._entity._name,
                                                   self._name,
-                                                  type(obj).__name__,
+                                                  type(obj).__qualname__,
                                                   attr_name))
                     raise AttributeError(msg)
                 else:
@@ -176,7 +176,7 @@ class Bus:
                     msg = ("Unable to sample from {0}.{1} because {2} is missing "
                            "attribute {3}".format(self._entity._name,
                                                   self._name,
-                                                  type(obj).__name__,
+                                                  type(obj).__qualname__,
                                                   attr_name))
                     raise AttributeError(msg)
                 else:

--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -42,7 +42,7 @@ class BaseClock:
     @lazy_property
     def log(self):
         return SimLog("cocotb.%s.%s" % (
-            type(self).__name__, self.signal._name
+            type(self).__qualname__, self.signal._name
         ))
 
 
@@ -152,4 +152,4 @@ class Clock(BaseClock):
                 await t
 
     def __str__(self):
-        return type(self).__name__ + "(%3.1f MHz)" % self.frequency
+        return type(self).__qualname__ + "(%3.1f MHz)" % self.frequency

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -100,7 +100,8 @@ class RunningTask:
             raise TypeError(
                 "%s isn't a valid coroutine! Did you forget to use the yield keyword?" % inst)
         self._coro = inst
-        self.__name__ = "%s" % inst.__name__
+        self.__name__ = inst.__name__
+        self.__qualname__ = inst.__qualname__
         self._started = False
         self._callbacks = []
         self._outcome = None
@@ -109,10 +110,7 @@ class RunningTask:
     def log(self):
         # Creating a logger is expensive, only do it if we actually plan to
         # log anything
-        if hasattr(self, "__name__"):
-            return SimLog("cocotb.coroutine.%s" % self.__name__, id(self))
-        else:
-            return SimLog("cocotb.coroutine.fail")
+        return SimLog("cocotb.coroutine.%s" % self.__qualname__, id(self))
 
     @property
     def retval(self):
@@ -128,7 +126,7 @@ class RunningTask:
         return self
 
     def __str__(self):
-        return str(self.__name__)
+        return str(self.__qualname__)
 
     def _advance(self, outcome):
         """Advance to the next yield in this coroutine.
@@ -236,7 +234,7 @@ class RunningTest(RunningCoroutine):
     def __init__(self, inst, parent):
         self.error_messages = []
         RunningCoroutine.__init__(self, inst, parent)
-        self.log = SimLog("cocotb.test.%s" % self.__name__, id(self))
+        self.log = SimLog("cocotb.test.%s" % self.__qualname__, id(self))
         self.started = False
         self.start_time = 0
         self.start_sim_time = 0
@@ -295,12 +293,11 @@ class coroutine:
 
     def __init__(self, func):
         self._func = func
-        self.__name__ = self._func.__name__
         functools.update_wrapper(self, func)
 
     @lazy_property
     def log(self):
-        return SimLog("cocotb.coroutine.%s" % self._func.__name__, id(self))
+        return SimLog("cocotb.coroutine.%s" % self._func.__qualname__, id(self))
 
     def __call__(self, *args, **kwargs):
         return RunningCoroutine(self._func(*args, **kwargs), self)
@@ -314,7 +311,7 @@ class coroutine:
         return self
 
     def __str__(self):
-        return str(self._func.__name__)
+        return str(self._func.__qualname__)
 
 
 @public
@@ -331,7 +328,7 @@ class function:
 
     @lazy_property
     def log(self):
-        return SimLog("cocotb.function.%s" % self._coro.__name__, id(self))
+        return SimLog("cocotb.function.%s" % self._coro.__qualname__, id(self))
 
     def __call__(self, *args, **kwargs):
         return cocotb.scheduler.queue_function(self._coro(*args, **kwargs))
@@ -352,7 +349,7 @@ class external:
     """
     def __init__(self, func):
         self._func = func
-        self._log = SimLog("cocotb.external.%s" % self._func.__name__, id(self))
+        self._log = SimLog("cocotb.external.%s" % self._func.__qualname__, id(self))
 
     def __call__(self, *args, **kwargs):
         return cocotb.scheduler.run_in_executor(self._func, *args, **kwargs)

--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -102,7 +102,7 @@ class Driver:
 
         # Sub-classes may already set up logging
         if not hasattr(self, "log"):
-            self.log = SimLog("cocotb.driver.%s" % (type(self).__name__))
+            self.log = SimLog("cocotb.driver.%s" % (type(self).__qualname__))
 
         # Create an independent coroutine which can send stuff
         self._thread = cocotb.scheduler.add(self._send_thread())

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -130,7 +130,7 @@ class SimHandleBase:
             deffile = self._def_file
             if deffile:
                 desc += " (at "+deffile+")"
-        return type(self).__name__ + "(" + desc + ")"
+        return type(self).__qualname__ + "(" + desc + ")"
 
     def __str__(self):
         return self._path

--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -82,7 +82,7 @@ class Monitor:
 
         # Sub-classes may already set up logging
         if not hasattr(self, "log"):
-            self.log = SimLog("cocotb.monitor.%s" % (type(self).__name__))
+            self.log = SimLog("cocotb.monitor.%s" % (type(self).__qualname__))
 
         if callback is not None:
             self.add_callback(callback)
@@ -109,7 +109,7 @@ class Monitor:
             callback (callable): The function to call back.
         """
         self.log.debug("Adding callback of function %s to monitor",
-                       callback.__name__)
+                       callback.__qualname__)
         self._callbacks.append(callback)
 
     @coroutine
@@ -194,4 +194,4 @@ class BusMonitor(Monitor):
         return False
 
     def __str__(self):
-        return "%s(%s)" % (type(self).__name__, self.name)
+        return "%s(%s)" % (type(self).__qualname__, self.name)

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -313,7 +313,7 @@ class RegressionManager:
                                     ratio_time="0.0")
             result_pass, sim_failed = self._score_test(test_func, test_init_outcome)
             # Save results
-            self._store_test_result(test_func.__module__, test_func.__name__, result_pass, 0.0, 0.0, 0.0)
+            self._store_test_result(test_func.__module__, test_func.__qualname__, result_pass, 0.0, 0.0, 0.0)
             if not result_pass:
                 self.xunit.add_failure()
                 self.failures += 1
@@ -346,7 +346,7 @@ class RegressionManager:
         # Helper for logging result
         def _result_was():
             result_was = ("{} (result was {})".format
-                          (test.__name__, type(result).__name__))
+                          (test.__qualname__, type(result).__qualname__))
             return result_was
 
         # scoring outcomes
@@ -363,7 +363,7 @@ class RegressionManager:
         if (isinstance(result, TestSuccess) and
                 not test.expect_fail and
                 not test.expect_error):
-            self.log.info("Test Passed: %s" % test.__name__)
+            self.log.info("Test Passed: %s" % test.__qualname__)
 
         elif (isinstance(result, AssertionError) and
                 test.expect_fail):
@@ -534,6 +534,7 @@ def _create_test(function, name, documentation, mod, *args, **kwargs):
         await function(dut, *args, **kwargs)
 
     _my_test.__name__ = name
+    _my_test.__qualname__ = name
     _my_test.__doc__ = documentation
     _my_test.__module__ = mod.__name__
     return cocotb.test()(_my_test)
@@ -591,7 +592,7 @@ class TestFactory:
         if not isinstance(test_function, cocotb.coroutine):
             raise TypeError("TestFactory requires a cocotb coroutine")
         self.test_function = test_function
-        self.name = self.test_function._func.__name__
+        self.name = self.test_function._func.__qualname__
 
         self.args = args
         self.kwargs_constant = kwargs
@@ -647,7 +648,7 @@ class TestFactory:
                         desc = "No docstring supplied"
                     else:
                         desc = optvalue.__doc__.split('\n')[0]
-                    doc += "\t%s: %s (%s)\n" % (optname, optvalue.__name__,
+                    doc += "\t%s: %s (%s)\n" % (optname, optvalue.__qualname__,
                                                 desc)
                 else:
                     doc += "\t%s: %s\n" % (optname, repr(optvalue))

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -424,7 +424,7 @@ class Scheduler:
 
 
                 if _debug:
-                    debugstr = "\n\t".join([coro.__name__ for coro in scheduling])
+                    debugstr = "\n\t".join([coro.__qualname__ for coro in scheduling])
                     if len(scheduling):
                         debugstr = "\n\t" + debugstr
                     self.log.debug("%d pending coroutines for event %s%s" %
@@ -435,10 +435,10 @@ class Scheduler:
 
                 for coro in scheduling:
                     if _debug:
-                        self.log.debug("Scheduling coroutine %s" % (coro.__name__))
+                        self.log.debug("Scheduling coroutine %s" % (coro.__qualname__))
                     self.schedule(coro, trigger=trigger)
                     if _debug:
-                        self.log.debug("Scheduled coroutine %s" % (coro.__name__))
+                        self.log.debug("Scheduled coroutine %s" % (coro.__qualname__))
 
                 # Schedule may have queued up some events so we'll burn through those
                 while self._pending_events:
@@ -616,7 +616,7 @@ class Scheduler:
         async def wrapper():
             waiter = external_waiter()
             thread = threading.Thread(group=None, target=execute_external,
-                                      name=func.__name__ + "_thread",
+                                      name=func.__qualname__ + "_thread",
                                       args=([func, waiter]), kwargs={})
 
             waiter.thread = thread
@@ -660,7 +660,7 @@ class Scheduler:
             )
 
         if _debug:
-            self.log.debug("Adding new coroutine %s" % coroutine.__name__)
+            self.log.debug("Adding new coroutine %s" % coroutine.__qualname__)
 
         self.schedule(coroutine)
         self._check_termination()
@@ -682,14 +682,14 @@ class Scheduler:
     def _trigger_from_started_coro(self, result: cocotb.decorators.RunningTask) -> Trigger:
         if _debug:
             self.log.debug("Joining to already running coroutine: %s" %
-                           result.__name__)
+                           result.__qualname__)
         return result.join()
 
     def _trigger_from_unstarted_coro(self, result: cocotb.decorators.RunningTask) -> Trigger:
         self.queue(result)
         if _debug:
             self.log.debug("Scheduling nested coroutine: %s" %
-                           result.__name__)
+                           result.__qualname__)
         return result.join()
 
     def _trigger_from_waitable(self, result: cocotb.triggers.Waitable) -> Trigger:
@@ -753,7 +753,7 @@ class Scheduler:
             result = coroutine._advance(send_outcome)
             if _debug:
                 self.log.debug("Coroutine %s yielded %s (mode %d)" %
-                               (coroutine.__name__, str(result), self._mode))
+                               (coroutine.__qualname__, str(result), self._mode))
 
         except cocotb.decorators.CoroutineComplete as exc:
             if _debug:

--- a/cocotb/scoreboard.py
+++ b/cocotb/scoreboard.py
@@ -204,7 +204,7 @@ class Scoreboard:
         # Enforce some type checking as we only work with a real monitor
         if not isinstance(monitor, Monitor):
             raise TypeError("Expected monitor on the interface but got %s" %
-                            (type(monitor).__name__))
+                            (type(monitor).__qualname__))
 
         if compare_fn is not None:
             if callable(compare_fn):
@@ -222,7 +222,7 @@ class Scoreboard:
             if monitor.name:
                 log_name = self.log.name + '.' + monitor.name
             else:
-                log_name = self.log.name + '.' + type(monitor).__name__
+                log_name = self.log.name + '.' + type(monitor).__qualname__
 
             log = logging.getLogger(log_name)
 

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -78,7 +78,7 @@ class Trigger(Awaitable):
 
     @lazy_property
     def log(self):
-        return SimLog("cocotb.%s" % (type(self).__name__), id(self))
+        return SimLog("cocotb.%s" % (type(self).__qualname__), id(self))
 
     @abc.abstractmethod
     def prime(self, callback):
@@ -212,7 +212,7 @@ class Timer(GPITrigger):
 
     def __repr__(self):
         return "<{} of {:1.2f}ps at {}>".format(
-            type(self).__name__,
+            type(self).__qualname__,
             get_time_from_sim_steps(self.sim_steps, units='ps'),
             _pointer_str(self)
         )
@@ -249,7 +249,7 @@ class ReadOnly(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         GPITrigger.prime(self, callback)
 
     def __repr__(self):
-        return "{}()".format(type(self).__name__)
+        return "{}()".format(type(self).__qualname__)
 
 
 class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
@@ -273,7 +273,7 @@ class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         GPITrigger.prime(self, callback)
 
     def __repr__(self):
-        return "{}()".format(type(self).__name__)
+        return "{}()".format(type(self).__qualname__)
 
 
 class NextTimeStep(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
@@ -295,7 +295,7 @@ class NextTimeStep(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         GPITrigger.prime(self, callback)
 
     def __repr__(self):
-        return "{}()".format(type(self).__name__)
+        return "{}()".format(type(self).__qualname__)
 
 
 class _EdgeBase(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
@@ -327,7 +327,7 @@ class _EdgeBase(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         super(_EdgeBase, self).prime(callback)
 
     def __repr__(self):
-        return "{}({!r})".format(type(self).__name__, self.signal)
+        return "{}({!r})".format(type(self).__qualname__, self.signal)
 
 
 class RisingEdge(_EdgeBase):
@@ -425,7 +425,7 @@ class Event:
             fmt = "<{0} at {2}>"
         else:
             fmt = "<{0} for {1} at {2}>"
-        return fmt.format(type(self).__name__, self.name, _pointer_str(self))
+        return fmt.format(type(self).__qualname__, self.name, _pointer_str(self))
 
 
 class _Lock(PythonTrigger):
@@ -516,7 +516,7 @@ class Lock:
         else:
             fmt = "<{0} for {1} [{2} waiting] at {3}>"
         return fmt.format(
-            type(self).__name__, self.name, len(self._pending_primed),
+            type(self).__qualname__, self.name, len(self._pending_primed),
             _pointer_str(self)
         )
 
@@ -556,7 +556,7 @@ class NullTrigger(Trigger):
             fmt = "<{0} at {2}>"
         else:
             fmt = "<{0} for {1} at {2}>"
-        return fmt.format(type(self).__name__, self.name, _pointer_str(self))
+        return fmt.format(type(self).__qualname__, self.name, _pointer_str(self))
 
 
 class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
@@ -617,7 +617,7 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
             super(Join, self).prime(callback)
 
     def __repr__(self):
-        return "{}({!r})".format(type(self).__name__, self._coroutine)
+        return "{}({!r})".format(type(self).__qualname__, self._coroutine)
 
 
 class Waitable(Awaitable):
@@ -655,14 +655,14 @@ class _AggregateWaitable(Waitable):
             if not isinstance(trigger, allowed_types):
                 raise TypeError(
                     "All triggers must be instances of Trigger! Got: {}"
-                    .format(type(trigger).__name__)
+                    .format(type(trigger).__qualname__)
                 )
 
     def __repr__(self):
         # no _pointer_str here, since this is not a trigger, so identity
         # doesn't matter.
         return "{}({})".format(
-            type(self).__name__, ", ".join(repr(t) for t in self.triggers)
+            type(self).__qualname__, ", ".join(repr(t) for t in self.triggers)
         )
 
 
@@ -790,7 +790,7 @@ class ClockCycles(Waitable):
             fmt = "{}({!r}, {!r})"
         else:
             fmt = "{}({!r}, {!r}, rising=False)"
-        return fmt.format(type(self).__name__, self.signal, self.num_cycles)
+        return fmt.format(type(self).__qualname__, self.signal, self.num_cycles)
 
 
 async def with_timeout(trigger, timeout_time, timeout_unit=None):

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -514,7 +514,7 @@ class lazy_property:
             return self
 
         value = self.fget(obj)
-        setattr(obj, self.fget.__name__, value)
+        setattr(obj, self.fget.__qualname__, value)
         return value
 
 


### PR DESCRIPTION
Solves one aspect of #1289.

Also added `__qualname__` to `RunningTask` for consistency in use and to parallel async coroutine's interface. Did not update the old `name` aliases seen in `RunningCoroutine`, `RunningTask`, and `hook`; it is a user variable, thus arbitrary, and should probably be removed anyways.