### PR TITLE
Remove dead code

### DIFF
--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -266,10 +266,6 @@ int FliLogicObjHdl::initialise(std::string &name, std::string &fq_name)
                 m_num_enum    = mti_TickLength(elemType);
 
                 m_mti_buff    = new char[m_num_elems+1];
-                if (!m_mti_buff) {
-                    LOG_CRITICAL("Unable to alloc mem for value object mti read buffer: ABORTING");
-                    return -1;
-                }
             }
             break;
         default:
@@ -282,9 +278,6 @@ int FliLogicObjHdl::initialise(std::string &name, std::string &fq_name)
     }
 
     m_val_buff = new char[m_num_elems+1];
-    if (!m_val_buff) {
-        LOG_CRITICAL("Unable to alloc mem for value object read buffer: ABORTING");
-    }
     m_val_buff[m_num_elems] = '\0';
 
     return FliValueObjHdl::initialise(name, fq_name);
@@ -403,10 +396,6 @@ int FliIntObjHdl::initialise(std::string &name, std::string &fq_name)
     m_num_elems   = 1;
 
     m_val_buff = new char[33];  // Integers are always 32-bits
-    if (!m_val_buff) {
-        LOG_CRITICAL("Unable to alloc mem for value object read buffer: ABORTING");
-        return -1;
-    }
     m_val_buff[m_num_elems] = '\0';
 
     return FliValueObjHdl::initialise(name, fq_name);
@@ -465,10 +454,6 @@ int FliRealObjHdl::initialise(std::string &name, std::string &fq_name)
     m_num_elems   = 1;
 
     m_mti_buff    = new double;
-    if (!m_mti_buff) {
-        LOG_CRITICAL("Unable to alloc mem for value object mti read buffer: ABORTING");
-        return -1;
-    }
 
     return FliValueObjHdl::initialise(name, fq_name);
 }
@@ -512,16 +497,8 @@ int FliStringObjHdl::initialise(std::string &name, std::string &fq_name)
     m_indexable   = true;
 
     m_mti_buff    = new char[m_num_elems];
-    if (!m_mti_buff) {
-        LOG_CRITICAL("Unable to alloc mem for value object mti read buffer: ABORTING");
-        return -1;
-    }
 
     m_val_buff    = new char[m_num_elems+1];
-    if (!m_val_buff) {
-        LOG_CRITICAL("Unable to alloc mem for value object read buffer: ABORTING");
-        return -1;
-    }
     m_val_buff[m_num_elems] = '\0';
 
     return FliValueObjHdl::initialise(name, fq_name);

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -296,9 +296,6 @@ int VhpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
             m_value.bufSize = static_cast<bufSize_type>(bufSize);
             m_value.value.str = new vhpiCharT[bufSize];
             m_value.numElems = m_num_elems;
-            if (!m_value.value.str) {
-                LOG_CRITICAL("Unable to alloc mem for write buffer");
-            }
             LOG_DEBUG("Overriding num_elems to %d", m_num_elems);
             break;
         }
@@ -318,10 +315,6 @@ int VhpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
         int bufSize = m_num_elems * static_cast<int>(sizeof(vhpiCharT)) + 1;
         m_binvalue.bufSize = static_cast<bufSize_type>(bufSize);
         m_binvalue.value.str = new vhpiCharT[bufSize];
-
-        if (!m_binvalue.value.str) {
-            LOG_CRITICAL("Unable to alloc mem for read buffer of signal %s", name.c_str());
-        }
     }
 
     return GpiObjHdl::initialise(name, fq_name);
@@ -367,9 +360,6 @@ int VhpiLogicSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
         int bufSize = m_num_elems * static_cast<int>(sizeof(vhpiEnumT));
         m_value.bufSize = static_cast<bufSize_type>(bufSize);
         m_value.value.enumvs = new vhpiEnumT[bufSize];
-        if (!m_value.value.enumvs) {
-            LOG_CRITICAL("Unable to alloc mem for write buffer: ABORTING");
-        }
     }
 
     if (m_indexable && get_range(handle, 0, &m_range_left, &m_range_right)) {
@@ -380,10 +370,6 @@ int VhpiLogicSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
         int bufSize = m_num_elems * static_cast<int>(sizeof(vhpiCharT)) + 1;
         m_binvalue.bufSize = static_cast<bufSize_type>(bufSize);
         m_binvalue.value.str = new vhpiCharT[bufSize];
-
-        if (!m_binvalue.value.str) {
-            LOG_CRITICAL("Unable to alloc mem for read buffer of signal %s", name.c_str());
-        }
     }
 
     return GpiObjHdl::initialise(name, fq_name);


### PR DESCRIPTION
The C++ standard mandates that `new T ` can never return NULL.
If an allocation fails, it must throw `std::bad_alloc`.

The only way `new` can return NULL is in the case `new (std::nothrow) T`, which we do not use.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
