### PR TITLE
Fix segfault due to uninitialized PyTypeObject

### DIFF
--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -113,7 +113,7 @@ namespace {
     // Initialize the python type slots
     template<typename gpi_hdl>
     PyTypeObject fill_common_slots() {
-        PyTypeObject type;
+        PyTypeObject type = {};
         type.ob_base = {PyObject_HEAD_INIT(NULL) 0};
         type.tp_basicsize = sizeof(gpi_hdl_Object<gpi_hdl>);
         type.tp_repr = (reprfunc)gpi_hdl_repr<gpi_hdl>;


### PR DESCRIPTION
On importing `cocotb.simulator` the program may segfault in `PyType_Ready` due to accesses to invalid addresses.

Fix the segfault by initiliazing unused fields of `PyTypeObject` to `0`. 