### PR TITLE
Fix Questa regressions

### DIFF
--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -48,7 +48,7 @@ module sample_module (
     output real                                 stream_out_real,
     output integer                              stream_out_int,
     input  test_if                              inout_if,
-    input string                                string_input_port,
+    input string                                stream_in_string,
 `endif
     input  [7:0]                                stream_in_data,
     input  [63:0]                               stream_in_data_wide,

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -29,7 +29,7 @@ def _check_logic(tlog, hdl, expected):
         tlog.info("   Found {0!r} ({1}) with value=0x{2:X}".format(hdl, hdl._type, int(hdl)))
 
 def _check_str(tlog, hdl, expected):
-    if str(hdl) != expected:
+    if hdl.value != expected:
         raise TestFailure("{2!r}: Expected >{0}< but got >{1}<".format(expected, str(hdl), hdl))
     else:
         tlog.info("   Found {0!r} ({1}) with value={2}".format(hdl, hdl._type, str(hdl)))
@@ -65,7 +65,7 @@ def test_read_write(dut):
         _check_int (tlog, dut.param_int , 6)
         _check_real(tlog, dut.param_real, 3.14)
         _check_int (tlog, dut.param_char, ord('p'))
-        _check_str (tlog, dut.param_str , "ARRAYMOD")
+        _check_str (tlog, dut.param_str , b"ARRAYMOD")
 
         if not cocotb.SIM_NAME.lower().startswith(("riviera")):
             _check_logic(tlog, dut.param_rec.a        , 0)
@@ -90,7 +90,7 @@ def test_read_write(dut):
         _check_int (tlog, dut.const_int , 12)
         _check_real(tlog, dut.const_real, 6.28)
         _check_int (tlog, dut.const_char, ord('c'))
-        _check_str (tlog, dut.const_str , "MODARRAY")
+        _check_str (tlog, dut.const_str , b"MODARRAY")
 
         if not cocotb.SIM_NAME.lower().startswith(("riviera")):
             _check_logic(tlog, dut.const_rec.a        , 1)
@@ -156,7 +156,7 @@ def test_read_write(dut):
         _check_int (tlog, dut.port_int_out , 5000)
         _check_real(tlog, dut.port_real_out, 22.54)
         _check_int (tlog, dut.port_char_out, ord('Z'))
-        _check_str (tlog, dut.port_str_out , "Testing")
+        _check_str (tlog, dut.port_str_out , b"Testing")
 
         _check_logic(tlog, dut.port_rec_out.a        , 1)
         _check_logic(tlog, dut.port_rec_out.b[0]     , 0x01)
@@ -195,7 +195,7 @@ def test_read_write(dut):
         _check_logic(tlog, dut.sig_t6[0][2][7], 0)
 
     if cocotb.LANGUAGE in ["vhdl"]:
-        _check_str(tlog, dut.port_str_out, "TEsting")  # the uppercase "E" from a few lines before
+        _check_str(tlog, dut.port_str_out, b"TEsting")  # the uppercase "E" from a few lines before
 
         _check_logic(tlog, dut.port_rec_out.b[1]     , 0xA3)
         _check_logic(tlog, dut.port_cmplx_out[1].b[1], 0xEE)

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -48,6 +48,7 @@ async def test_returnvalue_deprecated(dut):
 async def test_unicode_handle_assignment_deprecated(dut):
     with assert_deprecated() as warns:
         dut.string_input_port <= "Bad idea"
+        await cocotb.triggers.ReadWrite()
     assert "bytes" in str(warns[0].message)
 
 

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -47,7 +47,7 @@ async def test_returnvalue_deprecated(dut):
 @cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
 async def test_unicode_handle_assignment_deprecated(dut):
     with assert_deprecated() as warns:
-        dut.string_input_port <= "Bad idea"
+        dut.stream_in_string <= "Bad idea"
         await cocotb.triggers.ReadWrite()
     assert "bytes" in str(warns[0].message)
 

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -41,8 +41,8 @@ def test_bad_attr(dut):
 # strings are not supported on Icarus
 @cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
 async def test_string_handle_takes_bytes(dut):
-    dut.string_input_port.value = b"bytes"
+    dut.stream_in_string.value = b"bytes"
     await cocotb.triggers.Timer(10, 'ns')
-    val = dut.string_input_port.value
+    val = dut.stream_in_string.value
     assert isinstance(val, bytes)
     assert val == b"bytes"

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -209,16 +209,16 @@ def access_string_vhdl(dut):
     tlog.info("%r is %s" % (constant_string, str(constant_string)))
     if not isinstance(constant_string, ConstantObject):
         raise TestFailure("EXAMPLE_STRING was not constant")
-    if constant_string != "TESTING":
+    if constant_string != b"TESTING":
         raise TestFailure("EXAMPLE_STRING was not == \'TESTING\'")
 
     tlog.info("Test writing under size")
 
-    test_string = "cocotb"
+    test_string = b"cocotb"
     dut.stream_in_string.setimmediatevalue(test_string)
 
     variable_string = dut.stream_out_string
-    if variable_string != '':
+    if variable_string != b'':
         raise TestFailure("%r not \'\'" % variable_string)
 
     yield Timer(10)
@@ -226,7 +226,7 @@ def access_string_vhdl(dut):
     if variable_string != test_string:
         raise TestFailure("%r %s != '%s'" % (variable_string, str(variable_string), test_string))
 
-    test_string = "longer_than_the_array"
+    test_string = b"longer_than_the_array"
     tlog.info("Test writing over size with '%s'" % test_string)
 
     dut.stream_in_string.setimmediatevalue(test_string)
@@ -248,9 +248,8 @@ def access_string_vhdl(dut):
     result_slice = variable_string[idx]
 
     # String is defined as string(1 to 8) so idx=3 will access the 3rd character
-    if chr(result_slice) != test_string[idx-1]:
-        raise TestFailure("Single character did not match '%c' != '%c'" %
-                          (result_slice, test_string[idx]))
+    if result_slice != test_string[idx - 1]:
+        raise TestFailure("Single character did not match {} != {}".format(result_slice, test_string[idx - 1]))
 
     tlog.info("Test write access to a string character")
 


### PR DESCRIPTION
Using Questa 2019.1 on RHEL 7.

With Verilog the following tests unexpectedly fail:
```
Failure in testsuite: 'all' classname: 'test_cocotb_array' testcase: 'test_in_vect_packed_packed_unpacked' with parameters 'all'
Failure in testsuite: 'all' classname: 'test_cocotb_array' testcase: 'test_in_arr_packed_unpacked' with parameters 'all'
Failure in testsuite: 'all' classname: 'test_cocotb_array' testcase: 'test_in_2d_arr_unpacked' with parameters 'all'
Failure in testsuite: 'all' classname: 'test_deprecated' testcase: 'test_unicode_handle_assignment_deprecated' with parameters 'all'
Failure in testsuite: 'all' classname: 'test_endian_swapper_hal' testcase: 'initial_hal_test' with parameters 'all'
Ran a total of 1 TestSuites and 224 TestCases
```
The issues with `test_cocotb_array` are an outstanding issue and will not be addressed.

With VHDL the following tests unexpectedly fail:
```
Failure in testsuite: 'all' classname: 'test_array' testcase: 'test_read_write' with parameters 'all'
Failure in testsuite: 'all' classname: 'test_discovery' testcase: 'access_string_vhdl' with parameters 'all'
Failure in testsuite: 'all' classname: 'test_deprecated' testcase: 'test_unicode_handle_assignment_deprecated' with parameters 'all'
Failure in testsuite: 'all' classname: 'test_timing_triggers' testcase: 'test_readwrite_in_readonly' with parameters 'all'
Failure in testsuite: 'all' classname: 'test_handle' testcase: 'test_string_handle_takes_bytes' with parameters 'all'
Ran a total of 1 TestSuites and 161 TestCases
```
The issue in `test_readwrite_in_readonly` is an outstanding issue with Questa and will not be addressed.