### PR TITLE
Unconditional import of cocotb and removal of COCOTB_SIM

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -47,11 +47,6 @@ from cocotb.regression import RegressionManager
 # Things we want in the cocotb namespace
 from cocotb.decorators import test, coroutine, hook, function, external  # noqa: F401
 
-# Singleton scheduler instance
-# NB this cheekily ensures a singleton since we're replacing the reference
-# so that cocotb.scheduler gives you the singleton instance and not the
-# scheduler package
-
 from ._version import __version__
 
 # GPI logging instance
@@ -102,6 +97,12 @@ if "COCOTB_SIM" in os.environ:
     # warning settings in their test module.
     if not sys.warnoptions:
         warnings.simplefilter("default")
+
+
+# Singleton scheduler instance
+# NB this cheekily ensures a singleton since we're replacing the reference
+# so that cocotb.scheduler gives you the singleton instance and not the
+# scheduler package
 
 scheduler = Scheduler()
 """The global scheduler instance."""

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -112,8 +112,10 @@ regression_manager = None
 plusargs = {}
 """A dictionary of "plusargs" handed to the simulation."""
 
-# To save typing provide an alias to scheduler.add
-fork = scheduler.add
+
+def fork(coro):
+    """ Schedule a coroutine to be run concurrently. See :ref:`coroutines` for details on it's use. """
+    return scheduler.add(coro)
 
 # FIXME is this really required?
 _rlock = threading.RLock()

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -49,13 +49,9 @@ from cocotb.decorators import test, coroutine, hook, function, external  # noqa:
 
 from ._version import __version__
 
-# GPI logging instance
-if "COCOTB_SIM" in os.environ:
 
-    # sys.path normally includes "" (the current directory), but does not appear to when python is embedded.
-    # Add it back because users expect to be able to import files in their test directory.
-    # TODO: move this to gpi_embed.cpp
-    sys.path.insert(0, "")
+def _setup_logging():
+    global log
 
     def _reopen_stream_with_buffering(stream_name):
         try:
@@ -92,12 +88,6 @@ if "COCOTB_SIM" in os.environ:
 
     del _stderr_buffer_result, _stdout_buffer_result
 
-    # From https://www.python.org/dev/peps/pep-0565/#recommended-filter-settings-for-test-runners
-    # If the user doesn't want to see these, they can always change the global
-    # warning settings in their test module.
-    if not sys.warnoptions:
-        warnings.simplefilter("default")
-
 
 # Singleton scheduler instance
 # NB this cheekily ensures a singleton since we're replacing the reference
@@ -116,6 +106,7 @@ plusargs = {}
 def fork(coro):
     """ Schedule a coroutine to be run concurrently. See :ref:`coroutines` for details on it's use. """
     return scheduler.add(coro)
+
 
 # FIXME is this really required?
 _rlock = threading.RLock()
@@ -153,6 +144,19 @@ def _initialise_testbench(argv_):
         elif '.' in root_name:
             # Skip any library component of the toplevel
             root_name = root_name.split(".", 1)[1]
+
+    # sys.path normally includes "" (the current directory), but does not appear to when python is embedded.
+    # Add it back because users expect to be able to import files in their test directory.
+    # TODO: move this to gpi_embed.cpp
+    sys.path.insert(0, "")
+
+    _setup_logging()
+
+    # From https://www.python.org/dev/peps/pep-0565/#recommended-filter-settings-for-test-runners
+    # If the user doesn't want to see these, they can always change the global
+    # warning settings in their test module.
+    if not sys.warnoptions:
+        warnings.simplefilter("default")
 
     from cocotb import simulator
 

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -38,6 +38,7 @@ import random
 import time
 import warnings
 
+import cocotb._os_compat  # must appear first, before the first import of cocotb.simulator
 import cocotb.handle
 import cocotb.log
 from cocotb.scheduler import Scheduler

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -104,7 +104,7 @@ if "COCOTB_SIM" in os.environ:
 # so that cocotb.scheduler gives you the singleton instance and not the
 # scheduler package
 
-scheduler = Scheduler()
+scheduler = None
 """The global scheduler instance."""
 
 regression_manager = None
@@ -170,6 +170,9 @@ def _initialise_testbench(argv_):
     # Create the base handle type
 
     process_plusargs()
+
+    global scheduler
+    scheduler = Scheduler()
 
     # Seed the Python random number generator to make this repeatable
     global RANDOM_SEED

