### PR TITLE
Use conda to build documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,10 +4,14 @@
 
 version: 2
 
+# Use conda because default Python is not compiled with --enable-shared
+conda:
+  environment: documentation/conda.yml
+
 python:
-  version: 3.7
   install:
-    - requirements: documentation/requirements.txt
+    - method: pip
+      path: .
 
 sphinx:
   configuration: documentation/source/conf.py

--- a/documentation/conda.yml
+++ b/documentation/conda.yml
@@ -4,11 +4,6 @@ name: cocotb-docs3
 dependencies:
   - python=3.8
   - pip
-  # ReadTheDoc dependencies
-  - mock
-  - pillow
-  - sphinx
-  - sphinx_rtd_theme
   # Packages installed from PyPI
   - pip:
       - -r requirements.txt

--- a/documentation/conda.yml
+++ b/documentation/conda.yml
@@ -1,0 +1,14 @@
+# Python environment and dependencies to build the documentation
+
+name: cocotb-docs3
+dependencies:
+  - python=3.8
+  - pip
+  # ReadTheDoc dependencies
+  - mock
+  - pillow
+  - sphinx
+  - sphinx_rtd_theme
+  # Packages installed from PyPI
+  - pip:
+      - -r requirements.txt

--- a/documentation/conda.yml
+++ b/documentation/conda.yml
@@ -1,6 +1,6 @@
 # Python environment and dependencies to build the documentation
 
-name: cocotb-docs3
+name: cocotb-docs
 dependencies:
   - python=3.8
   - pip

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -12,11 +12,6 @@ import os
 import subprocess
 import sys
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../..'))
-
 # Add in-tree extensions to path
 sys.path.insert(0, os.path.abspath('../sphinxext'))
 


### PR DESCRIPTION
Conda is built with `--enable-shared` by default.
Closes https://github.com/cocotb/cocotb/issues/1569
In favor of https://github.com/cocotb/cocotb/pull/1573