### PR TITLE
Closes #268: allow using full 32-bit range of set_signal_val_long()

### DIFF
--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -51,6 +51,7 @@ module sample_module (
     input string                                stream_in_string,
 `endif
     input  [7:0]                                stream_in_data,
+    input  [31:0]                               stream_in_data_dword,
     input  [63:0]                               stream_in_data_wide,
 
     input                                       stream_out_ready,

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -42,6 +42,7 @@ entity sample_module is
         clk                             : in    std_ulogic;
 
         stream_in_data                  : in    std_ulogic_vector(7 downto 0);
+        stream_in_data_dword            : in    std_ulogic_vector(31 downto 0);
         stream_in_data_wide             : in    std_ulogic_vector(63 downto 0);
         stream_in_valid                 : in    std_ulogic;
         stream_in_func_en               : in    std_ulogic;

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -54,6 +54,96 @@ async def test_string_handle_takes_bytes(dut):
     assert val == b"bytes"
 
 
+@cocotb.test()
+async def test_int_vector_32bit_signed(dut):
+    """
+    Test signed integer access to 32-bit vector
+    """
+    N = len(dut.stream_in_data_dword)
+    S_MIN = -2**(N-1)
+    S_MAX = 2**(N-1)-1
+
+    for value in [0, 1, -1, 4, -4, S_MIN, S_MAX]:
+        dut.stream_in_data_dword = value
+        await Timer(10, 'ns')
+        got = dut.stream_in_data_dword.value.signed_integer
+        assert got == value
+
+
+@cocotb.test()
+async def test_int_vector_32bit_unsigned(dut):
+    """
+    Test unsigned integer access to 32-bit vector
+    """
+    N = len(dut.stream_in_data_dword)
+    U_MIN = 0
+    U_MAX = 2**N-1
+
+    for value in [0, 1, 4, 2**(N-1)-1, U_MIN, U_MAX]:
+        dut.stream_in_data_dword = value
+        await Timer(10, 'ns')
+        got = int(dut.stream_in_data_dword)
+        assert got == value
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_vector_32bit_overflow(dut):
+    """
+    Test 32-bit vector integer overflow
+    """
+    N = len(dut.stream_in_data_dword)
+    value = 2**N
+    dut.stream_in_data_dword = value
+    await Timer(10, 'ns')
+    got = int(dut.stream_in_data_dword)
+    assert got == value
+
+
+@cocotb.test()
+async def test_int_vector_8bit_signed(dut):
+    """
+    Test signed integer access to 8-bit vector
+    """
+    N = len(dut.stream_in_data)
+    S_MIN = -2**(N-1)
+    S_MAX = 2**(N-1)-1
+
+    for value in [0, 1, -1, 4, -4, S_MIN, S_MAX]:
+        dut.stream_in_data = value
+        await Timer(10, 'ns')
+        got = dut.stream_in_data.value.signed_integer
+        assert got == value
+
+
+@cocotb.test()
+async def test_int_vector_8bit_unsigned(dut):
+    """
+    Test unsigned integer access to 8-bit vector
+    """
+    N = len(dut.stream_in_data)
+    U_MIN = 0
+    U_MAX = 2**N-1
+
+    for value in [0, 1, 4, 2**(N-1)-1, U_MIN, U_MAX]:
+        dut.stream_in_data = value
+        await Timer(10, 'ns')
+        got = int(dut.stream_in_data)
+        assert got == value
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_vector_8bit_underflow(dut):
+    """
+    Test 8-bit vector integer underflow
+    """
+    N = len(dut.stream_in_data)
+    value = -2**(N-1)-1
+    dut.stream_in_data = value
+    await Timer(10, 'ns')
+    got = int(dut.stream_in_data)
+    assert got == value
+
+
 async def test_delayed_assignment_still_errors(dut):
     """ Writing a bad value should fail even if the write is scheduled to happen later """
 


### PR DESCRIPTION
- For signals up to 32-bit wide, set_signal_val_long() can be used to set the full signed ```(-2**31 to 2**31-1)``` and unsigned ```(0 - 2**32-1)``` data range using a python integer value.
- Added a check for max width of 32 bits and a signal width dependent overflow check to set_signal_val_long().
- Added some tests.
- This should improve performance of setting values > 2**31-1 on 32-bit signals 

