### PR TITLE
Make `gpi_iterator_hdl` objects natively iterable

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -31,7 +31,6 @@
 
 import ctypes
 import warnings
-import collections.abc
 
 import os
 
@@ -190,7 +189,7 @@ class RegionObject(SimHandleBase):
         if self._discovered:
             return
         self._log.debug("Discovering all on %s", self._name)
-        for thing in _SimIterator(self._handle, simulator.OBJECTS):
+        for thing in simulator.iterate(self._handle, simulator.OBJECTS):
             name = simulator.get_name_string(thing)
             try:
                 hdl = SimHandle(thing, self._child_path(name))
@@ -559,27 +558,17 @@ class NonHierarchyIndexableObject(NonHierarchyObject):
             self[self_idx].value = value[val_idx]
 
 
-class _SimIterator(collections.abc.Iterator):
-    """Iterator over simulator objects. For internal use only."""
-
-    def __init__(self, handle, mode):
-        self._iter = simulator.iterate(handle, mode)
-
-    def __next__(self):
-        return simulator.next(self._iter)
-
-
 class NonConstantObject(NonHierarchyIndexableObject):
     """ A non-constant object"""
     # FIXME: what is the difference to ModifiableObject? Explain in docstring.
 
     def drivers(self):
         """An iterator for gathering all drivers for a signal."""
-        return _SimIterator(self._handle, simulator.DRIVERS)
+        return simulator.iterate(self._handle, simulator.DRIVERS)
 
     def loads(self):
         """An iterator for gathering all loads on a signal."""
-        return _SimIterator(self._handle, simulator.LOADS)
+        return simulator.iterate(self._handle, simulator.LOADS)
 
 class _SetAction:
     """Base class representing the type of action used while write-accessing a handle."""

--- a/cocotb/share/lib/simulator/simulatormodule.h
+++ b/cocotb/share/lib/simulator/simulatormodule.h
@@ -83,7 +83,6 @@ static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args);
 static PyObject *stop_simulator(PyObject *self, PyObject *args);
 
 static PyObject *iterate(PyObject *self, PyObject *args);
-static PyObject *next(PyObject *self, PyObject *args);
 
 static PyObject *get_sim_time(PyObject *self, PyObject *args);
 static PyObject *get_precision(PyObject *self, PyObject *args);
@@ -119,7 +118,6 @@ static PyMethodDef SimulatorMethods[] = {
     {"register_rwsynch_callback", register_rwsynch_callback, METH_VARARGS, "Register a callback for the read-write section"},
     {"stop_simulator", stop_simulator, METH_VARARGS, "Instruct the attached simulator to stop"},
     {"iterate", iterate, METH_VARARGS, "Get an iterator handle to loop over all members in an object"},
-    {"next", next, METH_VARARGS, "Get the next object from the iterator"},
     {"log_level", log_level, METH_VARARGS, "Set the log level for GPI"},
 
     // FIXME METH_NOARGS => initialization from incompatible pointer type


### PR DESCRIPTION
This saves some python wrapping and some argument parsing

Follow up to #1540.

This removes `cocotb.simulator.next(iterator_hdl)`, which is now just spelt `next(iterator_hdl)`.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
