### PR TITLE
Fix warning/error of Verilator linter

### DIFF
--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -85,7 +85,7 @@ always @(stream_in_real)
     stream_out_real      = stream_in_real;
 
 always @(stream_in_int)
-    stream_out_int <= stream_in_int;
+    stream_out_int = stream_in_int;
 
 test_if struct_var;
 `endif


### PR DESCRIPTION
Warning/error is
```
%Warning-COMBDLY: /workspace/cocotb/tests/test_cases/test_cocotb/../../../tests/designs/sample_module/sample_module.sv:88:20: Delayed assignments (<=) in non-clocked (non flop or latch) block
                                                                                                                            : ... Suggest blocking assignments (=)
   88 |     stream_out_int <= stream_in_int;
      |                    ^~
                  ... Use "/* verilator lint_off COMBDLY */" and lint_on around source to disable this message.
                  *** See the manual before disabling this,
                  else you may end up with different sim results.
%Error: Exiting due to 1 warning(s)
```