### PR TITLE
Remove unused includes in embed.h

### DIFF
--- a/cocotb/share/include/embed.h
+++ b/cocotb/share/include/embed.h
@@ -31,7 +31,6 @@
 #define COCOTB_EMBED_H_
 
 #include <gpi.h>
-#include <gpi_logging.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/cocotb/share/include/embed.h
+++ b/cocotb/share/include/embed.h
@@ -32,8 +32,6 @@
 
 #include <gpi.h>
 #include <gpi_logging.h>
-#include <vpi_user_ext.h>
-#include <sv_vpi_user.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
These includes are not used and can be cleaned up. VPI interfaces are abstracted in `libcocotbvpi_*` and should not be included here.