### PR TITLE
Scheduler Refactor

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -258,18 +258,20 @@ def _sim_event(level, message):
     from cocotb.result import TestFailure, SimFailure
 
     if level is SIM_TEST_FAIL:
-        scheduler.log.error("Failing test at simulator request")
-        scheduler.finish_test(TestFailure("Failure from external source: %s" %
-                              message))
+        if cocotb.regression_manager is not None:
+            # the regression manager may not have been created (_initialize_testbench failed)
+            msg = "Failing test at request of external source: " + message
+            cocotb.log.error(msg)
+            scheduler.finish_test(TestFailure(msg))
     elif level is SIM_FAIL:
-        # We simply return here as the simulator will exit
-        # so no cleanup is needed
-        msg = ("Failing test at simulator request before test run completion: "
-               "%s" % message)
-        scheduler.log.error(msg)
-        scheduler.finish_scheduler(SimFailure(msg))
+        if cocotb.regression_manager is not None:
+            # the regression manager may not have been created (_initialize_testbench failed)
+            msg = ("Failing remaining tests at request of external source "
+                   "before test run completion: ") + message
+            cocotb.log.error(msg)
+            scheduler.finish_scheduler(SimFailure(msg))
     else:
-        scheduler.log.error("Unsupported sim event")
+        cocotb.log.error("Unsupported sim event")
 
     return True
 

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -262,14 +262,14 @@ def _sim_event(level, message):
             # the regression manager may not have been created (_initialize_testbench failed)
             msg = "Failing test at request of external source: " + message
             cocotb.log.error(msg)
-            scheduler.finish_test(TestFailure(msg))
+            regression_manager._finish_test(TestFailure(msg))
     elif level is SIM_FAIL:
         if cocotb.regression_manager is not None:
             # the regression manager may not have been created (_initialize_testbench failed)
             msg = ("Failing remaining tests at request of external source "
                    "before test run completion: ") + message
             cocotb.log.error(msg)