--- a/cocotb/_os_compat.py
+++ b/cocotb/_os_compat.py
@@ -1,0 +1,21 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+OS-specific hacks
+"""
+import os
+import sys
+
+# This is necessary for Windows, which does not support RPATH, causing it
+# to not be able to locate the simulator module, which is imported
+# unconditionally.
+
+extra_dll_dir = os.path.join(os.path.dirname(__file__), 'libs')
+
+if sys.platform == 'win32' and os.path.isdir(extra_dll_dir):
+    if sys.version_info >= (3, 8):
+        os.add_dll_directory(extra_dll_dir)
+    else:
+        os.environ.setdefault('PATH', '')
+        os.environ['PATH'] += os.pathsep + extra_dll_dir

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -32,14 +32,8 @@
 import ctypes
 import warnings
 
-import os
-
-if "COCOTB_SIM" in os.environ:
-    from cocotb import simulator
-else:
-    simulator = None
-
 import cocotb
+from cocotb import simulator
 from cocotb.binary import BinaryValue
 from cocotb.log import SimLog
 from cocotb.result import TestError

--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -96,9 +96,8 @@ def default_config():
 
     # Notify GPI of log level, which it uses as an optimization to avoid
     # calling into Python.
-    if "COCOTB_SIM" in os.environ:
-        from cocotb import simulator
-        simulator.log_level(_default_log)
+    from cocotb import simulator
+    simulator.log_level(_default_log)
 
 
 class SimBaseLog(logging.getLoggerClass()):

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -46,15 +46,12 @@ from cocotb.decorators import test as Test, hook as Hook, RunningTask
 from cocotb.outcomes import Outcome, Error
 from cocotb.handle import SimHandle
 
+from cocotb import simulator
+
 if "COCOTB_PDB_ON_EXCEPTION" in os.environ:
     _pdb_on_exception = True
 else:
     _pdb_on_exception = False
-
-if "COCOTB_SIM" in os.environ:
-    from cocotb import simulator
-else:
-    simulator = None
 
 # Optional support for coverage collection of testbench files
 coverage = None

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -207,11 +207,6 @@ void gpi_load_extra_libs()
     /* Lets look at what other libs we were asked to load too */
     char *lib_env = getenv("GPI_EXTRA");
 
-    /* inform python that we are in simulation
-     * TODO[gh-1566]: Eliminate the need for this completely. */
-    static char cocotb_sim_env[] = "COCOTB_SIM=1";
-    putenv(cocotb_sim_env);  // putenv requires the array lifetime to be as long as the program lifetime, hence the static
-
     if (lib_env) {
         std::string lib_list = lib_env;
         std::string const delim = ",";

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -27,15 +27,10 @@
 
 """A collections of triggers which a testbench can await."""
 
-import os
 import abc
 from collections.abc import Awaitable
 
-if "COCOTB_SIM" in os.environ:
-    from cocotb import simulator
-else:
-    simulator = None
-
+from cocotb import simulator
 from cocotb.log import SimLog
 from cocotb.utils import (
     get_sim_steps, get_time_from_sim_steps, ParametrizedSingleton,

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -33,7 +33,7 @@ from collections.abc import Awaitable
 from cocotb import simulator
 from cocotb.log import SimLog
 from cocotb.utils import (
-    get_sim_steps, get_time_from_sim_steps, ParametrizedSingleton,
+    get_sim_steps, ParametrizedSingleton,
     lazy_property, remove_traceback_frames,
 )
 from cocotb import outcomes
@@ -196,7 +196,13 @@ class Timer(GPITrigger):
             :func:`~cocotb.utils.get_sim_steps`
         """
         GPITrigger.__init__(self)
-        self.sim_steps = get_sim_steps(time_ps, units)
+        self._time_ps = time_ps
+        self._units = units
+
+    @lazy_property
+    def sim_steps(self):
+        # lazy so we don't call into the simulator until we need to
+        return get_sim_steps(self._time_ps, self._units)
 
     def prime(self, callback):
         """Register for a timed callback."""
@@ -208,9 +214,10 @@ class Timer(GPITrigger):
         GPITrigger.prime(self, callback)
 
     def __repr__(self):
