### PR TITLE
Debug: Improve RunningTask.__repr__

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -107,6 +107,7 @@ class RunningTask:
         self._started = False
         self._callbacks = []
         self._outcome = None
+        self._trigger = None
 
     @lazy_property
     def log(self):

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -35,7 +35,7 @@ import os
 import cocotb
 from cocotb.log import SimLog
 from cocotb.result import ReturnValue
-from cocotb.utils import get_sim_time, lazy_property, remove_traceback_frames
+from cocotb.utils import get_sim_time, lazy_property, remove_traceback_frames, extract_coro_stack
 from cocotb import outcomes
 
 # Sadly the Python standard logging module is very slow so it's better not to
@@ -87,6 +87,8 @@ class RunningTask:
         triggers to fire.
     """
 
+    _id_count = 0  # used by the scheduler for debug
+
     def __init__(self, inst):
 
         if inspect.iscoroutine(inst):
@@ -102,12 +104,15 @@ class RunningTask:
             raise TypeError(
                 "%s isn't a valid coroutine! Did you forget to use the yield keyword?" % inst)
         self._coro = inst
-        self.__name__ = inst.__name__
-        self.__qualname__ = inst.__qualname__
         self._started = False
         self._callbacks = []
         self._outcome = None
         self._trigger = None
+
+        self._task_id = self._id_count
+        RunningTask._id_count += 1
+        self.__name__ = "Task %d" % self._task_id
+        self.__qualname__ = self.__name__
 
     @lazy_property
     def log(self):
@@ -129,7 +134,48 @@ class RunningTask:
         return self
 
     def __str__(self):
-        return str(self.__qualname__)
+        return "<{}>".format(self.__name__)
+
+    def _get_coro_stack(self):
+        """Get the coroutine callstack of this Task."""
+        coro_stack = extract_coro_stack(self._coro)
+
+        # Remove Trigger.__await__() from the stack, as it's not really useful
+        if self._natively_awaitable and len(coro_stack):
+            if coro_stack[-1].name == '__await__':
+                coro_stack.pop()
+
+        return coro_stack
+
+    def __repr__(self):
+        coro_stack = self._get_coro_stack()
+
+        if cocotb.scheduler._current_task is self:
+            fmt = "<{name} running coro={coro}()>"
+        elif self._finished:
+            fmt = "<{name} finished coro={coro}() outcome={outcome}>"
+        elif self._trigger is not None:
+            fmt = "<{name} pending coro={coro}() trigger={trigger}>"
+        elif not self._started:
+            fmt = "<{name} created coro={coro}()>"
+        else:
+            fmt = "<{name} adding coro={coro}()>"
+
+        try:
+            coro_name = coro_stack[-1].name
+        # coro_stack may be empty if:
+        # - exhausted generator
+        # - finished coroutine
+        except IndexError:
+            coro_name = self._coro.__name__
+
+        repr_string = fmt.format(
+            name=self.__name__,
+            coro=coro_name,
+            trigger=self._trigger,
+            outcome=self._outcome
+        )
+        return repr_string
 
     def _advance(self, outcome):
         """Advance to the next yield in this coroutine.
@@ -238,7 +284,7 @@ class RunningTest(RunningCoroutine):
     def __init__(self, inst, parent):
         self.error_messages = []
         RunningCoroutine.__init__(self, inst, parent)
-        self.log = SimLog("cocotb.test.%s" % self.__qualname__, id(self))
+        self.log = SimLog("cocotb.test.%s" % inst.__qualname__, id(self))
         self.started = False
         self.start_time = 0
         self.start_sim_time = 0
@@ -246,10 +292,14 @@ class RunningTest(RunningCoroutine):
         self.expect_error = parent.expect_error
         self.skip = parent.skip
         self.stage = parent.stage
-        self._id = parent._id
+        self.__name__ = "Test %s" % inst.__name__
+        self.__qualname__ = "Test %s" % inst.__qualname__
 
         # make sure not to create a circular reference here
         self.handler = RunningTest.ErrorLogHandler(self.error_messages.append)
