### PR TITLE
Change how cocotb is built for documentation

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -21,6 +21,7 @@ help: .venv
 	python3 -m venv .venv
 	.venv/bin/pip -q install --upgrade pip
 	.venv/bin/pip -q install -r requirements.txt
+	.venv/bin/pip -q install ..
 
 .PHONY: clean
 clean: .venv Makefile


### PR DESCRIPTION
Encountered an error while building documentation locally on master. It seems that the cocotb package doesn't make it into the virtualenv that the documentation build uses. I get the following error.

```
~/dev/cocotb/documentation (master) $ make html
make .venv
make[1]: Entering directory '/home/kaleb/dev/cocotb/documentation'
make[1]: '.venv' is up to date.
make[1]: Leaving directory '/home/kaleb/dev/cocotb/documentation'
source .venv/bin/activate; .venv/bin/sphinx-build -M html "source" "build"  
/bin/sh: 1: source: not found
Running Sphinx v3.0.3

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/kaleb/dev/cocotb/documentation/.venv/lib/python3.7/site-packages/sphinx/config.py", line 319, in eval_config_file
    execfile_(filename, namespace)
  File "/home/kaleb/dev/cocotb/documentation/.venv/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 81, in execfile_
    exec(code, _globals)
  File "/home/kaleb/dev/cocotb/documentation/source/conf.py", line 18, in <module>
    import cocotb
ModuleNotFoundError: No module named 'cocotb'

make: *** [Makefile:43: html] Error 2
```

I added cocotb to the list of packages to install in the Makefile. Should this instead go into the `requirements.txt`?