### PR TITLE
Don't include unistd.h on windows

### DIFF
--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -30,7 +30,6 @@
 // Embed Python into the simulator using GPI
 
 #include <Python.h>
-#include <unistd.h>
 #include <cocotb_utils.h>
 #include "embed.h"
 #include "locale.h"
@@ -38,9 +37,12 @@
 #if defined(_WIN32)
 #include <windows.h>
 #define sleep(n) Sleep(1000 * n)
+#define getpid() GetCurrentProcessId()
 #ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
 #endif
+#else
+#include <unistd.h>
 #endif
 static PyThreadState *gtstate = NULL;
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -30,7 +30,6 @@
 #include "gpi_priv.h"
 #include <cocotb_utils.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <vector>
 #include <map>
 #include <algorithm>


### PR DESCRIPTION
Only `getpid()` is used on windows from `unistd.h`. As it is not always present use `GetCurrentProcessId()` and include it only for non-windows platforms.