### PR TITLE
Update test_endian_swapper.py

### DIFF
--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -101,7 +101,7 @@ class EndianSwapperTB(object):
         self.pkts_sent += 1
 
     @cocotb.coroutine
-    def reset(self, duration=10):
+    def reset(self, duration=20):
         self.dut._log.debug("Resetting DUT")
         self.dut.reset_n <= 0
         self.stream_in.bus.valid <= 0
@@ -115,7 +115,7 @@ class EndianSwapperTB(object):
 def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None,
              backpressure_inserter=None):
 
-    cocotb.fork(Clock(dut.clk, 5, units='ns').start())
+    cocotb.fork(Clock(dut.clk, 10, units='ns').start())
     tb = EndianSwapperTB(dut)
 
     yield tb.reset()
@@ -182,7 +182,7 @@ def wavedrom_test(dut):
     """
     Generate a JSON wavedrom diagram of a trace and save it to wavedrom.json
     """
-    cocotb.fork(Clock(dut.clk, 5, units='ns').start())
+    cocotb.fork(Clock(dut.clk, 10, units='ns').start())
     yield RisingEdge(dut.clk)
     tb = EndianSwapperTB(dut)
     yield tb.reset()


### PR DESCRIPTION
Make sure ``half_period`` is an integer number of ns

With this, no extra ``SIM_ARGS`` to select a finer simulator precision are necessary.
Closes #1801
