### PR TITLE
Move build_libs.py out of cocotb package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-include cocotb/share *.c* *.h *.def Makefile.* Makefile
 recursive-include examples *.v *.py Makefile *.tcl *.cfg
 include version
 include README.md
+include cocotb_build_libs.py

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -16,7 +16,7 @@ from distutils.file_util import copy_file
 
 
 logger = logging.getLogger(__name__)
-cocotb_share_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "share"))
+cocotb_share_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "cocotb", "share"))
 
 
 def _get_lib_ext_name():

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,9 @@ from setuptools import find_packages
 from os import path, walk
 from io import StringIO
 
-# note: cocotb is not installed properly yet, but we can import it anyway
-# because it's in the current directory. We'll need to change this if we
-# add `install_requires` to the `setup()` call.
-from cocotb._build_libs import get_ext, build_ext
+# Note: cocotb is not installed properly yet and is missing dependencies and binaries
+# We can still import other files next to setup.py, as long as they're in MANIFEST.in
+from cocotb_build_libs import get_ext, build_ext
 
 def read_file(fname):
     with open(path.join(path.dirname(__file__), fname), encoding='utf8') as f:


### PR DESCRIPTION
Prevents the running of the cocotb package when importing. Need for unconditioned import of the simulator module. Closes #1716.