### PR TITLE
Move product and version information to simulatormodule

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -137,6 +137,14 @@ def _initialise_testbench(root_name):
     """
     _rlock.acquire()
 
+    from cocotb import simulator
+
+    global SIM_NAME, SIM_VERSION
+    SIM_NAME = simulator.get_simulator_product()
+    SIM_VERSION = simulator.get_simulator_version()
+
+    cocotb.log.info("Running on {} version {}".format(SIM_NAME, SIM_VERSION))
+
     memcheck_port = os.getenv('MEMCHECK')
     if memcheck_port is not None:
         mem_debug(int(memcheck_port))

--- a/cocotb/share/include/embed.h
+++ b/cocotb/share/include/embed.h
@@ -41,7 +41,7 @@ extern "C" {
 
 extern void embed_init_python(void);
 extern void embed_sim_cleanup(void);
-extern int embed_sim_init(gpi_sim_info_t *info);
+extern int embed_sim_init(int argc, char const* const* argv);
 extern void embed_sim_event(gpi_event_t level, const char *msg);
 
 #ifdef __cplusplus

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -111,15 +111,6 @@ typedef enum gpi_event_e {
     SIM_FAIL = 2,
 } gpi_event_t;
 
-typedef struct gpi_sim_info_s
-{
-    int32_t   argc;
-    char      **argv;
-    char      *product;
-    char      *version;
-    int32_t   *reserved[4];
-} gpi_sim_info_t;
-
 // Functions for controlling/querying the simulation state
 
 // Stop the simulator
@@ -132,6 +123,19 @@ void gpi_cleanup(void);
 void gpi_get_sim_time(uint32_t *high, uint32_t *low);
 void gpi_get_sim_precision(int32_t *precision);
 
+/**
+ * Returns a string with the running simulator product information
+ *
+ * @return simulator product string
+ */
+const char *gpi_get_simulator_product(void);
+
+/**
+ * Returns a string with the running simulator version
+ *
+ * @return simulator version string
+ */
+const char *gpi_get_simulator_version(void);
 
 // Functions for extracting a gpi_sim_hdl to an object
 // Returns a handle to the root simulation object,

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -219,7 +219,7 @@ static int get_module_ref(const char *modname, PyObject **mod)
     return 0;
 }
 
-extern "C" int embed_sim_init(gpi_sim_info_t *info)
+extern "C" int embed_sim_init(int argc, char const * const * argv)
 {
     FENTER
 
@@ -257,8 +257,11 @@ extern "C" int embed_sim_init(gpi_sim_info_t *info)
     PyGILState_STATE gstate = PyGILState_Ensure();
     to_python();
 
-    if (get_module_ref("cocotb", &cocotb_module))
+    if (get_module_ref("cocotb", &cocotb_module)) {
         goto cleanup;
+    }
+
+    LOG_INFO("Python interpreter initialized and cocotb loaded!");
 
     if (get_module_ref("cocotb.log", &cocotb_log_module)) {
         goto cleanup;
@@ -295,16 +298,16 @@ extern "C" int embed_sim_init(gpi_sim_info_t *info)
     set_log_filter(simlog_func);                                        // Note: This function steals a reference to simlog_func.
 
     // Build argv for cocotb module
-    argv_list = PyList_New(info->argc);                                 // New reference
+    argv_list = PyList_New(argc);                                       // New reference
     if (argv_list == NULL) {
         PyErr_Print();
         LOG_ERROR("Unable to create argv list");
         goto cleanup;
     }
-    for (i = 0; i < info->argc; i++) {
+    for (i = 0; i < argc; i++) {
         // Decode, embedding non-decodable bytes using PEP-383. This can only
         // fail with MemoryError or similar.
-        PyObject *argv_item = PyUnicode_DecodeLocale(info->argv[i], "surrogateescape");  // New reference
+        PyObject *argv_item = PyUnicode_DecodeLocale(argv[i], "surrogateescape");  // New reference
         if (argv_item == NULL) {
             PyErr_Print();
             LOG_ERROR("Unable to convert command line argument %d to Unicode string.", i);
@@ -323,25 +326,9 @@ extern "C" int embed_sim_init(gpi_sim_info_t *info)
     }
 
     // Add argc to cocotb module
-    if (-1 == PyModule_AddIntConstant(cocotb_module, "argc", info->argc)) {
+    if (-1 == PyModule_AddIntConstant(cocotb_module, "argc", argc)) {
         PyErr_Print();
         LOG_ERROR("Unable to set argc");
-        goto cleanup;
-    }
-
-    LOG_INFO("Running on %s version %s", info->product, info->version);
-    LOG_INFO("Python interpreter initialized and cocotb loaded!");
-
-    // Now that logging has been set up ok, we initialize the testbench
-    if (-1 == PyModule_AddStringConstant(cocotb_module, "SIM_NAME", info->product)) {
-        PyErr_Print();
-        LOG_ERROR("Unable to set SIM_NAME");
-        goto cleanup;
-    }
-
-    if (-1 == PyModule_AddStringConstant(cocotb_module, "SIM_VERSION", info->version)) {
-        PyErr_Print();
-        LOG_ERROR("Unable to set SIM_VERSION");
         goto cleanup;
     }
 

--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -192,42 +192,16 @@ static std::vector<std::string> get_argv()
 
 int FliStartupCbHdl::run_callback()
 {
-    gpi_sim_info_t sim_info;
 
-    char *c_info       = mti_GetProductVersion();      // Returned pointer must not be freed
-    std::string info   = c_info;
-    std::string search = " Version ";
-    std::size_t found  = info.find(search);
-
-    std::string product_str = c_info;
-    std::string version_str = c_info;
-
-    if (found != std::string::npos) {
-        product_str = info.substr(0,found);
-        version_str = info.substr(found+search.length());
-
-        LOG_DEBUG("Found Version string at %d", found);
-        LOG_DEBUG("   product: %s", product_str.c_str());
-        LOG_DEBUG("   version: %s", version_str.c_str());
+    std::vector<std::string> const argv_storage = get_argv();
+    std::vector<const char*> argv_cstr;
+    for (const auto& arg : argv_storage) {
+        argv_cstr.push_back(arg.c_str());
     }
+    int argc = static_cast<int>(argv_storage.size());
+    const char** argv = argv_cstr.data();
 
-    std::vector<char> product(product_str.begin(), product_str.end());
-    std::vector<char> version(version_str.begin(), version_str.end());
-    product.push_back('\0');
-    version.push_back('\0');
-
-    sim_info.product = &product[0];
-    sim_info.version = &version[0];
-
-    std::vector<std::string> argv = get_argv();
-    std::vector<char*> argv_cstr;
-    for (const auto& arg : argv) {
-        argv_cstr.push_back(const_cast<char*>(arg.c_str()));
-    }
-    sim_info.argc = static_cast<int>(argv.size());
-    sim_info.argv = argv_cstr.data();
-
-    gpi_embed_init(&sim_info);
+    gpi_embed_init(argc, argv);
 
     return 0;
 }

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -434,6 +434,30 @@ void FliImpl::get_sim_precision(int32_t *precision)
     *precision = mti_GetResolutionLimit();
 }
 
+const char *FliImpl::get_simulator_product()
+{
+    if (m_product.empty() && m_version.empty()) {
+        const std::string info = mti_GetProductVersion(); // Returned pointer must not be freed, does not fail
+        const std::string search = " Version ";
+        const std::size_t found = info.find(search);
+
+        if (found != std::string::npos) {
+            m_product = info.substr(0, found);
+            m_version = info.substr(found + search.length());
+        } else {
+            m_product = info;
+            m_version = "UNKNOWN";
+        }
+    }
+    return m_product.c_str();
+}
+
+const char *FliImpl::get_simulator_version()
+{
+    get_simulator_product();
+    return m_version.c_str();
+}
+
 /**
  * @name    Find the root handle
  * @brief   Find the root handle using an optional name

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -472,6 +472,8 @@ public:
     void sim_end() override;
     void get_sim_time(uint32_t *high, uint32_t *low) override;
     void get_sim_precision(int32_t *precision) override;
+    const char *get_simulator_product() override;
+    const char *get_simulator_version() override;
 
     /* Hierachy related */
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) override;

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -124,9 +124,9 @@ int gpi_register_impl(GpiImplInterface *func_tbl)
     return 0;
 }
 
-void gpi_embed_init(gpi_sim_info_t *info)
+void gpi_embed_init(int argc, char const* const* argv)
 {
-    if (embed_sim_init(info))
+    if (embed_sim_init(argc, argv))
         gpi_embed_end();
 }
 
@@ -256,6 +256,16 @@ void gpi_get_sim_precision(int32_t *precision)
 
     *precision = val;
 
+}
+
+const char *gpi_get_simulator_product()
+{
+    return registered_impls[0]->get_simulator_product();
+}
+
+const char *gpi_get_simulator_version()
+{
+    return registered_impls[0]->get_simulator_version();
 }
 
 gpi_sim_hdl gpi_get_root_handle(const char *name)

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -289,6 +289,8 @@ public:
     virtual void sim_end() = 0;
     virtual void get_sim_time(uint32_t *high, uint32_t *low) = 0;
     virtual void get_sim_precision(int32_t *precision) = 0;
+    virtual const char* get_simulator_product() = 0;
+    virtual const char* get_simulator_version() = 0;
 
     /* Hierarchy related */
     virtual GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) = 0;
@@ -309,12 +311,15 @@ public:
 
 private:
     std::string m_name;
+protected:
+    std::string m_product;
+    std::string m_version;
 };
 
 /* Called from implementation layers back up the stack */
 int gpi_register_impl(GpiImplInterface *func_tbl);
 
-void gpi_embed_init(gpi_sim_info_t *info);
+void gpi_embed_init(int argc, char const* const* argv);
 void gpi_cleanup();
 void gpi_embed_end();
 void gpi_embed_event(gpi_event_t level, const char *msg);

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -761,6 +761,20 @@ static PyObject *get_precision(PyObject *self, PyObject *args)
     return PyLong_FromLong(precision);
 }
 
+static PyObject *get_simulator_product(PyObject *m, PyObject *args)
+{
+    COCOTB_UNUSED(m);
+    COCOTB_UNUSED(args);
+    return Py_BuildValue("s", gpi_get_simulator_product());
+}
+
+static PyObject *get_simulator_version(PyObject *m, PyObject *args)
+{
+    COCOTB_UNUSED(m);
+    COCOTB_UNUSED(args);
+    return Py_BuildValue("s", gpi_get_simulator_version());
+}
+
 static PyObject *get_num_elems(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args)
 {
     COCOTB_UNUSED(args);

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -765,7 +765,7 @@ static PyObject *get_simulator_product(PyObject *m, PyObject *args)
 {
     COCOTB_UNUSED(m);
     COCOTB_UNUSED(args);
-    return Py_BuildValue("s", gpi_get_simulator_product());
+    return PyUnicode_FromString(gpi_get_simulator_product());
 }
 
 static PyObject *get_simulator_version(PyObject *m, PyObject *args)

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -772,7 +772,7 @@ static PyObject *get_simulator_version(PyObject *m, PyObject *args)
 {
     COCOTB_UNUSED(m);
     COCOTB_UNUSED(args);
-    return Py_BuildValue("s", gpi_get_simulator_version());
+    return PyUnicode_FromString(gpi_get_simulator_version());
 }
 
 static PyObject *get_num_elems(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args)

--- a/cocotb/share/lib/simulator/simulatormodule.h
+++ b/cocotb/share/lib/simulator/simulatormodule.h
@@ -64,6 +64,8 @@ static PyObject *stop_simulator(PyObject *self, PyObject *args);
 
 static PyObject *get_sim_time(PyObject *self, PyObject *args);
 static PyObject *get_precision(PyObject *self, PyObject *args);
+static PyObject *get_simulator_product(PyObject *self, PyObject *args);
+static PyObject *get_simulator_version(PyObject *self, PyObject *args);
 
 static PyObject *log_level(PyObject *self, PyObject *args);
 
@@ -80,6 +82,8 @@ static PyMethodDef SimulatorMethods[] = {
 
     {"get_sim_time", get_sim_time, METH_NOARGS, "Get the current simulation time as an int tuple"},
     {"get_precision", get_precision, METH_NOARGS, "Get the precision of the simulator"},
+    {"get_simulator_product", get_simulator_product, METH_NOARGS, "Simulator product information"},
+    {"get_simulator_version", get_simulator_version, METH_NOARGS, "Simulator product version information"},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -833,16 +833,11 @@ VhpiStartupCbHdl::VhpiStartupCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
 
 int VhpiStartupCbHdl::run_callback() {
     vhpiHandleT tool, argv_iter, argv_hdl;
-    gpi_sim_info_t sim_info;
     char **tool_argv = NULL;
     int tool_argc = 0;
     int i = 0;
 
     tool = vhpi_handle(vhpiTool, NULL);
-
-    sim_info.product = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiNameP, tool)));
-    sim_info.version = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiToolVersionP, tool)));
-
     if (tool) {
         tool_argc = static_cast<int>(vhpi_get(vhpiArgcP, tool));
         tool_argv = new char*[tool_argc];
@@ -856,13 +851,11 @@ int VhpiStartupCbHdl::run_callback() {
             }
             vhpi_release_handle(argv_iter);
         }
-        sim_info.argc = tool_argc;
-        sim_info.argv = tool_argv;
 
         vhpi_release_handle(tool);
     }
 
-    gpi_embed_init(&sim_info);
+    gpi_embed_init(tool_argc, tool_argv);
     delete [] tool_argv;
 
     return 0;

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -110,6 +110,34 @@ void VhpiImpl::get_sim_precision(int32_t *precision)
     *precision = log10int(femtoseconds) - 15;
 }
 
+const char *VhpiImpl::get_simulator_product()
+{
+    if (m_product.empty()) {
+        vhpiHandleT tool = vhpi_handle(vhpiTool, NULL);
+        if (tool) {
+            m_product = vhpi_get_str(vhpiNameP, tool);
+            vhpi_release_handle(tool);
+        } else {
+            m_product = "UNKNOWN";
+        }
+    }
+    return m_product.c_str();
+}
+
+const char *VhpiImpl::get_simulator_version()
+{
+    if (m_version.empty()) {
+        vhpiHandleT tool = vhpi_handle(vhpiTool, NULL);
+        if (tool) {
+            m_version = vhpi_get_str(vhpiToolVersionP, tool);
+            vhpi_release_handle(tool);
+        } else {
+            m_version = "UNKNOWN";
+        }
+    }
+    return m_version.c_str();
+}
+
 // Determine whether a VHPI object type is a constant or not
 bool is_const(vhpiHandleT hdl)
 {

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -247,6 +247,8 @@ public:
     void sim_end() override;
     void get_sim_time(uint32_t *high, uint32_t *low) override;
     void get_sim_precision(int32_t *precision) override;
+    const char *get_simulator_product() override;
+    const char *get_simulator_version() override;
 
     /* Hierachy related */
     GpiObjHdl *get_root_handle(const char *name) override;

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -486,16 +486,14 @@ VpiStartupCbHdl::VpiStartupCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
 
 int VpiStartupCbHdl::run_callback() {
     s_vpi_vlog_info info;
-    gpi_sim_info_t sim_info;
 
-    vpi_get_vlog_info(&info);
+    if (!vpi_get_vlog_info(&info)) {
+        LOG_WARN("Unable to get argv and argc from simulator");
+        info.argc = 0;
+        info.argv = nullptr;
+    }
 
-    sim_info.argc = info.argc;
-    sim_info.argv = info.argv;
-    sim_info.product = info.product;
-    sim_info.version = info.version;
-
-    gpi_embed_init(&sim_info);
+    gpi_embed_init(info.argc, info.argv);
 
     return 0;
 }

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -72,6 +72,28 @@ void VpiImpl::get_sim_precision(int32_t *precision)
     *precision = vpi_get(vpiTimePrecision, NULL);
 }
 
+const char *VpiImpl::get_simulator_product()
+{
+    if (m_product.empty() && m_version.empty()) {
+        s_vpi_vlog_info info;
+        if (!vpi_get_vlog_info(&info)) {
+            LOG_WARN("Could not obtain info about the simulator");
+            m_product = "UNKNOWN";
+            m_version = "UNKNOWN";
+        } else {
+            m_product = info.product;
+            m_version = info.version;
+        }
+    }
+    return m_product.c_str();
+}
+
+const char *VpiImpl::get_simulator_version()
+{
+    get_simulator_product();
+    return m_version.c_str();
+}
+
 gpi_objtype_t to_gpi_objtype(int32_t vpitype)
 {
     switch (vpitype) {

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -241,6 +241,8 @@ public:
     void sim_end(void) override;
     void get_sim_time(uint32_t *high, uint32_t *low) override;
     void get_sim_precision(int32_t *precision) override;
+    const char *get_simulator_product() override;
+    const char *get_simulator_version() override;
 
     /* Hierarchy related */
     GpiObjHdl *get_root_handle(const char *name) override;


### PR DESCRIPTION
Previously, this information was gathered during startup, and passed to Python via gpi_embed. This change reduces the responsibility of gpi_embed and allows either C code or Python code to determine the product information.