### PR TITLE
GPI embed cleanup

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -125,7 +125,7 @@ def mem_debug(port):
     cocotb.memdebug.start(port)
 
 
-def _initialise_testbench(root_name):
+def _initialise_testbench():
     """Initialize testbench.
 
     This function is called after the simulator has elaborated all
@@ -138,6 +138,14 @@ def _initialise_testbench(root_name):
     comma-separated list of modules to be executed before the first test.
     """
     _rlock.acquire()
+
+    root_name = os.getenv("TOPLEVEL")
+    if root_name is not None:
+        if root_name == "":
+            root_name = None
+        elif '.' in root_name:
+            # Skip any library component of the toplevel
+            root_name = root_name.split(".", 1)[1]
 
     from cocotb import simulator
 

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -117,6 +117,8 @@ fork = scheduler.add
 # FIXME is this really required?
 _rlock = threading.RLock()
 
+LANGUAGE = os.getenv("TOPLEVEL_LANG")
+
 
 def mem_debug(port):
     import cocotb.memdebug

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -125,7 +125,7 @@ def mem_debug(port):
     cocotb.memdebug.start(port)
 
 
-def _initialise_testbench():
+def _initialise_testbench(argv_):
     """Initialize testbench.
 
     This function is called after the simulator has elaborated all
@@ -138,6 +138,10 @@ def _initialise_testbench():
     comma-separated list of modules to be executed before the first test.
     """
     _rlock.acquire()
+
+    global argc, argv
+    argv = argv_
+    argc = len(argv)
 
     root_name = os.getenv("TOPLEVEL")
     if root_name is not None:

--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -58,14 +58,6 @@ enum gpi_log_levels {
     exit(1); \
 } while (0)
 
-// #ifdef DEBUG
-// #define FENTER LOG_DEBUG(__func__)
-// #define FEXIT  LOG_DEBUG(__func__)
-// #else
-#define FENTER
-#define FEXIT
-// #endif
-
 void set_log_handler(void *handler);
 void clear_log_handler(void);
 void set_log_filter(void *filter);

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -332,30 +332,6 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
         goto cleanup;
     }
 
-    // Set language in use as an attribute to cocotb module, or None if not provided
-    {
-        const char *lang = getenv("TOPLEVEL_LANG");
-        PyObject *PyLang;
-        if (lang) {
-            PyLang = PyUnicode_FromString(lang);                            // New reference
-        } else {
-            Py_INCREF(Py_None);
-            PyLang = Py_None;
-        }
-        if (PyLang == NULL) {
-            PyErr_Print();
-            LOG_ERROR("Unable to create Python object for cocotb.LANGUAGE");
-            goto cleanup;
-        }
-        if (-1 == PyObject_SetAttrString(cocotb_module, "LANGUAGE", PyLang)) {
-            PyErr_Print();
-            LOG_ERROR("Unable to set LANGUAGE");
-            Py_DECREF(PyLang);
-            goto cleanup;
-        }
-        Py_DECREF(PyLang);
-    }
-
     pEventFn = PyObject_GetAttrString(cocotb_module, "_sim_event");     // New reference
     if (pEventFn == NULL) {
         PyErr_Print();

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -230,22 +230,6 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
     if (pEventFn)
         return ret;
 
-    // Find the simulation root
-    const char *dut = getenv("TOPLEVEL");
-
-    if (dut != NULL) {
-        if (!strcmp("", dut)) {
-            /* Empty string passed in, treat as NULL */
-            dut = NULL;
-        } else {
-            // Skip any library component of the toplevel
-            const char *dot = strchr(dut, '.');
-            if (dot != NULL) {
-                dut += (dot - dut + 1);
-            }
-        }
-    }
-
     PyObject *cocotb_module, *cocotb_init, *cocotb_retval;
     PyObject *cocotb_log_module = NULL;
     PyObject *simlog_func;
@@ -357,21 +341,7 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
         goto cleanup;
     }
 