-            scheduler.finish_scheduler(SimFailure(msg))
+            regression_manager._finish_test(SimFailure(msg))
     else:
         cocotb.log.error("Unsupported sim event")
 

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -270,15 +270,10 @@ class RunningTest(RunningCoroutine):
         `exc` is the exception that the test should report as its reason for
         aborting.
         """
-        if self._outcome is not None:
-            # imported here to avoid circular imports
-            from cocotb.scheduler import InternalError
-            raise InternalError("Outcome already has a value, but is being set again.")
         outcome = outcomes.Error(exc)
         if _debug:
             self.log.debug("outcome forced to {}".format(outcome))
         self._outcome = outcome
-        cocotb.scheduler.unschedule(self)
 
     def sort_name(self):
         if self.stage is None:

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -95,7 +95,6 @@ class RegressionManager:
         self.count = 0
         self.skipped = 0
         self.failures = 0
-        self._tearing_down = False
 
         # Setup XUnit
         ###################
@@ -232,12 +231,6 @@ class RegressionManager:
             return cocotb.scheduler.add(test)
 
     def tear_down(self) -> None:
-        # prevent re-entering the tear down procedure
-        if not self._tearing_down:
-            self._tearing_down = True
-        else:
-            return
-
         # fail remaining tests
         while True:
             test = self.next_test()

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -478,6 +478,16 @@ class RegressionManager:
 
         cocotb.scheduler.schedule(self._test_task)
 
+    def _finish_test(self, exc: Exception) -> None:
+        """
+        Finishes the test with the given exception as the outcome. Not to be called by the user.
+        """
+        try:
+            self._test_task.abort(exc)
+        except _EscapeHatch:
+            pass
+        self._check_termination()
+
     def _log_test_summary(self) -> None:
 
         if self.failures:

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -39,7 +39,7 @@ from typing import Any, Optional, Tuple, Iterable
 import cocotb
 import cocotb.ANSI as ANSI
 from cocotb.log import SimLog
-from cocotb.result import TestSuccess, SimFailure
+from cocotb.result import TestSuccess, SimFailure, _EscapeHatch
 from cocotb.utils import get_sim_time, remove_traceback_frames, want_color_output
 from cocotb.xunit_reporter import XUnitReporter
 from cocotb.decorators import test as Test, hook as Hook, RunningTask
@@ -328,7 +328,10 @@ class RegressionManager:
         return test
 
     def _react(self, trigger: Trigger) -> None:
-        cocotb.scheduler.react(trigger)
+        try:
+            cocotb.scheduler.react(trigger)
+        except _EscapeHatch:
+            pass
         self._check_termination()
 
     def _check_termination(self):

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -140,3 +140,8 @@ class SimFailure(TestComplete):
 class SimTimeoutError(TimeoutError):
     """Exception for when a timeout, in terms of simulation time, occurs."""
     pass
+
+
+class _EscapeHatch(BaseException):
+    """Internal class used to prevent issue with schedule re-entrancy."""
+    pass

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -60,7 +60,7 @@ import cocotb.decorators
 from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly,
                              NextTimeStep, ReadWrite, Event, Join, NullTrigger)
 from cocotb.log import SimLog
-from cocotb.result import TestComplete
+from cocotb.result import TestComplete, _EscapeHatch
 from cocotb.utils import remove_traceback_frames
 from cocotb import _py_compat
 
@@ -721,7 +721,10 @@ class Scheduler:
             self.add(self._pending_coros.pop(0))
 
     def finish_test(self, exc):
-        cocotb.regression_manager._test_task.abort(exc)
+        try:
+            cocotb.regression_manager._test_task.abort(exc)
+        except _EscapeHatch:
+            pass
         cocotb.regression_manager._check_termination()
 
     def finish_scheduler(self, exc):

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -60,7 +60,7 @@ import cocotb.decorators
 from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly,
                              NextTimeStep, ReadWrite, Event, Join, NullTrigger)
 from cocotb.log import SimLog
-from cocotb.result import TestComplete, _EscapeHatch
+from cocotb.result import TestComplete
 from cocotb.utils import remove_traceback_frames
 from cocotb import _py_compat
 
@@ -719,19 +719,6 @@ class Scheduler:
         # Handle any newly queued coroutines that need to be scheduled
         while self._pending_coros:
             self.add(self._pending_coros.pop(0))
-
-    def finish_test(self, exc):
-        try:
-            cocotb.regression_manager._test_task.abort(exc)
-        except _EscapeHatch:
-            pass
-        cocotb.regression_manager._check_termination()
-
-    def finish_scheduler(self, exc):
-        """Directly call into the regression manager and end test
-           once we return the sim will close us so no cleanup is needed.
-        """
-        self.finish_test(exc)
 
     def restart(self) -> None:
         """Sets the scheduler back in a valid state to start a new test"""

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -85,7 +85,7 @@ private:
 static GpiHandleStore unique_handles;
 
 #define CHECK_AND_STORE(_x) unique_handles.check_and_store(_x)
-#define CLEAR_STORE() unique_handles.clear()
+#define CLEAR_STORE() (void)0
 
 #else
 


### PR DESCRIPTION
Moves the concept of tests out of the scheduler, closes #791. Fixes #1688 and fixes #1347 by implementing what was talked about in https://github.com/cocotb/cocotb/pull/1690#issuecomment-620932033. Fixes #1803 by not allowing `tear_down` to recurse. Fixes #1675 by implementing the methods correctly.

From the commit message
> This moves the concept of the test out of the scheduler and into the
regression manager. This requires the regression manager to hook all
trigger reactions, so that it can check for test end, do cleanup,
score the test, and enter the regression manager's execution loop
all without re-entry.
>
> To accomplish cleanup, all cleanup operations were moved to a central
place ('cleanup') rather than being smeared across that and
'_check_termination'.
> 
> Test start up requires us to enter the scheduler after react to ensure
consistent scheduling behavior, and also catch immediate test end via
the sole 'check_termination' run by the regression manager's react hook.
Additionally, test following the first are started after a wait of
'Timer(1)' to ensure they start in normal operating mode.

Follow on clean up commits and commits that add tests from #1690 are expected. While the change is mostly split up, this change is not really decomposable, it all works in tandem.