### PR TITLE
Document multiple newsfragment support.

### DIFF
--- a/documentation/source/newsfragments/README.rst
+++ b/documentation/source/newsfragments/README.rst
@@ -26,6 +26,14 @@ and do not use a bullet point at the beginning of the file.
 Use Sphinx references (see https://sphinx-tutorial.readthedocs.io/cheatsheet/)
 if you refer to added classes, methods etc.
 
+Additional newsfragments of the same ``<TYPE>`` for a single ``<ISSUE_OR_PR>`` are
+supported, using the name format ``<ISSUE_OR_PR>.<TYPE>.<#>.rst``.
+
+Example:
+
+* ``<ISSUE_OR_PR>.bugfix.rst``
+* ``<ISSUE_OR_PR>.bugfix.1.rst``
+
 An example file could consist of the content between the marks:
 
 --8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<


### PR DESCRIPTION
Add note to the newsfragment README.

Multiple newsfragments of the same type are supported for a single PR.
Each shows up as its own bullet point in the release notes.

See https://github.com/garmin-mjames/cocotb/tree/multi_newsfragments/documentation/source/newsfragments for how Github renders the README.

See https://cocotb--1705.org.readthedocs.build/en/1705/release_notes.html#bugfixes for an example of the result (#1705 bug fixes).