### PR TITLE
Start tests with react

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -811,6 +811,7 @@ class Scheduler:
 
     def finish_test(self, exc):
         self._test.abort(exc)
+        self._check_termination()
 
     def finish_scheduler(self, exc):
         """Directly call into the regression manager and end test

--- a/documentation/source/newsfragments/1705.bugfix.rst
+++ b/documentation/source/newsfragments/1705.bugfix.rst
@@ -1,0 +1,1 @@
+Scheduling behavior is now consistent before and after the first :keyword:`await` of a :class:`~cocotb.triggers.GPITrigger`.

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -95,9 +95,6 @@ and test_and_gate(and_output, stream_in_ready, stream_in_valid);
 initial begin
     $dumpfile("waveform.vcd");
     $dumpvars(0,sample_module);
-
-//   TODO: Move into a separate test
-//     #500000 $fail_test("Test timed out, failing...");
 end
 
 reg[3:0] temp;


### PR DESCRIPTION
Currently tests are started with `add`. This causes problems with how
certain Triggers behave, namely `Event` and `NullTrigger`.

They behave differently at the beginning of a test than after the test
awaits a `GPITrigger`. Using `react` to start the test makes the
triggers behave the same during the entirety of the test.

Trigger behavior is different when in a `react` event loop versus a straight `schedule` called through `add`.

Found while discussing scheduler details in #1541. Thanks to @ktbarrett for `NullTrigger` test.