### PR TITLE
Enable flake8 for examples and tests

### DIFF
--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -1,12 +1,8 @@
 import os
-import sys
 import cocotb
-import logging
 from cocotb.result import TestFailure
 from cocotb.result import TestSuccess
 from cocotb.clock import Clock
-import time
-from array import array as Array
 from cocotb.triggers import Timer
 from cocotb.drivers.amba import AXI4LiteMaster
 from cocotb.drivers.amba import AXIProtocolError
@@ -20,7 +16,7 @@ def setup_dut(dut):
     cocotb.fork(Clock(dut.clk, CLK_PERIOD_NS, units='ns').start())
 
 # Write to address 0 and verify that value got through
-@cocotb.test(skip = False)
+@cocotb.test()
 def write_address_0(dut):
     """Write to the register at address 0, verify the value has changed.
 
@@ -32,7 +28,7 @@ def write_address_0(dut):
     """
 
     # Reset
-    dut.rst <=  1
+    dut.rst <= 1
     dut.test_id <= 0
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
@@ -55,7 +51,7 @@ def write_address_0(dut):
 
 
 # Read back a value at address 0x01
-@cocotb.test(skip = False)
+@cocotb.test()
 def read_address_1(dut):
     """Use cocotb to set the value of the register at address 0x01.
     Use AXIML to read the contents of that register and
@@ -67,7 +63,7 @@ def read_address_1(dut):
         The value read from the register is the same as the value written.
     """
     # Reset
-    dut.rst <=  1
+    dut.rst <= 1
     dut.test_id <= 1
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
@@ -92,7 +88,7 @@ def read_address_1(dut):
 
 
 
-@cocotb.test(skip = False)
+@cocotb.test()
 def write_and_read(dut):
     """Write to the register at address 0.
     Read back from that register and verify the value is the same.
@@ -104,7 +100,7 @@ def write_and_read(dut):
     """
 
     # Reset
-    dut.rst <=  1
+    dut.rst <= 1
     dut.test_id <= 2
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
@@ -130,7 +126,7 @@ def write_and_read(dut):
 
     dut._log.info("Write 0x%08X to address 0x%08X" % (int(value), ADDRESS))
 
-@cocotb.test(skip = False)
+@cocotb.test()
 def write_fail(dut):
     """Attempt to write data to an address that doesn't exist. This test
     should fail.
@@ -142,7 +138,7 @@ def write_fail(dut):
         to write to an invalid address.
     """
     # Reset
-    dut.rst <=  1
+    dut.rst <= 1
     dut.test_id <= 3
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
@@ -162,7 +158,7 @@ def write_fail(dut):
     raise TestFailure("AXI bus should have raised an error when writing to \
                         an invalid address")
 
