### PR TITLE
Add visibility attributes for functions/classes/variables to be exported

### DIFF
--- a/cocotb/share/include/cocotb_utils.h
+++ b/cocotb/share/include/cocotb_utils.h
@@ -30,6 +30,13 @@
 #ifndef COCOTB_UTILS_H_
 #define COCOTB_UTILS_H_
 
+#include <exports.h>
+#ifdef COCOTBUTILS_EXPORTS
+#define COCOTBUTILS_EXPORT COCOTB_EXPORT
+#else
+#define COCOTBUTILS_EXPORT COCOTB_IMPORT
+#endif
+
 #include <gpi_logging.h>
 
 #ifdef __cplusplus
@@ -39,10 +46,10 @@ extern "C" {
 #define xstr(a) str(a)
 #define str(a) #a
 
-extern void* utils_dyn_open(const char* lib_name);
-extern void* utils_dyn_sym(void *handle, const char* sym_name);
+extern COCOTBUTILS_EXPORT void* utils_dyn_open(const char* lib_name);
+extern COCOTBUTILS_EXPORT void* utils_dyn_sym(void *handle, const char* sym_name);
 
-extern int is_python_context;
+extern COCOTBUTILS_EXPORT int is_python_context;
 
 // to_python and to_simulator are implemented as macros instead of functions so
 // that the logs reference the user's lineno and filename

--- a/cocotb/share/include/embed.h
+++ b/cocotb/share/include/embed.h
@@ -30,16 +30,23 @@
 #ifndef COCOTB_EMBED_H_
 #define COCOTB_EMBED_H_
 
+#include <exports.h>
+#ifdef COCOTB_EMBED_EXPORTS
+#define COCOTB_EMBED_EXPORT COCOTB_EXPORT
+#else
+#define COCOTB_EMBED_EXPORT COCOTB_IMPORT
+#endif
+
 #include <gpi.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern void embed_init_python(void);
-extern void embed_sim_cleanup(void);
-extern int embed_sim_init(int argc, char const* const* argv);
-extern void embed_sim_event(gpi_event_t level, const char *msg);
+extern COCOTB_EMBED_EXPORT void embed_init_python(void);
+extern COCOTB_EMBED_EXPORT void embed_sim_cleanup(void);
+extern COCOTB_EMBED_EXPORT int embed_sim_init(int argc, char const* const* argv);
+extern COCOTB_EMBED_EXPORT void embed_sim_event(gpi_event_t level, const char *msg);
 
 #ifdef __cplusplus
 }

--- a/cocotb/share/include/exports.h
+++ b/cocotb/share/include/exports.h
@@ -1,0 +1,19 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef COCOTB_EXPORTS_H_
+#define COCOTB_EXPORTS_H_
+
+// Make cocotb work correctly when the default visibility is changed to hidden
+// Changing the default visibility to hidden has the advantage of significantly reducing the code size,
+// load times as well as letting the optimizer produce better code
+#if defined(__linux__) || defined(__APPLE__)
+#define COCOTB_EXPORT __attribute__ ((visibility ("default")))
+#define COCOTB_IMPORT
+#else
+#define COCOTB_EXPORT __declspec(dllexport)
+#define COCOTB_IMPORT __declspec(dllimport)
+#endif
+
+#endif

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -51,6 +51,13 @@ we have to create a process with the signal on the sensitivity list to imitate a
 
 */
 