-    PyObject *dut_arg;
-    if (dut == NULL) {
-        Py_INCREF(Py_None);
-        dut_arg = Py_None;
-    } else {
-        dut_arg = PyUnicode_FromString(dut);                            // New reference
-    }
-    if (dut_arg == NULL) {
-        PyErr_Print();
-        LOG_ERROR("Unable to create Python object for dut argument of _initialise_testbench");
-        goto cleanup;
-    }
-
-    cocotb_retval = PyObject_CallFunctionObjArgs(cocotb_init, dut_arg, NULL);
-    Py_DECREF(dut_arg);
+    cocotb_retval = PyObject_CallFunctionObjArgs(cocotb_init, NULL);
     Py_DECREF(cocotb_init);
 
     if (cocotb_retval != NULL) {

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -258,11 +258,6 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
         LOG_ERROR("Failed to get the _log_from_c function");
         goto cleanup;
     }
-    if (!PyCallable_Check(simlog_func)) {
-        LOG_ERROR("_log_from_c is not callable");
-        Py_DECREF(simlog_func);
-        goto cleanup;
-    }
 
     set_log_handler(simlog_func);                                       // Note: This function steals a reference to simlog_func.
 
@@ -271,11 +266,6 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
     if (simlog_func == NULL) {
         PyErr_Print();
         LOG_ERROR("Failed to get the _filter_from_c method");
-        goto cleanup;
-    }
-    if (!PyCallable_Check(simlog_func)) {
-        LOG_ERROR("_filter_from_c is not callable");
-        Py_DECREF(simlog_func);
         goto cleanup;
     }
 
@@ -287,22 +277,11 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
         LOG_ERROR("Failed to get the _sim_event method");
         goto cleanup;
     }
-    if (!PyCallable_Check(pEventFn)) {
-        LOG_ERROR("cocotb._sim_event is not callable");
-        Py_DECREF(pEventFn);
-        pEventFn = NULL;
-        goto cleanup;
-    }
 
     cocotb_init = PyObject_GetAttrString(cocotb_module, "_initialise_testbench");   // New reference
     if (cocotb_init == NULL) {
         PyErr_Print();
         LOG_ERROR("Failed to get the _initialise_testbench method");
-        goto cleanup;
-    }
-    if (!PyCallable_Check(cocotb_init)) {
-        LOG_ERROR("cocotb._initialise_testbench is not callable");
-        Py_DECREF(cocotb_init);
         goto cleanup;
     }
 

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -110,7 +110,6 @@ static void set_program_name_in_venv(void)
 
 extern "C" void embed_init_python(void)
 {
-    FENTER;
 
 #ifndef PYTHON_SO_LIB
 #error "Python version needs passing in with -DPYTHON_SO_LIB=libpython<ver>.so"
@@ -146,19 +145,17 @@ extern "C" void embed_init_python(void)
            as well as correct parses that would be sliced by the narrowing cast */
         if (errno == ERANGE || sleep_time >= UINT_MAX) {
             LOG_ERROR("COCOTB_ATTACH only needs to be set to ~30 seconds");
-            goto out;
+            return;
         }
         if ((errno != 0 && sleep_time == 0) ||
             (sleep_time <= 0)) {
             LOG_ERROR("COCOTB_ATTACH must be set to an integer base 10 or omitted");
-            goto out;
+            return;
         }
 
         LOG_ERROR("Waiting for %lu seconds - attach to PID %d with your debugger\n", sleep_time, getpid());
         sleep((unsigned int)sleep_time);
     }
-out:
-    FEXIT;
 }
 
 /**
@@ -221,7 +218,6 @@ static int get_module_ref(const char *modname, PyObject **mod)
 
 extern "C" int embed_sim_init(int argc, char const * const * argv)
 {
-    FENTER
 
     int i;
     int ret = 0;
@@ -319,7 +315,6 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
         goto cleanup;
     }
 
-    FEXIT
     goto ok;
 
 cleanup:
@@ -336,7 +331,6 @@ ok:
 
 extern "C" void embed_sim_event(gpi_event_t level, const char *msg)
 {
-    FENTER
     /* Indicate to the upper layer a sim event occurred */
 
     if (pEventFn) {
@@ -357,6 +351,4 @@ extern "C" void embed_sim_event(gpi_event_t level, const char *msg)
         PyGILState_Release(gstate);
         to_simulator();
     }
-
-    FEXIT
 }

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -281,41 +281,6 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
 
     set_log_filter(simlog_func);                                        // Note: This function steals a reference to simlog_func.
 
