### PR TITLE
Use GPI log in cocotb_utils

### DIFF
--- a/cocotb/share/include/cocotb_utils.h
+++ b/cocotb/share/include/cocotb_utils.h
@@ -30,6 +30,8 @@
 #ifndef COCOTB_UTILS_H_
 #define COCOTB_UTILS_H_
 
+#include <gpi_logging.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,8 +44,26 @@ extern void* utils_dyn_sym(void *handle, const char* sym_name);
 
 extern int is_python_context;
 
-void to_python(void);
-void to_simulator(void);
+// to_python and to_simulator are implemented as macros instead of functions so
+// that the logs reference the user's lineno and filename
+
+#define to_python() do { \
+    if (is_python_context) { \
+        LOG_ERROR("FATAL: We are calling up again"); \
+        exit(1); \
+    } \
+    ++is_python_context; \
+    LOG_DEBUG("Returning to Python"); \
+} while (0)
+
+#define to_simulator() do { \
+    if (!is_python_context) { \
+        LOG_ERROR("FATAL: We have returned twice from python\n"); \
+        exit(1); \
+    } \
+    --is_python_context; \
+    LOG_DEBUG("Returning to simulator"); \
+} while (0)
 
 #define COCOTB_UNUSED(x) ((void)x)
 

--- a/cocotb/share/lib/utils/cocotb_utils.cpp
+++ b/cocotb/share/lib/utils/cocotb_utils.cpp
@@ -28,7 +28,7 @@
 ******************************************************************************/
 
 #include <cocotb_utils.h>
-#include <stdio.h>
+#include <gpi_logging.h>
 #include <stdlib.h>
 
 #if defined(__linux__) || defined(__APPLE__)
@@ -47,17 +47,17 @@ extern "C" void* utils_dyn_open(const char* lib_name)
     SetErrorMode(0);
     ret = static_cast<void*>(LoadLibrary(lib_name));
     if (!ret) {
-        printf("Unable to open lib %s", lib_name);
+        const char *log_fmt = "Unable to open lib %s%s%s\n";
         LPSTR msg_ptr;
         if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
                            FORMAT_MESSAGE_ALLOCATE_BUFFER, NULL,
                            GetLastError(),
                            MAKELANGID(LANG_NEUTRAL, SUBLANG_SYS_DEFAULT),
                            (LPSTR)&msg_ptr, 255, NULL)) {
-            printf(": %s", msg_ptr);
+            LOG_ERROR(log_fmt, lib_name, ": ", msg_ptr);
             LocalFree(msg_ptr);
         } else {
-            printf("\n");
+            LOG_ERROR(log_fmt, lib_name, "", "");
         }
     }
 #else
@@ -66,7 +66,7 @@ extern "C" void* utils_dyn_open(const char* lib_name)
 
     ret = dlopen(lib_name, RTLD_LAZY | RTLD_GLOBAL);
     if (!ret) {
-        printf("Unable to open lib %s (%s)\n", lib_name, dlerror());
+        LOG_ERROR("Unable to open lib %s: %s\n", lib_name, dlerror());
     }
 #endif
     return ret;
@@ -78,23 +78,23 @@ extern "C" void* utils_dyn_sym(void *handle, const char* sym_name)
 #if ! defined(__linux__) && ! defined(__APPLE__)
     entry_point = reinterpret_cast<void*>(GetProcAddress(static_cast<HMODULE>(handle), sym_name));
     if (!entry_point) {
-        printf("Unable to find symbol %s", sym_name);
+        const char *log_fmt = "Unable to find symbol %s%s%s\n";
         LPSTR msg_ptr;
         if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
                            FORMAT_MESSAGE_ALLOCATE_BUFFER, NULL,
                            GetLastError(),
                            MAKELANGID(LANG_NEUTRAL, SUBLANG_SYS_DEFAULT),
                            (LPSTR)&msg_ptr, 255, NULL)) {
-            printf(": %s", msg_ptr);
+            LOG_ERROR(log_fmt, sym_name, ": ", msg_ptr);
             LocalFree(msg_ptr);
         } else {
-            printf("\n");
+            LOG_ERROR(log_fmt, sym_name, "", "");
         }
     }
 #else
     entry_point = dlsym(handle, sym_name);
     if (!entry_point) {
-        printf("Unable to find symbol %s (%s)\n", sym_name, dlerror());
+        LOG_ERROR("Unable to find symbol %s: %s\n", sym_name, dlerror());
     }
 #endif
     return entry_point;

--- a/cocotb/share/lib/utils/cocotb_utils.cpp
+++ b/cocotb/share/lib/utils/cocotb_utils.cpp
@@ -40,25 +40,6 @@
 // Tracks if we are in the context of Python or Simulator
 int is_python_context = 0;
 
-extern "C" void to_python(void) {
-    if (is_python_context) {
-        fprintf(stderr, "FATAL: We are calling up again\n");
-        exit(1);
-    }
-    ++is_python_context;
-    //fprintf(stderr, "INFO: Calling up to python %d\n", is_python_context);
-}
-
-extern "C" void to_simulator(void) {
-    if (!is_python_context) {
-        fprintf(stderr, "FATAL: We have returned twice from python\n");
-        exit(1);
-    }
-
-    --is_python_context;
-    //fprintf(stderr, "INFO: Returning back to simulator %d\n", is_python_context);
-}
-
 extern "C" void* utils_dyn_open(const char* lib_name)
 {
     void *ret = NULL;

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -203,6 +203,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     libcocotbutils = Extension(
         os.path.join("cocotb", "libs", "libcocotbutils"),
         include_dirs=[include_dir],
+        libraries=["gpilog"],
         sources=[os.path.join(share_lib_dir, "utils", "cocotb_utils.cpp")],
         extra_link_args=_extra_link_args(lib_name="libcocotbutils", rpath="$ORIGIN"),
         extra_compile_args=_extra_cxx_compile_args,
@@ -218,7 +219,6 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     libgpilog = Extension(
         os.path.join("cocotb", "libs", "libgpilog"),
         include_dirs=[include_dir],
-        libraries=["cocotbutils"],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "gpi_log", "gpi_logging.cpp")],
         extra_link_args=_extra_link_args(lib_name="libgpilog", rpath="$ORIGIN"),
@@ -268,7 +268,10 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         extra_link_args=_extra_link_args(rpath="$ORIGIN/libs"),
     )
 
-    return [libcocotbutils, libgpilog, libcocotb, libgpi, libsim]
+    # The libraries in this list are compiled in order of their appearance.
+    # If there is a linking dependency on one library to another,
+    # the linked library must be built first.
+    return [libgpilog, libcocotbutils, libcocotb, libgpi, libsim]
 
 
 def _get_vpi_lib_ext(


### PR DESCRIPTION
`to_python` and `to_simulator` were updated to use the `LOG_*` macros. This required we change them to macro functions so we get a useful line number in the log message. Updated the dynamic loading helpers to use the `LOG_*` macros as well.

xref #1736.