### PR TITLE
Issue #1778: Add SystemVerilog verion of mean example.

### DIFF
--- a/examples/mean/hdl/mean.sv
+++ b/examples/mean/hdl/mean.sv
@@ -1,0 +1,72 @@
+// This file is public domain, it can be freely copied without restrictions.
+// SPDX-License-Identifier: CC0-1.0
+
+//-----------------------------------------------------------------------------
+// Calculates mean of data input bus
+//-----------------------------------------------------------------------------
+
+`timescale 1ns/1ps
+
+
+module mean #(
+  parameter int BUS_WIDTH = 4,
+  parameter int DATA_WIDTH = 6
+) (
+  input  logic                  clk,
+  input  logic                  rst,
+  input  logic                  i_valid,
+  input  logic [DATA_WIDTH-1:0] i_data [0:BUS_WIDTH-1],
+  output logic                  o_valid,
+  output logic [DATA_WIDTH-1:0] o_data
+  );
+
+
+  localparam int SUM_WIDTH = DATA_WIDTH + $clog2(BUS_WIDTH);
+//  localparam int SUM_WIDTH = DATA_WIDTH + $clog2(BUS_WIDTH) - 1;  // introduce bug
+
+  logic [SUM_WIDTH-1:0] v_sum;
+  logic [SUM_WIDTH-1:0] s_sum;
+  logic s_valid;
+
+  initial begin
+    if (BUS_WIDTH != 2**($clog2(BUS_WIDTH))) begin
+      $fatal(1, "parameter BUS_WIDTH should be a power of 2!");
+    end
+  end
+
+
+  always @* begin
+    v_sum = '0;
+
+    for (int i = 0; i < BUS_WIDTH; i++) begin
+      v_sum = v_sum + i_data[i];
+    end
+  end
+
+  always @(posedge clk) begin
+    s_valid <= i_valid;
+
+    if (i_valid) begin
+      s_sum <= v_sum;
+    end
+
+    if (rst) begin
+      s_sum <= '0;
+      s_valid <= 1'b0;
+    end
+  end
+
+  assign o_valid = s_valid;
+  assign o_data = s_sum >> $clog2(BUS_WIDTH);
+
+
+  initial begin
+    int idx;
+    $dumpfile("dump.vcd");
+    $dumpvars(0, mean);
+    for (idx = 0; idx < BUS_WIDTH; idx++)
+        $dumpvars(0, i_data[idx]);
+    #1;
+  end
+
+endmodule

--- a/examples/mean/hdl/mean.vhd
+++ b/examples/mean/hdl/mean.vhd
@@ -9,7 +9,7 @@ use work.mean_pkg.all;
 
 entity mean is
 generic (
-  BUS_WIDTH : natural := 2);
+  BUS_WIDTH : natural := 4);
 port (
   clk      : in  std_logic;
   rst      : in  std_logic;
@@ -23,8 +23,11 @@ end mean;
 
 architecture RTL of mean is
 
-  signal s_sum : unsigned(DATA_WIDTH + clog2(BUS_WIDTH-1)-1 downto 0) := (others => '0');  -- introduce bug
---  signal s_sum : unsigned(DATA_WIDTH + clog2(BUS_WIDTH)-1 downto 0) := (others => '0');
+  constant DATA_WIDTH : natural := C_DATA_WIDTH;
+  constant SUM_WIDTH  : natural := DATA_WIDTH + clog2(BUS_WIDTH);
+--  constant SUM_WIDTH : natural := DATA_WIDTH + clog2(BUS_WIDTH) - 1;  -- introduce bug
+
+  signal s_sum : unsigned(SUM_WIDTH-1 downto 0) := (others => '0');
   signal s_valid : std_logic := '0';
 
 begin

--- a/examples/mean/hdl/mean.vhd
+++ b/examples/mean/hdl/mean.vhd
@@ -1,3 +1,6 @@
+-- This file is public domain, it can be freely copied without restrictions.
+-- SPDX-License-Identifier: CC0-1.0
+
 -------------------------------------------------------------------------------
 -- Calculates mean of data input bus
 -------------------------------------------------------------------------------

--- a/examples/mean/hdl/mean_pkg.vhd
+++ b/examples/mean/hdl/mean_pkg.vhd
@@ -9,9 +9,9 @@ use ieee.math_real.all;
 
 package mean_pkg is
 
-  constant DATA_WIDTH : natural := 6;
+  constant C_DATA_WIDTH : natural := 6;
 
-  subtype t_data is unsigned(DATA_WIDTH-1 downto 0);
+  subtype t_data is unsigned(C_DATA_WIDTH-1 downto 0);
   type t_data_array is array (natural range <>) of t_data;
 
   function clog2(n : positive) return natural;

--- a/examples/mean/hdl/mean_pkg.vhd
+++ b/examples/mean/hdl/mean_pkg.vhd
@@ -1,3 +1,6 @@
+-- This file is public domain, it can be freely copied without restrictions.
+-- SPDX-License-Identifier: CC0-1.0
+
 -------------------------------------------------------------------------------
 -- Package with constants, types & functions for mean.vhd
 -------------------------------------------------------------------------------

--- a/examples/mean/hdl/mean_sv.sv
+++ b/examples/mean/hdl/mean_sv.sv
@@ -1,3 +1,6 @@
+// This file is public domain, it can be freely copied without restrictions.
+// SPDX-License-Identifier: CC0-1.0
+
 //-----------------------------------------------------------------------------
 //  sv wrapper for mean.vhd
 //-----------------------------------------------------------------------------

--- a/examples/mean/hdl/mean_sv.sv
+++ b/examples/mean/hdl/mean_sv.sv
@@ -17,7 +17,7 @@ module mean_sv #(
 
 
 // make constant from package visible
-parameter DATA_WIDTH = data_width;
+parameter DATA_WIDTH = c_data_width;
 
 // VHDL DUT
   mean #(

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -1,0 +1,24 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+TOPLEVEL_LANG ?= verilog
+
+PWD=$(shell pwd)
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+    VERILOG_SOURCES = $(PWD)/../hdl/mean.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+    VHDL_SOURCES = $(PWD)/../hdl/mean_pkg.vhd
+    VHDL_SOURCES += $(PWD)/../hdl/mean.vhd
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
+
+TOPLEVEL := mean
+MODULE := test_mean
+
+ifneq ($(filter $(SIM),ius xcelium),)
+    SIM_ARGS += -v93
+endif
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/examples/mean/tests/test_mean.py
+++ b/examples/mean/tests/test_mean.py
@@ -1,3 +1,6 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
 from __future__ import print_function
 from __future__ import division
 

--- a/examples/mean/tests/test_mean.py
+++ b/examples/mean/tests/test_mean.py
@@ -29,12 +29,12 @@ class StreamBusMonitor(BusMonitor):
 
 
 @cocotb.coroutine
-def clock_gen(signal, period=10):
+def clock_gen(signal, period=10, units='ns'):
     while True:
         signal <= 0
-        yield Timer(period/2, units='ns')
+        yield Timer(period/2, units=units)
         signal <= 1
-        yield Timer(period/2, units='ns')
+        yield Timer(period/2, units=units)
 
 
 @cocotb.coroutine

--- a/examples/mean/tests_mixedlang/Makefile
+++ b/examples/mean/tests_mixedlang/Makefile
@@ -1,3 +1,5 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
 
 TOPLEVEL_LANG ?= verilog
 

--- a/examples/mean/tests_mixedlang/Makefile
+++ b/examples/mean/tests_mixedlang/Makefile
@@ -13,11 +13,13 @@ TOPLEVEL := mean_sv
 
 PWD=$(shell pwd)
 
+export PYTHONPATH := $(PWD)/../tests:$(PYTHONPATH)
+
 VHDL_SOURCES = $(PWD)/../hdl/mean_pkg.vhd
 VHDL_SOURCES += $(PWD)/../hdl/mean.vhd
 
-ifeq ($(SIM),questa)
-COMPILE_ARGS = -mixedsvvh
+ifneq ($(filter $(SIM),questa modelsim),)
+    COMPILE_ARGS += -mixedsvvh
 endif
 
 VERILOG_SOURCES = $(PWD)/../hdl/mean_sv.sv


### PR DESCRIPTION
More details: issue #1778 
xref #1769

Seems to run fine locally with Icarus on macOS running iverilog version 10.3
Not sure which iverilog version we use on CI?