### PR TITLE
Some cleanup to Regression Manager

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -178,7 +178,6 @@ def _initialise_testbench(root_name):
     global regression_manager
 
     regression_manager = RegressionManager(root_name, modules, tests=test_str, seed=RANDOM_SEED, hooks=hooks)
-    regression_manager.initialise()
     regression_manager.execute()
 
     _rlock.release()

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -176,7 +176,7 @@ def _initialise_testbench(root_name):
 
     # start Regression Manager
     global regression_manager
-    regression_manager = RegressionManager(dut)
+    regression_manager = RegressionManager.from_discovery(dut)
     regression_manager.execute()
 
     _rlock.release()

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -165,19 +165,8 @@ def _initialise_testbench(root_name):
         log.info("Seeding Python random module with supplied seed %d" % (RANDOM_SEED))
     random.seed(RANDOM_SEED)
 
-    module_str = os.getenv('MODULE')
-    test_str = os.getenv('TESTCASE')
-    hooks_str = os.getenv('COCOTB_HOOKS', '')
-
-    if module_str is None:
-        raise ValueError("Environment variable MODULE, which defines the module(s) to execute, is not defined.")
-
-    modules = [s.strip() for s in module_str.split(',') if s.strip()]
-    hooks = [s.strip() for s in hooks_str.split(',') if s.strip()]
-
     global regression_manager
-
-    regression_manager = RegressionManager(root_name, modules, tests=test_str, seed=RANDOM_SEED, hooks=hooks)
+    regression_manager = RegressionManager(root_name)
     regression_manager.execute()
 
     _rlock.release()

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -165,8 +165,18 @@ def _initialise_testbench(root_name):
         log.info("Seeding Python random module with supplied seed %d" % (RANDOM_SEED))
     random.seed(RANDOM_SEED)
 
+    # Setup DUT object
+    from cocotb import simulator
+
+    handle = simulator.get_root_handle(root_name)
+    if not handle:
+        raise RuntimeError("Can not find root handle ({})".format(root_name))
+
+    dut = cocotb.handle.SimHandle(handle)
+
+    # start Regression Manager
     global regression_manager
-    regression_manager = RegressionManager(root_name)
+    regression_manager = RegressionManager(dut)
     regression_manager.execute()
 
     _rlock.release()

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -65,6 +65,7 @@ from cocotb.utils import get_sim_time, remove_traceback_frames, want_color_outpu
 from cocotb.xunit_reporter import XUnitReporter
 from cocotb.decorators import test as Test, hook as Hook, RunningTask
 from cocotb.outcomes import Outcome
+from cocotb.handle import SimHandle
 
 
 def _my_import(name: str) -> Any:
@@ -78,13 +79,12 @@ def _my_import(name: str) -> Any:
 class RegressionManager:
     """Encapsulates all regression capability into a single place"""
 
-    def __init__(self, root_name: str):
+    def __init__(self, dut: SimHandle):
         """
         Args:
-            root_name (str): The name of the root handle.
+            dut (SimHandle): The root handle to pass into test functions.
         """
-        self._root_name = root_name
-        self._dut = None
+        self._dut = dut
         self._running_test = None
         self._cov = None
         self.log = SimLog("cocotb.regression")
@@ -114,17 +114,6 @@ class RegressionManager:
             self.log.info("Enabling coverage collection of Python code")
             self._cov = coverage.coverage(branch=True, omit=["*cocotb*"])
             self._cov.start()
-
-        # Setup DUT object
-        #######################
-
-        handle = simulator.get_root_handle(self._root_name)
-
-        self._dut = cocotb.handle.SimHandle(handle) if handle else None
-
-        if self._dut is None:
-            raise AttributeError("Can not find Root Handle (%s)" %
-                                 self._root_name)
 
         # Test Discovery
         ####################

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -97,9 +97,6 @@ class RegressionManager:
         self.log = SimLog("cocotb.regression")
         self._seed = seed
         self._hooks = hooks
-
-    def initialise(self):
-
         self.start_time = time.time()
         self.test_results = []
         self.ntests = 0

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -328,7 +328,15 @@ class RegressionManager:
         else:
             test = test_init_outcome.get()
             if test.skip:
