### PR TITLE
Move variable help text out of Makefile.sim

### DIFF
--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -41,6 +41,7 @@ Global variables:
 import argparse
 import os
 import sys
+import textwrap
 import cocotb
 
 __all__ = ["share_dir", "makefiles_dir"]
@@ -48,6 +49,48 @@ __all__ = ["share_dir", "makefiles_dir"]
 
 share_dir = os.path.join(os.path.dirname(cocotb.__file__), "share")
 makefiles_dir = os.path.join(os.path.dirname(cocotb.__file__), "share", "makefiles")
+
+
+def help_vars_text():
+    if "dev" in cocotb.__version__:
+        doclink = "https://docs.cocotb.org/en/latest/building.html"
+    else:
+        doclink = "https://docs.cocotb.org/en/v{}/building.html".format(cocotb.__version__)
+
+    # NOTE: make sure to keep "helpmsg" aligned with documentation/source/building.rst
+    # Also keep it at 80 chars.
+    helpmsg = textwrap.dedent("""\
+    Cocotb
+    ------
+    TOPLEVEL                  Instance in the hierarchy to use as the DUT
+    RANDOM_SEED               Random seed, to recreate a previous test stimulus
+    COCOTB_ANSI_OUTPUT        Force cocotb to print or not print in color
+    COCOTB_REDUCED_LOG_FMT    Display log lines shorter
+    COCOTB_ATTACH             Pause time value in seconds before the simulator start
+    COCOTB_ENABLE_PROFILING   Performance analysis of the Python portion of cocotb
+    COCOTB_LOG_LEVEL          Default logging level (default INFO)
+    COCOTB_RESOLVE_X          How to resolve X, Z, U, W on integer conversion
+    MEMCHECK                  HTTP port to use for debugging Python memory usage
+
+    Regression Manager
+    ------------------
+    COCOTB_PDB_ON_EXCEPTION   Drop into the Python debugger (pdb) on exception
+    MODULE                    Modules to search for test functions (comma-separated)
+    TESTCASE                  Test function(s) to run (comma-separated list)
+    COCOTB_RESULTS_FILE       File name for xUnit XML tests results
+    COVERAGE                  Report Python coverage (also HDL for some simulators)
+    COCOTB_HOOKS              Comma-separated module list to be executed before test
+
+    GPI
+    ---
+    GPI_EXTRA                 Extra libraries to load at runtime (comma-separated)
+
+    Scheduler
+    ---------
+    COCOTB_SCHEDULER_DEBUG    Enable additional output of coroutine scheduler
+
+    For details, see {}""").format(doclink)
+    return helpmsg
 
 
 class PrintAction(argparse.Action):
@@ -89,6 +132,12 @@ def get_parser():
         help="echo the path to the Python binary cocotb is installed for",
         action=PrintAction,
         text=python_bin,
+    )
+    parser.add_argument(
+        "--help-vars",
+        help="show help about supported variables",
+        action=PrintAction,
+        text=help_vars_text(),
     )
     parser.add_argument(
         "-v",

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -32,45 +32,17 @@
 .PHONY: all
 all: sim
 
-# NOTE: make sure to keep "helpmsg" aligned with documentation/source/building.rst
-# Also keep it at 80 chars.
-define helpmsg =
+# NOTE: keep this at 80 chars.
+define help_targets =
 Targets
--------
+=======
 sim                       Unconditionally re-run the simulator (default)
 regression                Run simulator when dependencies have changes
 clean                     Remove build and simulation artefacts
 help                      This help text
 
-GPI
----
-GPI_EXTRA                 Extra libraries to load at runtime (comma-separated)
-
-Cocotb
-------
-TOPLEVEL                  Instance in the hierarchy to use as the DUT
-RANDOM_SEED               Random seed, to recreate a previous test stimulus
-COCOTB_ANSI_OUTPUT        Force cocotb to print or not print in color
-COCOTB_REDUCED_LOG_FMT    Display log lines shorter
-COCOTB_ATTACH             Pause time value in seconds before the simulator start
-COCOTB_ENABLE_PROFILING   Performance analysis of the Python portion of cocotb
-COCOTB_LOG_LEVEL          Default logging level (default INFO)
-COCOTB_RESOLVE_X          How to resolve X, Z, U, W on integer conversion
-MEMCHECK                  HTTP port to use for debugging Python memory usage
-
-Regression Manager
-------------------
-COCOTB_PDB_ON_EXCEPTION   Drop into the Python debugger (pdb) on exception
-MODULE                    Modules to search for test functions (comma-separated)
-TESTCASE                  Test function(s) to run (comma-separated list)
-COCOTB_RESULTS_FILE       File name for xUnit XML tests results
-COVERAGE                  Report Python coverage (also HDL for some simulators)
-COCOTB_HOOKS              Comma-separated module list to be executed before test
-
-Scheduler
----------
-COCOTB_SCHEDULER_DEBUG    Enable additional output of coroutine scheduler
-
+Variables
+=========
 Makefile-based Test Scripts
 ---------------------------
 GUI                       Set this to 1 to enable the GUI mode in the simulator
@@ -90,20 +62,22 @@ CUSTOM_SIM_DEPS           Add additional dependencies to the simulation target
 SIM_BUILD                 Define a scratch directory for use by the simulator
 SCRIPT_FILE               Simulator script to run (for e.g. wave traces)
 
-    For details, see $(DOCLINK)
+endef
+
+
+# NOTE: keep *two* empty lines between "define" and "endef":
+define newline
+
 
 endef
 
 # this cannot be a regular target because of the way Makefile.$(SIM) is included
 ifeq ($(MAKECMDGOALS),help)
-    _VERSION := $(shell cocotb-config -v)
-    # for non-intuitive use of ifneq see https://www.gnu.org/software/make/manual/make.html#Testing-Flags
-    ifneq (,$(findstring dev,$(_VERSION)))
-        DOCLINK := https://docs.cocotb.org/en/latest/building.html
-    else
-        DOCLINK := https://docs.cocotb.org/en/v$(_VERSION)/building.html
-    endif
-    $(info $(helpmsg))
+    $(info $(help_targets))
+    # hack to get newlines in output, see https://stackoverflow.com/a/54539610
+    # NOTE: the output of the command must not include a '%' sign, otherwise the formatting will break
+    help_vars := $(subst %,${newline},$(shell cocotb-config --help-vars | tr \\n %))
+    $(info ${help_vars})
     # is there a cleaner way to exit here?
     $(error "Stopping after printing help")
 endif

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -35,7 +35,7 @@ Variables
 The following sections document makefile variables and environment variables according to their owner/consumer.
 
 ..
-  If you edit the following sections, please also update the "helpmsg" text in cocotb/share/makefiles/Makefile.sim
+  If you edit the following sections, please also update the "helpmsg" text in cocotb/config.py
 
 Cocotb
 ------


### PR DESCRIPTION
This allows to get the short help summary for available variables for Makefiles (as before) but also other flows we may want to support in the future.

I am  (mis?)using ``cocotb-config`` here which is not optimal, but an extra binary seems overkill... In the past, a manpage has been suggested, but IMO this is not as discoverable and flexible.
Any other options or opinions?