### PR TITLE
Cleanup shutdown behavior in GPI

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -285,8 +285,8 @@ def _sim_event(level, message):
             cocotb.log.error(msg)
 
     elif level is SIM_FAIL:
-        if regression_manager is None:  # pragma: no cover
-            # Sim failure/end before regression manager started. Should never happen.
+        if regression_manager is None:
+            # Sim failure/end before regression manager started. Occurs when initialization fails.
             cocotb.log.error("Regression ended before Regression Manager started: " + message)
 
         elif not regression_manager.finished:

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -251,21 +251,21 @@ class RegressionManager:
         self._log_test_summary()
         self._log_sim_summary()
 
-        # Generate output reports
+        # Write user coverage
         self.xunit.write()
         if self._cov:
             self._cov.stop()
             self.log.info("Writing coverage data")
             self._cov.save()
             self._cov.html_report()
-        if cocotb._library_coverage is not None:
-            # TODO: move this once we have normal shutdown behavior to _sim_event
-            cocotb._library_coverage.stop()
-            cocotb._library_coverage.save()
 
         # Setup simulator finalization
         self._finished = True
         simulator.stop_simulator("Shutting down...")
+
+        if cocotb._library_coverage is not None:
+            cocotb._library_coverage.stop()
+            cocotb._library_coverage.save()  # pragma: no cover
 
     @property
     def finished(self) -> bool:

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -95,7 +95,6 @@ class RegressionManager:
         self.count = 0
         self.skipped = 0
         self.failures = 0
-        self._tearing_down = False
 
         # Setup XUnit
         ###################
@@ -236,12 +235,6 @@ class RegressionManager:
             return cocotb.scheduler.add(test)
 
     def tear_down(self) -> None:
-        # prevent re-entering the tear down procedure
-        if not self._tearing_down:
-            self._tearing_down = True
-        else:
-            return
-
         # fail remaining tests
         while True:
             test = self.next_test()

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -95,6 +95,7 @@ class RegressionManager:
         self.count = 0
         self.skipped = 0
         self.failures = 0
+        self._finished = False
 
         # Setup XUnit
         ###################
@@ -249,7 +250,6 @@ class RegressionManager:
         # Write out final log messages
         self._log_test_summary()
         self._log_sim_summary()
-        self.log.info("Shutting down...")
 
         # Generate output reports
         self.xunit.write()
@@ -264,7 +264,18 @@ class RegressionManager:
             cocotb._library_coverage.save()
 
         # Setup simulator finalization
-        simulator.stop_simulator()
+        self._finished = True
+        simulator.stop_simulator("Shutting down...")
+
+    @property
+    def finished(self) -> bool:
+        """
+        Returns ``True`` once the regression manager has finished.
+
+        Finished implies all tests have been run or skipped and test results
+        and coverage information written out to their respective files.
+        """
+        return self._finished
 
     def next_test(self) -> Optional[Test]:
         """Get the next test to run"""

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -130,9 +130,6 @@ GPI_EXPORT bool gpi_has_registered_impl(void);
 // Stop the simulator
 GPI_EXPORT void gpi_sim_end(void);
 