-@cocotb.test(skip = False)
+@cocotb.test()
 def read_fail(dut):
     """Attempt to read data from an address that doesn't exist. This test
     should fail.

--- a/examples/dff/tests/dff_cocotb.py
+++ b/examples/dff/tests/dff_cocotb.py
@@ -10,13 +10,13 @@
 # License:
 # ==============================================================================
 # Copyright 2016 Technische Universitaet Dresden - Germany
-#		 Chair for VLSI-Design, Diagnostics and Architecture
+# Chair for VLSI-Design, Diagnostics and Architecture
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#		http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,13 +30,12 @@ import random
 import cocotb
 from cocotb.clock import Clock
 from cocotb.decorators import coroutine
-from cocotb.triggers import Timer, RisingEdge, ReadOnly
+from cocotb.triggers import RisingEdge
 from cocotb.monitors import Monitor
 from cocotb.drivers import BitDriver
 from cocotb.binary import BinaryValue
 from cocotb.regression import TestFactory
 from cocotb.scoreboard import Scoreboard
-from cocotb.result import TestFailure, TestSuccess
 
 #      dut
 #    ________
@@ -93,7 +92,7 @@ class DFF_TB(object):
         self.output_mon = BitMonitor(name="output", signal=dut.q, clk=dut.c)
 
         # Create a scoreboard on the outputs
-        self.expected_output = [ init_val ]  # a list with init_val as the first element
+        self.expected_output = [init_val]  # a list with init_val as the first element
         self.scoreboard = Scoreboard(dut)
         self.scoreboard.add_interface(self.output_mon, self.expected_output)
 

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -192,5 +192,5 @@ def wavedrom_test(dut):
         yield tb.csr.read(0)
         yield RisingEdge(dut.clk)
         yield RisingEdge(dut.clk)
-        dut._log.info(waves.dumpj(header = {'text':'WaveDrom example', 'tick':0}))
-        waves.write('wavedrom.json', header = {'tick':0}, config = {'hscale':3})
+        dut._log.info(waves.dumpj(header={'text':'WaveDrom example', 'tick':0}))
+        waves.write('wavedrom.json', header={'tick':0}, config={'hscale':3})

--- a/examples/ping_tun_tap/tests/test_icmp_reply.py
+++ b/examples/ping_tun_tap/tests/test_icmp_reply.py
@@ -24,7 +24,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import random
 import logging
 
 import fcntl
@@ -62,7 +61,7 @@ def create_tun(name="tun0", ip="192.168.255.1"):
             # Errno 16 if tun device already exists, otherwise this
             # failed for different reason.
             if e.errno != 16:
-               raise e
+                raise e
 
         tun_num += 1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,9 @@
 exclude =
     bin
     documentation
-    examples
     makefiles
-    tests
     venv
+    examples/endian_swapper/cosim
 
 # TODO: fix some of these
 ignore =

--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 
-import cocotb
 from cocotb.binary import BinaryValue, BinaryRepresentation
 
 
@@ -162,8 +161,8 @@ def test_init_short_binstr_value():
 def test_defaults():
     bin1 = BinaryValue(17)
     assert bin1.binaryRepresentation == BinaryRepresentation.UNSIGNED
-    assert bin1.big_endian == True
-    assert bin1._n_bits == None
+    assert bin1.big_endian is True
+    assert bin1._n_bits is None
     assert bin1.integer == 17
 
 def test_index():
@@ -209,12 +208,12 @@ def test_general():
 
     vec = BinaryValue(value=0, n_bits=16)
     assert vec.n_bits == 16
-    assert vec.big_endian == True
+    assert vec.big_endian is True
     assert vec.integer == 0
 
     # Checking single index assignment works as expected on a Little Endian BinaryValue
     vec = BinaryValue(value=0, n_bits=16, bigEndian=False)
-    assert vec.big_endian == False
+    assert vec.big_endian is False
     for idx in range(vec.n_bits):
         vec[idx] = '1'
         expected_value = 2**(idx+1) - 1

--- a/tests/test_cases/issue_120/issue_120.py
+++ b/tests/test_cases/issue_120/issue_120.py
@@ -2,9 +2,8 @@
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge, Timer, ReadOnly
+from cocotb.triggers import RisingEdge, ReadOnly
 from cocotb.result import TestFailure
-from cocotb.binary import BinaryValue
 
 
 @cocotb.coroutine

--- a/tests/test_cases/issue_134/test_integers.py
+++ b/tests/test_cases/issue_134/test_integers.py
@@ -1,12 +1,8 @@
 import logging
-import random
-import sys
 
 import cocotb
-from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge, Timer, ReadOnly
+from cocotb.triggers import Timer
 from cocotb.result import TestFailure
-from cocotb.binary import BinaryValue
 
 
 @cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"])

--- a/tests/test_cases/issue_134/test_reals.py
+++ b/tests/test_cases/issue_134/test_reals.py
@@ -1,12 +1,9 @@
 import logging
 import random
-import sys
 
 import cocotb
-from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge, Timer, ReadOnly
+from cocotb.triggers import Timer
 from cocotb.result import TestFailure
-from cocotb.binary import BinaryValue
 
 
 @cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"])
@@ -21,7 +18,7 @@ def assign_double(dut):
     log.info("Setting the value %g" % val)
     dut.stream_in_real = val
     yield Timer(1)
-    yield Timer(1) # Workaround for VHPI scheduling - needs investigation
+    yield Timer(1)  # FIXME: Workaround for VHPI scheduling - needs investigation
     got = float(dut.stream_out_real)
     log.info("Read back value %g" % got)
     if got != val:
@@ -39,7 +36,7 @@ def assign_int(dut):
     log.info("Setting the value %i" % val)
     dut.stream_in_real <= val
     yield Timer(1)
-    yield Timer(1) # Workaround for VHPI scheduling - needs investigation
+    yield Timer(1)  # FIXME: Workaround for VHPI scheduling - needs investigation
     got = dut.stream_out_real
     log.info("Read back value %d" % got)
     if got != float(val):

--- a/tests/test_cases/issue_142/issue_142.py
+++ b/tests/test_cases/issue_142/issue_142.py
@@ -2,7 +2,7 @@
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge, Timer, ReadOnly
+from cocotb.triggers import RisingEdge
 from cocotb.result import TestFailure
 from cocotb.binary import BinaryValue
 

--- a/tests/test_cases/issue_253/issue_253.py
+++ b/tests/test_cases/issue_253/issue_253.py
@@ -1,10 +1,8 @@
 # A set of regression tests for open issues
 
 import cocotb
-from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge, Timer, ReadOnly
+from cocotb.triggers import Timer
 from cocotb.result import TestFailure
-from cocotb.binary import BinaryValue
 
 @cocotb.coroutine
 def toggle_clock(dut):

--- a/tests/test_cases/issue_330/issue_330.py
+++ b/tests/test_cases/issue_330/issue_330.py
@@ -2,10 +2,8 @@
 
 import cocotb
 import logging
-from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge, Timer, ReadOnly
+from cocotb.triggers import Timer
 from cocotb.result import TestFailure
-from cocotb.binary import BinaryValue
 
 @cocotb.test(skip=cocotb.SIM_NAME in ["Icarus Verilog"])
 def issue_330_direct(dut):
@@ -38,4 +36,3 @@ def issue_330_iteration(dut):
 
     if count != 2:
         raise TestFailure("There should have been two members of the structure")
-

--- a/tests/test_cases/issue_348/issue_348.py
+++ b/tests/test_cases/issue_348/issue_348.py
@@ -1,9 +1,7 @@
 import cocotb
 from cocotb.log import SimLog
-from cocotb.triggers import Timer, Edge, RisingEdge, FallingEdge, Join
+from cocotb.triggers import Timer, Edge, RisingEdge, FallingEdge
 from cocotb.result import TestFailure
-
-import sys
 
 @cocotb.coroutine
 def clock_gen(signal, num):

--- a/tests/test_cases/issue_588/issue_588.py
+++ b/tests/test_cases/issue_588/issue_588.py
@@ -2,9 +2,7 @@
 # This is a very simple test; it just makes sure we can yield a list of both.
 
 import cocotb
-from cocotb import triggers, result, utils, clock
-
-import sys
+from cocotb import triggers, result, utils
 
 @cocotb.coroutine
 def sample_coroutine(dut):

--- a/tests/test_cases/issue_768_a/issue_768.py
+++ b/tests/test_cases/issue_768_a/issue_768.py
@@ -8,7 +8,6 @@ no more tests can be added to this file.
 """
 import cocotb
 from cocotb.triggers import Timer, ReadOnly
