### PR TITLE
Add is_set method to Event

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -420,6 +420,10 @@ class Event:
         :meth:`~cocotb.triggers.Event.set` is called again."""
         self.fired = False
 
+    def is_set(self):
+        """ Return true if event has been set """
+        return self.fired
+
     def __repr__(self):
         if self.name is None:
             fmt = "<{0} at {2}>"

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -420,7 +420,7 @@ class Event:
         :meth:`~cocotb.triggers.Event.set` is called again."""
         self.fired = False
 
-    def is_set(self):
+    def is_set(self) -> bool:
         """ Return true if event has been set """
         return self.fired
 

--- a/documentation/source/newsfragments/1723.feature.rst
+++ b/documentation/source/newsfragments/1723.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`~cocotb.triggers.Event.is_set`, so users may check if an :class:`~cocotb.triggers.Event` has fired.

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -145,3 +145,14 @@ def test_combine(dut):
     crs = [cocotb.fork(do_something(dly)) for dly in [10, 30, 20]]
 
     yield Combine(*(cr.join() for cr in crs))
+
+
+@cocotb.test()
+async def test_event_is_set(dut):
+    e = Event()
+
+    assert not e.is_set()
+    e.set()
+    assert e.is_set()
+    e.clear()
+    assert not e.is_set()


### PR DESCRIPTION
Mirrors [`asyncio.Event`](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Event.is_set). While `.fired` does exist, and is public, it is not documented.