### PR TITLE
Add support for MSVC

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -238,6 +238,9 @@ jobs:
       run: python -m pip install  --global-option build_ext --global-option --compiler=mingw32 -e .
     - name: Install Python testing dependencies (Windows)
       run: pip install coverage xunitparser pytest pytest-cov
+    - name: SxS trace test (Windows)
+      if: startsWith(matrix.os, 'windows')
+      run: .\tests\sxs.ps1
     - name: Test (Windows)
       if: startsWith(matrix.os, 'windows')
       id: windowstesting

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -137,6 +137,16 @@ jobs:
             lang: verilog
             python-version: 3.8
             os: windows-latest
+            toolchain: mingw
+            extra_name: "mingw | "
+
+          - sim: icarus             # use msvc instead of mingw
+            sim-version: master
+            lang: verilog
+            python-version: 3.8
+            os: windows-latest
+            toolchain: msvc
+            extra_name: "msvc | "
 
             # Other
 
@@ -230,14 +240,22 @@ jobs:
         sudo make install
 
       # Windows Testing
-    - name: Install cocotb build dependencies (Windows)
-      if: startsWith(matrix.os, 'windows')
-      run: conda install --yes -c msys2 m2-base m2-make m2w64-toolchain libpython
-    - name: Install cocotb (Windows)
-      if: startsWith(matrix.os, 'windows')
-      run: python -m pip install  --global-option build_ext --global-option --compiler=mingw32 -e .
     - name: Install Python testing dependencies (Windows)
       run: pip install coverage xunitparser pytest pytest-cov