-from cocotb.binary import BinaryValue
 
 # this line is different between the two files
 value = 0

--- a/tests/test_cases/issue_893/issue_893.py
+++ b/tests/test_cases/issue_893/issue_893.py
@@ -1,13 +1,12 @@
 import cocotb
-from cocotb.triggers import Timer, NullTrigger
+from cocotb.triggers import Timer
 
 @cocotb.coroutine
 def coroutine_with_undef():
-    new_variable = undefined_variable
+    new_variable = undefined_variable  # noqa
     yield Timer(1, units='ns')
 
 @cocotb.test(expect_error=True)
 def fork_erroring_coroutine(dut):
     cocotb.fork(coroutine_with_undef())
     yield Timer(10, units='ns')
-

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -6,7 +6,7 @@ import logging
 import cocotb
 
 from cocotb.clock import Clock
-from cocotb.triggers import Timer, RisingEdge
+from cocotb.triggers import Timer
 from cocotb.result import TestError, TestFailure
 from cocotb.handle import HierarchyObject, HierarchyArrayObject, ModifiableObject, NonHierarchyIndexableObject, ConstantObject
 
@@ -61,11 +61,11 @@ def test_read_write(dut):
     _check_logic(tlog, dut.param_logic_vec, 0xDA)
 
     if cocotb.LANGUAGE in ["vhdl"]:
-        _check_int (tlog, dut.param_bool, 1)
-        _check_int (tlog, dut.param_int , 6)
+        _check_int(tlog, dut.param_bool, 1)
+        _check_int(tlog, dut.param_int , 6)
         _check_real(tlog, dut.param_real, 3.14)
-        _check_int (tlog, dut.param_char, ord('p'))
-        _check_str (tlog, dut.param_str , b"ARRAYMOD")
+        _check_int(tlog, dut.param_char, ord('p'))
+        _check_str(tlog, dut.param_str , b"ARRAYMOD")
 
         if not cocotb.SIM_NAME.lower().startswith(("riviera")):
             _check_logic(tlog, dut.param_rec.a        , 0)
@@ -86,11 +86,11 @@ def test_read_write(dut):
     _check_logic(tlog, dut.const_logic_vec, 0x3D)
 
     if cocotb.LANGUAGE in ["vhdl"]:
-        _check_int (tlog, dut.const_bool, 0)
-        _check_int (tlog, dut.const_int , 12)
+        _check_int(tlog, dut.const_bool, 0)
+        _check_int(tlog, dut.const_int , 12)
         _check_real(tlog, dut.const_real, 6.28)
-        _check_int (tlog, dut.const_char, ord('c'))
-        _check_str (tlog, dut.const_str , b"MODARRAY")
+        _check_int(tlog, dut.const_char, ord('c'))
+        _check_str(tlog, dut.const_str , b"MODARRAY")
 
         if not cocotb.SIM_NAME.lower().startswith(("riviera")):
             _check_logic(tlog, dut.const_rec.a        , 1)
@@ -152,11 +152,11 @@ def test_read_write(dut):
     _check_logic(tlog, dut.sig_t4[3][7], 0xCC)
 
     if cocotb.LANGUAGE in ["vhdl"]:
-        _check_int (tlog, dut.port_bool_out, 1)
-        _check_int (tlog, dut.port_int_out , 5000)
+        _check_int(tlog, dut.port_bool_out, 1)
+        _check_int(tlog, dut.port_int_out , 5000)
         _check_real(tlog, dut.port_real_out, 22.54)
-        _check_int (tlog, dut.port_char_out, ord('Z'))
-        _check_str (tlog, dut.port_str_out , b"Testing")
+        _check_int(tlog, dut.port_char_out, ord('Z'))
+        _check_str(tlog, dut.port_str_out , b"Testing")
 
         _check_logic(tlog, dut.port_rec_out.a        , 1)
         _check_logic(tlog, dut.port_rec_out.b[0]     , 0x01)
@@ -320,7 +320,7 @@ def test_discover_all(dut):
     #
     # DO NOT REMOVE.  Aldec cannot iterate over the complex records due to bugs in the VPI interface.
     if (cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(("riviera")) and
-        cocotb.SIM_VERSION.startswith(("2016.02"))) :
+       cocotb.SIM_VERSION.startswith(("2016.02"))) :
         if len(dut._sub_handles) != 0:
             dut._sub_handles = {}
 

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -6,7 +6,6 @@ import contextlib
 import logging
 
 import cocotb
-from cocotb.binary import BinaryValue
 from cocotb.clock import Clock
 from cocotb.result import TestFailure
 from cocotb.triggers import Timer

