### PR TITLE
Remove unused LIB_LOAD makefile variable.

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -62,7 +62,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(CUSTOM_COMPILE_DEPS) $(CUSTOM_S
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do | tee $(SIM_BUILD)/sim.log
+	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do | tee $(SIM_BUILD)/sim.log
 
 	$(call check_for_results_file)
 

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -146,7 +146,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(CUSTOM_COMPILE_DEPS) $(CUSTOM_
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.tcl | tee $(SIM_BUILD)/sim.log
+	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.tcl | tee $(SIM_BUILD)/sim.log
 
 	$(call check_for_results_file)
 

--- a/tests/test_cases/issue_253/Makefile
+++ b/tests/test_cases/issue_253/Makefile
@@ -56,7 +56,7 @@ empty_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	mkdir -p $@_result && mv results.xml $@_result/
 
 no_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
-	$(LIB_LOAD) MODULE=$(MODULE) \
+	MODULE=$(MODULE) \
 	TESTCASE=issue_253_none \
 	vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 	mkdir -p $@_result && mv results.xml $@_result/


### PR DESCRIPTION
`LIB_LOAD` is leftover from past changes (mostly windows support).