### PR TITLE
Prevent killed coroutines from running in corner case

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -434,6 +434,9 @@ class Scheduler:
                 trigger.unprime()
 
                 for coro in scheduling:
+                    if coro._outcome is not None:
+                        # coroutine was unscheduled by another coroutine waiting on the same trigger
+                        continue
                     if _debug:
                         self.log.debug("Scheduling coroutine %s" % (coro.__qualname__))
                     self.schedule(coro, trigger=trigger)

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -435,7 +435,7 @@ class Scheduler:
 
                 for coro in scheduling:
                     if coro._outcome is not None:
-                        # coroutine was unscheduled by another coroutine waiting on the same trigger
+                        # coroutine was killed by another coroutine waiting on the same trigger
                         continue
                     if _debug:
                         self.log.debug("Scheduling coroutine %s" % (coro.__qualname__))


### PR DESCRIPTION
From #1348. There is a corner case in the scheduling logic: if two coroutines are waiting on the same trigger and one kills the other, and if the killer is scheduled *before* the victim, the victim will still be scheduled.

This is distinct from #1349, this fixes the issue in the scheduling logic, while that PR attempts to add a feature to the scheduler.