-    // Build argv for cocotb module
-    argv_list = PyList_New(argc);                                       // New reference
-    if (argv_list == NULL) {
-        PyErr_Print();
-        LOG_ERROR("Unable to create argv list");
-        goto cleanup;
-    }
-    for (i = 0; i < argc; i++) {
-        // Decode, embedding non-decodable bytes using PEP-383. This can only
-        // fail with MemoryError or similar.
-        PyObject *argv_item = PyUnicode_DecodeLocale(argv[i], "surrogateescape");  // New reference
-        if (argv_item == NULL) {
-            PyErr_Print();
-            LOG_ERROR("Unable to convert command line argument %d to Unicode string.", i);
-            Py_DECREF(argv_list);
-            goto cleanup;
-        }
-        PyList_SET_ITEM(argv_list, i, argv_item);                       // Note: This function steals the reference to argv_item
-    }
-
-    // Add argv list to cocotb module
-    if (-1 == PyModule_AddObject(cocotb_module, "argv", argv_list)) {   // Note: This function steals the reference to argv_list if successful
-        PyErr_Print();
-        LOG_ERROR("Unable to set argv");
-        Py_DECREF(argv_list);
-        goto cleanup;
-    }
-
-    // Add argc to cocotb module
-    if (-1 == PyModule_AddIntConstant(cocotb_module, "argc", argc)) {
-        PyErr_Print();
-        LOG_ERROR("Unable to set argc");
-        goto cleanup;
-    }
-
     pEventFn = PyObject_GetAttrString(cocotb_module, "_sim_event");     // New reference
     if (pEventFn == NULL) {
         PyErr_Print();
@@ -341,7 +306,29 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
         goto cleanup;
     }
 
-    cocotb_retval = PyObject_CallFunctionObjArgs(cocotb_init, NULL);
+    // Build argv for cocotb module
+    argv_list = PyList_New(argc);                                       // New reference
+    if (argv_list == NULL) {
+        PyErr_Print();
+        LOG_ERROR("Unable to create argv list");
+        goto cleanup;
+    }
+    for (i = 0; i < argc; i++) {
+        // Decode, embedding non-decodable bytes using PEP-383. This can only
+        // fail with MemoryError or similar.
+        PyObject *argv_item = PyUnicode_DecodeLocale(argv[i], "surrogateescape");  // New reference
+        if (argv_item == NULL) {
+            PyErr_Print();
+            LOG_ERROR("Unable to convert command line argument %d to Unicode string.", i);
+            Py_DECREF(argv_list);
+            goto cleanup;
+        }
+        PyList_SET_ITEM(argv_list, i, argv_item);                       // Note: This function steals the reference to argv_item
+    }
+
+
+    cocotb_retval = PyObject_CallFunctionObjArgs(cocotb_init, argv_list, NULL);
+    Py_DECREF(argv_list);
     Py_DECREF(cocotb_init);
 
     if (cocotb_retval != NULL) {

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -1039,18 +1039,14 @@ void handle_fli_callback(void *data)
 
 static void register_initial_callback()
 {
-    FENTER
     sim_init_cb = new FliStartupCbHdl(fli_table);
     sim_init_cb->arm_callback();
-    FEXIT
 }
 
 static void register_final_callback()
 {
-    FENTER
     sim_finish_cb = new FliShutdownCbHdl(fli_table);
     sim_finish_cb->arm_callback();
-    FEXIT
 }
 
 static void register_embed()

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -294,7 +294,6 @@ static callback_data *callback_data_new(PyObject *func, PyObject *args, PyObject
 static PyObject *register_readonly_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
-    FENTER
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -325,7 +324,6 @@ static PyObject *register_readonly_callback(PyObject *self, PyObject *args)
     gpi_cb_hdl hdl = gpi_register_readonly_callback((gpi_function_t)handle_gpi_callback, cb_data);
 
     PyObject *rv = gpi_hdl_New(hdl);
-    FEXIT
 
     return rv;
 }
@@ -334,7 +332,6 @@ static PyObject *register_readonly_callback(PyObject *self, PyObject *args)
 static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
-    FENTER
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -366,7 +363,6 @@ static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args)
         (gpi_function_t)handle_gpi_callback, cb_data);
 
     PyObject *rv = gpi_hdl_New(hdl);
-    FEXIT
 
     return rv;
 }