--- a/tests/test_cases/test_avalon/test_avalon.py
+++ b/tests/test_cases/test_avalon/test_avalon.py
@@ -33,16 +33,11 @@ A set of tests that demonstrate cocotb functionality
 Also used as regression test of cocotb capabilities
 """
 
-import logging
-
 import cocotb
 from cocotb.drivers.avalon import AvalonMemory
-from cocotb.triggers import (Timer, Join, RisingEdge, FallingEdge, Edge,
-                             ReadOnly, ReadWrite)
+from cocotb.triggers import Timer, RisingEdge
 from cocotb.clock import Clock
-from cocotb.result import TestFailure, TestError, TestSuccess
-
-
+from cocotb.result import TestFailure
 
 class BurstAvlReadTest(object):
     """ class to test avalon burst """
@@ -60,6 +55,7 @@ class BurstAvlReadTest(object):
                                   memory=self.memdict,
                                   readlatency_min=0,
                                   avl_properties=avlproperties)
+
     @cocotb.coroutine
     def init_sig(self, burstcount_w, address):
         """ Initialize all signals """

--- a/tests/test_cases/test_avalon_stream/test_avalon_stream.py
+++ b/tests/test_cases/test_avalon_stream/test_avalon_stream.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 """Test to demonstrate functionality of the avalon basic streaming interface"""
 
-import logging
 import random
 import struct
-import sys
 
 import cocotb
 from cocotb.drivers import BitDriver
@@ -55,7 +53,7 @@ def test_avalon_stream(dut):
     tb.backpressure.start(wave())
 
     for _ in range(20):
-        data = random.randint(0,(2^7)-1)
+        data = random.randint(0, (2**7)-1)
         yield tb.send_data(data)
         yield tb.clkedge
 

--- a/tests/test_cases/test_cocotb/test_generator_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_generator_coroutines.py
@@ -50,7 +50,7 @@ def test_function_not_decorated(dut):
     except TypeError as exc:
         assert "yielded" in str(exc)
         assert "scheduler can't handle" in str(exc)
-    except:
+    else:
         raise TestFailure
 
 
@@ -94,7 +94,7 @@ def test_yield_list(dut):
 @cocotb.coroutine
 def syntax_error():
     yield Timer(100)
-    fail
+    fail  # noqa
 
 
 @cocotb.test(expect_error=True)

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -26,7 +26,8 @@ def test_lessthan_raises_error(dut):
         )
 
     # to make this a generator
-    if False: yield
+    if False:
+        yield
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -10,7 +10,7 @@ Test for scheduler and coroutine behavior
 """
 
 import cocotb
-from cocotb.triggers import Join, Timer, RisingEdge, Trigger, NullTrigger, ReadOnly
+from cocotb.triggers import Join, Timer, RisingEdge, Trigger, NullTrigger
 from cocotb.result import TestFailure
 from cocotb.clock import Clock
 from common import clock_gen

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -18,7 +18,7 @@ from common import clock_gen
 def test_syntax_error(dut):
     """Syntax error in the test"""
     yield clock_gen(dut.clk)
-    fail
+    fail  # noqa
 
 
 @cocotb.test()

--- a/tests/test_cases/test_configuration/test_configurations.py
+++ b/tests/test_cases/test_configuration/test_configurations.py
@@ -36,4 +36,3 @@ def iterate(dut):
     yield Timer(100)
     sub_iterate(dut)
     yield Timer(100)
-

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -38,6 +38,7 @@ from cocotb.handle import IntegerObject, ConstantObject, HierarchyObject, String
 def recursive_discover(dut):
     """Discover absolutely everything in the DUT"""
     yield Timer(0)
+
     def _discover(obj):
         for thing in obj:
             dut._log.info("Found %s (%s)", thing._name, type(thing))
@@ -118,10 +119,10 @@ def access_single_bit(dut):
                  (str(dut.stream_in_data), len(dut.stream_in_data)))
     dut.stream_in_data[2] <= 1
     yield Timer(10)
-    if dut.stream_out_data_comb.value.integer != (1<<2):
+    if dut.stream_out_data_comb.value.integer != (1 << 2):
         raise TestError("%s.%s != %d" %
                         (str(dut.stream_out_data_comb),
-                         dut.stream_out_data_comb.value.integer, (1<<2)))
+                         dut.stream_out_data_comb.value.integer, (1 << 2)))
 
 
 @cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"],
@@ -138,10 +139,10 @@ def access_single_bit_assignment(dut):
                  (str(dut.stream_in_data), len(dut.stream_in_data)))
     dut.stream_in_data[2] = 1
     yield Timer(10)
-    if dut.stream_out_data_comb.value.integer != (1<<2):
+    if dut.stream_out_data_comb.value.integer != (1 << 2):
         raise TestError("%s.%s != %d" %
                         (str(dut.stream_out_data_comb),
-                         dut.stream_out_data_comb.value.integer, (1<<2)))
+                         dut.stream_out_data_comb.value.integer, (1 << 2)))
 
 
 @cocotb.test(expect_error=True)
@@ -336,8 +337,8 @@ def access_boolean(dut):
 
     return
 
-    #if not isinstance(boolean, IntegerObject):
-    #    raise TestFailure("dut.stream_in_boolean is not a IntegerObject is %s" % type(boolean))
+    # if not isinstance(boolean, IntegerObject):
+    #     raise TestFailure("dut.stream_in_boolean is not a IntegerObject is %s" % type(boolean))
 
     try:
         bit = boolean[3]
@@ -462,11 +463,11 @@ def type_check_verilog(dut):
     ]
 
     if cocotb.SIM_NAME.lower().startswith(("icarus")):
-        test_handles.append((dut.logic_a, "GPI_NET")) # https://github.com/steveicarus/iverilog/issues/312
+        test_handles.append((dut.logic_a, "GPI_NET"))  # https://github.com/steveicarus/iverilog/issues/312
     else:
         test_handles.append((dut.logic_a, "GPI_REGISTER"))
 
     for handle in test_handles:
-        tlog.info("Handle %s" %  (handle[0]._fullname,))
+        tlog.info("Handle %s" % (handle[0]._fullname,))
         if handle[0]._type != handle[1]:
             raise TestFailure("Expected %s found %s for %s" % (handle[1], handle[0]._type, handle[0]._fullname))

--- a/tests/test_cases/test_discovery/test_vhdl_block.py
+++ b/tests/test_cases/test_discovery/test_vhdl_block.py
@@ -26,11 +26,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import cocotb
-import logging
-from cocotb.handle import ModifiableObject
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
-from cocotb.handle import IntegerObject
+from cocotb.result import TestFailure
 
 
 @cocotb.test()

--- a/tests/test_cases/test_discovery/test_vhdl_indexed_name.py
+++ b/tests/test_cases/test_discovery/test_vhdl_indexed_name.py
@@ -24,17 +24,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import cocotb
-import logging
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
-from cocotb.handle import IntegerObject
-
 
 @cocotb.test()
 def index_name_iter(dut):
     """Access a non local indexed name"""
     yield Timer(0)
     total_count = 0
+
     def _discover(obj):
         count = 0
         for thing in obj:
@@ -45,4 +42,3 @@ def index_name_iter(dut):
     total_count = _discover(dut.isample_module1)
 
     dut._log.info("Number of objects in non local vhpiIndexedNameK is %d" % total_count)
-

--- a/tests/test_cases/test_exit_error/test_exit.py
+++ b/tests/test_cases/test_exit_error/test_exit.py
@@ -3,6 +3,6 @@ from cocotb.triggers import Timer
 
 @cocotb.test()
 def typosyntax_error():
-	# this syntax error makes the whole file unimportable, so the file contents
-	# don't really matter.
-    yield Timer(100)a
+    # this syntax error makes the whole file unimportable, so the file contents
+    # don't really matter.
+    yield Timer(100)a  # noqa

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -34,11 +34,9 @@ Also used a regression test of cocotb capabilities
 """
 
 import threading
-import time
 import cocotb
-import pdb
 from cocotb.result import TestFailure
-from cocotb.triggers import Timer, Join, RisingEdge, ReadOnly, Edge, ReadWrite
+from cocotb.triggers import Timer, RisingEdge, ReadOnly
 from cocotb.clock import Clock
 from cocotb.decorators import external
 from cocotb.utils import get_sim_time

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -27,7 +27,7 @@ import logging
 
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
+from cocotb.result import TestFailure
 
 
 def recursive_dump(parent, log):
@@ -104,4 +104,3 @@ def recursive_discovery_boundary(dut):
     tlog.info("Found a total of %d things", total)
     if total != pass_total:
         raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
-

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -27,7 +27,7 @@ import logging
 
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
+from cocotb.result import TestFailure
 
 @cocotb.test(expect_fail=cocotb.SIM_NAME in ["Icarus Verilog"])
 def recursive_discovery(dut):
@@ -45,6 +45,7 @@ def recursive_discovery(dut):
 
     tlog = logging.getLogger("cocotb.test")
     yield Timer(100)
+
     def dump_all_the_things(parent):
         count = 0
         for thing in parent:
@@ -69,4 +70,3 @@ def dual_iteration(dut):
     loop_two = cocotb.fork(iteration_loop(dut))
 
     yield [loop_one.join(), loop_two.join()]
-

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -35,7 +35,7 @@ def recursive_discovery(dut):
     Recursively discover every single object in the design
     """
     if (cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim", "modelsim")) or
-        (cocotb.SIM_NAME.lower().startswith("riviera") and not cocotb.SIM_VERSION.startswith("2016.02"))):
+       (cocotb.SIM_NAME.lower().startswith("riviera") and not cocotb.SIM_VERSION.startswith("2016.02"))):
         # Finds regions, signal, generics, constants, varibles and ports.
         pass_total = 34569
     else:
@@ -43,6 +43,7 @@ def recursive_discovery(dut):
 
     tlog = logging.getLogger("cocotb.test")
     yield Timer(100)
+
     def dump_all_the_things(parent):
         count = 0
         for thing in parent:
@@ -62,8 +63,8 @@ def discovery_all(dut):
     yield Timer(0)
     for thing in dut:
         thing._log.info("Found something: %s", thing._fullname)
-        #for subthing in thing:
-        #    thing._log.info("Found something: %s" % thing._fullname)
+        # for subthing in thing:
+        #     thing._log.info("Found something: %s" % thing._fullname)
 
     dut._log.info("length of dut.inst_acs is %d", len(dut.gen_acs))
     item = dut.gen_acs[3]
@@ -89,7 +90,7 @@ def get_clock(dut):
     yield Timer(1)
     dut.aclk <= 1
     yield Timer(1)
-    if int(dut.aclk) is not 1:
+    if int(dut.aclk) != 1:
         raise TestFailure("dut.aclk is not what we expected (got %d)" % int(dut.aclk))
 
 @cocotb.test()

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -1,11 +1,6 @@
-import logging
-import random
-
 import cocotb
 from cocotb.result import TestFailure
 from cocotb.triggers import Timer
-
-from cocotb import simulator
 
 @cocotb.test()
 def test_in_vect_packed(dut):
@@ -14,7 +9,7 @@ def test_in_vect_packed(dut):
     dut.in_vect_packed = 0x5
     yield Timer(10)
     print("Getting: dut.out_vect_packed type %s" % type(dut.out_vect_packed))
