### PR TITLE
Ensure errors happen immediately when using delayed assignment

### DIFF
--- a/documentation/source/newsfragments/1661.bugfix.rst
+++ b/documentation/source/newsfragments/1661.bugfix.rst
@@ -1,0 +1,1 @@
+``signal <= value_of_wrong_type`` no longer breaks the scheduler, and throws an error immediately.

--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -6,6 +6,7 @@ Common utilities shared my many tests in this directory
 """
 import re
 import traceback
+from contextlib import contextmanager
 
 import cocotb
 from cocotb.result import TestFailure
@@ -41,3 +42,13 @@ def _check_traceback(running_coro, exc_type, pattern):
                 "{}"
             ).format(tb_text, pattern)
         )
+
+
+@contextmanager
+def assert_raises(exc_type):
+    try:
+        yield
+    except exc_type:
+        pass
+    else:
+        raise AssertionError("{} was not raised".format(exc_type.__name__))

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -4,6 +4,7 @@
 import cocotb
 import warnings
 from contextlib import contextmanager
+from common import assert_raises
 
 
 @contextmanager
@@ -18,15 +19,6 @@ def assert_deprecated():
         assert len(warns) == 1
         assert issubclass(warns[0].category, DeprecationWarning), "Expected DeprecationWarning"
 
-
-@contextmanager
-def assert_raises(exc_type):
-    try:
-        yield
-    except exc_type:
-        pass
-    else:
-        raise AssertionError("{} was not raised".format(exc_type.__name__))
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -7,6 +7,8 @@ Tests for handles
 import cocotb
 from cocotb.result import TestFailure
 
+from common import assert_raises
+
 
 @cocotb.test()
 def test_lessthan_raises_error(dut):
@@ -46,3 +48,19 @@ async def test_string_handle_takes_bytes(dut):
     val = dut.string_input_port.value
     assert isinstance(val, bytes)
     assert val == b"bytes"
+
+
+async def test_delayed_assignment_still_errors(dut):
+    """ Writing a bad value should fail even if the write is scheduled to happen later """
+
+    # note: all these fail because BinaryValue.assign rejects them
+
+    with assert_raises(ValueError):
+        dut.stream_in_int.setimmediatevalue("1010 not a real binary string")
+    with assert_raises(TypeError):
+        dut.stream_in_int.setimmediatevalue([])
+
+    with assert_raises(ValueError):
+        dut.stream_in_int <= "1010 not a real binary string"
+    with assert_raises(TypeError):
+        dut.stream_in_int <= []


### PR DESCRIPTION
Fixes gh-1657.

This possibly results in the docs being a bit less useful, as now every handle type has a `.value` property with exactly the same documentation. The documentation would be a lot more useful with https://github.com/sphinx-doc/sphinx/issues/7383, but alas that's probably a way off.