### PR TITLE
Closes #913: fix setting ints to signals wider than 32-bit (Python only solution)

### DIFF
--- a/documentation/source/newsfragments/913.bugfix.rst
+++ b/documentation/source/newsfragments/913.bugfix.rst
@@ -1,0 +1,1 @@
+Assigning Python ints to signals greater than 32-bit wide will now work correctly for negative values.

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -152,6 +152,42 @@ writes are not applied immediately, but delayed until the next write cycle.
 Use ``sig.setimmediatevalue(new_val)`` to set a new value immediately
 (see :meth:`~cocotb.handle.NonHierarchyObject.setimmediatevalue`).
 
+Signed and unsigned values
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Both signed and unsigned values can be assigned to signals using a Python int.
+Cocotb makes no assumptions regarding the signedness of the signal. It only
+considers the width of the signal, so it will allow values in the range from
+the minimum negative value for a signed number up to the maximum positive
+value for an unsigned number: ``-2**(Nbits - 1) <= value <= 2**Nbits - 1``
+Note: assigning out-of-range values will raise an :exc:`OverflowError`.
+
+A :class:`BinaryValue` object can be used instead of a Python int to assign a
+value to signals with more fine-grained control (e.g. signed values only).
+
+.. code-block:: verilog
+
+    module my_module (
+        input   logic       clk,
+        input   logic       rst,
+        input   logic [2:0] data_in,
+        output  logic [2:0] data_out
+        );
+
+.. code-block:: python3
+
+    # assignment of negative value
+    dut.data_in <= -4
+
+    # assignment of positive value
+    dut.data_in <= 7
+
+    # assignment of out-of-range values
+    dut.data_in <= 8   # raises OverflowError
+    dut.data_in <= -5  # raises OverflowError
+
+Forcing and freezing signals
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In addition to regular value assignments (deposits), signals can be forced
 to a predetermined value or frozen at their current value. To achieve this,
 the various actions described in :ref:`assignment-methods` can be used.

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -51,7 +51,10 @@ module sample_module (
     input  string                               stream_in_string,
 `endif
     input  [7:0]                                stream_in_data,
+    input  [31:0]                               stream_in_data_dword,
+    input  [38:0]                               stream_in_data_39bit,
     input  [63:0]                               stream_in_data_wide,
+    input  [127:0]                              stream_in_data_dqword,
 
     input                                       stream_out_ready,
     output reg [7:0]                            stream_out_data_comb,

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -42,7 +42,10 @@ entity sample_module is
         clk                             : in    std_ulogic;
 
         stream_in_data                  : in    std_ulogic_vector(7 downto 0);
+        stream_in_data_dword            : in    std_ulogic_vector(31 downto 0);
+        stream_in_data_39bit            : in    std_ulogic_vector(38 downto 0);
         stream_in_data_wide             : in    std_ulogic_vector(63 downto 0);
+        stream_in_data_dqword           : in    std_ulogic_vector(127 downto 0);
         stream_in_valid                 : in    std_ulogic;
         stream_in_func_en               : in    std_ulogic;
         stream_in_ready                 : out   std_ulogic;

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -70,6 +70,147 @@ async def test_delayed_assignment_still_errors(dut):
         dut.stream_in_int <= []
 
 
+async def int_values_test(signal, values):
+    """Test integer access to a signal."""
+
+    log = logging.getLogger("cocotb.test")
+    for val in values:
+        signal <= val
+        await Timer(10, 'ns')
+
+        if val < 0:
+            got = signal.value.signed_integer
+        else:
+            got = int(signal)
+
+        if got != val:
+            log.error("Expected value %d, got value %d" %(val, got))
+        assert got == val
+
+
+def gen_int_test_values(n_bits):
+    """Generates a list of int test values for a given number of bits."""
+    unsigned_min = 0
+    unsigned_max = 2**n_bits-1
+    signed_min = -2**(n_bits-1)
+    signed_max = 2**(n_bits-1)-1
+
+    return [1, -1, 4, -4, unsigned_min, unsigned_max, signed_min, signed_max]
+
+
+def gen_int_ovfl_value(n_bits):
+    return 2**n_bits
+
+
+def gen_int_unfl_value(n_bits):
+    return -2**(n_bits-1)-1
+
+
+@cocotb.test()
+async def test_int_8bit(dut):
+    """Test int access to 8-bit vector."""
+    values = gen_int_test_values(len(dut.stream_in_data))
+    await int_values_test(dut.stream_in_data, values)
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_8bit_overflow(dut):
+    """Test 8-bit vector overflow."""
+    value = gen_int_ovfl_value(len(dut.stream_in_data))
+    await int_values_test(dut.stream_in_data, [value])
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_8bit_underflow(dut):
+    """Test 8-bit vector underflow."""
+    value = gen_int_unfl_value(len(dut.stream_in_data))
+    await int_values_test(dut.stream_in_data, [value])
+
+
+@cocotb.test()
+async def test_int_32bit(dut):
+    """Test int access to 32-bit vector."""
+    values = gen_int_test_values(len(dut.stream_in_data_dword))
+    await int_values_test(dut.stream_in_data_dword, values)
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_32bit_overflow(dut):
+    """Test 32-bit vector overflow."""
+    value = gen_int_ovfl_value(len(dut.stream_in_data_dword))
+    await int_values_test(dut.stream_in_data_dword, [value])
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_32bit_underflow(dut):
+    """Test 32-bit vector underflow."""
+    value = gen_int_unfl_value(len(dut.stream_in_data_dword))
+    await int_values_test(dut.stream_in_data_dword, [value])
+
+
+@cocotb.test()
+async def test_int_39bit(dut):
+    """Test int access to 39-bit vector."""
+    values = gen_int_test_values(len(dut.stream_in_data_39bit))
+    await int_values_test(dut.stream_in_data_39bit, values)
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_39bit_overflow(dut):
+    """Test 39-bit vector overflow."""
+    value = gen_int_ovfl_value(len(dut.stream_in_data_39bit))
+    await int_values_test(dut.stream_in_data_39bit, [value])
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_39bit_underflow(dut):
+    """Test 39-bit vector underflow."""
+    value = gen_int_unfl_value(len(dut.stream_in_data_39bit))
+    await int_values_test(dut.stream_in_data_39bit, [value])
+
+
+@cocotb.test()
+async def test_int_64bit(dut):
+    """Test int access to 64-bit vector."""
+    values = gen_int_test_values(len(dut.stream_in_data_wide))
+    await int_values_test(dut.stream_in_data_wide, values)
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_64bit_overflow(dut):
+    """Test 64-bit vector overflow."""
+    value = gen_int_ovfl_value(len(dut.stream_in_data_wide))
+    await int_values_test(dut.stream_in_data_wide, [value])
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_64bit_underflow(dut):
+    """Test 64-bit vector underflow."""
+    value = gen_int_unfl_value(len(dut.stream_in_data_wide))
+    await int_values_test(dut.stream_in_data_wide, [value])
+
+
+@cocotb.test()
+async def test_int_128bit(dut):
+    """Test int access to 128-bit vector."""
+    values = gen_int_test_values(len(dut.stream_in_data_dqword))
+    await int_values_test(dut.stream_in_data_dqword, values)
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_128bit_overflow(dut):
+    """Test 128-bit vector overflow."""
+    value = gen_int_ovfl_value(len(dut.stream_in_data_dqword))
+    await int_values_test(dut.stream_in_data_dqword, [value])
+
+
+@cocotb.test(expect_error=OverflowError)
+async def test_int_128bit_underflow(dut):
+    """Test 128-bit vector underflow."""
+    value = gen_int_unfl_value(len(dut.stream_in_data_dqword))
+    await int_values_test(dut.stream_in_data_dqword, [value])
+
+
 @cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"])
 def test_integer(dut):
     """


### PR DESCRIPTION
- Fix handling of negative numbers for signal widths wider than 32-bit (issue #913)
- Add value range check
- Add testcases
- Add documentation about signed and unsigned values and supported range

Alternative solution to #1766 as discussed here: https://github.com/cocotb/cocotb/pull/1766#issuecomment-627008793 