-    if dut.out_vect_packed !=  0x5:
+    if dut.out_vect_packed != 0x5:
         raise TestFailure("Failed to readback dut.out_vect_packed")
 
 @cocotb.test()
@@ -23,8 +18,8 @@ def test_in_vect_unpacked(dut):
     print("Setting: dut.in_vect_unpacked type %s" % type(dut.in_vect_unpacked))
     dut.in_vect_unpacked = [0x1, 0x0, 0x1]
     yield Timer(10)
-    print("Getting: dut.out_vect_unpacked type %s" % type( dut.out_vect_unpacked))
-    if dut.out_vect_unpacked !=  [0x1, 0x0, 0x1]:
+    print("Getting: dut.out_vect_unpacked type %s" % type(dut.out_vect_unpacked))
+    if dut.out_vect_unpacked != [0x1, 0x0, 0x1]:
         raise TestFailure("Failed to readback dut.out_vect_unpacked")
 
 @cocotb.test()
@@ -33,8 +28,8 @@ def test_in_arr(dut):
     print("Setting: dut.in_arr type %s" % type(dut.in_arr))
     dut.in_arr = 0x5
     yield Timer(10)
-    print("Getting: dut.out_arr type %s" % type( dut.out_arr))
-    if dut.out_arr !=  0x5:
+    print("Getting: dut.out_arr type %s" % type(dut.out_arr))
+    if dut.out_arr != 0x5:
         raise TestFailure("Failed to readback dut.out_arr")
 
 @cocotb.test()
@@ -43,8 +38,8 @@ def test_in_2d_vect_packed_packed(dut):
     print("Setting: dut.in_2d_vect_packed_packed type %s" % type(dut.in_2d_vect_packed_packed))
     dut.in_2d_vect_packed_packed = (0x5 << 6) | (0x5 << 3) | 0x5
     yield Timer(10)
-    print("Getting: dut.out_2d_vect_packed_packed type %s" % type( dut.out_2d_vect_packed_packed))
-    if dut.out_2d_vect_packed_packed !=  (0x5 << 6) | (0x5 << 3) | 0x5:
+    print("Getting: dut.out_2d_vect_packed_packed type %s" % type(dut.out_2d_vect_packed_packed))
+    if dut.out_2d_vect_packed_packed != (0x5 << 6) | (0x5 << 3) | 0x5:
         raise TestFailure("Failed to readback dut.out_2d_vect_packed_packed")
 
 @cocotb.test()
@@ -53,8 +48,8 @@ def test_in_2d_vect_packed_unpacked(dut):
     print("Setting: dut.in_2d_vect_packed_unpacked type %s" % type(dut.in_2d_vect_packed_unpacked))
     dut.in_2d_vect_packed_unpacked = [0x5, 0x5, 0x5]
     yield Timer(10)
-    print("Getting: dut.out_2d_vect_packed_unpacked type %s" % type( dut.out_2d_vect_packed_unpacked))
-    if dut.out_2d_vect_packed_unpacked !=  [0x5, 0x5, 0x5]:
+    print("Getting: dut.out_2d_vect_packed_unpacked type %s" % type(dut.out_2d_vect_packed_unpacked))
+    if dut.out_2d_vect_packed_unpacked != [0x5, 0x5, 0x5]:
         raise TestFailure("Failed to readback dut.out_2d_vect_packed_unpacked")
 
 @cocotb.test()
@@ -63,8 +58,8 @@ def test_in_2d_vect_unpacked_unpacked(dut):
     print("Setting: dut.in_2d_vect_unpacked_unpacked type %s" % type(dut.in_2d_vect_unpacked_unpacked))
     dut.in_2d_vect_unpacked_unpacked = 3*[[0x1, 0x0, 0x1]]
     yield Timer(10)
-    print("Getting: dut.out_2d_vect_unpacked_unpacked type %s" % type( dut.out_2d_vect_unpacked_unpacked))
-    if dut.out_2d_vect_unpacked_unpacked !=  3*[[0x1, 0x0, 0x1]]:
+    print("Getting: dut.out_2d_vect_unpacked_unpacked type %s" % type(dut.out_2d_vect_unpacked_unpacked))
+    if dut.out_2d_vect_unpacked_unpacked != 3*[[0x1, 0x0, 0x1]]:
         raise TestFailure("Failed to readback dut.out_2d_vect_unpacked_unpacked")
 
 @cocotb.test()
@@ -73,8 +68,8 @@ def test_in_arr_packed(dut):
     print("Setting: dut.in_arr_packed type %s" % type(dut.in_arr_packed))
     dut.in_arr_packed = 365
     yield Timer(10)
-    print("Getting: dut.out_arr_packed type %s" % type( dut.out_arr_packed))
-    if dut.out_arr_packed !=  365:
+    print("Getting: dut.out_arr_packed type %s" % type(dut.out_arr_packed))
+    if dut.out_arr_packed != 365:
         raise TestFailure("Failed to readback dut.out_arr_packed")
 
 @cocotb.test()
@@ -83,8 +78,8 @@ def test_in_arr_unpacked(dut):
     print("Setting: dut.in_arr_unpackedtype %s" % type(dut.in_arr_unpacked))
     dut.in_arr_unpacked = [0x5, 0x5, 0x5]
     yield Timer(10)
-    print("Getting: dut.out_arr_unpackedtype %s" % type( dut.out_arr_unpacked))
-    if dut.out_arr_unpacked !=  [0x5, 0x5, 0x5]:
+    print("Getting: dut.out_arr_unpackedtype %s" % type(dut.out_arr_unpacked))
+    if dut.out_arr_unpacked != [0x5, 0x5, 0x5]:
         raise TestFailure("Failed to readback dut.out_arr_unpacked")
 
 @cocotb.test()
