### PR TITLE
Remove not needed includes of Makefile.inc

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ VERILOG_SOURCES = $(shell pwd)/dff.sv
 TOPLEVEL = dff
 MODULE = test_dff
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 ```
 

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -173,7 +173,6 @@ Python test script to load.
     # MODULE is the name of the Python test file:
     MODULE=test_my_design
 
-    include $(shell cocotb-config --makefiles)/Makefile.inc
     include $(shell cocotb-config --makefiles)/Makefile.sim
 
 We would then create a file called ``test_my_design.py`` containing our tests.

--- a/examples/adder/tests/Makefile
+++ b/examples/adder/tests/Makefile
@@ -44,5 +44,4 @@ endif
 TOPLEVEL := adder
 MODULE   := test_adder
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/examples/axi_lite_slave/tests/Makefile
+++ b/examples/axi_lite_slave/tests/Makefile
@@ -29,6 +29,5 @@ GPI_IMPL := vpi
 export TOPLEVEL_LANG
 MODULE=test_axi_lite_slave
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 

--- a/examples/dff/tests/Makefile
+++ b/examples/dff/tests/Makefile
@@ -30,7 +30,6 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 # list all required Python files here

--- a/examples/endian_swapper/tests/Makefile
+++ b/examples/endian_swapper/tests/Makefile
@@ -57,7 +57,6 @@ ifeq ($(OS),Linux)
     export LD_LIBRARY_PATH
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 ifeq ($(OS),Linux)

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -28,7 +28,6 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -34,7 +34,6 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/examples/ping_tun_tap/tests/Makefile
+++ b/examples/ping_tun_tap/tests/Makefile
@@ -43,7 +43,6 @@ PWD=$(shell pwd)
 VERILOG_SOURCES = $(PWD)/../hdl/icmp_reply.sv
 MODULE=test_icmp_reply
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/makefiles/Makefile.inc
+++ b/makefiles/Makefile.inc
@@ -10,6 +10,5 @@ ifeq ($(COCOTB_CONFIG_CMD),)
 endif
 
 $(error 'Deprecated cocotb file structure detected. \
-         Use "include $$(shell cocotb-config --makefile)/Makefile.inc" instead. \
          Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#creating-a-makefile \
          for instructions.')

--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -50,5 +50,4 @@ else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/avalon_module/Makefile
+++ b/tests/designs/avalon_module/Makefile
@@ -45,7 +45,6 @@ COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_module/burst_read_master.v
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/avalon_streaming_module/Makefile
+++ b/tests/designs/avalon_streaming_module/Makefile
@@ -16,7 +16,6 @@ COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_streaming_module/avalon_streaming.sv
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/basic_hierarchy_module/Makefile
+++ b/tests/designs/basic_hierarchy_module/Makefile
@@ -20,7 +20,6 @@ COCOTB?=$(PWD)/../../..
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/basic_hierarchy_module/basic_hierarchy_module.v
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/close_module/Makefile
+++ b/tests/designs/close_module/Makefile
@@ -46,7 +46,6 @@ COCOTB?=$(PWD)/../../..
 VERILOG_SOURCES = $(COCOTB)/tests/designs/close_module/close_module.v
 
 ifneq ($(SIM),vcs)
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 else
 all:

--- a/tests/designs/multi_dimension_array/Makefile
+++ b/tests/designs/multi_dimension_array/Makefile
@@ -46,7 +46,6 @@ COCOTB?=$(PWD)/../../..
 VERILOG_SOURCES = $(COCOTB)/tests/designs/multi_dimension_array/cocotb_array_pkg.sv \
                   $(COCOTB)/tests/designs/multi_dimension_array/cocotb_array.sv
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -47,5 +47,4 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -47,5 +47,4 @@ else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -36,7 +36,6 @@ ifeq ($(SIM),$(filter $(SIM),ius xcelium))
     SIM_ARGS += -v93
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -34,7 +34,6 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -65,7 +65,6 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif

--- a/tests/test_cases/test_iteration_verilog/Makefile
+++ b/tests/test_cases/test_iteration_verilog/Makefile
@@ -44,7 +44,6 @@ TOPLEVEL = endian_swapper_sv
 
 MODULE = test_iteration_es
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 endif


### PR DESCRIPTION
Thanks to #1629 we can remove all Makefile.inc from examples, test, and documentation.