### PR TITLE
Make mean example runnable with GHDL simulator (WIP)

### DIFF
--- a/examples/mean/hdl/mean.vhd
+++ b/examples/mean/hdl/mean.vhd
@@ -9,7 +9,8 @@ use work.mean_pkg.all;
 
 entity mean is
 generic (
-  BUS_WIDTH : natural := 2);
+  DATA_WIDTH : natural := DATA_WIDTH;
+  BUS_WIDTH  : natural := 2);
 port (
   clk      : in  std_logic;
   rst      : in  std_logic;

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -1,15 +1,14 @@
 
 TOPLEVEL_LANG ?= verilog
 
-ifneq ($(TOPLEVEL_LANG),verilog)
-
-all:
-	@echo "Skipping example due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
-clean::
-
+ifeq ($(TOPLEVEL_LANG),verilog)
+  VERILOG_SOURCES = $(PWD)/../hdl/mean_sv.sv
+  TOPLEVEL := mean_sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+  TOPLEVEL := mean
 else
-
-TOPLEVEL := mean_sv
+  $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
 
 PWD=$(shell pwd)
 
@@ -20,8 +19,6 @@ ifeq ($(SIM),questa)
 COMPILE_ARGS = -mixedsvvh
 endif
 
-VERILOG_SOURCES = $(PWD)/../hdl/mean_sv.sv
-
 MODULE := test_mean
 
 ifneq ($(filter $(SIM),ius xcelium),)
@@ -29,5 +26,3 @@ ifneq ($(filter $(SIM),ius xcelium),)
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim
-
-endif

--- a/examples/mean/tests/test_mean.py
+++ b/examples/mean/tests/test_mean.py
@@ -29,7 +29,7 @@ class StreamBusMonitor(BusMonitor):
 
 
 @cocotb.coroutine
-def clock_gen(signal, period=10):
+def clock_gen_ns(signal, period=10):
     while True:
         signal <= 0
         yield Timer(period/2, units='ns')
@@ -46,7 +46,7 @@ def value_test(dut, num):
     dut._log.info('Detected DATA_WIDTH = %d, BUS_WIDTH = %d' %
                  (data_width, bus_width))
 
-    cocotb.fork(clock_gen(dut.clk, period=CLK_PERIOD_NS, units='ns'))
+    cocotb.fork(clock_gen_ns(dut.clk, period=CLK_PERIOD_NS))
 
     dut.rst <= 1
     for i in range(bus_width):
@@ -101,7 +101,7 @@ def mean_randomised_test(dut):
     dut._log.info('Detected DATA_WIDTH = %d, BUS_WIDTH = %d' %
                  (data_width, bus_width))
 
-    cocotb.fork(clock_gen(dut.clk, period=CLK_PERIOD_NS, units='ns'))
+    cocotb.fork(clock_gen_ns(dut.clk, period=CLK_PERIOD_NS))
 
     dut.rst <= 1
     for i in range(bus_width):


### PR DESCRIPTION
I am trying to get mean example work with GHDL simulator. However, when I run the test, I get
```
     0.00ns ERROR    cocotb.regression                         regression.py:386  in _score_test                     Test Failed: mean_randomised_test (result was AttributeError)
                                                                                                                     Traceback (most recent call last):
                                                                                                                       File "/home/mkru/workspace/cocotb/examples/mean/tests/test_mean.py", line 108, in mean_randomised_test
                                                                                                                         dut.i_data[i] = 0
                                                                                                                       File "/home/mkru/.local/lib/python3.8/site-packages/cocotb-1.4.0.dev0-py3.8-linux-x86_64.egg/cocotb/handle.py", line 286, in __getattr__
                                                                                                                         raise AttributeError("%s contains no object named %s" % (self._name, name))
                                                                                                                     AttributeError: mean contains no object named i_data
```

I do not know what is wrong, as `mean` entity has `i_data` port.