+#include <exports.h>
+#ifdef GPI_EXPORTS
+#define GPI_EXPORT COCOTB_EXPORT
+#else
+#define GPI_EXPORT COCOTB_IMPORT
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -118,39 +125,39 @@ typedef enum gpi_event_e {
  *
  * Useful for checking if a simulator is running.
  */
-bool gpi_has_registered_impl(void);
+GPI_EXPORT bool gpi_has_registered_impl(void);
 
 // Stop the simulator
-void gpi_sim_end(void);
+GPI_EXPORT void gpi_sim_end(void);
 
 // Cleanup GPI resources during sim shutdown
-void gpi_cleanup(void);
+GPI_EXPORT void gpi_cleanup(void);
 
 // Returns simulation time as two uints. Units are default sim units
-void gpi_get_sim_time(uint32_t *high, uint32_t *low);
-void gpi_get_sim_precision(int32_t *precision);
+GPI_EXPORT void gpi_get_sim_time(uint32_t *high, uint32_t *low);
+GPI_EXPORT void gpi_get_sim_precision(int32_t *precision);
 
 /**
  * Returns a string with the running simulator product information
  *
  * @return simulator product string
  */
-const char *gpi_get_simulator_product(void);
+GPI_EXPORT const char *gpi_get_simulator_product(void);
 
 /**
  * Returns a string with the running simulator version
  *
  * @return simulator version string
  */
-const char *gpi_get_simulator_version(void);
+GPI_EXPORT const char *gpi_get_simulator_version(void);
 
 // Functions for extracting a gpi_sim_hdl to an object
 // Returns a handle to the root simulation object,
 // Should be freed with gpi_free_handle
-gpi_sim_hdl gpi_get_root_handle(const char *name);
-gpi_sim_hdl gpi_get_handle_by_name(gpi_sim_hdl parent, const char *name);
-gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl parent, int32_t index);
-void gpi_free_handle(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT gpi_sim_hdl gpi_get_root_handle(const char *name);
+GPI_EXPORT gpi_sim_hdl gpi_get_handle_by_name(gpi_sim_hdl parent, const char *name);
+GPI_EXPORT gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl parent, int32_t index);
+GPI_EXPORT void gpi_free_handle(gpi_sim_hdl gpi_hdl);
 
 // Types that can be passed to the iterator.
 //