+
+    def __str__(self):
+        return "<{}>".format(self.__name__)
 
     def _advance(self, outcome):
         if not self.started:

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -227,9 +227,6 @@ class Scheduler:
         # indexed by trigger
         self._trigger2coros = _py_compat.insertion_ordered_dict()
 
-        # A dictionary mapping coroutines to the trigger they are waiting for
-        self._coro2trigger = _py_compat.insertion_ordered_dict()
-
         # Our main state
         self._mode = Scheduler._MODE_NORMAL
 
@@ -285,7 +282,6 @@ class Scheduler:
 
             self._timer1.prime(self._test_completed)
             self._trigger2coros = _py_compat.insertion_ordered_dict()
-            self._coro2trigger = _py_compat.insertion_ordered_dict()
             self._terminate = False
             self._write_calls = _py_compat.insertion_ordered_dict()
             self._writes_pending.clear()
@@ -470,12 +466,9 @@ class Scheduler:
         """Unschedule a coroutine.  Unprime any pending triggers"""
 
         # Unprime the trigger this coroutine is waiting on
-        try:
-            trigger = self._coro2trigger.pop(coro)
-        except KeyError:
-            # coroutine probably finished
-            pass
-        else:
+        trigger = coro._trigger
+        if trigger is not None:
+            coro._trigger = None
             if coro in self._trigger2coros.setdefault(trigger, []):
                 self._trigger2coros[trigger].remove(coro)
             if not self._trigger2coros[trigger]:
@@ -523,7 +516,7 @@ class Scheduler:
 
     def _resume_coro_upon(self, coro, trigger):
         """Schedule `coro` to be resumed when `trigger` fires."""
-        self._coro2trigger[coro] = trigger
+        coro._trigger = trigger
 
         trigger_coros = self._trigger2coros.setdefault(trigger, [])
         if coro is self._write_coro_inst:
@@ -758,6 +751,7 @@ class Scheduler:
 
         coro_completed = False
         try:
+            coroutine._trigger = None
             result = coroutine._advance(send_outcome)
             if _debug:
                 self.log.debug("Coroutine %s yielded %s (mode %d)" %

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -426,7 +426,7 @@ class Scheduler:
                     continue
 
                 if _debug:
-                    debugstr = "\n\t".join([coro.__qualname__ for coro in scheduling])
+                    debugstr = "\n\t".join([coro._coro.__qualname__ for coro in scheduling])
                     if len(scheduling):
                         debugstr = "\n\t" + debugstr
                     self.log.debug("%d pending coroutines for event %s%s" %
@@ -440,10 +440,10 @@ class Scheduler:
                         # coroutine was killed by another coroutine waiting on the same trigger
                         continue
                     if _debug:
-                        self.log.debug("Scheduling coroutine %s" % (coro.__qualname__))
+                        self.log.debug("Scheduling coroutine %s" % (coro._coro.__qualname__))
                     self.schedule(coro, trigger=trigger)
                     if _debug:
-                        self.log.debug("Scheduled coroutine %s" % (coro.__qualname__))
+                        self.log.debug("Scheduled coroutine %s" % (coro._coro.__qualname__))
 
                 # Schedule may have queued up some events so we'll burn through those
                 while self._pending_events:
@@ -660,7 +660,7 @@ class Scheduler:
             )
 
         if _debug:
-            self.log.debug("Adding new coroutine %s" % coroutine.__qualname__)
+            self.log.debug("Adding new coroutine %s" % coroutine._coro.__qualname__)
 
         self.schedule(coroutine)
         self._check_termination()
@@ -686,14 +686,14 @@ class Scheduler:
     def _trigger_from_started_coro(self, result: cocotb.decorators.RunningTask) -> Trigger:
         if _debug:
             self.log.debug("Joining to already running coroutine: %s" %
-                           result.__qualname__)
+                           result._coro.__qualname__)
         return result.join()
 
     def _trigger_from_unstarted_coro(self, result: cocotb.decorators.RunningTask) -> Trigger:
         self.queue(result)
         if _debug:
             self.log.debug("Scheduling nested coroutine: %s" %
-                           result.__qualname__)
+                           result._coro.__qualname__)
         return result.join()
 
     def _trigger_from_waitable(self, result: cocotb.triggers.Waitable) -> Trigger:
@@ -769,7 +769,7 @@ class Scheduler:
                 result = coroutine._advance(send_outcome)
                 if _debug:
                     self.log.debug("Coroutine %s yielded %s (mode %d)" %
-                                   (coroutine.__qualname__, str(result), self._mode))
+                                   (coroutine._coro.__qualname__, str(result), self._mode))
 
             except cocotb.decorators.CoroutineComplete:
                 if _debug:

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -33,6 +33,7 @@ FIXME: We have a problem here.  If a coroutine schedules a read-only but we
 also have pending writes we have to schedule the ReadWrite callback before
 the ReadOnly (and this is invalid, at least in Modelsim).
 """
+from contextlib import contextmanager
 import os
 import sys
 import logging
@@ -242,6 +243,8 @@ class Scheduler:
         self._terminate = False
         self._test = None
         self._main_thread = threading.current_thread()
+
+        self._current_task = None
 
         self._is_reacting = False
 
@@ -734,6 +737,16 @@ class Scheduler:
             .format(type(result), result)
         )
 
+    @contextmanager
+    def _task_context(self, task):
+        """Context manager for the currently running task."""
+        old_task = self._current_task
+        self._current_task = task
+        try:
+            yield
+        finally:
+            self._current_task = old_task
+
     def schedule(self, coroutine, trigger=None):
         """Schedule a coroutine by calling the send method.
 
