### PR TITLE
Centralize type checking/coercion

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -641,7 +641,7 @@ class TestFactory:
     """
 
     def __init__(self, test_function, *args, **kwargs):
-        if not isinstance(test_function, cocotb.coroutine):
+        if not cocotb.decorators.iscoroutinefunction(test_function):
             raise TypeError("TestFactory requires a cocotb coroutine")
         self.test_function = test_function
         self.name = self.test_function._func.__qualname__

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -639,37 +639,12 @@ class Scheduler:
         Just a wrapper around self.schedule which provides some debug and
         useful error messages in the event of common gotchas.
         """
-        if isinstance(coroutine, cocotb.decorators.coroutine):
-            raise TypeError(
-                "Attempt to schedule a coroutine that hasn't started: {}.\n"
-                "Did you forget to add parentheses to the @cocotb.test() "
-                "decorator?"
-                .format(coroutine)
-            )
-
-        if inspect.iscoroutine(coroutine):
-            return self.add(cocotb.decorators.RunningTask(coroutine))
-
-        elif sys.version_info >= (3, 6) and inspect.isasyncgen(coroutine):
-            raise TypeError(
-                "{} is an async generator, not a coroutine. "
-                "You likely used the yield keyword instead of await.".format(
-                    coroutine.__qualname__))
-
-        elif not isinstance(coroutine, cocotb.decorators.RunningTask):
-            raise TypeError(
-                "Attempt to add a object of type {} to the scheduler, which "
-                "isn't a coroutine: {!r}\n"
-                "Did you forget to use the @cocotb.coroutine decorator?"
-                .format(type(coroutine), coroutine)
-            )
-
+        task = cocotb.decorators.make_task(coroutine)
         if _debug:
-            self.log.debug("Adding new coroutine %s" % coroutine.__qualname__)
-
-        self.schedule(coroutine)
+            self.log.debug("Adding new task %s" % task.__qualname__)
+        self.schedule(task)
         self._check_termination()
-        return coroutine
+        return task
 
     def add_test(self, test_coro):
         """Called by the regression manager to queue the next test"""

--- a/tests/test_cases/test_cocotb/test_generator_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_generator_coroutines.py
@@ -61,7 +61,7 @@ def test_function_not_decorated_fork(dut):
     try:
         cocotb.fork(normal_function(dut))
     except TypeError as exc:
-        assert "isn't a coroutine" in str(exc)
+        assert "isn't a valid cocotb coroutine" in str(exc)
     else:
         raise TestFailure()
 
@@ -76,7 +76,7 @@ def test_adding_a_coroutine_without_starting(dut):
     try:
         forked = cocotb.fork(clock_gen)
     except TypeError as exc:
-        assert "a coroutine that hasn't started" in str(exc)
+        assert "unstarted coroutine function" in str(exc)
     else:
         raise TestFailure
 

--- a/tests/test_cases/test_cocotb/test_generator_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_generator_coroutines.py
@@ -34,7 +34,7 @@ def test_function_not_a_coroutine(dut):
         # failure should occur before we even try to yield or fork the coroutine
         coro = function_not_a_coroutine()
     except TypeError as exc:
-        assert "isn't a valid coroutine" in str(exc)
+        assert "isn't a valid cocotb coroutine" in str(exc)
     else:
         raise TestFailure
 

--- a/tests/test_cases/test_cocotb/test_generator_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_generator_coroutines.py
@@ -48,8 +48,7 @@ def test_function_not_decorated(dut):
     try:
         yield normal_function(dut)
     except TypeError as exc:
-        assert "yielded" in str(exc)
-        assert "scheduler can't handle" in str(exc)
+        assert "isn't a valid cocotb coroutine" in str(exc)
     else:
         raise TestFailure
 


### PR DESCRIPTION
Partially fixes #1550.

Introduces new functions for type checking values to be a cocotb coroutine function, coroutine object (`RunningTask`), or 'yieldable' object. Introduces functions for coercing values into either a coroutine function or a coroutine object. Moves all type checking to for coroutine functions to the constructor of `RunningTask`. Seeks to replace all similar logic in the core library and user code with a central definition that covers all cases. For instance, the logic in `scheduer.add` (AKA `fork`) was replaced with `make_task`.

Originally I had type checking for `coroutine` in the constructor, but it is currently expected that invalid `coroutine` decorated objects not fail because it would cause the test module to fail to load. It is expected to catch it when it is constructed into a task.

Will look for other places to use these functions, I've seen similar code in several places.