+    - name: Install cocotb build dependencies (Windows, mingw)
+      if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'mingw'
+      run: conda install --yes -c msys2 m2-base m2-make m2w64-toolchain libpython
+    - name: Install cocotb (Windows, mingw)
+      if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'mingw'
+      run: python -m pip install  --global-option build_ext --global-option --compiler=mingw32 -v -e .
+      continue-on-error: ${{matrix.may_fail || false}}
+    - name: Install cocotb (Windows, msvc)
+      if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'msvc'
+      run: python -m pip install -v -e .
+      continue-on-error: ${{matrix.may_fail || false}}
+    - name: Install cocotb runtime dependencies (Windows, msvc)
+      if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'msvc'
+      run: conda install --yes -c msys2 m2-base m2-make
     - name: SxS trace test (Windows)
       if: startsWith(matrix.os, 'windows')
       run: .\tests\sxs.ps1

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ After installing these dependencies, the latest stable version of cocotb can be 
 pip install cocotb
 ```
 
-**!!! Windows Users !!!** See [here](https://docs.cocotb.org/en/stable/install.html) for installation instructions.
-
 For more details on installation, including prerequisites,
 see [the documentation](https://docs.cocotb.org/en/stable/install.html).
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -159,6 +159,11 @@ void gpi_embed_event(gpi_event_t level, const char *msg)
 static void gpi_load_libs(std::vector<std::string> to_load)
 {
 #define DOT_LIB_EXT "." xstr(LIB_EXT)
+#ifdef LIB_PREFIX
+#define LIB_PREFIX_STR xstr(LIB_PREFIX)
+#else
+#define LIB_PREFIX_STR ""
+#endif
     std::vector<std::string>::iterator iter;
 
     for (iter = to_load.begin();
@@ -182,7 +187,7 @@ static void gpi_load_libs(std::vector<std::string> to_load)
             func_name = std::string(it+1, arg.end());
         }
 
-        std::string full_name = "lib" + lib_name + DOT_LIB_EXT;
+        std::string full_name = LIB_PREFIX_STR + lib_name + DOT_LIB_EXT;
         void *lib_handle = utils_dyn_open(full_name.c_str());
         if (!lib_handle) {
             printf("cocotb: Error loading shared library %s\n", full_name.c_str());

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -64,9 +64,13 @@ PYTHON_BIN ?= $(realpath $(shell cocotb-config --python-bin))
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.deprecations
 
 LIB_DIR=$(COCOTB_PY_DIR)/cocotb/libs
+LIB_PREFIX := lib
 
 ifeq ($(OS),Msys)
     LIB_EXT := dll
+    ifneq (,$(wildcard $(LIB_DIR)/cocotb.dll))
+        LIB_PREFIX :=
+    endif
 else
     LIB_EXT := so
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -31,14 +31,14 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     # backslashes needed because we embed in `echo` below
     GPI_ARGS = -pli \"$(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_aldec)\"
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = cocotbvhpi_aldec:cocotbvhpi_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_aldec.$(LIB_EXT):cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     # backslashes needed because we embed in `echo` below
     GPI_ARGS = -loadvhpi \"$(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvhpi_aldec):vhpi_startup_routines_bootstrap\"
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = cocotbvpi_aldec:cocotbvpi_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbvpi_aldec.$(LIB_EXT):cocotbvpi_entry_point
 endif
 else
    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -29,14 +29,14 @@ ACOM_ARGS += -dbg
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
     # backslashes needed because we embed in `echo` below
-    GPI_ARGS = -pli \"$(call to_tcl_path,$(LIB_DIR)/libcocotbvpi_aldec)\"
+    GPI_ARGS = -pli \"$(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_aldec)\"
 ifneq ($(VHDL_SOURCES),)
     GPI_EXTRA = cocotbvhpi_aldec:cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     # backslashes needed because we embed in `echo` below
-    GPI_ARGS = -loadvhpi \"$(call to_tcl_path,$(LIB_DIR)/libcocotbvhpi_aldec):vhpi_startup_routines_bootstrap\"
+    GPI_ARGS = -loadvhpi \"$(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvhpi_aldec):vhpi_startup_routines_bootstrap\"
 ifneq ($(VERILOG_SOURCES),)
     GPI_EXTRA = cocotbvpi_aldec:cocotbvpi_entry_point
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -63,7 +63,7 @@ endif
 $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	MODULE=$(MODULE) \
 	TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=$(LIB_DIR)/libcocotbvpi_modelsim:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+        $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_modelsim:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 ifeq ($(CVC_ITERP),1)
@@ -80,7 +80,7 @@ ifeq ($(CVC_ITERP),1)
     debug:  $(CUSTOM_SIM_DEPS)
 	MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        gdb --args $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=$(LIB_DIR)/modelsim/libcocotbvpi:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+        gdb --args $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=$(LIB_DIR)/modelsim/$(LIB_PREFIX)cocotbvpi:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 else
     debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	MODULE=$(MODULE) \

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -76,7 +76,7 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) --vpi=$(LIB_DIR)/libcocotbvpi_ghdl.$(LIB_EXT) $(SIM_ARGS) $(PLUSARGS)
+	$(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) --vpi=$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_ghdl.$(LIB_EXT) $(SIM_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -69,7 +69,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
+        $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m $(LIB_PREFIX)cocotbvpi_icarus $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
 
 	$(call check_for_results_file)
 
@@ -77,7 +77,7 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+        gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m $(LIB_PREFIX)cocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -70,7 +70,7 @@ ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
-# GPI_EXTRA=cocotbvhpi if needed.
+# GPI_EXTRA=$(LIB_PREFIX)cocotbvhpi.$(LIB_EXT) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if vpi library name is libvpi.so
 GPI_ARGS = -loadvpi $(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_ius:vlog_startup_routines_bootstrap
@@ -81,10 +81,10 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     ROOT_LEVEL = $(TOPLEVEL)
 ifneq ($(VHDL_SOURCES),)
     HDL_SOURCES += $(VHDL_SOURCES)
-    GPI_EXTRA = cocotbvhpi_ius:cocotbvhpi_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_ius.$(LIB_EXT):cocotbvhpi_entry_point
 endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_EXTRA = cocotbvhpi_ius:cocotbvhpi_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_ius.$(LIB_EXT):cocotbvhpi_entry_point
     EXTRA_ARGS += -v93
     EXTRA_ARGS += -top $(TOPLEVEL)
     RTL_LIBRARY ?= $(TOPLEVEL)

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -73,7 +73,7 @@ endif
 # GPI_EXTRA=cocotbvhpi if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if vpi library name is libvpi.so
-GPI_ARGS = -loadvpi $(LIB_DIR)/libcocotbvpi_ius:vlog_startup_routines_bootstrap
+GPI_ARGS = -loadvpi $(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_ius:vlog_startup_routines_bootstrap
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     EXTRA_ARGS += -v93

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -81,13 +81,13 @@ ifeq ($(TOPLEVEL_LANG),vhdl)
     CUSTOM_COMPILE_DEPS += $(FLI_LIB)
     VSIM_ARGS += -foreign \"cocotb_init $(call to_tcl_path,$(FLI_LIB))\"
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = cocotbvpi_modelsim:cocotbvpi_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbvpi_modelsim.$(LIB_EXT):cocotbvpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),verilog)
     VSIM_ARGS += -pli $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_modelsim.$(LIB_EXT))
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = cocotbfli_modelsim:cocotbfli_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbfli_modelsim.$(LIB_EXT):cocotbfli_entry_point
 endif
 
 else

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -69,7 +69,7 @@ else
     VSIM_ARGS += -onfinish exit
 endif
 
-FLI_LIB := $(LIB_DIR)/libcocotbfli_modelsim.$(LIB_EXT)
+FLI_LIB := $(LIB_DIR)/$(LIB_PREFIX)cocotbfli_modelsim.$(LIB_EXT)
 # if this target is run, then cocotb did not build the library
 $(FLI_LIB):
 	@echo -e "ERROR: cocotb was not installed with an FLI library, as the mti.h header could not be located.\n\
@@ -85,7 +85,7 @@ ifneq ($(VERILOG_SOURCES),)
 endif
 
 else ifeq ($(TOPLEVEL_LANG),verilog)
-    VSIM_ARGS += -pli $(call to_tcl_path,$(LIB_DIR)/libcocotbvpi_modelsim.$(LIB_EXT))
+    VSIM_ARGS += -pli $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_modelsim.$(LIB_EXT))
 ifneq ($(VHDL_SOURCES),)
     GPI_EXTRA = cocotbfli_modelsim:cocotbfli_entry_point
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -86,13 +86,13 @@ endif
 
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
-    GPI_ARGS = -pli $(call to_tcl_path,$(LIB_DIR)/libcocotbvpi_aldec)
+    GPI_ARGS = -pli $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_aldec)
 ifneq ($(VHDL_SOURCES),)
     GPI_EXTRA = cocotbvhpi_aldec:cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_ARGS = -loadvhpi $(call to_tcl_path,$(LIB_DIR)/libcocotbvhpi_aldec):vhpi_startup_routines_bootstrap
+    GPI_ARGS = -loadvhpi $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvhpi_aldec):vhpi_startup_routines_bootstrap
 ifneq ($(VERILOG_SOURCES),)
     GPI_EXTRA = cocotbvpi_aldec:cocotbvpi_entry_point
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -88,13 +88,13 @@ GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
     GPI_ARGS = -pli $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_aldec)
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = cocotbvhpi_aldec:cocotbvhpi_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_aldec.$(LIB_EXT):cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     GPI_ARGS = -loadvhpi $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvhpi_aldec):vhpi_startup_routines_bootstrap
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = cocotbvpi_aldec:cocotbvpi_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbvpi_aldec.$(LIB_EXT):cocotbvpi_entry_point
 endif
 
 else

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -75,7 +75,7 @@ $(SIM_BUILD)/simv: $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(CUSTOM_COMPILE_DEPS
 	TOPLEVEL=$(TOPLEVEL) \
 	$(CMD) -top $(TOPLEVEL) $(PLUSARGS) +acc+1 +vpi -P pli.tab +define+COCOTB_SIM=1 -sverilog \
 	-timescale=$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) -debug -load $(LIB_DIR)/libcocotbvpi_vcs.so $(COMPILE_ARGS) $(VERILOG_SOURCES)
+	$(EXTRA_ARGS) -debug -load $(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_vcs.so $(COMPILE_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -81,7 +81,7 @@ endif
 # GPI_EXTRA=cocotbvhpi if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if VPI library name is libvpi.so
-GPI_ARGS = -loadvpi $(LIB_DIR)/libcocotbvpi_ius:vlog_startup_routines_bootstrap
+GPI_ARGS = -loadvpi $(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_ius:vlog_startup_routines_bootstrap
 ifeq ($(TOPLEVEL_LANG),verilog)
     HDL_SOURCES = $(VERILOG_SOURCES)
     ROOT_LEVEL = $(TOPLEVEL)

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -78,7 +78,7 @@ ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
-# GPI_EXTRA=cocotbvhpi if needed.
+# GPI_EXTRA=$(LIB_PREFIX)cocotbvhpi.$(LIB_EXT) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if VPI library name is libvpi.so
 GPI_ARGS = -loadvpi $(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_ius:vlog_startup_routines_bootstrap
@@ -88,11 +88,10 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     EXTRA_ARGS += -top $(TOPLEVEL)
     ifneq ($(VHDL_SOURCES),)
         HDL_SOURCES += $(VHDL_SOURCES)
-        GPI_EXTRA = cocotbvhpi_ius:cocotbvhpi_entry_point
+        GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_ius.$(LIB_EXT):cocotbvhpi_entry_point
     endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    # GPI_EXTRA will internally be extended to lib<GPI_EXTRA>.so
-    GPI_EXTRA = cocotbvhpi_ius:cocotbvhpi_entry_point
+    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_ius.$(LIB_EXT):cocotbvhpi_entry_point
     EXTRA_ARGS += -top $(TOPLEVEL)
     RTL_LIBRARY ?= $(TOPLEVEL)
     MAKE_LIB = -makelib $(RTL_LIBRARY)

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -214,6 +214,10 @@ class build_ext(_build_ext):
 
             ext.extra_link_args += ["-Wl,-rpath,%s" % rpath for rpath in rpaths]
 
+        # vpi_user.h and vhpi_user.h require that WIN32 is defined
+        if os.name == "nt":
+            ext.define_macros += [("WIN32", "")]
+
         old_build_temp = self.build_temp
         self.build_temp = os.path.join(self.build_temp, ext.name)
         super().build_extension(ext)

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -259,6 +259,13 @@ class build_ext(_build_ext):
         if lib_name == "libgpi" and not self._uses_msvc():
             ext.define_macros += [("LIB_PREFIX", "lib")]
 
+        if lib_name == "libembed":
+            if self._uses_msvc():
+                embed_lib_name = "cocotb"
+            else:
+                embed_lib_name = "libcocotb"
+            ext.define_macros += [("EMBED_IMPL_LIB", embed_lib_name + "." + _get_lib_ext_name())]
+
         old_build_temp = self.build_temp
         self.build_temp = os.path.join(self.build_temp, ext.name)
         super().build_extension(ext)
@@ -467,7 +474,6 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         os.path.join("cocotb", "libs", "libembed"),
         define_macros=[
             ("COCOTB_EMBED_EXPORTS", ""),
-            ("EMBED_IMPL_LIB", "libcocotb." + _get_lib_ext_name()),
             ("PYTHON_LIB", _get_python_lib())] + _extra_defines,
         include_dirs=[include_dir],
         libraries=["gpilog", "cocotbutils"],

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -192,6 +192,11 @@ class build_ext(_build_ext):
                 if not self.compiler.initialized:
                     self.compiler.initialize()
 
+                # Setuptools defaults to activate automatic manifest generation for msvc,
+                # disable it here as we manually generate it to also support mingw on windows
+                for (k, ldflags) in self.compiler._ldflags.items():
+                    self.compiler._ldflags[k] = [x for x in ldflags if not x.startswith("/MANIFEST")] + ["/MANIFEST:NO"]
+
                 self.compiler.compile_options = [x for x in self.compiler.compile_options if not x.startswith("/W")] + ["/W4"]
 
             def_dir = os.path.join(cocotb_share_dir, "def")

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -318,15 +318,25 @@ class build_ext(_build_ext):
         """
 
         for sim in ["icarus", "modelsim", "aldec", "ghdl"]:
-            subprocess.run(
-                [
-                    "dlltool",
-                    "-d",
-                    os.path.join(def_dir, sim + ".def"),
-                    "-l",
-                    os.path.join(def_dir, "lib" + sim + ".a"),
-                ]
-            )
+            if self._uses_msvc():
+                subprocess.run(
+                    [
+                        self.compiler.lib,
+                        "/def:" + os.path.join(def_dir, sim + ".def"),
+                        "/out:" + os.path.join(def_dir, sim + ".lib"),
+                        "/machine:" + ("X64" if sys.maxsize > 2**32 else "X86")
+                    ]
+                )
+            else:
+                subprocess.run(
+                    [
+                        "dlltool",
+                        "-d",
+                        os.path.join(def_dir, sim + ".def"),
+                        "-l",
+                        os.path.join(def_dir, "lib" + sim + ".a"),
+                    ]
+                )
 
 
 def _get_python_lib_link():

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -224,6 +224,8 @@ class build_ext(_build_ext):
 
         A normal PEP 517 install still works as the temp directories are discarded anyway.
         """
+        lib_name = os.path.split(ext.name)[-1]
+
         if self._uses_msvc():
             ext.extra_compile_args += _extra_cxx_compile_args_msvc
         else:
@@ -234,8 +236,6 @@ class build_ext(_build_ext):
                 ext.extra_link_args += ["-Wl,--exclude-all-symbols"]
             else:
                 ext.extra_link_args += ["-flto"]
-
-                lib_name = os.path.split(ext.name)[-1]
 
                 rpaths = []
                 if lib_name == "simulator":
@@ -255,6 +255,9 @@ class build_ext(_build_ext):
         # vpi_user.h and vhpi_user.h require that WIN32 is defined
         if os.name == "nt":
             ext.define_macros += [("WIN32", "")]
+
+        if lib_name == "libgpi" and not self._uses_msvc():
+            ext.define_macros += [("LIB_PREFIX", "lib")]
 
         old_build_temp = self.build_temp
         self.build_temp = os.path.join(self.build_temp, ext.name)

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -256,9 +256,6 @@ class build_ext(_build_ext):
         if os.name == "nt":
             ext.define_macros += [("WIN32", "")]
 
-        if lib_name == "libgpi" and not self._uses_msvc():
-            ext.define_macros += [("LIB_PREFIX", "lib")]
-
         if lib_name == "libembed":
             if self._uses_msvc():
                 embed_lib_name = "cocotb"

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -200,18 +200,25 @@ GPI
 .. envvar:: GPI_EXTRA
 
     A comma-separated list of extra libraries that are dynamically loaded at runtime.
-    A function from each of these libraries will be called as an entry point prior to elaboration, allowing these libraries to register
-    system functions and callbacks. Note that :term:`HDL` objects cannot be accessed at this time.
-    The function name defaults to ``{library_name}_entry_point``, but a custom name can be specified using a ``:``, which follows an existing simulator convention.
+    A function from each of these libraries will be called as an entry point prior to elaboration,
+    allowing these libraries to register system functions and callbacks.
+    Note that :term:`HDL` objects cannot be accessed at this time.
+    An entry point function must be named following a ``:`` separator,
+    which follows an existing simulator convention.
 
     For example:
 
-    * ``GPI_EXTRA=name`` will load ``libname.so`` with default entry point ``name_entry_point``.
-    * ``GPI_EXTRA=nameA:entryA,nameB:entryB`` will first load ``libnameA.so`` with entry point ``entryA`` , then load ``libnameB.so`` with entry point ``entryB``.
+    * ``GPI_EXTRA=libnameA.so:entryA,libnameB.so:entryB`` will first load ``libnameA.so`` with entry point ``entryA`` , then load ``libnameB.so`` with entry point ``entryB``.
 
     .. versionchanged:: 1.4.0
         Support for the custom entry point via ``:`` was added.
         Previously ``:`` was used as a separator between libraries instead of ``,``.
+
+    .. versionchanged:: 1.5.0
+        Library name must be fully specified.
+        This allows using relative or absolute paths in library names,
+        and loading from libraries that `aren't` prefixed with "lib".
+        Paths `should not` contain commas.
 
 
 Makefile-based Test Scripts

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -18,7 +18,7 @@ The current stable version of cocotb requires:
 
 * Python 3.5+
 * Python-dev packages
