### PR TITLE
Ignore png files in CI whitespace check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
     - stage: Lint
       name: whitespace
       os: linux
-      script: "[[ -z \"$(git ls-files | xargs egrep -l '\\s+$')\" ]]"
+      script: "! git --no-pager grep --color --line-number --full-name --extended-regexp -I '\\s+$'"
 
     - stage: Lint
       name: flake8


### PR DESCRIPTION
I have a PR (#1051) that includes PNG files, and our whitespace check in CI trips over them.