### PR TITLE
Closes #1202: set IntegerObject using 32-bit set_signal_value_int().

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -31,6 +31,7 @@
 
 import ctypes
 import warnings
+import enum
 
 import cocotb
 from cocotb import simulator
@@ -40,6 +41,11 @@ from cocotb.result import TestError
 
 # Only issue a warning for each deprecated attribute access
 _deprecation_warned = set()
+
+
+class _Limits(enum.IntEnum):
+    NONE         = 0
+    SIGNED_32BIT = 1  # -2**(Nbits - 1) <= value <= 2**(Nbits - 1)  where Nbits = 32
 
 
 class SimHandleBase:
@@ -651,7 +657,7 @@ class ModifiableObject(NonConstantObject):
         value, set_action = self._check_for_set_action(value)
 
         if isinstance(value, int) and value < 0x7fffffff and len(self) <= 32:
-            call_sim(self, self._handle.set_signal_val_long, set_action, value)
+            call_sim(self, self._handle.set_signal_val_int, set_action, value, int(_Limits.NONE))
             return
         if isinstance(value, ctypes.Structure):
             value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
@@ -755,7 +761,7 @@ class EnumObject(ModifiableObject):
                 "Unsupported type for enum value assignment: {} ({!r})"
                 .format(type(value), value))
 
-        call_sim(self, self._handle.set_signal_val_long, set_action, value)
+        call_sim(self, self._handle.set_signal_val_int, set_action, value, int(_Limits.NONE))
 
     @ModifiableObject.value.getter
     def value(self) -> int:
@@ -790,7 +796,7 @@ class IntegerObject(ModifiableObject):
                 "Unsupported type for integer value assignment: {} ({!r})"
                 .format(type(value), value))
 
-        call_sim(self, self._handle.set_signal_val_int, set_action, value)
+        call_sim(self, self._handle.set_signal_val_int, set_action, value, int(_Limits.SIGNED_32BIT))
 
     @ModifiableObject.value.getter
     def value(self) -> int:

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -777,6 +777,9 @@ class IntegerObject(ModifiableObject):
         Raises:
             TypeError: If target has an unsupported type for
                  integer value assignment.
