### PR TITLE
Add support for launching IPython

### DIFF
--- a/cocotb/ipython_support.py
+++ b/cocotb/ipython_support.py
@@ -1,0 +1,89 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+import IPython
+from IPython.terminal.ipapp import load_default_config
+from IPython.terminal.prompts import Prompts, Token
+
+import cocotb
+
+
+class SimTimePrompt(Prompts):
+    """ custom prompt that shows the sim time after a trigger fires """
+    _show_time = 1
+
+    def in_prompt_tokens(self, cli=None):
+        tokens = super().in_prompt_tokens()
+        if self._show_time == self.shell.execution_count:
+            tokens = [
+                (Token.Comment, "sim time: {}".format(cocotb.utils.get_sim_time())),
+                (Token.Text, "\n"),
+            ] + tokens
+        return tokens
+
+
+def _runner(shell, x):
+    """ Handler for async functions """
+    ret = cocotb.scheduler.queue_function(x)
+    shell.prompts._show_time = shell.execution_count
+    return ret
+
+
+async def embed(user_ns: dict = {}):
+    """
+    Start an ipython shell in the current coroutine.
+
+    Unlike using :func:`IPython.embed` directly, the :keyword:`await` keyword
+    can be used directly from the shell to wait for triggers.
+    The :keyword:`yield` keyword from the legacy :ref:`yield-syntax` is not supported.
+
+    This coroutine will complete only when the user exits the interactive session.
+
+    Args:
+        user_ns:
+            The variables to have made available in the shell.
+            Passing ``locals()`` is often a good idea.
+            ``cocotb`` will automatically be included.
+
+    Notes:
+
+        If your simulator does not provide an appropriate ``stdin``, you may
+        find you cannot type in the resulting shell. Using simulators in batch
+        or non-gui mode may resolve this. This feature is experimental, and
+        not all simulators are supported.
+    """
+    # ensure cocotb is in the namespace, for convenience
+    default_ns = dict(cocotb=cocotb)
+    default_ns.update(user_ns)
+
+    # build the config to enable `await`
+    c = load_default_config()
+    c.TerminalInteractiveShell.loop_runner = lambda x: _runner(shell, x)
+    c.TerminalInteractiveShell.autoawait = True
+
+    # create a shell with access to the dut, and cocotb pre-imported
+    shell = IPython.terminal.embed.InteractiveShellEmbed(
+        user_ns=default_ns,
+        config=c,
+    )
+
+    # add our custom prompts
+    shell.prompts = SimTimePrompt(shell)
+
+    # start the shell in a background thread
+    @cocotb.external
+    def run_shell():
+        shell()
+    await run_shell()
+
+
+@cocotb.test()
+async def run_ipython(dut):
+    """ A test that launches an interactive Python shell.
+
+    Do not call this directly - use this as ``make MODULE=cocotb.ipython_support``.
+
+    Within the shell, a global ``dut`` variable pointing to the design will be present.
+    """
+    await cocotb.triggers.Timer(0)  # workaround for gh-637
+    await embed(user_ns=dict(dut=dut))

--- a/cocotb/ipython_support.py
+++ b/cocotb/ipython_support.py
@@ -49,7 +49,7 @@ async def embed(user_ns: dict = {}):
 
         If your simulator does not provide an appropriate ``stdin``, you may
         find you cannot type in the resulting shell. Using simulators in batch
