### PR TITLE
Remove obsolete comment about Icarus and COCOTB_HDL_TIME*

### DIFF
--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -105,8 +105,6 @@ and
       Allowed values are 1, 10, and 100.
       Allowed units are ``s``, ``ms``, ``us``, ``ns``, ``ps``, ``fs``.
 
-      NOTE: Icarus Verilog does not support this variable
-
       .. versionadded:: 1.3
 
 .. make:var:: COCOTB_HDL_TIMEPRECISION
@@ -115,8 +113,6 @@ and
       If this isn't specified then it is assumed to be ``1ps``.
       Allowed values are 1, 10, and 100.
       Allowed units are ``s``, ``ms``, ``us``, ``ns``, ``ps``, ``fs``.
-
-      NOTE: Icarus Verilog does not support this variable
 
       .. versionadded:: 1.3
 


### PR DESCRIPTION
We support ``COCOTB_HDL_TIMEUNIT`` and ``COCOTB_HDL_TIMEPRECISION`` for Icarus since #1711