### PR TITLE
Force doctest for `cocotb.utils` to run uncolored

### DIFF
--- a/tests/test_cases/test_cocotb/test_doctests.py
+++ b/tests/test_cases/test_cocotb/test_doctests.py
@@ -2,12 +2,15 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import doctest
+import os
 
 import cocotb
 
 
 @cocotb.test()
 async def test_utils(dut):
+    # prevent failure in case colored output is requested from the environment
+    os.environ['COCOTB_ANSI_OUTPUT'] = "0"
     failures, n = doctest.testmod(cocotb.utils, verbose=True)
     assert failures == 0
 


### PR DESCRIPTION
When color output had been requested via environment variables,
`test_utils` would fail because of the ANSI codes being put into
the output of `hexdiffs()`.
Thus, force this test to run in an uncolored environment.