-* GCC 4.8.1+ or Clang 3.3+ and associated development packages
+* GCC 4.8.1+, Clang 3.3+ or Microsoft Visual C++ 14.21+ and associated development packages
 * GNU Make
 * A Verilog or VHDL simulator, depending on your :term:`RTL` source code
 
@@ -39,7 +39,7 @@ The installation instructions vary depending on your operating system:
 
       .. code-block::
 
-         conda install -c msys2 m2-base m2-make m2w64-toolchain libpython
+         conda install -c msys2 m2-base m2-make
 
    .. group-tab:: Linux - Debian
 
@@ -73,39 +73,11 @@ The installation instructions vary depending on your operating system:
 Installation of cocotb
 ======================
 
-.. tabs::
+The **latest release** of cocotb can be installed by running
 
-   .. group-tab:: Windows
+.. code-block:: bash
 
-      The **latest release** of cocotb can be installed by running
-
-      .. code-block:: bash
-
-          pip install --global-option build_ext --global-option --compiler=mingw32 cocotb
-
-   .. group-tab:: Linux - Debian
-
-      The **latest release** of cocotb can be installed by running
-
-      .. code-block:: bash
-
-          pip install cocotb
-
-   .. group-tab:: Linux - Red Hat
-
-      The **latest release** of cocotb can be installed by running
-
-      .. code-block:: bash
-
-          pip install cocotb
-
-   .. group-tab:: macOS
-
-      The **latest release** of cocotb can be installed by running
-
-      .. code-block:: bash
-
-          pip install cocotb
+    pip install cocotb
 
 .. note::
 