@@ -93,8 +88,8 @@ def test_in_2d_arr(dut):
     print("Setting: dut.in_2d_arr type %s" % type(dut.in_2d_arr))
     dut.in_2d_arr = 365
     yield Timer(10)
-    print("Getting: dut.out_2d_arr type %s" % type( dut.out_2d_arr))
-    if dut.out_2d_arr !=  365:
+    print("Getting: dut.out_2d_arr type %s" % type(dut.out_2d_arr))
+    if dut.out_2d_arr != 365:
         raise TestFailure("Failed to readback dut.out_2d_arr")
 
 @cocotb.test()
@@ -103,8 +98,8 @@ def test_in_vect_packed_packed_packed(dut):
     print("Setting: dut.in_vect_packed_packed_packed type %s" % type(dut.in_vect_packed_packed_packed))
     dut.in_vect_packed_packed_packed = 95869805
     yield Timer(10)
-    print("Getting: dut.out_vect_packed_packed_packed type %s" % type( dut.out_vect_packed_packed_packed))
-    if dut.out_vect_packed_packed_packed !=  95869805:
+    print("Getting: dut.out_vect_packed_packed_packed type %s" % type(dut.out_vect_packed_packed_packed))
+    if dut.out_vect_packed_packed_packed != 95869805:
         raise TestFailure("Failed to readback dut.out_vect_packed_packed_packed")
 
 @cocotb.test()
@@ -113,8 +108,8 @@ def test_in_vect_packed_packed_unpacked(dut):
     print("Setting: dut.in_vect_packed_packed_unpacked type %s" % type(dut.in_vect_packed_packed_unpacked))
     dut.in_vect_packed_packed_unpacked = [95869805, 95869805, 95869805]
     yield Timer(10)
-    print("Getting: dut.out_vect_packed_packed_unpacked type %s" % type( dut.out_vect_packed_packed_unpacked))
-    if dut.out_vect_packed_packed_unpacked !=  [365, 365, 365]:
+    print("Getting: dut.out_vect_packed_packed_unpacked type %s" % type(dut.out_vect_packed_packed_unpacked))
+    if dut.out_vect_packed_packed_unpacked != [365, 365, 365]:
         raise TestFailure("Failed to readback dut.out_vect_packed_packed_unpacked")
 
 @cocotb.test()
@@ -123,8 +118,8 @@ def test_in_vect_packed_unpacked_unpacked(dut):
     print("Setting: dut.in_vect_packed_unpacked_unpacked type %s" % type(dut.in_vect_packed_unpacked_unpacked))
     dut.in_vect_packed_unpacked_unpacked = 3 *[3 * [5] ]
     yield Timer(10)
-    print("Getting: dut.out_vect_packed_unpacked_unpacked type %s" % type( dut.out_vect_packed_unpacked_unpacked))
-    if dut.out_vect_packed_unpacked_unpacked !=  3 *[3 * [5] ]:
+    print("Getting: dut.out_vect_packed_unpacked_unpacked type %s" % type(dut.out_vect_packed_unpacked_unpacked))
+    if dut.out_vect_packed_unpacked_unpacked != 3 *[3 * [5] ]:
         raise TestFailure("Failed to readback dut.out_vect_packed_unpacked_unpacked")
 
 @cocotb.test()
@@ -133,8 +128,8 @@ def test_in_vect_unpacked_unpacked_unpacked(dut):
     print("Setting: dut.in_vect_unpacked_unpacked_unpacked type %s" % type(dut.in_vect_unpacked_unpacked_unpacked))
     dut.in_vect_unpacked_unpacked_unpacked = 3 *[3 * [[1, 0, 1]]]
     yield Timer(10)
-    print("Getting: dut.out_vect_unpacked_unpacked_unpacked type %s" % type( dut.out_vect_unpacked_unpacked_unpacked))
-    if dut.out_vect_unpacked_unpacked_unpacked !=  3 *[3 * [[1, 0, 1]]]:
+    print("Getting: dut.out_vect_unpacked_unpacked_unpacked type %s" % type(dut.out_vect_unpacked_unpacked_unpacked))
+    if dut.out_vect_unpacked_unpacked_unpacked != 3 *[3 * [[1, 0, 1]]]:
         raise TestFailure("Failed to readback dut.out_vect_unpacked_unpacked_unpacked")
 
 @cocotb.test()
@@ -143,8 +138,8 @@ def test_in_arr_packed_packed(dut):
     print("Setting: dut.in_arr_packed_packed type %s" % type(dut.in_arr_packed_packed))
     dut.in_arr_packed_packed = (365 << 18) | (365 << 9) | (365)
     yield Timer(10)
-    print("Getting: dut.out_arr_packed_packed type %s" % type( dut.out_arr_packed_packed))
-    if dut.out_arr_packed_packed !=  (365 << 18) | (365 << 9) | (365):
+    print("Getting: dut.out_arr_packed_packed type %s" % type(dut.out_arr_packed_packed))
+    if dut.out_arr_packed_packed != (365 << 18) | (365 << 9) | (365):
         raise TestFailure("Failed to readback dut.out_arr_packed_packed")
 
 @cocotb.test()
@@ -153,8 +148,8 @@ def test_in_arr_packed_unpacked(dut):
     print("Setting: dut.in_arr_packed_unpacked type %s" % type(dut.in_arr_packed_unpacked))
     dut.in_arr_packed_unpacked = [365, 365, 365]
     yield Timer(10)
