### PR TITLE
Add info to CONTRIBUTING.md that examples should get the CC0/PD SPDX header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,11 +72,16 @@ All changes which should go into the main codebase of cocotb must follow this se
      Use this text to discuss things which are not obvious from the code, especially *why* changes were made.
      Include the GitHub issue number (if one exists) in the form "Fixes #nnn" ([read more about that](https://help.github.com/articles/closing-issues-using-keywords/)).
      Keep each description line below 72 characters.
-- Use the following header for new files:
+- Use the following header for new non-example files:
   ```python
   # Copyright cocotb contributors
   # Licensed under the Revised BSD License, see LICENSE for details.
   # SPDX-License-Identifier: BSD-3-Clause
+  ```
+- Use the following header for new example files:
+  ```python
+  # This file is public domain, it can be freely copied without restrictions.
+  # SPDX-License-Identifier: CC0-1.0
   ```
 
 Managing of Issues and Pull Requests


### PR DESCRIPTION
See also https://github.com/cocotb/cocotb/pull/1620#issuecomment-622070911