@@ -375,7 +371,6 @@ static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args)
 static PyObject *register_nextstep_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
-    FENTER
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -407,7 +402,6 @@ static PyObject *register_nextstep_callback(PyObject *self, PyObject *args)
         (gpi_function_t)handle_gpi_callback, cb_data);
 
     PyObject *rv = gpi_hdl_New(hdl);
-    FEXIT
 
     return rv;
 }
@@ -420,7 +414,6 @@ static PyObject *register_nextstep_callback(PyObject *self, PyObject *args)
 static PyObject *register_timed_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
-    FENTER
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -467,7 +460,6 @@ static PyObject *register_timed_callback(PyObject *self, PyObject *args)
 
     // Check success
     PyObject *rv = gpi_hdl_New(hdl);
-    FEXIT
 
     return rv;
 }
@@ -480,7 +472,6 @@ static PyObject *register_timed_callback(PyObject *self, PyObject *args)
 static PyObject *register_value_change_callback(PyObject *self, PyObject *args) //, PyObject *keywds)
 {
     COCOTB_UNUSED(self);
-    FENTER
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -523,7 +514,6 @@ static PyObject *register_value_change_callback(PyObject *self, PyObject *args) 
 
     // Check success
     PyObject *rv = gpi_hdl_New(hdl);
-    FEXIT
 
     return rv;
 }
@@ -811,11 +801,9 @@ static PyObject *stop_simulator(PyObject *self, PyObject *args)
 static PyObject *deregister(gpi_hdl_Object<gpi_cb_hdl> *self, PyObject *args)
 {
     COCOTB_UNUSED(args);
-    FENTER
 
     gpi_deregister_callback(self->hdl);
 
-    FEXIT
     Py_RETURN_NONE;
 }
 

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -957,18 +957,14 @@ void handle_vhpi_callback(const vhpiCbDataT *cb_data)
 
 static void register_initial_callback()
 {
-    FENTER
     sim_init_cb = new VhpiStartupCbHdl(vhpi_table);
     sim_init_cb->arm_callback();
-    FEXIT
 }
 
 static void register_final_callback()
 {
-    FENTER
     sim_finish_cb = new VhpiShutdownCbHdl(vhpi_table);
     sim_finish_cb->arm_callback();
-    FEXIT
 }
 
 static void register_embed()

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -283,7 +283,6 @@ int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
 
 const char* VpiSignalObjHdl::get_signal_value_binstr()
 {
-    FENTER
     s_vpi_value value_s = {vpiBinStrVal, {NULL}};
 
     vpi_get_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s);
@@ -304,7 +303,6 @@ const char* VpiSignalObjHdl::get_signal_value_str()
 
 double VpiSignalObjHdl::get_signal_value_real()
 {
-    FENTER
     s_vpi_value value_s = {vpiRealVal, {NULL}};
 
     vpi_get_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s);
@@ -315,7 +313,6 @@ double VpiSignalObjHdl::get_signal_value_real()
 
 long VpiSignalObjHdl::get_signal_value_long()
 {
-    FENTER
     s_vpi_value value_s = {vpiIntVal, {NULL}};
 
     vpi_get_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s);
@@ -373,7 +370,6 @@ int VpiSignalObjHdl::set_signal_value_str(std::string &value, gpi_set_action_t a
 
 int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s, gpi_set_action_t action)
 {
-    FENTER
     PLI_INT32 vpi_put_flag = -1;
     s_vpi_time vpi_time_s;
 
@@ -411,7 +407,6 @@ int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s, gpi_set_action_t acti
 
     check_vpi_error();
 
-    FEXIT
     return 0;
 }
 


### PR DESCRIPTION
Moves `TOPLEVEL`, `LANGUAGE`, `argc`, and `argv` cocotb module attributes from C into Python. There wasn't much of a justification for having this stuff in C to begin with. Also cleans up the `embed_sim_init`'s ref-counting and removes the currently pointless `FENTER` and `FEXIT` macros from the C codebase.

Following PRs will almost move the responsibility of registering `_sim_event` as the callback for simulator event, and the registering of the cocotb logger as the logger for the GPI, from C into Python. The only thing in gpi_embed should be interpreter initialization, loading the entry module and entry function (which will be made customizable), calling the entry function with the argument list, and interpreter finalization.