@@ -742,67 +755,68 @@ class Scheduler:
             trigger (cocotb.triggers.Trigger): The trigger that caused this
                 coroutine to be scheduled.
         """
-        if trigger is None:
-            send_outcome = outcomes.Value(None)
-        else:
-            send_outcome = trigger._outcome
-        if _debug:
-            self.log.debug("Scheduling with {}".format(send_outcome))
-
-        coro_completed = False
-        try:
-            coroutine._trigger = None
-            result = coroutine._advance(send_outcome)
+        with self._task_context(coroutine):
+            if trigger is None:
+                send_outcome = outcomes.Value(None)
+            else:
+                send_outcome = trigger._outcome
             if _debug:
-                self.log.debug("Coroutine %s yielded %s (mode %d)" %
-                               (coroutine.__qualname__, str(result), self._mode))
+                self.log.debug("Scheduling with {}".format(send_outcome))
 
-        except cocotb.decorators.CoroutineComplete:
-            if _debug:
-                self.log.debug("Coroutine {} completed with {}".format(
-                    coroutine, coroutine._outcome
-                ))
-            coro_completed = True
-
-        # this can't go in the else above, as that causes unwanted exception
-        # chaining
-        if coro_completed:
-            self.unschedule(coroutine)
-
-        # Don't handle the result if we're shutting down
-        if self._terminate:
-            return
-
-        if not coro_completed:
+            coro_completed = False
             try:
-                result = self._trigger_from_any(result)
-            except TypeError as exc:
-                # restart this coroutine with an exception object telling it that
-                # it wasn't allowed to yield that
-                result = NullTrigger(outcome=outcomes.Error(exc))
-
-            self._resume_coro_upon(coroutine, result)
-
-        # We do not return from here until pending threads have completed, but only
-        # from the main thread, this seems like it could be problematic in cases
-        # where a sim might change what this thread is.
-
-        if self._main_thread is threading.current_thread():
-
-            for ext in self._pending_threads:
-                ext.thread_start()
+                coroutine._trigger = None
+                result = coroutine._advance(send_outcome)
                 if _debug:
-                    self.log.debug("Blocking from %s on %s" % (threading.current_thread(), ext.thread))
-                state = ext.thread_wait()
-                if _debug:
-                    self.log.debug("Back from wait on self %s with newstate %d" % (threading.current_thread(), state))
-                if state == external_state.EXITED:
-                    self._pending_threads.remove(ext)
-                    self._pending_events.append(ext.event)
+                    self.log.debug("Coroutine %s yielded %s (mode %d)" %
+                                   (coroutine.__qualname__, str(result), self._mode))
 
-        # Handle any newly queued coroutines that need to be scheduled
-        while self._pending_coros:
-            self.add(self._pending_coros.pop(0))
+            except cocotb.decorators.CoroutineComplete:
+                if _debug:
+                    self.log.debug("Coroutine {} completed with {}".format(
+                        coroutine, coroutine._outcome
+                    ))
+                coro_completed = True
+
+            # this can't go in the else above, as that causes unwanted exception
+            # chaining
+            if coro_completed:
+                self.unschedule(coroutine)
+
+            # Don't handle the result if we're shutting down
+            if self._terminate:
+                return
+
+            if not coro_completed:
+                try:
+                    result = self._trigger_from_any(result)
+                except TypeError as exc:
+                    # restart this coroutine with an exception object telling it that
+                    # it wasn't allowed to yield that
+                    result = NullTrigger(outcome=outcomes.Error(exc))
+
+                self._resume_coro_upon(coroutine, result)
+
+            # We do not return from here until pending threads have completed, but only
+            # from the main thread, this seems like it could be problematic in cases
+            # where a sim might change what this thread is.
+
+            if self._main_thread is threading.current_thread():
+
+                for ext in self._pending_threads:
+                    ext.thread_start()
+                    if _debug:
+                        self.log.debug("Blocking from %s on %s" % (threading.current_thread(), ext.thread))
+                    state = ext.thread_wait()
+                    if _debug:
+                        self.log.debug("Back from wait on self %s with newstate %d" % (threading.current_thread(), state))
+                    if state == external_state.EXITED:
+                        self._pending_threads.remove(ext)
+                        self._pending_events.append(ext.event)
+
+            # Handle any newly queued coroutines that need to be scheduled
+            while self._pending_coros:
+                self.add(self._pending_coros.pop(0))
 
     def finish_test(self, exc):
         self._test.abort(exc)

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -709,7 +709,12 @@ class _AggregateWaitable(Waitable):
         # no _pointer_str here, since this is not a trigger, so identity
         # doesn't matter.
         return "{}({})".format(
-            type(self).__qualname__, ", ".join(repr(t) for t in self.triggers)
+            type(self).__qualname__,
+            ", ".join(
+                repr(Join(t)) if isinstance(t, cocotb.decorators.RunningTask)
+                else repr(t)
+                for t in self.triggers
+            )
         )
 
 

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -619,7 +619,7 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
             super(Join, self).prime(callback)
 
     def __repr__(self):
-        return "{}({!r})".format(type(self).__qualname__, self._coroutine)
+        return "{}({!s})".format(type(self).__qualname__, self._coroutine)
 
 
 class Waitable(Awaitable):

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -31,6 +31,7 @@ import ctypes
 import math
 import os
 import sys
+import traceback
 import weakref
 import functools
 import warnings
@@ -580,3 +581,39 @@ def remove_traceback_frames(tb_or_exc, frame_names):
             assert tb.tb_frame.f_code.co_name == frame_name
             tb = tb.tb_next
         return tb
+
+
+def walk_coro_stack(coro):
+    """Walk down the coroutine stack, starting at *coro*.
+
+    Supports coroutines and generators.
+    """
+    while coro is not None:
+        try:
+            f = getattr(coro, 'cr_frame')
+            coro = coro.cr_await
+        except AttributeError:
+            try:
+                f = getattr(coro, 'gi_frame')
+                coro = coro.gi_yieldfrom
+            except AttributeError:
+                f = None
+                coro = None
+        if f is not None:
+            yield (f, f.f_lineno)
+
+
+def extract_coro_stack(coro, limit=None):
+    """Create a list of pre-processed entries from the coroutine stack.
+
+    This is based on :func:`traceback.extract_tb`.
+
+    If *limit* is omitted or ``None``, all entries are extracted.
+    The list is a :class:`traceback.StackSummary` object, and
+    each entry in the list is a :class:`traceback.FrameSummary` object
+    containing attributes ``filename``, ``lineno``, ``name``, and ``line``
+    representing the information that is usually printed for a stack
+    trace.  The line is a string with leading and trailing
+    whitespace stripped; if the source is not available it is ``None``.
+    """
+    return traceback.StackSummary.extract(walk_coro_stack(coro), limit=limit)

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -8,9 +8,11 @@ Test for scheduler and coroutine behavior
 * join
 * kill
 """