-                self.log.info("Skipping test %s" % test_func.name)
+                hilight_start = ANSI.COLOR_TEST if want_color_output() else ''
+                hilight_end = ANSI.COLOR_DEFAULT if want_color_output() else ''
+                # Want this to stand out a little bit
+                self.log.info("{}Skipping test {}/{}:{} {}".format(
+                    hilight_start,
+                    self.count,
+                    self.ntests,
+                    hilight_end,
+                    test_func.__qualname__))
                 self.xunit.add_testcase(name=test_func.name,
                                         classname=test.module,
                                         time="0.0",

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -85,7 +85,7 @@ class RegressionManager:
             dut (SimHandle): The root handle to pass into test functions.
         """
         self._dut = dut
-        self._running_test = None
+        self._test_task = None
         self._cov = None
         self.log = SimLog("cocotb.regression")
         self.start_time = time.time()
@@ -245,7 +245,7 @@ class RegressionManager:
         Args:
             test: The test that completed
         """
-        assert test is self._running_test
+        assert test is self._test_task
 
         real_time = time.time() - self._test_start_time
         sim_time_ns = get_sim_time('ns') - self._test_start_sim_time
@@ -255,7 +255,7 @@ class RegressionManager:
 
         self._record_result(
             test=self._test,
-            outcome=self._running_test._outcome,
+            outcome=self._test_task._outcome,
             wall_time_s=real_time,
             sim_time_ns=sim_time_ns)
 
@@ -405,8 +405,8 @@ class RegressionManager:
             if self._test is None:
                 return self.tear_down()
 
-            self._running_test = self._init_test(self._test)
-            if self._running_test:
+            self._test_task = self._init_test(self._test)
+            if self._test_task:
                 return self._start_test()
 
     def _start_test(self) -> None:
@@ -423,11 +423,11 @@ class RegressionManager:
                        self._test.__qualname__))
 
         # start capturing log output
-        cocotb.log.addHandler(self._running_test.handler)
+        cocotb.log.addHandler(self._test_task.handler)
 
         self._test_start_time = time.time()
         self._test_start_sim_time = get_sim_time('ns')
-        cocotb.scheduler.add_test(self._running_test)
+        cocotb.scheduler.add_test(self._test_task)
 
     def _log_test_summary(self) -> None:
 

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -315,7 +315,8 @@ class RegressionManager:
         test_init_outcome = cocotb.outcomes.capture(test, self._dut)
 
         if isinstance(test_init_outcome, cocotb.outcomes.Error):
-            self.log.error("Failed to initialize test %s" % test.__qualname__, exc_info=True)
+            self.log.error("Failed to initialize test %s" % test.__qualname__,
+                           exc_info=test_init_outcome.error)
             self._record_result(test, test_init_outcome, 0, 0)
             return
 

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -259,8 +259,8 @@ class RegressionManager:
         """
         assert test is self._running_test
 
-        real_time = time.time() - test.start_time
-        sim_time_ns = get_sim_time('ns') - test.start_sim_time
+        real_time = time.time() - self._test_start_time
+        sim_time_ns = get_sim_time('ns') - self._test_start_sim_time
         ratio_time = self._safe_divide(sim_time_ns, real_time)
 
         self.xunit.add_testcase(name=self._test.__qualname__,
@@ -434,6 +434,8 @@ class RegressionManager:
         # start capturing log output
         cocotb.log.addHandler(self._running_test.handler)
 
+        self._test_start_time = time.time()
+        self._test_start_sim_time = get_sim_time('ns')
         cocotb.scheduler.add_test(self._running_test)
 
     def _log_test_summary(self) -> None:


### PR DESCRIPTION
Addresses some issues from #1604 relating to the `RegressionManager`.

* Encapsulates all test/hook discovery into a single method
* Defers test initialization
* Saves `cocotb.test` function object for each test
* Uses the saved `cocotb.test` object to obtain test information, making `RunningTest` mostly useless
* Implements test timing, moving it out of `RunningTest`
* adds type annotations
* some shifting of responsibility/cleanup

This sets the stage for deprecation of `RunningTest` and the RM/scheduler refactor to remove all knowledge of tests from the scheduler.