### PR TITLE
Use https://docs.cocotb.org for `url` temporarily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     cmdclass={'build_ext': build_ext},
     version=__version__,  # noqa: F821
     description='cocotb is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.',
-    url='https://cocotb.org',
+    url='https://docs.cocotb.org',
     license='BSD',
     long_description=read_file('README.md'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The original `https://cocotb.org` only works as http (not https) right now.
Closes #1809