-    print("Getting: dut.out_arr_packed_unpacked type %s" % type( dut.out_arr_packed_unpacked))
-    if dut.out_arr_packed_unpacked !=  [365, 365, 365]:
+    print("Getting: dut.out_arr_packed_unpacked type %s" % type(dut.out_arr_packed_unpacked))
+    if dut.out_arr_packed_unpacked != [365, 365, 365]:
         raise TestFailure("Failed to readback dut.out_arr_packed_unpacked")
 
 @cocotb.test()
@@ -163,8 +158,8 @@ def test_in_arr_unpacked_unpacked(dut):
     print("Setting: dut.in_arr_unpacked_unpacked type %s" % type(dut.in_arr_unpacked_unpacked))
     dut.in_arr_unpacked_unpacked = 3 *[3 * [5] ]
     yield Timer(10)
-    print("Getting: dut.out_arr_unpacked_unpacked type %s" % type( dut.out_arr_unpacked_unpacked))
-    if dut.out_arr_unpacked_unpacked !=  3 *[3 * [5] ]:
+    print("Getting: dut.out_arr_unpacked_unpacked type %s" % type(dut.out_arr_unpacked_unpacked))
+    if dut.out_arr_unpacked_unpacked != 3 *[3 * [5] ]:
         raise TestFailure("Failed to readback dut.out_arr_unpacked_unpacked")
 
 @cocotb.test()
@@ -173,8 +168,8 @@ def test_in_2d_arr_packed(dut):
     print("Setting: dut.in_2d_arr_packed type %s" % type(dut.in_2d_arr_packed))
     dut.in_2d_arr_packed = (365 << 18) | (365 << 9) | (365)
     yield Timer(10)
-    print("Getting: dut.out_2d_arr_packed type %s" % type( dut.out_2d_arr_packed))
-    if dut.out_2d_arr_packed !=  (365 << 18) | (365 << 9) | (365):
+    print("Getting: dut.out_2d_arr_packed type %s" % type(dut.out_2d_arr_packed))
+    if dut.out_2d_arr_packed != (365 << 18) | (365 << 9) | (365):
         raise TestFailure("Failed to readback dut.out_2d_arr_packed")
 
 @cocotb.test()
@@ -183,8 +178,8 @@ def test_in_2d_arr_unpacked(dut):
     print("Setting: dut.in_2d_arr_unpacked type %s" % type(dut.in_2d_arr_unpacked))
     dut.in_2d_arr_unpacked = [365, 365, 365]
     yield Timer(10)
-    print("Getting: dut.out_2d_arr_unpacked type %s" % type( dut.out_2d_arr_unpacked))
-    if dut.out_2d_arr_unpacked !=  [365, 365, 365]:
+    print("Getting: dut.out_2d_arr_unpacked type %s" % type(dut.out_2d_arr_unpacked))
+    if dut.out_2d_arr_unpacked != [365, 365, 365]:
         raise TestFailure("Failed to readback dut.out_2d_arr_unpacked")
 
 @cocotb.test()
@@ -193,6 +188,6 @@ def test_in_3d_arr(dut):
     print("Setting: dut.in_3d_arr type %s" % type(dut.in_3d_arr))
     dut.in_3d_arr = (365 << 18) | (365 << 9) | (365)
     yield Timer(10)
-    print("Getting: dut.out_3d_arr type %s" % type( dut.out_3d_arr))
-    if dut.out_3d_arr !=  (365 << 18) | (365 << 9) | (365):
+    print("Getting: dut.out_3d_arr type %s" % type(dut.out_3d_arr))
+    if dut.out_3d_arr != (365 << 18) | (365 << 9) | (365):
         raise TestFailure("Failed to readback dut.out_3d_arr")

--- a/tests/test_cases/test_plusargs/plusargs.py
+++ b/tests/test_cases/test_plusargs/plusargs.py
@@ -32,11 +32,8 @@
 from __future__ import print_function
 
 import cocotb
-from cocotb.decorators import coroutine
 from cocotb.result import TestFailure
-from cocotb.triggers import Timer, Edge, Event
-
-import sys
+from cocotb.triggers import Timer
 
 
 @cocotb.test()

--- a/tests/test_cases/test_verilog_access/test_verilog_access.py
+++ b/tests/test_cases/test_verilog_access/test_verilog_access.py
@@ -26,9 +26,9 @@
 import logging
 
 import cocotb
-from cocotb.handle import HierarchyObject, ModifiableObject, RealObject, IntegerObject, ConstantObject
+from cocotb.handle import HierarchyObject, ModifiableObject
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
+from cocotb.result import TestFailure
 
 @cocotb.test()
 def port_not_hierarchy(dut):

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -26,9 +26,9 @@
 import logging
 
 import cocotb
-from cocotb.handle import HierarchyObject, ModifiableObject, RealObject, IntegerObject, ConstantObject, EnumObject
+from cocotb.handle import HierarchyObject, ModifiableObject, IntegerObject, ConstantObject, EnumObject
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
+from cocotb.result import TestFailure
 
 @cocotb.test()
 def check_enum_object(dut):


### PR DESCRIPTION
Do not exclude the directories ``examples`` and ``tests`` from the flake8 config in ``setup.cfg`` anymore;
fix flake8 reports in those directories.

There is one point where I wasn't entirely sure whether that's the best fix; it is marked with
``# FIXME: can we be more specific?``, please review.