### PR TITLE
Add test for VHDL-on-top in test_iteration_mixedlang

### DIFF
--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -1,41 +1,38 @@
 TOPLEVEL_LANG ?= verilog
 
-ifneq ($(TOPLEVEL_LANG),verilog)
-
-all:
-	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
-clean::
-
-else
-
 PWD=$(shell pwd)
 
 COCOTB?=$(PWD)/../../..
 
 SRC_BASE = $(COCOTB)/tests/designs/uart2bus
 
-VHDL_SOURCES =      $(SRC_BASE)/vhdl/uart2BusTop_pkg.vhd \
-                    $(SRC_BASE)/vhdl/baudGen.vhd \
-                    $(SRC_BASE)/vhdl/uartParser.vhd \
-                    $(SRC_BASE)/vhdl/uartRx.vhd \
-                    $(SRC_BASE)/vhdl/uartTx.vhd \
-                    $(SRC_BASE)/vhdl/uartTop.vhd \
-                    $(SRC_BASE)/vhdl/uart2BusTop.vhd
+VHDL_SOURCES += $(SRC_BASE)/vhdl/uart2BusTop_pkg.vhd
+VHDL_SOURCES += $(SRC_BASE)/vhdl/baudGen.vhd
+VHDL_SOURCES += $(SRC_BASE)/vhdl/uartParser.vhd
+VHDL_SOURCES += $(SRC_BASE)/vhdl/uartRx.vhd
+VHDL_SOURCES += $(SRC_BASE)/vhdl/uartTx.vhd
+VHDL_SOURCES += $(SRC_BASE)/vhdl/uartTop.vhd
+VHDL_SOURCES += $(SRC_BASE)/vhdl/uart2BusTop.vhd
+VHDL_SOURCES += $(SRC_BASE)/top/vhdl_toplevel.vhdl
 
-VERILOG_SOURCES =   $(SRC_BASE)/verilog/baud_gen.v \
-                    $(SRC_BASE)/verilog/uart_parser.v \
-                    $(SRC_BASE)/verilog/uart_rx.v \
-                    $(SRC_BASE)/verilog/uart_tx.v \
-                    $(SRC_BASE)/verilog/uart_top.v \
-                    $(SRC_BASE)/verilog/uart2bus_top.v
-
+VERILOG_SOURCES += $(SRC_BASE)/verilog/baud_gen.v
+VERILOG_SOURCES += $(SRC_BASE)/verilog/uart_parser.v
+VERILOG_SOURCES += $(SRC_BASE)/verilog/uart_rx.v
+VERILOG_SOURCES += $(SRC_BASE)/verilog/uart_tx.v
+VERILOG_SOURCES += $(SRC_BASE)/verilog/uart_top.v
+VERILOG_SOURCES += $(SRC_BASE)/verilog/uart2bus_top.v
 VERILOG_SOURCES += $(SRC_BASE)/top/verilog_toplevel.sv
-TOPLEVEL = verilog_toplevel
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+    TOPLEVEL = vhdl_toplevel
+else
+    TOPLEVEL = verilog_toplevel
+endif
 
 ifeq ($(SIM),$(filter $(SIM),ius xcelium))
     SIM_ARGS += -v93
+    # needed for the two different possible toplevels:
+    SIM_ARGS += -smartorder
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-endif

--- a/tests/designs/uart2bus/top/vhdl_toplevel.vhdl
+++ b/tests/designs/uart2bus/top/vhdl_toplevel.vhdl
@@ -1,0 +1,74 @@
+-- We simply connect two UARTs together in different languages
+--
+-- Also define a record to help the testcase
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity vhdl_toplevel is
+  port (
+    clk   : in std_ulogic;
+    reset : in std_ulogic);
+end;
+
+architecture impl of vhdl_toplevel is
+
+  type bus_struct_t is record
+    address : std_logic_vector(15 downto 0);
+    wr_data : std_logic_vector(7 downto 0);
+    read    : std_ulogic;
+    write   : std_ulogic;
+  end record bus_struct_t;
+
+  signal bus_verilog : bus_struct_t;
+  signal bus_vhdl    : bus_struct_t;
+
+  signal serial_v2h      : std_ulogic;
+  signal serial_h2v      : std_ulogic;
+  signal verilog_rd_data : std_logic_vector(7 downto 0);
+  signal vhdl_rd_data    : std_logic_vector(7 downto 0);
+
+begin
+
+  i_verilog : entity work.uart2bus_top
+    port map (
+      -- global signals
+      clock       => clk,
+      reset       => reset,
+      -- uart serial signals
+      ser_in      => serial_h2v,
+      ser_out     => serial_v2h,
+      -- internal bus to register file
+      int_address => bus_verilog.address,
+      int_wr_data => bus_verilog.wr_data,
+      int_write   => bus_verilog.write,
+      int_read    => bus_verilog.read,
+      int_rd_data => verilog_rd_data,
+
+      int_req => open,
+      int_gnt => '1'
+      );
+
+  i_vhdl : entity work.uart2BusTop
+    generic map (
+      AW => 16)                         -- [integer]
+    port map (
+      -- global signals
+      clk        => clk,                -- [in  STD_LOGIC]
+      clr        => reset,              -- [in  STD_LOGIC]
+      -- uart serial signals
+      serIn      => serial_v2h,         -- [in  STD_LOGIC]
+      serOut     => serial_h2v,         -- [out STD_LOGIC]
+      -- internal bus to register file
+      intAddress => bus_vhdl.address,   -- [out STD_LOGIC_VECTOR (AW - 1 downto 0)]
+      intWrData  => bus_vhdl.wr_data,   -- [out STD_LOGIC_VECTOR (7 downto 0)]
+      intWrite   => bus_vhdl.write,     -- [out STD_LOGIC]
+      intRead    => bus_vhdl.read,      -- [out STD_LOGIC]
+      intRdData  => vhdl_rd_data,       -- [in  STD_LOGIC_VECTOR (7 downto 0)]
+
+      intAccessReq => open,             -- [out std_logic]
+      intAccessGnt => '1'               -- [in  std_logic]
+      );
+
+end architecture;

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -66,8 +66,11 @@ def recursive_discovery(dut):
     Recursively discover every single object in the design
     """
     if cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
-        # vpiAlways = 31 and vpiStructVar = 2 do not show up in IUS/Xcelium
-        pass_total = 917
+        if cocotb.LANGUAGE == "verilog":
+            # vpiAlways = 31 and vpiStructVar = 2 do not show up in IUS/Xcelium
+            pass_total = 917
+        else:
+            pass_total = 975
     elif cocotb.SIM_NAME.lower().startswith(("modelsim")):
         pass_total = 933
     else:


### PR DESCRIPTION
Only Cadence simulators are supported because they use a single call to compile everything in one step and have a ``-smartorder`` switch.
For others, see #1707.

Closes #1686 
