### PR TITLE
Time unit and precision in Icarus

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -54,10 +54,11 @@ else
     export ICARUS_BIN_DIR
 endif
 
-COMPILE_ARGS += -g2012 # Default to latest SystemVerilog standard
+COMPILE_ARGS += -f $(SIM_BUILD)/cmds.f -g2012 # Default to latest SystemVerilog standard
 
 # Compilation phase
 $(SIM_BUILD)/sim.vvp: $(SIM_BUILD) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS)
+	@echo "+timescale+$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)" > $(SIM_BUILD)/cmds.f
 	$(CMD) -o $(SIM_BUILD)/sim.vvp -D COCOTB_SIM=1 -s $(TOPLEVEL) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -59,14 +59,6 @@ to the top component as shown in the example below:
     `endif
     endmodule
 
-.. _sim-icarus-time:
-
-Time unit and precision
------------------------
-
-Setting the time unit and time precision is not possible from the command-line,
-and therefore the make variables :make:var:`COCOTB_HDL_TIMEUNIT` and :make:var:`COCOTB_HDL_TIMEPRECISION` are ignored.
-
 
 .. _sim-verilator:
 


### PR DESCRIPTION
It is possible to set timescale through a command file - https://github.com/steveicarus/iverilog/issues/189

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