-        return "<{} of {:1.2f}ps at {}>".format(
+        return "<{} of {:1.2f}{} at {}>".format(
             type(self).__qualname__,
-            get_time_from_sim_steps(self.sim_steps, units='ps'),
+            self._time_ps,
+            self._units,
             _pointer_str(self)
         )
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -38,6 +38,14 @@ import warnings
 from cocotb import simulator
 
 
+def _get_simulator_precision():
+    # cache and replace this function
+    precision = simulator.get_precision()
+    global _get_simulator_precision
+    _get_simulator_precision = precision.__int__
+    return _get_simulator_precision()
+
+
 def get_python_integer_types():
     warnings.warn(
         "This is an internal cocotb function, use six.integer_types instead",
@@ -89,7 +97,7 @@ def get_time_from_sim_steps(steps, units):
     Returns:
         The simulation time in the specified units.
     """
-    return _ldexp10(steps, simulator.get_precision() - _get_log_time_scale(units))
+    return _ldexp10(steps, _get_simulator_precision() - _get_log_time_scale(units))
 
 
 def get_sim_steps(time, units=None):
@@ -109,14 +117,14 @@ def get_sim_steps(time, units=None):
     """
     result = time
     if units is not None:
-        result = _ldexp10(result, _get_log_time_scale(units) - simulator.get_precision())
+        result = _ldexp10(result, _get_log_time_scale(units) - _get_simulator_precision())
 
     result_rounded = math.floor(result)
 
     if result_rounded != result:
         raise ValueError("Unable to accurately represent {0}({1}) with the "
                          "simulator precision of 1e{2}".format(
-                             time, units, simulator.get_precision()))
+                             time, units, _get_simulator_precision()))
 
     return int(result_rounded)
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -35,12 +35,7 @@ import weakref
 import functools
 import warnings
 
-if "COCOTB_SIM" in os.environ:
-    from cocotb import simulator
-    _LOG_SIM_PRECISION = simulator.get_precision()  # request once and cache
-else:
-    simulator = None
-    _LOG_SIM_PRECISION = -15
+from cocotb import simulator
 
 
 def get_python_integer_types():
@@ -94,7 +89,7 @@ def get_time_from_sim_steps(steps, units):
     Returns:
         The simulation time in the specified units.
     """
-    return _ldexp10(steps, _LOG_SIM_PRECISION - _get_log_time_scale(units))
+    return _ldexp10(steps, simulator.get_precision() - _get_log_time_scale(units))
 
 
 def get_sim_steps(time, units=None):
@@ -114,14 +109,14 @@ def get_sim_steps(time, units=None):
     """
     result = time
     if units is not None:
-        result = _ldexp10(result, _get_log_time_scale(units) - _LOG_SIM_PRECISION)
+        result = _ldexp10(result, _get_log_time_scale(units) - simulator.get_precision())
 
     result_rounded = math.floor(result)
 
     if result_rounded != result:
         raise ValueError("Unable to accurately represent {0}({1}) with the "
                          "simulator precision of 1e{2}".format(
-                             time, units, _LOG_SIM_PRECISION))
+                             time, units, simulator.get_precision()))
 
     return int(result_rounded)
 

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -21,7 +21,7 @@ help: .venv
 	python3 -m venv .venv
 	.venv/bin/pip -q install --upgrade pip
 	.venv/bin/pip -q install -r requirements.txt
-	.venv/bin/pip -q install ..
+	.venv/bin/pip -q install -e ..
 
 .PHONY: clean
 clean: .venv Makefile

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -336,7 +336,8 @@ graphviz_output_format = 'svg'
 # -- Extra setup for towncrier -------------------------------------------------
 # see also https://towncrier.readthedocs.io/en/actual-freaking-docs/
 
-in_progress_notes = subprocess.check_output(['towncrier', '--draft'],
+# we pass the name and version directly, to avoid towncrier failing to import the non-installed version
+in_progress_notes = subprocess.check_output(['towncrier', '--draft', '--name', 'cocotb', '--version', release],
                                             cwd='../..',
                                             universal_newlines=True)
 with open('generated/master-notes.rst', 'w') as f:


### PR DESCRIPTION
Closes #1566. This removes `COCOTB_SIM` from the cocotb Python package. It was typically used to condition import of the simulator module. There was a number of accesses on the simulator module that caused segfaults if it wasn't conditioned. Now,

- the simulator module is imported unconditionally (usage still causes a segfault). Supplants #1568.
- all code that accessed the simulator module that ran at cocotb module's load has been moved so it runs later, in code paths only used for actual simulations
- because of that unconditional import when loading the package, the build script had to be moved out of the package. See #1716.

#1713 is a sister PR to remove the variable from the makefiles.

The merge commit was done so we can retain the history from `_build_libs.py` in `setup.py`. I know it looks weird. Perhaps that can be squashed? EDIT: no it cannot.