-// Cleanup GPI resources during sim shutdown
-GPI_EXPORT void gpi_cleanup(void);
-
 // Returns simulation time as two uints. Units are default sim units
 GPI_EXPORT void gpi_get_sim_time(uint32_t *high, uint32_t *low);
 GPI_EXPORT void gpi_get_sim_precision(int32_t *precision);

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -127,8 +127,12 @@ typedef enum gpi_event_e {
  */
 GPI_EXPORT bool gpi_has_registered_impl(void);
 
-// Stop the simulator
-GPI_EXPORT void gpi_sim_end(void);
+/**
+ * Stop the simulator.
+ *
+ * @param msg message to give GPI users about why you are ending the sim, NULL gives default reason message
+ */
+GPI_EXPORT void gpi_sim_end(char const *msg);
 
 // Returns simulation time as two uints. Units are default sim units
 GPI_EXPORT void gpi_get_sim_time(uint32_t *high, uint32_t *low);

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -42,13 +42,10 @@ static FliImpl         *fli_table;
 
 void FliImpl::sim_end()
 {
-    if (GPI_DELETE != sim_finish_cb->get_call_state()) {
-        sim_finish_cb->set_call_state(GPI_DELETE);
-        if (mti_NowUpper() == 0 && mti_Now() == 0 && mti_Delta() == 0) {
-            mti_Quit();
-        } else {
-            mti_Break();
-        }
+    if (mti_NowUpper() == 0 && mti_Now() == 0 && mti_Delta() == 0) {
+        mti_Quit();
+    } else {
+        mti_Break();
     }
 }
 

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -1019,8 +1019,7 @@ void handle_fli_callback(void *data)
     FliProcessCbHdl *cb_hdl = (FliProcessCbHdl*)data;
 
     if (!cb_hdl) {
-        LOG_CRITICAL("FLI: Callback data corrupted: ABORTING");
-        gpi_embed_end();
+        gpi_sim_end("FLI: Callback data corrupted: ABORTING");
         return;
     }
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -131,24 +131,19 @@ bool gpi_has_registered_impl()
 void gpi_embed_init(int argc, char const* const* argv)
 {
     if (embed_sim_init(argc, argv))
-        gpi_embed_end();
+        gpi_sim_end();
 }
 
 void gpi_embed_end()
 {
-    embed_sim_event(SIM_FAIL, "Simulator shutdown prematurely");
-    gpi_cleanup();
+    gpi_embed_event(SIM_FAIL, "Simulator shutdown prematurely");
+    CLEAR_STORE();
+    embed_sim_cleanup();
 }
 
 void gpi_sim_end()
 {
     registered_impls[0]->sim_end();
-}
-
-void gpi_cleanup(void)
-{
-    CLEAR_STORE();
-    embed_sim_cleanup();
 }
 
 void gpi_embed_event(gpi_event_t level, const char *msg)

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -94,6 +94,7 @@ static GpiHandleStore unique_handles;
 
 #endif
 
+static std::string sim_end_msg = "Simulator shutdown prematurely";
 
 size_t gpi_print_registered_impl()
 {
@@ -130,19 +131,23 @@ bool gpi_has_registered_impl()
 
 void gpi_embed_init(int argc, char const* const* argv)
 {
-    if (embed_sim_init(argc, argv))
-        gpi_sim_end();
+    if (embed_sim_init(argc, argv)) {
+        gpi_sim_end("Python initialization failed.");
+    }
 }
 
 void gpi_embed_end()
 {
-    gpi_embed_event(SIM_FAIL, "Simulator shutdown prematurely");
+    gpi_embed_event(SIM_FAIL, sim_end_msg.c_str());
     CLEAR_STORE();
     embed_sim_cleanup();
 }
 
-void gpi_sim_end()
+void gpi_sim_end(char const *msg)
 {
+    if (msg) {
+        sim_end_msg = msg;
+    }
     registered_impls[0]->sim_end();
 }
 

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -274,7 +274,6 @@ protected:
 GPI_EXPORT int gpi_register_impl(GpiImplInterface *func_tbl);
 
 GPI_EXPORT void gpi_embed_init(int argc, char const* const* argv);
-GPI_EXPORT void gpi_cleanup();
 GPI_EXPORT void gpi_embed_end();
 GPI_EXPORT void gpi_embed_event(gpi_event_t level, const char *msg);
 GPI_EXPORT void gpi_load_extra_libs();

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -37,8 +37,6 @@
 static int takes = 0;
 static int releases = 0;
 
-static int sim_ending = 0;
-
 #include <cocotb_utils.h>     // COCOTB_UNUSED
 #include <type_traits>
 #include <Python.h>
@@ -237,7 +235,6 @@ int handle_gpi_callback(void *user_data)
             PyErr_Print();
 
             gpi_sim_end();
-            sim_ending = 1;
             ret = 0;
             goto out;
         }
@@ -260,13 +257,6 @@ out:
 
 err:
     to_simulator();
-
-    if (sim_ending) {
-        // This is the last callback of a successful run,
-        // so call the cleanup function as we'll never return
-        // to Python
-        gpi_cleanup();
-    }
     return ret;
 }
 
@@ -883,7 +873,6 @@ static PyObject *stop_simulator(PyObject *self, PyObject *args)
     }
 
     gpi_sim_end();
-    sim_ending = 1;
     Py_RETURN_NONE;
 }
 

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -231,10 +231,9 @@ int handle_gpi_callback(void *user_data)
         // The best thing to do here is shutdown as any subsequent
         // calls will go back to Python which is now in an unknown state
         if (pValue == NULL) {
-            fprintf(stderr, "ERROR: called callback function threw exception\n");
             PyErr_Print();
 
-            gpi_sim_end();
+            gpi_sim_end("ERROR: called callback function threw exception");
             ret = 0;
             goto out;
         }