@@ -190,49 +197,49 @@ typedef enum gpi_set_action_e {
 // Unlike `vpi_iterate` the iterator handle may only be NULL if the `type` is
 // not supported, If no objects of the requested type are found, an empty
 // iterator is returned.
-gpi_iterator_hdl gpi_iterate(gpi_sim_hdl base, gpi_iterator_sel_t type);
+GPI_EXPORT gpi_iterator_hdl gpi_iterate(gpi_sim_hdl base, gpi_iterator_sel_t type);
 
 // Returns NULL when there are no more objects
-gpi_sim_hdl gpi_next(gpi_iterator_hdl iterator);
+GPI_EXPORT gpi_sim_hdl gpi_next(gpi_iterator_hdl iterator);
 
 // Returns the number of objects in the collection of the handle
-int gpi_get_num_elems(gpi_sim_hdl gpi_sim_hdl);
+GPI_EXPORT int gpi_get_num_elems(gpi_sim_hdl gpi_sim_hdl);
 
 // Returns the left side of the range constraint
-int gpi_get_range_left(gpi_sim_hdl gpi_sim_hdl);
+GPI_EXPORT int gpi_get_range_left(gpi_sim_hdl gpi_sim_hdl);
 
 // Returns the right side of the range constraint
-int gpi_get_range_right(gpi_sim_hdl gpi_sim_hdl);
+GPI_EXPORT int gpi_get_range_right(gpi_sim_hdl gpi_sim_hdl);
 
 // Functions for querying the properties of a handle
 // Caller responsible for freeing the returned string.
 // This is all slightly verbose but it saves having to enumerate various value types
 // We only care about a limited subset of values.
-const char *gpi_get_signal_value_binstr(gpi_sim_hdl gpi_hdl);
-const char *gpi_get_signal_value_str(gpi_sim_hdl gpi_hdl);
-double gpi_get_signal_value_real(gpi_sim_hdl gpi_hdl);
-long gpi_get_signal_value_long(gpi_sim_hdl gpi_hdl);
-const char *gpi_get_signal_name_str(gpi_sim_hdl gpi_hdl);
-const char *gpi_get_signal_type_str(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT const char *gpi_get_signal_value_binstr(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT const char *gpi_get_signal_value_str(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT double gpi_get_signal_value_real(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT long gpi_get_signal_value_long(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT const char *gpi_get_signal_name_str(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT const char *gpi_get_signal_type_str(gpi_sim_hdl gpi_hdl);
 
 // Returns one of the types defined above e.g. gpiMemory etc.
-gpi_objtype_t gpi_get_object_type(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT gpi_objtype_t gpi_get_object_type(gpi_sim_hdl gpi_hdl);
 
 // Get information about the definition of a handle
-const char* gpi_get_definition_name(gpi_sim_hdl gpi_hdl);
-const char* gpi_get_definition_file(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT const char* gpi_get_definition_name(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT const char* gpi_get_definition_file(gpi_sim_hdl gpi_hdl);
 
 // Determine whether an object value is constant (parameters / generics etc)
-int gpi_is_constant(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT int gpi_is_constant(gpi_sim_hdl gpi_hdl);
 
 // Determine whether an object is indexable
-int gpi_is_indexable(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT int gpi_is_indexable(gpi_sim_hdl gpi_hdl);
 
 // Functions for setting the properties of a handle
-void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value, gpi_set_action_t action);
-void gpi_set_signal_value_long(gpi_sim_hdl gpi_hdl, long value, gpi_set_action_t action);
-void gpi_set_signal_value_binstr(gpi_sim_hdl gpi_hdl, const char *str, gpi_set_action_t action); // String of binary char(s) [1, 0, x, z]
-void gpi_set_signal_value_str(gpi_sim_hdl gpi_hdl, const char *str, gpi_set_action_t action);    // String of ASCII char(s)
+GPI_EXPORT void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value, gpi_set_action_t action);
+GPI_EXPORT void gpi_set_signal_value_long(gpi_sim_hdl gpi_hdl, long value, gpi_set_action_t action);
+GPI_EXPORT void gpi_set_signal_value_binstr(gpi_sim_hdl gpi_hdl, const char *str, gpi_set_action_t action); // String of binary char(s) [1, 0, x, z]
+GPI_EXPORT void gpi_set_signal_value_str(gpi_sim_hdl gpi_hdl, const char *str, gpi_set_action_t action);    // String of ASCII char(s)
 
 typedef enum gpi_edge {
     GPI_RISING = 1,
@@ -240,23 +247,23 @@ typedef enum gpi_edge {
 } gpi_edge_e;
 
 // The callback registering functions
-gpi_cb_hdl gpi_register_timed_callback                  (int (*gpi_function)(const void *), void *gpi_cb_data, uint64_t time_ps);
-gpi_cb_hdl gpi_register_value_change_callback           (int (*gpi_function)(const void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl, int edge);
-gpi_cb_hdl gpi_register_readonly_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
-gpi_cb_hdl gpi_register_nexttime_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
-gpi_cb_hdl gpi_register_readwrite_callback              (int (*gpi_function)(const void *), void *gpi_cb_data);
+GPI_EXPORT gpi_cb_hdl gpi_register_timed_callback                  (int (*gpi_function)(const void *), void *gpi_cb_data, uint64_t time_ps);
+GPI_EXPORT gpi_cb_hdl gpi_register_value_change_callback           (int (*gpi_function)(const void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl, int edge);
+GPI_EXPORT gpi_cb_hdl gpi_register_readonly_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
+GPI_EXPORT gpi_cb_hdl gpi_register_nexttime_callback               (int (*gpi_function)(const void *), void *gpi_cb_data);
+GPI_EXPORT gpi_cb_hdl gpi_register_readwrite_callback              (int (*gpi_function)(const void *), void *gpi_cb_data);
 
 // Calling convention is that 0 = success and negative numbers a failure
 // For implementers of GPI the provided macro GPI_RET(x) is provided
-void gpi_deregister_callback(gpi_cb_hdl gpi_hdl);
+GPI_EXPORT void gpi_deregister_callback(gpi_cb_hdl gpi_hdl);
 
 // Because the internal structures may be different for different implementations
 // of GPI we provide a convenience function to extract the callback data
-void *gpi_get_callback_data(gpi_cb_hdl gpi_hdl);
+GPI_EXPORT void *gpi_get_callback_data(gpi_cb_hdl gpi_hdl);
 
 // Print out what implementations are registered. Python needs to be loaded for this,
 // Returns the number of libs
-size_t gpi_print_registered_impl(void);
+GPI_EXPORT size_t gpi_print_registered_impl(void);
 
 #define GPI_RET(_code) \
     if (_code == 1) \

--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -30,6 +30,13 @@
 #ifndef COCOTB_GPI_LOGGING_H_
 #define COCOTB_GPI_LOGGING_H_
 
+#include <exports.h>
+#ifdef GPILOG_EXPORTS
+#define GPILOG_EXPORT COCOTB_EXPORT
+#else
+#define GPILOG_EXPORT COCOTB_IMPORT
+#endif
+
 #ifdef __cplusplus
 # define EXTERN_C_START extern "C" {
 # define EXTERN_C_END }
@@ -55,13 +62,13 @@ enum gpi_log_levels {
 #define LOG_ERROR(...)     gpi_log("cocotb.gpi", GPIError,         __FILE__, __func__, __LINE__, __VA_ARGS__);
 #define LOG_CRITICAL(...)  gpi_log("cocotb.gpi", GPICritical,      __FILE__, __func__, __LINE__, __VA_ARGS__);
 
-void set_log_handler(void *handler);
-void clear_log_handler(void);
-void set_log_filter(void *filter);
-void clear_log_filter(void);
-void set_log_level(enum gpi_log_levels new_level);
+GPILOG_EXPORT void set_log_handler(void *handler);
+GPILOG_EXPORT void clear_log_handler(void);
+GPILOG_EXPORT void set_log_filter(void *filter);
+GPILOG_EXPORT void clear_log_filter(void);
+GPILOG_EXPORT void set_log_level(enum gpi_log_levels new_level);
 
-void gpi_log(const char *name, enum gpi_log_levels level, const char *pathname, const char *funcname, long lineno, const char *msg, ...);
+GPILOG_EXPORT void gpi_log(const char *name, enum gpi_log_levels level, const char *pathname, const char *funcname, long lineno, const char *msg, ...);
 
 EXTERN_C_END
 

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -28,6 +28,13 @@
 #ifndef COCOTB_FLI_IMPL_H_
 #define COCOTB_FLI_IMPL_H_
 
+#include <exports.h>
+#ifdef COCOTBFLI_EXPORTS
+#define COCOTBFLI_EXPORT COCOTB_EXPORT
+#else
+#define COCOTBFLI_EXPORT COCOTB_IMPORT
+#endif
+
 #include "../gpi/gpi_priv.h"
 #include "mti.h"
 
@@ -35,7 +42,7 @@
 #include <map>
 
 extern "C" {
-void cocotb_init();
+COCOTBFLI_EXPORT void cocotb_init();
 void handle_fli_callback(void *data);
 }
 

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -29,6 +29,13 @@
 #ifndef COCOTB_GPI_PRIV_H_
 #define COCOTB_GPI_PRIV_H_
 
+#include <exports.h>
+#ifdef GPI_EXPORTS
+#define GPI_EXPORT COCOTB_EXPORT
+#else
+#define GPI_EXPORT COCOTB_IMPORT
+#endif
+
 #include <gpi.h>
 #include <embed.h>
 #include <string>
@@ -50,7 +57,7 @@ class GpiIterator;
 class GpiCbHdl;
 
 /* Base GPI class others are derived from */
-class GpiHdl {
+class GPI_EXPORT GpiHdl {
 public:
     GpiHdl(GpiImplInterface *impl, void *hdl = NULL) : m_impl(impl), m_obj_hdl(hdl) { }
     virtual ~GpiHdl() = default;
@@ -78,7 +85,7 @@ protected:
 // Subsequent operations to get children go through this handle.
 // GpiObjHdl::get_handle_by_name/get_handle_by_index are really factories
 // that construct an object derived from GpiSignalObjHdl or GpiObjHdl
-class GpiObjHdl : public GpiHdl {
+class GPI_EXPORT GpiObjHdl : public GpiHdl {
 public:
     GpiObjHdl(
         GpiImplInterface *impl,
@@ -134,7 +141,7 @@ protected:
 //
 // Identical to an object but adds additional methods for getting/setting the
 // value of the signal (which doesn't apply to non signal items in the hierarchy
-class GpiSignalObjHdl : public GpiObjHdl {
+class GPI_EXPORT GpiSignalObjHdl : public GpiObjHdl {
 public:
     using GpiObjHdl::GpiObjHdl;
 
@@ -161,7 +168,7 @@ public:
 /* GPI Callback handle */
 // To set a callback it needs the signal to do this on,
 // vpiHandle/vhpiHandleT for instance. The
-class GpiCbHdl : public GpiHdl {
+class GPI_EXPORT GpiCbHdl : public GpiHdl {
 public:
     GpiCbHdl(GpiImplInterface *impl) : GpiHdl(impl) { }
 
@@ -185,7 +192,7 @@ protected:
     gpi_cb_state_e m_state = GPI_FREE;         // GPI state of the callback through its cycle
 };
 
-class GpiValueCbHdl : public virtual GpiCbHdl {
+class GPI_EXPORT GpiValueCbHdl : public virtual GpiCbHdl {
 public:
     GpiValueCbHdl(GpiImplInterface *impl, GpiSignalObjHdl *signal, int edge);
     int run_callback() override;
@@ -195,7 +202,7 @@ protected:
     GpiSignalObjHdl *m_signal;
 };
 
-class GpiIterator : public GpiHdl {
+class GPI_EXPORT GpiIterator : public GpiHdl {
 public:
     enum Status {
         NATIVE,             // Fully resolved object was created
@@ -225,7 +232,7 @@ protected:
 };
 
 
-class GpiImplInterface {
+class GPI_EXPORT GpiImplInterface {
 public:
     GpiImplInterface(const std::string& name) : m_name(name) { }
     const char *get_name_c();
@@ -264,13 +271,13 @@ protected:
 };
 
 /* Called from implementation layers back up the stack */
-int gpi_register_impl(GpiImplInterface *func_tbl);
+GPI_EXPORT int gpi_register_impl(GpiImplInterface *func_tbl);
 
-void gpi_embed_init(int argc, char const* const* argv);
-void gpi_cleanup();
-void gpi_embed_end();
-void gpi_embed_event(gpi_event_t level, const char *msg);
-void gpi_load_extra_libs();
+GPI_EXPORT void gpi_embed_init(int argc, char const* const* argv);
+GPI_EXPORT void gpi_cleanup();
+GPI_EXPORT void gpi_embed_end();
+GPI_EXPORT void gpi_embed_event(gpi_event_t level, const char *msg);
+GPI_EXPORT void gpi_load_extra_libs();
 
 typedef void (*layer_entry_func)();
 

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -1083,6 +1083,13 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#if defined(__linux__) || defined(__APPLE__)
+// Only required for Python < 3.9, default for 3.9+ (bpo-11410)
+#pragma GCC visibility push(default)
+PyMODINIT_FUNC PyInit_simulator(void);
+#pragma GCC visibility pop
+#endif
+
 PyMODINIT_FUNC PyInit_simulator(void)
 {
     /* initialize the extension types */

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -977,7 +977,7 @@ static void register_embed()
 }
 
 // pre-defined VHPI registration table
-void (*vhpi_startup_routines[])() = {
+COCOTBVHPI_EXPORT void (*vhpi_startup_routines[])() = {
     register_embed,
     gpi_load_extra_libs,
     register_initial_callback,
@@ -986,7 +986,7 @@ void (*vhpi_startup_routines[])() = {
 };
 
 // For non-VHPI compliant applications that cannot find vhpi_startup_routines
-void vhpi_startup_routines_bootstrap() {
+COCOTBVHPI_EXPORT void vhpi_startup_routines_bootstrap() {
     void (*routine)();
     int i;
     routine = vhpi_startup_routines[0];

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -28,6 +28,13 @@
 #ifndef COCOTB_VHPI_IMPL_H_
 #define COCOTB_VHPI_IMPL_H_
 
+#include <exports.h>
+#ifdef COCOTBVHPI_EXPORTS
+#define COCOTBVHPI_EXPORT COCOTB_EXPORT
+#else
+#define COCOTBVHPI_EXPORT COCOTB_IMPORT
+#endif
+
 #include "../gpi/gpi_priv.h"
 #include <vhpi_user.h>
 #include <vhpi_user_ext.h>

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -717,7 +717,7 @@ static void register_system_functions()
 
 }
 
-void (*vlog_startup_routines[])() = {
+COCOTBVPI_EXPORT void (*vlog_startup_routines[])() = {
     register_embed,
     gpi_load_extra_libs,
     register_system_functions,
@@ -728,7 +728,7 @@ void (*vlog_startup_routines[])() = {
 
 
 // For non-VPI compliant applications that cannot find vlog_startup_routines symbol
-void vlog_startup_routines_bootstrap() {
+COCOTBVPI_EXPORT void vlog_startup_routines_bootstrap() {
     // call each routine in turn like VPI would
     for (auto it = &vlog_startup_routines[0]; *it != nullptr; it++) {
         auto routine = *it;

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -28,6 +28,13 @@
 #ifndef COCOTB_VPI_IMPL_H_
 #define COCOTB_VPI_IMPL_H_
 
+#include <exports.h>
+#ifdef COCOTBVPI_EXPORTS
+#define COCOTBVPI_EXPORT COCOTB_EXPORT
+#else
+#define COCOTBVPI_EXPORT COCOTB_IMPORT
+#endif
+
 #include "../gpi/gpi_priv.h"
 #include <vpi_user_ext.h>
 #include <sv_vpi_user.h>

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -133,6 +133,9 @@ def _extra_link_args(lib_name=None, rpaths=[]):
         if sys.platform == "darwin":
             rpath = rpath.replace("$ORIGIN", "@loader_path")
         args += ["-Wl,-rpath,%s" % rpath]
+    if os.name == "nt":
+        # Align behavior of gcc with msvc and export only symbols marked with __declspec(dllexport)
+        args += ["-Wl,--exclude-all-symbols"]
     return args
 
 
@@ -167,7 +170,7 @@ def _get_python_lib():
 # TODO [gh-1372]: make this work for MSVC which has a different flag syntax
 _base_warns = ["-Wall", "-Wextra", "-Wcast-qual", "-Wwrite-strings", "-Wconversion"]
 _ccx_warns = _base_warns + ["-Wnon-virtual-dtor", "-Woverloaded-virtual"]
-_extra_cxx_compile_args = ["-std=c++11"] + _ccx_warns
+_extra_cxx_compile_args = ["-std=c++11", "-fvisibility=hidden", "-fvisibility-inlines-hidden"] + _ccx_warns
 
 # Make PRI* format macros available with C++11 compiler but older libc, e.g. on RHEL6.
 _extra_cxx_compile_args += ["-D__STDC_FORMAT_MACROS"]
@@ -186,6 +189,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     #
     libcocotbutils = Extension(
         os.path.join("cocotb", "libs", "libcocotbutils"),
+        define_macros=[("COCOTBUTILS_EXPORTS", "")],
         include_dirs=[include_dir],
         libraries=["gpilog"],
         sources=[os.path.join(share_lib_dir, "utils", "cocotb_utils.cpp")],
@@ -202,6 +206,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
 
     libgpilog = Extension(
         os.path.join("cocotb", "libs", "libgpilog"),
+        define_macros=[("GPILOG_EXPORTS", "")],
         include_dirs=[include_dir],
         library_dirs=python_lib_dirs,
         sources=[os.path.join(share_lib_dir, "gpi_log", "gpi_logging.cpp")],
@@ -214,7 +219,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     #
     libcocotb = Extension(
         os.path.join("cocotb", "libs", "libcocotb"),
-        define_macros=[("PYTHON_SO_LIB", _get_python_lib())],
+        define_macros=[("COCOTB_EMBED_EXPORTS", ""), ("PYTHON_SO_LIB", _get_python_lib())],
         include_dirs=[include_dir],
         libraries=[_get_python_lib_link(), "gpilog", "cocotbutils"],
         library_dirs=python_lib_dirs,
@@ -228,7 +233,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     #
     libgpi = Extension(
         os.path.join("cocotb", "libs", "libgpi"),
-        define_macros=[("LIB_EXT", _get_lib_ext_name()), ("SINGLETON_HANDLES", "")],
+        define_macros=[("GPI_EXPORTS", ""), ("LIB_EXT", _get_lib_ext_name()), ("SINGLETON_HANDLES", "")],
         include_dirs=[include_dir],
         libraries=["cocotbutils", "gpilog", "cocotb", "stdc++"],
         sources=[
@@ -264,7 +269,7 @@ def _get_vpi_lib_ext(
     lib_name = "libcocotbvpi_" + sim_define.lower()
     libcocotbvpi = Extension(
         os.path.join("cocotb", "libs", lib_name),
-        define_macros=[("VPI_CHECKING", "1")] + [(sim_define, "")],
+        define_macros=[("COCOTBVPI_EXPORTS", ""), ("VPI_CHECKING", "1")] + [(sim_define, "")],
         include_dirs=[include_dir],
         libraries=["gpi", "gpilog"] + extra_lib,
         library_dirs=extra_lib_dir,
@@ -286,7 +291,7 @@ def _get_vhpi_lib_ext(
     libcocotbvhpi = Extension(
         os.path.join("cocotb", "libs", lib_name),
         include_dirs=[include_dir],
-        define_macros=[("VHPI_CHECKING", 1)] + [(sim_define, "")],
+        define_macros=[("COCOTBVHPI_EXPORTS", ""), ("VHPI_CHECKING", 1)] + [(sim_define, "")],
         libraries=["gpi", "gpilog", "stdc++"] + extra_lib,
         library_dirs=extra_lib_dir,
         sources=[
@@ -368,6 +373,7 @@ def get_ext():
             lib_name = "libcocotbfli_modelsim"
             fli_ext = Extension(
                 os.path.join("cocotb", "libs", lib_name),
+                define_macros=[("COCOTBFLI_EXPORTS", "")],
                 include_dirs=[include_dir, modelsim_include_dir],
                 libraries=["gpi", "gpilog", "stdc++"] + modelsim_extra_lib,
                 library_dirs=modelsim_extra_lib_path,

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -136,6 +136,8 @@ def _extra_link_args(lib_name=None, rpaths=[]):
     if os.name == "nt":
         # Align behavior of gcc with msvc and export only symbols marked with __declspec(dllexport)
         args += ["-Wl,--exclude-all-symbols"]
+    else:
+        args += ["-flto"]
     return args
 
 
@@ -171,6 +173,8 @@ def _get_python_lib():
 _base_warns = ["-Wall", "-Wextra", "-Wcast-qual", "-Wwrite-strings", "-Wconversion"]
 _ccx_warns = _base_warns + ["-Wnon-virtual-dtor", "-Woverloaded-virtual"]
 _extra_cxx_compile_args = ["-std=c++11", "-fvisibility=hidden", "-fvisibility-inlines-hidden"] + _ccx_warns
+if os.name != "nt":
+    _extra_cxx_compile_args += ["-flto"]
 
 # Make PRI* format macros available with C++11 compiler but older libc, e.g. on RHEL6.
 _extra_cxx_compile_args += ["-D__STDC_FORMAT_MACROS"]


### PR DESCRIPTION
`*_EXPORT` macro is used to either mark a function, class or variable as exported with `__declspec(dllexport)` (on Windows) or `__attribute__ ((visibility ("default")))` for gcc and clang, if the matching `*_EXPORTS` macro is set or as imported with `__declspec(dllimport)`.

The naming convention for the macros used here is based on the library name `LIBNAME_EXPORT` and `LIBNAME_EXPORTS` which is defined during compilation of `LIBNAME`.

MSVC requires symbols to be exported to be marked with `__declspec(dllexport)` by specifying `-Wl,--exclude-all-symbols` we align the behavior between GCC and MSVC. This largely narrows the gap for future MSVC support. For non-windows platform the default visibility is changed to hidden by specifying `-fvisibility=hidden -fvisibility-inlines-hidden`. Therefore visible symbols in the shared libraries are the same across all (supported) platform compiler combinations.

Advantages are "very substantially improves load times", "lets the optimiser produce better code", "reduces the size of your DSO by 5-20%", "Much lower chance of symbol collision". For more details see [https://gcc.gnu.org/wiki/Visibility](https://gcc.gnu.org/wiki/Visibility).

On Linux code size is reduced by ~40% and performance increased by a few percent depending on the tests run.

Avoiding symbol collisions is important if a wrapper for runtime resolving is added. This helps slim down #1783 which only included exporting functions for `libcocotbvpi_*` and `libcocotbvhpi_*`.