### PR TITLE
Issue #913: fix setting ints to signals wider than 32-bit

### DIFF
--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -188,6 +188,9 @@ _extra_cxx_compile_args = ["-std=c++11"] + _ccx_warns
 # Make PRI* format macros available with C++11 compiler but older libc, e.g. on RHEL6.
 _extra_cxx_compile_args += ["-D__STDC_FORMAT_MACROS"]
 
+# Fix python deprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
+_extra_cxx_compile_args += ["-DPY_SSIZE_T_CLEAN"]
+
 
 def _get_common_lib_ext(include_dir, share_lib_dir):
     """

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -51,6 +51,8 @@ module sample_module (
     input string                                stream_in_string,
 `endif
     input  [7:0]                                stream_in_data,
+    input  [31:0]                               stream_in_data_dword,
+    input  [38:0]                               stream_in_data_39bit,
     input  [63:0]                               stream_in_data_wide,
 
     input                                       stream_out_ready,

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -42,6 +42,8 @@ entity sample_module is
         clk                             : in    std_ulogic;
 
         stream_in_data                  : in    std_ulogic_vector(7 downto 0);
+        stream_in_data_dword            : in    std_ulogic_vector(31 downto 0);
+        stream_in_data_39bit            : in    std_ulogic_vector(38 downto 0);
         stream_in_data_wide             : in    std_ulogic_vector(63 downto 0);
         stream_in_valid                 : in    std_ulogic;
         stream_in_func_en               : in    std_ulogic;

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -48,7 +48,7 @@ def test_bad_attr(dut):
 @cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
 async def test_string_handle_takes_bytes(dut):
     dut.stream_in_string.value = b"bytes"
-    await cocotb.triggers.Timer(10, 'ns')
+    await Timer(10, 'ns')
     val = dut.stream_in_string.value
     assert isinstance(val, bytes)
     assert val == b"bytes"
@@ -123,3 +123,93 @@ def test_real_assign_int(dut):
     log.info("Read back value %d" % got)
     if got != float(val):
         raise TestFailure("Values didn't match!")
+
+
+@cocotb.test()
+async def test_int_vector_32bit_signed(dut):
+    """
+    Test signed integer access to 32-bit vector
+    """
+    N = len(dut.stream_in_data_dword)
+    S_MIN = -2**(N-1)
+    S_MAX = 2**(N-1)-1
+
+    for value in [0, 1, -1, 4, -4, S_MIN, S_MAX]:
+        dut.stream_in_data_dword = value
+        await Timer(10, 'ns')
+        got = dut.stream_in_data_dword.value.signed_integer
+        assert got == value
+
+
+@cocotb.test()
+async def test_int_vector_32bit_unsigned(dut):
+    """
+    Test unsigned integer access to 32-bit vector
+    """
+    N = len(dut.stream_in_data_dword)
+    U_MIN = 0
+    U_MAX = 2**N-1
+
+    for value in [0, 1, 4, 2**(N-1)-1, U_MIN, U_MAX]:
+        dut.stream_in_data_dword = value
+        await Timer(10, 'ns')
+        got = int(dut.stream_in_data_dword)
+        assert got == value
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_vector_32bit_overflow(dut):
+    """
+    Test 32-bit vector integer overflow
+    """
+    N = len(dut.stream_in_data_dword)
+    value = 2**N
+    dut.stream_in_data_dword = value
+    await Timer(10, 'ns')
+    got = int(dut.stream_in_data_dword)
+    assert got == value
+
+
+@cocotb.test()
+async def test_int_vector_39bit_signed(dut):
+    """
+    Test signed integer access to 39-bit vector
+    """
+    N = len(dut.stream_in_data_39bit)
+    S_MIN = -2**(N-1)
+    S_MAX = 2**(N-1)-1
+
+    for value in [0, 1, -1, 4, -4, S_MIN, S_MAX]:
+        dut.stream_in_data_39bit = value
+        await Timer(10, 'ns')
+        got = dut.stream_in_data_39bit.value.signed_integer
+        assert got == value
+
+
+@cocotb.test()
+async def test_int_vector_39bit_unsigned(dut):
+    """
+    Test unsigned integer access to 39-bit vector
+    """
+    N = len(dut.stream_in_data_39bit)
+    U_MIN = 0
+    U_MAX = 2**N-1
+
+    for value in [0, 1, 4, 2**(N-1)-1, U_MIN, U_MAX]:
+        dut.stream_in_data_39bit = value
+        await Timer(10, 'ns')
+        got = int(dut.stream_in_data_39bit)
+        assert got == value
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_vector_39bit_overflow(dut):
+    """
+    Test 39-bit vector integer overflow
+    """
+    N = len(dut.stream_in_data_39bit)
+    value = 2**N
+    dut.stream_in_data_39bit = value
+    await Timer(10, 'ns')
+    got = int(dut.stream_in_data_39bit)
+    assert got == value


### PR DESCRIPTION
- Fix bug for setting signed ints to signals wider than 32-bit. (handle negative values correctly, Issue #913)
- Improve performance by using to_bytes rather than BinaryValue.
- Add overflow checks.
- Add tests for 32-bit and 39bit signals.