+
+            OverflowError: If value is out of range for assignment
+                 of 32-bit IntegerObject.
         """
         value, set_action = self._check_for_set_action(value)
 

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -787,7 +787,7 @@ class IntegerObject(ModifiableObject):
                 "Unsupported type for integer value assignment: {} ({!r})"
                 .format(type(value), value))
 
-        call_sim(self, self._handle.set_signal_val_long, set_action, value)
+        call_sim(self, self._handle.set_signal_val_int, set_action, value)
 
     @ModifiableObject.value.getter
     def value(self) -> int:

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -223,7 +223,7 @@ int gpi_is_indexable(gpi_sim_hdl gpi_hdl);
 
 // Functions for setting the properties of a handle
 void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value, gpi_set_action_t action);
-void gpi_set_signal_value_long(gpi_sim_hdl gpi_hdl, long value, gpi_set_action_t action);
+void gpi_set_signal_value_int(gpi_sim_hdl gpi_hdl, int32_t value, gpi_set_action_t action);
 void gpi_set_signal_value_binstr(gpi_sim_hdl gpi_hdl, const char *str, gpi_set_action_t action); // String of binary char(s) [1, 0, x, z]
 void gpi_set_signal_value_str(gpi_sim_hdl gpi_hdl, const char *str, gpi_set_action_t action);    // String of ASCII char(s)
 

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -241,7 +241,7 @@ public:
     double get_signal_value_real() override;
     long get_signal_value_long() override;
 
-    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action_t action) override;
     int set_signal_value(double value, gpi_set_action_t action) override;
     int set_signal_value_str(std::string &value, gpi_set_action_t action) override;
     int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
@@ -280,7 +280,7 @@ public:
     long get_signal_value_long() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
 
@@ -322,7 +322,7 @@ public:
     const char* get_signal_value_binstr() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action_t action) override;
     int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
@@ -353,7 +353,7 @@ public:
     long get_signal_value_long() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;
 };

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -140,11 +140,11 @@ long FliValueObjHdl::get_signal_value_long()
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value(long value, gpi_set_action_t action)
+int FliValueObjHdl::set_signal_value(int32_t value, gpi_set_action_t action)
 {
     COCOTB_UNUSED(value);
     COCOTB_UNUSED(action);
-    LOG_ERROR("Setting signal/variable value via long not supported for %s of type %d", m_fullname.c_str(), m_type);
+    LOG_ERROR("Setting signal/variable value via int32_t not supported for %s of type %d", m_fullname.c_str(), m_type);
     return -1;
 }
 
@@ -225,7 +225,7 @@ long FliEnumObjHdl::get_signal_value_long()
     }
 }
 
-int FliEnumObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
+int FliEnumObjHdl::set_signal_value(const int32_t value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
         LOG_CRITICAL("Force or release action not supported for FLI.");
@@ -238,9 +238,9 @@ int FliEnumObjHdl::set_signal_value(const long value, const gpi_set_action_t act
     }
 
     if (m_is_var) {
-        mti_SetVarValue(get_handle<mtiVariableIdT>(), value);
+        mti_SetVarValue(get_handle<mtiVariableIdT>(), static_cast<mtiLongT>(value));
     } else {
-        mti_SetSignalValue(get_handle<mtiSignalIdT>(), value);
+        mti_SetSignalValue(get_handle<mtiSignalIdT>(), static_cast<mtiLongT>(value));
     }
 
     return 0;
@@ -315,7 +315,7 @@ const char* FliLogicObjHdl::get_signal_value_binstr()
     return m_val_buff;
 }
 
-int FliLogicObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
+int FliLogicObjHdl::set_signal_value(const int32_t value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
         LOG_CRITICAL("Force or release action not supported for FLI.");
@@ -331,9 +331,9 @@ int FliLogicObjHdl::set_signal_value(const long value, const gpi_set_action_t ac
             mti_SetSignalValue(get_handle<mtiSignalIdT>(), enumVal);
         }
     } else {
-        LOG_DEBUG("set_signal_value(long)::0x%016x", value);
+        LOG_DEBUG("set_signal_value(int32_t)::0x%08x", value);
         for (int i = 0, idx = m_num_elems-1; i < m_num_elems; i++, idx--) {
-            mtiInt32T enumVal = value&(1L<<i) ? m_enum_map['1'] : m_enum_map['0'];
+            mtiInt32T enumVal = value&(1<<i) ? m_enum_map['1'] : m_enum_map['0'];
 
             m_mti_buff[idx] = (char)enumVal;
         }
@@ -432,7 +432,7 @@ long FliIntObjHdl::get_signal_value_long()
     return (long)value;
 }
 
-int FliIntObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
+int FliIntObjHdl::set_signal_value(const int32_t value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
         LOG_CRITICAL("Force or release action not supported for FLI.");
@@ -440,9 +440,9 @@ int FliIntObjHdl::set_signal_value(const long value, const gpi_set_action_t acti
     }
 
     if (m_is_var) {
-        mti_SetVarValue(get_handle<mtiVariableIdT>(), value);
+        mti_SetVarValue(get_handle<mtiVariableIdT>(), static_cast<mtiLongT>(value));
     } else {
-        mti_SetSignalValue(get_handle<mtiSignalIdT>(), value);
+        mti_SetSignalValue(get_handle<mtiSignalIdT>(), static_cast<mtiLongT>(value));
     }
 
     return 0;

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -504,7 +504,7 @@ int gpi_is_indexable(gpi_sim_hdl obj_hdl)
     return 0;
 }
 
-void gpi_set_signal_value_long(gpi_sim_hdl sig_hdl, long value, gpi_set_action_t action)
+void gpi_set_signal_value_int(gpi_sim_hdl sig_hdl, int32_t value, gpi_set_action_t action)
 {
     GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);
 

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -164,7 +164,7 @@ public:
 
     int m_length;
 
-    virtual int set_signal_value(const long value, gpi_set_action_t action) = 0;
+    virtual int set_signal_value(const int32_t value, gpi_set_action_t action) = 0;
     virtual int set_signal_value(const double value, gpi_set_action_t action) = 0;
     virtual int set_signal_value_str(std::string &value, gpi_set_action_t action) = 0;
     virtual int set_signal_value_binstr(std::string &value, gpi_set_action_t action) = 0;

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -617,6 +617,19 @@ static PyObject *set_signal_val_real(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject
     Py_RETURN_NONE;
 }
 
+static PyObject *set_signal_val_int(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args)
+{
+    int value;
+    gpi_set_action_t action;
+
+    if (!PyArg_ParseTuple(args, "ii:set_signal_val_int", &action, &value)) {
+        return NULL;
+    }
+
+    gpi_set_signal_value_int(self->hdl, static_cast<int32_t>(value), action);
+    Py_RETURN_NONE;
+}
+
 static PyObject *set_signal_val_long(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args)
 {
     long long value;
@@ -955,6 +968,13 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
             "set_signal_val_long($self, action, value, /)\n"
             "--\n\n"
             "Set the value of a signal using a long"
+        )
+    },
+    {"set_signal_val_int",
+        (PyCFunction)set_signal_val_int, METH_VARARGS, PyDoc_STR(
+            "set_signal_val_int($self, action, value, /)\n"
+            "--\n\n"
+            "Set the value of a signal using an int"
         )
     },
     {"set_signal_val_str",

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -156,6 +156,11 @@ struct sim_time {
 
 static struct sim_time cache_time;
 
+enum class limits_e : int {
+    NONE = 0,
+    SIGNED_32BIT = 1
+};
+
 /**
  * @name    Callback Handling
  * @brief   Handle a callback coming from GPI
@@ -622,29 +627,19 @@ static PyObject *set_signal_val_int(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject 
 {
     long long value;
     gpi_set_action_t action;
+    limits_e limits;
 
-    if (!PyArg_ParseTuple(args, "iL:set_signal_val_int", &action, &value)) {
+    if (!PyArg_ParseTuple(args, "iLi:set_signal_val_int", &action, &value, &limits)) {
         return NULL;
     }
 
-    if (value < std::numeric_limits<int32_t>::min() ||
-        value > std::numeric_limits<int32_t>::max()) {
-        const char *m_name = gpi_get_signal_name_str(self->hdl);
-        PyErr_Format(PyExc_OverflowError, "Value (%lld) out of range for assignment of 32-bit integer signal (%s)", value, m_name);
-        return NULL;
-    }
-
-    gpi_set_signal_value_int(self->hdl, static_cast<int32_t>(value), action);
-    Py_RETURN_NONE;
-}
-
-static PyObject *set_signal_val_long(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args)
-{
-    long long value;
-    gpi_set_action_t action;
-
-    if (!PyArg_ParseTuple(args, "iL:set_signal_val_long", &action, &value)) {
-        return NULL;
+    if (limits == limits_e::SIGNED_32BIT) {
+        if (value < std::numeric_limits<int32_t>::min() ||
+            value > std::numeric_limits<int32_t>::max()) {
+            const char *m_name = gpi_get_signal_name_str(self->hdl);
+            PyErr_Format(PyExc_OverflowError, "Value (%lld) out of range for assignment of 32-bit signed integer signal (%s)", value, m_name);
+            return NULL;
+        }
     }
 
     gpi_set_signal_value_int(self->hdl, static_cast<int32_t>(value), action);
@@ -971,16 +966,9 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
             "Get the value of a signal as a double precision float"
         )
     },
-    {"set_signal_val_long",
-        (PyCFunction)set_signal_val_long, METH_VARARGS, PyDoc_STR(
-            "set_signal_val_long($self, action, value, /)\n"
-            "--\n\n"
-            "Set the value of a signal using a long"
-        )
-    },
     {"set_signal_val_int",
         (PyCFunction)set_signal_val_int, METH_VARARGS, PyDoc_STR(
-            "set_signal_val_int($self, action, value, /)\n"
+            "set_signal_val_int($self, action, value, limits, /)\n"
             "--\n\n"
             "Set the value of a signal using an int"
         )

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -42,6 +42,7 @@ static int sim_ending = 0;
 #include "simulatormodule.h"
 #include <cocotb_utils.h>     // COCOTB_UNUSED
 #include <type_traits>
+#include <limits>
 
 
 /* define the extension types as templates */
@@ -619,10 +620,17 @@ static PyObject *set_signal_val_real(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject
 
 static PyObject *set_signal_val_int(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args)
 {
-    int value;
+    long long value;
     gpi_set_action_t action;
 
-    if (!PyArg_ParseTuple(args, "ii:set_signal_val_int", &action, &value)) {
+    if (!PyArg_ParseTuple(args, "iL:set_signal_val_int", &action, &value)) {
+        return NULL;
+    }
+
+    if (value < std::numeric_limits<int32_t>::min() ||
+        value > std::numeric_limits<int32_t>::max()) {
+        const char *m_name = gpi_get_signal_name_str(self->hdl);
+        PyErr_Format(PyExc_OverflowError, "Value (%lld) out of range for assignment of 32-bit integer signal (%s)", value, m_name);
         return NULL;
     }
 

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -619,14 +619,14 @@ static PyObject *set_signal_val_real(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject
 
 static PyObject *set_signal_val_long(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args)
 {
-    long value;
+    long long value;
     gpi_set_action_t action;
 
-    if (!PyArg_ParseTuple(args, "il:set_signal_val_long", &action, &value)) {
+    if (!PyArg_ParseTuple(args, "iL:set_signal_val_long", &action, &value)) {
         return NULL;
     }
 
-    gpi_set_signal_value_long(self->hdl, value, action);
+    gpi_set_signal_value_int(self->hdl, static_cast<int32_t>(value), action);
     Py_RETURN_NONE;
 }
 

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -478,7 +478,7 @@ vhpiEnumT VhpiSignalObjHdl::chr2vhpi(const char value)
 }
 
 // Value related functions
-int VhpiLogicSignalObjHdl::set_signal_value(long value, gpi_set_action_t action)
+int VhpiLogicSignalObjHdl::set_signal_value(int32_t value, gpi_set_action_t action)
 {
     switch (m_value.format) {
         case vhpiEnumVal:
@@ -491,7 +491,7 @@ int VhpiLogicSignalObjHdl::set_signal_value(long value, gpi_set_action_t action)
         case vhpiLogicVecVal: {
             int i;
             for (i=0; i<m_num_elems; i++)
-                m_value.value.enumvs[m_num_elems-i-1] = value&(1L<<i) ? vhpi1 : vhpi0;
+                m_value.value.enumvs[m_num_elems-i-1] = value&(1<<i) ? vhpi1 : vhpi0;
 
             m_value.numElems = m_num_elems;
             break;
@@ -557,14 +557,14 @@ int VhpiLogicSignalObjHdl::set_signal_value_binstr(std::string &value, gpi_set_a
 }
 
 // Value related functions
-int VhpiSignalObjHdl::set_signal_value(long value, gpi_set_action_t action)
+int VhpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action_t action)
 {
     switch (m_value.format) {
         case vhpiEnumVecVal:
         case vhpiLogicVecVal: {
             int i;
             for (i=0; i<m_num_elems; i++)
-                m_value.value.enumvs[m_num_elems-i-1] = value&(1L<<i) ? vhpi1 : vhpi0;
+                m_value.value.enumvs[m_num_elems-i-1] = value&(1<<i) ? vhpi1 : vhpi0;
 
             // Since we may not get the numElems correctly from the sim and have to infer it
             // we also need to set it here as well each time.
@@ -575,21 +575,11 @@ int VhpiSignalObjHdl::set_signal_value(long value, gpi_set_action_t action)
 
         case vhpiLogicVal:
         case vhpiEnumVal: {
-            using EnumLimits = std::numeric_limits<vhpiEnumT>;
-            if ((value > EnumLimits::max()) || (value < EnumLimits::min())) {
-                LOG_ERROR("Data loss detected");
-                return -1;
-            }
             m_value.value.enumv = static_cast<vhpiEnumT>(value);
             break;
         }
 
         case vhpiIntVal: {
-            using IntLimits = std::numeric_limits<vhpiIntT>;
-            if ((value > IntLimits::max()) || (value < IntLimits::min())) {
-                LOG_ERROR("Data loss detected");
-                return -1;
-            }
             m_value.value.intg = static_cast<vhpiIntT>(value);
             break;
         }

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -188,7 +188,7 @@ public:
     long get_signal_value_long() override;
 
     using GpiSignalObjHdl::set_signal_value;
-    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action_t action) override;
     int set_signal_value(double value, gpi_set_action_t action) override;
     int set_signal_value_str(std::string &value, gpi_set_action_t action) override;
     int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
@@ -215,7 +215,7 @@ public:
 
 
     using GpiSignalObjHdl::set_signal_value;
-    int set_signal_value(long value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action_t action) override;
     int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
 
     int initialise(std::string &name, std::string &fq_name) override;

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -322,11 +322,11 @@ long VpiSignalObjHdl::get_signal_value_long()
 }
 
 // Value related functions
-int VpiSignalObjHdl::set_signal_value(long value, gpi_set_action_t action)
+int VpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action_t action)
 {
     s_vpi_value value_s;
 
-    value_s.value.integer = (int)value;
+    value_s.value.integer = static_cast<PLI_INT32>(value);
     value_s.format = vpiIntVal;
 
     return set_signal_value(value_s, action);

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -173,7 +173,7 @@ public:
     double get_signal_value_real() override;
     long get_signal_value_long() override;
 
-    int set_signal_value(const long value, gpi_set_action_t action) override;
+    int set_signal_value(const int32_t value, gpi_set_action_t action) override;
     int set_signal_value(const double value, gpi_set_action_t action) override;
     int set_signal_value_binstr(std::string &value, gpi_set_action_t action) override;
     int set_signal_value_str(std::string &value, gpi_set_action_t action) override;


### PR DESCRIPTION
- Change gpi_set_signal_value_long(long) to gpi_set_signal_value_int(int32_t)
- Set IntegerObject using set_signal_value_int().  
- Check if value for IntegerObject is in 32-bit range and raise OverflowError for out of range values
- Add tests for the supported range and out of range
- Fixes a compilation warning on 32-bit platforms.
