### PR TITLE
Prevent printing summary multiple times

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -95,6 +95,7 @@ class RegressionManager:
         self.count = 0
         self.skipped = 0
         self.failures = 0
+        self._tearing_down = False
 
         # Setup XUnit
         ###################
@@ -229,6 +230,12 @@ class RegressionManager:
             return cocotb.scheduler.add(test)
 
     def tear_down(self) -> None:
+        # prevent re-entering the tear down procedure
+        if not self._tearing_down:
+            self._tearing_down = True
+        else:
+            return
+
         # fail remaining tests
         while True:
             test = self.next_test()


### PR DESCRIPTION
When a sim fails, it sets the outcome of the remaining tests to `SimFailure`, which causes the `tear_down` procedure to re-enter and print the summary multiple times. We add a bit of logic to prevent `tear_down` from being run more than once.

This is a temporary fix, a more permanent solution is pending in #1782.