@@ -872,7 +871,7 @@ static PyObject *stop_simulator(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    gpi_sim_end();
+    gpi_sim_end("Shutting down simulator at user request.");
     Py_RETURN_NONE;
 }
 

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -864,14 +864,18 @@ static PyObject *get_range(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args)
 static PyObject *stop_simulator(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
-    COCOTB_UNUSED(args);
 
     if (!gpi_has_registered_impl()) {
         PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
         return NULL;
     }
 
-    gpi_sim_end("Shutting down simulator at user request.");
+    char const *msg = NULL;
+    if (!PyArg_ParseTuple(args, "z:msg", &msg)) {
+        return NULL;
+    }
+
+    gpi_sim_end(msg);
     Py_RETURN_NONE;
 }
 
@@ -1009,9 +1013,9 @@ static PyMethodDef SimulatorMethods[] = {
         "Register a callback for the read-write section."
     )},
     {"stop_simulator", stop_simulator, METH_VARARGS, PyDoc_STR(
-        "stop_simulator()\n"
+        "stop_simulator(msg, /)\n"
         "--\n\n"
-        "stop_simulator() -> None\n"
+        "stop_simulator(msg: str) -> None\n"
         "Instruct the attached simulator to stop. Users should not call this function."
     )},
     {"log_level", log_level, METH_VARARGS, PyDoc_STR(

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -926,7 +926,6 @@ int VhpiImpl::deregister_callback(GpiCbHdl *gpi_hdl)
 
 void VhpiImpl::sim_end()
 {
-    sim_finish_cb->set_call_state(GPI_DELETE);
     vhpi_control(vhpiFinish, vhpiDiagTimeLoc);
     check_vhpi_error();
 }

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -938,8 +938,7 @@ void handle_vhpi_callback(const vhpiCbDataT *cb_data)
     VhpiCbHdl *cb_hdl = (VhpiCbHdl*)cb_data->user_data;
 
     if (!cb_hdl) {
-        LOG_CRITICAL("VHPI: Callback data corrupted: ABORTING");
-        gpi_embed_end();
+        gpi_sim_end("VHPI: Callback data corrupted: ABORTING");
         return;
     }
 

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -568,18 +568,10 @@ int VpiImpl::deregister_callback(GpiCbHdl *gpi_hdl)
     return gpi_hdl->cleanup_callback();
 }
 
-// If the Python world wants things to shut down then unregister
-// the callback for end of sim
 void VpiImpl::sim_end()
 {
-    /* Some sims do not seem to be able to deregister the end of sim callback
-     * so we need to make sure we have tracked this and not call the handler
-     */
-    if (GPI_DELETE != sim_finish_cb->get_call_state()) {
-        sim_finish_cb->set_call_state(GPI_DELETE);
-        vpi_control(vpiFinish, vpiDiagTimeLoc);
-        check_vpi_error();
-    }
+    vpi_control(vpiFinish, vpiDiagTimeLoc);
+    check_vpi_error();
 }
 
 extern "C" {

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -584,8 +584,7 @@ int32_t handle_vpi_callback(p_cb_data cb_data)
     VpiCbHdl *cb_hdl = (VpiCbHdl*)cb_data->user_data;
 
     if (!cb_hdl) {
-        LOG_CRITICAL("VPI: Callback data corrupted: ABORTING");
-        gpi_embed_end();
+        gpi_sim_end("VPI: Callback data corrupted: ABORTING");
         return -1;
     }
 

--- a/tests/test_cases/test_module_var_bad/Makefile
+++ b/tests/test_cases/test_module_var_bad/Makefile
@@ -1,0 +1,13 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# should cause a failure in cocotb._initialize_testbench which will trigger a path in
+# cocotb._sim_event that isn't otherwise seen
+MODULE := bad
+
+.PHONY: override_for_this_test
+override_for_this_test:
+	if $(MAKE) all; then echo "Expected this to fail"; false; else echo "Failed as expected"; fi
+
+include ../../designs/sample_module/Makefile


### PR DESCRIPTION
Shutdown cleanup was simplified to depend on the shutdown callback handler. This effectively side-steps the use-after-free issue seen in #1782.

It also unconditionally sends cocotb a sim event during shut down. This will be important once multiple GPI users are supported. They all need to be notified of a shut down.