+import logging
+import re
 
 import cocotb
-from cocotb.triggers import Join, Timer, RisingEdge, Trigger, NullTrigger, Combine, Event, ReadOnly
+from cocotb.triggers import Join, Timer, RisingEdge, Trigger, NullTrigger, Combine, Event, ReadOnly, First
 from cocotb.result import TestFailure
 from cocotb.clock import Clock
 from common import clock_gen
@@ -62,6 +64,7 @@ def clock_two(dut):
 
 @cocotb.test(expect_fail=False)
 def test_coroutine_close_down(dut):
+    log = logging.getLogger("cocotb.test")
     clk_gen = cocotb.fork(Clock(dut.clk, 100).start())
 
     coro_one = cocotb.fork(clock_one(dut))
@@ -70,7 +73,7 @@ def test_coroutine_close_down(dut):
     yield Join(coro_one)
     yield Join(coro_two)
 
-    dut._log.info("Back from joins")
+    log.info("Back from joins")
 
 
 @cocotb.test()
@@ -215,14 +218,14 @@ async def test_nulltrigger_reschedule(dut):
 
     The NullTrigger will be added to the end of the list of pending triggers.
     """
-
+    log = logging.getLogger("cocotb.test")
     last_fork = None
 
     @cocotb.coroutine   # TODO: Remove once Combine accepts bare coroutines
     async def reschedule(n):
         nonlocal last_fork
         for i in range(4):
-            cocotb.log.info("Fork {}, iteration {}, last fork was {}".format(n, i, last_fork))
+            log.info("Fork {}, iteration {}, last fork was {}".format(n, i, last_fork))
             assert last_fork != n
             last_fork = n
             await NullTrigger()
@@ -270,13 +273,14 @@ async def test_last_scheduled_write_wins(dut):
     """
     Test that the last scheduled write for a signal handle is the value that is written.
     """
+    log = logging.getLogger("cocotb.test")
     e = Event()
     dut.stream_in_data.setimmediatevalue(0)
 
     @cocotb.coroutine   # TODO: Remove once Combine accepts bare coroutines
     async def first():
         await Timer(1)
-        dut._log.info("scheduling stream_in_data <= 1")
+        log.info("scheduling stream_in_data <= 1")
         dut.stream_in_data <= 1
         e.set()
 
@@ -284,7 +288,7 @@ async def test_last_scheduled_write_wins(dut):
     async def second():
         await Timer(1)
         await e.wait()
-        dut._log.info("scheduling stream_in_data <= 2")
+        log.info("scheduling stream_in_data <= 2")
         dut.stream_in_data <= 2
 
     await Combine(first(), second())
@@ -300,3 +304,104 @@ async def test_last_scheduled_write_wins(dut):
     await ReadOnly()
 
     assert dut.array_7_downto_4.value == [10, 2, 3, 4]
+
+
+@cocotb.test()
+async def test_task_repr(dut):
+    """Test RunningTask.__repr__."""
+    log = logging.getLogger("cocotb.test")
+    gen_e = Event('generator_coro_inner')
+
+    def generator_coro_inner():
+        gen_e.set()
+        yield Timer(1, units='ns')
+        raise ValueError("inner")
+
+    @cocotb.coroutine
+    def generator_coro_outer():
+        yield from generator_coro_inner()
+
+    gen_task = generator_coro_outer()
+
+    log.info(repr(gen_task))
+    assert re.match(r"<Task \d+ created coro=generator_coro_outer\(\)>", repr(gen_task))
+
+    cocotb.fork(gen_task)
+
+    await gen_e.wait()
+
+    log.info(repr(gen_task))
+    assert re.match(r"<Task \d+ pending coro=generator_coro_inner\(\) trigger=<Timer of 1000.00ps at \w+>>", repr(gen_task))
+
+    try:
+        await Join(gen_task)
+    except ValueError:
+        pass
+
+    log.info(repr(gen_task))
+    assert re.match(r"<Task \d+ finished coro=generator_coro_outer\(\) outcome=Error\(ValueError\('inner',?\)\)>", repr(gen_task))
+
+    coro_e = Event('coroutine_inner')
+
+    async def coroutine_forked(task):
+        log.info(repr(task))
+        assert re.match(r"<Task \d+ adding coro=coroutine_outer\(\)>", repr(task))
+
+    @cocotb.coroutine
+    async def coroutine_wait():
+        await Timer(1, units='ns')
+
+    async def coroutine_inner():
+        await coro_e.wait()
+        this_task = coro_e.data
+        # cr_await is None while the coroutine is running, so we can't get the stack...
+        log.info(repr(this_task))
+        assert re.match(r"<Task \d+ running coro=coroutine_outer\(\)>", repr(this_task))
+
+        cocotb.fork(coroutine_forked(this_task))
+        await Combine(*(coroutine_wait() for _ in range(2)))
+
+        return "Combine done"
+
+    async def coroutine_middle():
+        return await coroutine_inner()
+
+    async def coroutine_outer():
+        return await coroutine_middle()
+
+    coro_task = cocotb.fork(coroutine_outer())
+
+    coro_e.set(coro_task)
+
+    await NullTrigger()
+
+    log.info(repr(coro_task))
+    assert re.match(
+        r"<Task \d+ pending coro=coroutine_inner\(\) trigger=Combine\(Join\(<Task \d+>\), Join\(<Task \d+>\)\)>",
+        repr(coro_task)
+    )
+
+    await Timer(2, units='ns')
+
+    log.info(repr(coro_task))
+    assert re.match(r"<Task \d+ finished coro=coroutine_outer\(\) outcome=Value\('Combine done'\)", repr(coro_task))
+
+    async def coroutine_first():
+        await First(coroutine_wait(), Timer(2, units='ns'))
+
+    coro_task = cocotb.fork(coroutine_first())
+
+    log.info(repr(coro_task))
+    assert re.match(
+        r"<Task \d+ pending coro=coroutine_first\(\) trigger=First\(Join\(<Task \d+>\), <Timer of 2000.00ps at \w+>\)>",
+        repr(coro_task)
+    )
+
+    async def coroutine_timer():
+        await Timer(1, units='ns')
+
+    coro_task = cocotb.fork(coroutine_timer())
+
+    # Trigger.__await__ should be popped from the coroutine stack
+    log.info(repr(coro_task))
+    assert re.match(r"<Task \d+ pending coro=coroutine_timer\(\) trigger=<Timer of 1000.00ps at \w+>>", repr(coro_task))


### PR DESCRIPTION
Add `RunningTask.__repr__` that shows current status and unique task id.

This is the base for a follow-on PR to overhaul scheduler debug.

Each `RunningTask` has it's own "coroutine stack", and currently that's not easily accessible, so it can be difficult during debugging to figure out the state and call location of a task. Generator coroutines can `yield from` other generators and coroutines can `await` other coroutines, both of which will bypass the scheduler.

Depending on the status of the task, the pending trigger object or outcome will also be displayed.

Example `repr()` outputs from `test_task_repr`:

- `<Task 2 created coro=generator_coro_outer()>`
- `<Task 2 pending coro=generator_coro_inner() trigger=<Timer of 1000.00ps at 0x0F0B2A58>>`
- `<Task 2 finished coro=generator_coro_outer() outcome=Error(ValueError('inner'))>`
- `<Task 3 adding coro=coroutine_outer()>`
- `<Task 3 running coro=coroutine_outer()>`
- ~~`<Task 3 pending coro=coroutine_inner() trigger=<<Event for Combine(<Task 4 pending coro=coroutine_wait() trigger=<Timer of 1000.00ps at 0x0F418210>>, <Task 5 pending coro=coroutine_wait() trigger=<Timer of 1000.00ps at 0x0F0B2AA8>>) at 0x0F0A038B>.wait() at 0x0F0B29B8>>`~~
- `<Task 3 pending coro=coroutine_inner() trigger=Combine(Join(<Task 4>), Join(<Task 5>)>`

Tests are displayed `<Test test_name ...>` rather than with the task id.

The current scheduler debug output is less useful after this PR, as `__name__` and `__qualname__` are repurposed, so I changed it to get them from the coroutine wrapped by `RunningTask`.