-        or non-gui mode may resolve this. This feature is experimental, and
+        or non-GUI mode may resolve this. This feature is experimental, and
         not all simulators are supported.
     """
     # ensure cocotb is in the namespace, for convenience

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -17,3 +17,4 @@ pyenchant
 sphinx-issues
 sphinx-argparse
 towncrier
+IPython

--- a/documentation/source/newsfragments/1649.feature.rst
+++ b/documentation/source/newsfragments/1649.feature.rst
@@ -1,0 +1,1 @@
+Support for using ``await`` inside an embedded IPython terminal, using :mod:`cocotb.ipython_support`.

--- a/documentation/source/troubleshooting.rst
+++ b/documentation/source/troubleshooting.rst
@@ -64,3 +64,19 @@ accessible via a TCP socket:
    .. code:: shell
 
       telnet 127.0.0.1 4000
+
+
+Embedding an IPython shell
+==========================
+
+.. module:: cocotb.ipython_support
+
+.. versionadded:: 1.4
+
+A prebuilt test is included to easily launch an IPython shell in an existing design.
+
+.. autofunction:: run_ipython
+
+To embed a shell within an existing test, where it can inspect local variables, the :func:`embed` function can be used.
+
+.. autofunction:: embed

--- a/examples/dff/tests/Makefile
+++ b/examples/dff/tests/Makefile
@@ -32,6 +32,3 @@ endif
 
 include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-# list all required Python files here
-sim: $(MODULE).py


### PR DESCRIPTION
Closes #1081

Also need to decide where this should live.
* Should it be an extension, `cocotb_ext.ipython`?
   * How about  living in the extension namespace, but distributed as part of cocotb itself?
   * If not an extension, how should we handle the dependency on `IPython`?
* Should I split this into `ipython_runner` and `ipython_support`, where the former is used in a `MODULE=cocotb.ipython_runner` type example, while the latter is used for providing general tools like the custom prompt options I added here?

You can test this today by pasting the contents of this file into a standalone module.

An example session with the `dff` example:
```
eric@eric-thinkpa:~/win-home/Repos/cocotb/examples/dff/tests$ make MODULE=cocotb.ipython_support
make results.xml
make[1]: Entering directory '/mnt/c/Users/wiese/Repos/cocotb/examples/dff/tests'
MODULE=cocotb.ipython_support \
        TESTCASE= TOPLEVEL=dff TOPLEVEL_LANG=verilog COCOTB_SIM=1 \
        /usr/bin/vvp -M /mnt/c/Users/wiese/Repos/cocotb/cocotb/libs -m libcocotbvpi_icarus   sim_build/sim.vvp
     -.--ns INFO     cocotb.gpi                         ..mbed/gpi_embed.cpp:71   in set_program_name_in_venv        Did not detect Python virtual environment. Using system-wide Python interpreter
     -.--ns INFO     cocotb.gpi                         ../gpi/GpiCommon.cpp:106  in gpi_print_registered_impl       VPI registered
     0.00ns INFO     cocotb.gpi                                gpi_embed.cpp:332  in embed_sim_init                  Running on Icarus Verilog version 10.1 (stable)
     0.00ns INFO     cocotb.gpi                                gpi_embed.cpp:333  in embed_sim_init                  Python interpreter initialized and cocotb loaded!
     0.00ns INFO     cocotb                                      __init__.py:145  in _initialise_testbench           Running tests with cocotb v1.4.0.dev0 from /mnt/c/Users/wiese/Repos/cocotb/cocotb
     0.00ns INFO     cocotb                                      __init__.py:162  in _initialise_testbench           Seeding Python random module with 1586771832
     0.00ns INFO     cocotb.regression                         regression.py:194  in initialise                      Found test cocotb.ipython_support.run_ipython
     0.00ns INFO     cocotb.regression                         regression.py:422  in execute                         Running test 1/1: run_ipython
     0.00ns INFO     ..b.test.run_ipython.0x7f865bb9b6a0       decorators.py:255  in _advance                        Starting test: "run_ipython"
                                                                                                                     Description: Launch an interactive Python shell.
Python 3.5.2 (default, Nov 23 2017, 16:37:01)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.9.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cocotb.clock import Clock

In [2]: cocotb.fork(Clock(dut.c, 10, 'us').start(start_high=False))
Out[2]: <cocotb.decorators.RunningTask at 0x7f86584e4e48>

In [3]: await cocotb.triggers.RisingEdge(dut.c)
Out[3]: RisingEdge(ModifiableObject(dff.c))

sim time: 5000000
In [4]: await cocotb.triggers.RisingEdge(dut.c)
Out[4]: RisingEdge(ModifiableObject(dff.c))

sim time: 15000000
In [5]:   
```

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