--- a/documentation/source/install_devel.rst
+++ b/documentation/source/install_devel.rst
@@ -14,32 +14,18 @@ than the stable version:
 
 * Python 3.5+
 * Python-dev packages
-* GCC 4.8.1+ or Clang 3.3+ and associated development packages
+* GCC 4.8.1+, Clang 3.3+ or Microsoft Visual C++ 14.21+ and associated development packages
 * GNU Make
 * A Verilog or VHDL simulator, depending on your :term:`RTL` source code
 
 Please refer to :ref:`install-prerequisites` for details.
 
 
-The instructions for installing the development version of cocotb itself vary depending on your operating system:
+The development version of cocotb can be installed by running
 
-.. tabs::
+.. code-block:: bash
 
-   .. group-tab:: Windows
-
-      The development version of cocotb can be installed by running
-
-      .. code-block:: bash
-
-          pip install --global-option build_ext --global-option --compiler=mingw32 git+https://github.com/cocotb/cocotb@master
-
-   .. group-tab:: Linux and macOS
-
-      The development version of cocotb can be installed by running
-
-      .. code-block:: bash
-
-          pip install git+https://github.com/cocotb/cocotb@master
+    pip install git+https://github.com/cocotb/cocotb@master
 
 .. note::
 

--- a/documentation/source/newsfragments/1798.feature.rst
+++ b/documentation/source/newsfragments/1798.feature.rst
@@ -1,0 +1,2 @@
+Support for building with Microsoft Visual C++ has been added.
+See :ref:`install` for more details.

