### PR TITLE
Avoid calling gpi_load_extra_libs reentrantly

### DIFF
--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -33,6 +33,7 @@
 #include <cocotb_utils.h>
 #include "embed.h"
 #include "locale.h"
+#include <cassert>
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -119,9 +120,7 @@ extern "C" void embed_init_python(void)
 #define PY_SO_LIB xstr(PYTHON_SO_LIB)
 #endif
 
-    // Don't initialize Python if already running
-    if (gtstate)
-        return;
+    assert(!gtstate);  // this function should not be called twice
 
     void * lib_handle = utils_dyn_open(PY_SO_LIB);
     if (!lib_handle) {

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -1053,7 +1053,6 @@ static void register_embed()
 {
     fli_table = new FliImpl("FLI");
     gpi_register_impl(fli_table);
-    gpi_load_extra_libs();
 }
 
 
@@ -1061,6 +1060,7 @@ void cocotb_init()
 {
     LOG_INFO("cocotb_init called\n");
     register_embed();
+    gpi_load_extra_libs();
     register_initial_callback();
     register_final_callback();
 }

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -199,11 +199,6 @@ static void gpi_load_libs(std::vector<std::string> to_load)
 
 void gpi_load_extra_libs()
 {
-    static bool loading = false;
-
-    if (loading)
-        return;
-
     /* Lets look at what other libs we were asked to load too */
     char *lib_env = getenv("GPI_EXTRA");
 
@@ -228,7 +223,6 @@ void gpi_load_extra_libs()
             to_load.push_back(lib_list);
         }
 
-        loading = true;
         gpi_load_libs(to_load);
     }
 

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -971,15 +971,15 @@ static void register_embed()
 {
     vhpi_table = new VhpiImpl("VHPI");
     gpi_register_impl(vhpi_table);
-    gpi_load_extra_libs();
 }
 
 // pre-defined VHPI registration table
 void (*vhpi_startup_routines[])() = {
     register_embed,
+    gpi_load_extra_libs,
     register_initial_callback,
     register_final_callback,
-    0
+    nullptr
 };
 
 // For non-VHPI compliant applications that cannot find vhpi_startup_routines

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -601,7 +601,6 @@ static void register_embed()
 {
     vpi_table = new VpiImpl("VPI");
     gpi_register_impl(vpi_table);
-    gpi_load_extra_libs();
 }
 
 
@@ -717,6 +716,7 @@ static void register_system_functions()
 
 void (*vlog_startup_routines[])() = {
     register_embed,
+    gpi_load_extra_libs,
     register_system_functions,
     register_initial_callback,
     register_final_callback,


### PR DESCRIPTION
Currently libraries specified in GPI_EXTRA are loaded using `gpi_load_extra_libs` which loads extra libs and calls their `register_embed` functions, which calls `gpi_load_extra_libs`... It is re-entrant, hence the funky static `is_loading` variable to prevent loading all the libraries again and calling `gpi_embed_init` more than once. This change makes the loading behavior more normal.