--- a/documentation/source/newsfragments/2341.change.rst
+++ b/documentation/source/newsfragments/2341.change.rst
@@ -1,0 +1,1 @@
+Changed how libraries are specified in :envvar:`GPI_EXTRA` to allow specifiying libraries with paths, and names that don't start with "lib".

--- a/tests/sxs.ps1
+++ b/tests/sxs.ps1
@@ -1,0 +1,8 @@
+$j = Start-Job -ScriptBlock { SxsTrace Trace -logfile:SxsTrace.etl }
+Start-Sleep -s 5
+python -c "import cocotb.simulator"
+Start-Sleep -s 5
+$j | Stop-Job
+SxsTrace Stoptrace
+SxsTrace Parse -logfile:SxsTrace.etl -outfile:SxsTrace.txt
+Get-Content SxsTrace.txt


### PR DESCRIPTION
This PR adds support for compiling with MSVC.

Depends on:
- [x] #1795 Don't include unistd.h on windows
- [x] #1797 Remove unused includes in embed.h
- [x] #1796 Add __declspec(dllexport) for functions/classes/variables to be exported

TODO:
- [x] Add CI
- [x] Clarify what warning level is desired on MSVC (at the moment the default `/W3` is used), W4 per recommendation on https://docs.microsoft.com/de-de/cpp/build/reference/compiler-option-warning-level
- [x] #2334 Portable compiler/linker flags
- [x] Make Makefiles work without lib prefix

Closes #1372, #2334, #2341