### PR TITLE
Update simulator module docstrings

### DIFF
--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -926,133 +926,133 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_signal_val_long, METH_NOARGS, PyDoc_STR(
             "get_signal_val_long($self)\n"
             "--\n\n"
-            "Get the value of a signal as a long"
+            "Get the value of a signal as an integer."
         )
     },
     {"get_signal_val_str",
         (PyCFunction)get_signal_val_str, METH_NOARGS, PyDoc_STR(
             "get_signal_val_str($self)\n"
             "--\n\n"
-            "Get the value of a signal as an ASCII string"
+            "Get the value of a signal as a string."
         )
     },
     {"get_signal_val_binstr",
         (PyCFunction)get_signal_val_binstr, METH_NOARGS, PyDoc_STR(
             "get_signal_val_binstr($self)\n"
             "--\n\n"
-            "Get the value of a signal as a binary string"
+            "Get the value of a logic vector signal as a string of (``0``, ``1``, ``X``, etc.), one element per character."
         )
     },
     {"get_signal_val_real",
         (PyCFunction)get_signal_val_real, METH_NOARGS, PyDoc_STR(
             "get_signal_val_real($self)\n"
             "--\n\n"
-            "Get the value of a signal as a double precision float"
+            "Get the value of a signal as a float."
         )
     },
     {"set_signal_val_long",
         (PyCFunction)set_signal_val_long, METH_VARARGS, PyDoc_STR(
             "set_signal_val_long($self, action, value, /)\n"
             "--\n\n"
-            "Set the value of a signal using a long"
+            "Set the value of a signal using an integer.\n"
         )
     },
     {"set_signal_val_str",
         (PyCFunction)set_signal_val_str, METH_VARARGS, PyDoc_STR(
             "set_signal_val_str($self, action, value, /)\n"
             "--\n\n"
-            "Set the value of a signal using an NUL-terminated 8-bit string"
+            "Set the value of a signal using a user-encoded string."
         )
     },
     {"set_signal_val_binstr",
         (PyCFunction)set_signal_val_binstr, METH_VARARGS, PyDoc_STR(
             "set_signal_val_binstr($self, action, value, /)\n"
             "--\n\n"
-            "Set the value of a signal using a string with a character per bit"
+            "Set the value of a logic vector signal using a string of (``0``, ``1``, ``X``, etc.), one element per character."
         )
     },
     {"set_signal_val_real",
         (PyCFunction)set_signal_val_real, METH_VARARGS, PyDoc_STR(
             "set_signal_val_real($self, action, value, /)\n"
             "--\n\n"
-            "Set the value of a signal using a double precision float"
+            "Set the value of a signal using a float."
         )
     },
     {"get_definition_name",
         (PyCFunction)get_definition_name, METH_NOARGS, PyDoc_STR(
             "get_definition_name($self)\n"
             "--\n\n"
-            "Get the name of a GPI object's definition"
+            "Get the name of a GPI object's definition."
         )
     },
     {"get_definition_file",
         (PyCFunction)get_definition_file, METH_NOARGS, PyDoc_STR(
             "get_definition_file($self)\n"
             "--\n\n"
-            "Get the file that sources the object's definition"
+            "Get the file that sources the object's definition."
         )
     },
     {"get_handle_by_name",
         (PyCFunction)get_handle_by_name, METH_VARARGS, PyDoc_STR(
             "get_handle_by_name($self, name, /)\n"
             "--\n\n"
-            "Get handle of a named object"
+            "Get a handle to a child object by name."
         )
     },
     {"get_handle_by_index",
         (PyCFunction)get_handle_by_index, METH_VARARGS, PyDoc_STR(
             "get_handle_by_index($self, index, /)\n"
             "--\n\n"
-            "Get handle of a object at an index in a parent"
+            "Get a handle to a child object by index."
         )
     },
     {"get_name_string",
         (PyCFunction)get_name_string, METH_NOARGS, PyDoc_STR(
             "get_name_string($self)\n"
             "--\n\n"
-            "Get the name of an object as a string"
+            "Get the name of an object as a string."
         )
     },
     {"get_type_string",
         (PyCFunction)get_type_string, METH_NOARGS, PyDoc_STR(
             "get_type_string($self)\n"
             "--\n\n"
-            "Get the type of an object as a string"
+            "Get the GPI type of an object as a string."
         )
     },
     {"get_type",
         (PyCFunction)get_type, METH_NOARGS, PyDoc_STR(
             "get_type($self)\n"
             "--\n\n"
-            "Get the type of an object, mapped to a GPI enumeration"
+            "Get the GPI type of an object as an enum."
         )
     },
     {"get_const",
         (PyCFunction)get_const, METH_NOARGS, PyDoc_STR(
             "get_const($self)\n"
             "--\n\n"
-            "Get a flag indicating whether the object is a constant"
+            "Return ``True`` if the object is a constant."
         )
     },
     {"get_num_elems",
         (PyCFunction)get_num_elems, METH_NOARGS, PyDoc_STR(
             "get_num_elems($self)\n"
             "--\n\n"
-            "Get the number of elements contained in the handle"
+            "Get the number of elements contained in the handle."
         )
     },
     {"get_range",
         (PyCFunction)get_range, METH_NOARGS, PyDoc_STR(
             "get_range($self)\n"
             "--\n\n"
-            "Get the range of elements (tuple) contained in the handle, returns None if not indexable"
+            "Get the range of elements (tuple) contained in the handle, return ``None`` if not indexable."
         )
     },
     {"iterate",
         (PyCFunction)iterate, METH_VARARGS, PyDoc_STR(
             "iterate($self, mode, /)\n"
             "--\n\n"
-            "Get an iterator handle to loop over all members in an object"
+            "Get an iterator handle to loop over all members in an object."
         )
     },
     {NULL, NULL, 0, NULL}        /* Sentinel */
@@ -1081,7 +1081,7 @@ static PyMethodDef gpi_cb_hdl_methods[] = {
         (PyCFunction)deregister, METH_NOARGS, PyDoc_STR(
             "deregister($self)\n"
             "--\n\n"
-            "De-register this callback"
+            "De-register this callback."
         )},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -921,11 +921,19 @@ PyMODINIT_FUNC PyInit_simulator(void)
     return simulator;
 }
 
+/* NOTE: in the following docstrings we are specifying the parameters twice, but this is necessary.
+ * The first docstring before the long '--' line specifies the __text_signature__ that is used
+ * by the help() function. And the second after the '--' line contains type annotations used by
+ * the `autodoc_docstring_signature` setting of sphinx.ext.autodoc for generating documentation
+ * because type annotations are not supported in __text_signature__.
+ */
+
 static PyMethodDef gpi_sim_hdl_methods[] = {
     {"get_signal_val_long",
         (PyCFunction)get_signal_val_long, METH_NOARGS, PyDoc_STR(
             "get_signal_val_long($self)\n"
             "--\n\n"
+            "get_signal_val_long(self) -> int\n"
             "Get the value of a signal as an integer."
         )
     },
@@ -933,13 +941,15 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_signal_val_str, METH_NOARGS, PyDoc_STR(
             "get_signal_val_str($self)\n"
             "--\n\n"
-            "Get the value of a signal as a string."
+            "get_signal_val_str(self) -> bytes\n"
+            "Get the value of a signal as a byte string."
         )
     },
     {"get_signal_val_binstr",
         (PyCFunction)get_signal_val_binstr, METH_NOARGS, PyDoc_STR(
             "get_signal_val_binstr($self)\n"
             "--\n\n"
+            "get_signal_val_binstr(self) -> str\n"
             "Get the value of a logic vector signal as a string of (``0``, ``1``, ``X``, etc.), one element per character."
         )
     },
@@ -947,6 +957,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_signal_val_real, METH_NOARGS, PyDoc_STR(
             "get_signal_val_real($self)\n"
             "--\n\n"
+            "get_signal_val_real(self) -> float\n"
             "Get the value of a signal as a float."
         )
     },
@@ -954,6 +965,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)set_signal_val_long, METH_VARARGS, PyDoc_STR(
             "set_signal_val_long($self, action, value, /)\n"
             "--\n\n"
+            "set_signal_val_long(self, action: int, value: int) -> None\n"
             "Set the value of a signal using an integer.\n"
         )
     },
@@ -961,6 +973,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)set_signal_val_str, METH_VARARGS, PyDoc_STR(
             "set_signal_val_str($self, action, value, /)\n"
             "--\n\n"
+            "set_signal_val_str(self, action: int, value: bytes) -> None\n"
             "Set the value of a signal using a user-encoded string."
         )
     },
@@ -968,6 +981,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)set_signal_val_binstr, METH_VARARGS, PyDoc_STR(
             "set_signal_val_binstr($self, action, value, /)\n"
             "--\n\n"
+            "set_signal_val_binstr(self, action: int, value: str) -> None\n"
             "Set the value of a logic vector signal using a string of (``0``, ``1``, ``X``, etc.), one element per character."
         )
     },
@@ -975,6 +989,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)set_signal_val_real, METH_VARARGS, PyDoc_STR(
             "set_signal_val_real($self, action, value, /)\n"
             "--\n\n"
+            "set_signal_val_real(self, action: int, value: float) -> None\n"
             "Set the value of a signal using a float."
         )
     },
@@ -982,6 +997,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_definition_name, METH_NOARGS, PyDoc_STR(
             "get_definition_name($self)\n"
             "--\n\n"
+            "get_definition_name(self) -> str\n"
             "Get the name of a GPI object's definition."
         )
     },
@@ -989,6 +1005,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_definition_file, METH_NOARGS, PyDoc_STR(
             "get_definition_file($self)\n"
             "--\n\n"
+            "get_definition_file(self) -> str\n"
             "Get the file that sources the object's definition."
         )
     },
@@ -996,6 +1013,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_handle_by_name, METH_VARARGS, PyDoc_STR(
             "get_handle_by_name($self, name, /)\n"
             "--\n\n"
+            "get_handle_by_name(self, name: str) -> cocotb.simulator.gpi_sim_hdl\n"
             "Get a handle to a child object by name."
         )
     },
@@ -1003,6 +1021,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_handle_by_index, METH_VARARGS, PyDoc_STR(
             "get_handle_by_index($self, index, /)\n"
             "--\n\n"
+            "get_handle_by_index(self, index: int) -> cocotb.simulator.gpi_sim_hdl\n"
             "Get a handle to a child object by index."
         )
     },
@@ -1010,6 +1029,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_name_string, METH_NOARGS, PyDoc_STR(
             "get_name_string($self)\n"
             "--\n\n"
+            "get_name_string(self) -> str\n"
             "Get the name of an object as a string."
         )
     },
@@ -1017,6 +1037,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_type_string, METH_NOARGS, PyDoc_STR(
             "get_type_string($self)\n"
             "--\n\n"
+            "get_type_string(self) -> str\n"
             "Get the GPI type of an object as a string."
         )
     },
@@ -1024,6 +1045,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_type, METH_NOARGS, PyDoc_STR(
             "get_type($self)\n"
             "--\n\n"
+            "get_type(self) -> int\n"
             "Get the GPI type of an object as an enum."
         )
     },
@@ -1031,6 +1053,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_const, METH_NOARGS, PyDoc_STR(
             "get_const($self)\n"
             "--\n\n"
+            "get_const(self) -> bool\n"
             "Return ``True`` if the object is a constant."
         )
     },
@@ -1038,6 +1061,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_num_elems, METH_NOARGS, PyDoc_STR(
             "get_num_elems($self)\n"
             "--\n\n"
+            "get_num_elems(self) -> int\n"
             "Get the number of elements contained in the handle."
         )
     },
@@ -1045,6 +1069,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_range, METH_NOARGS, PyDoc_STR(
             "get_range($self)\n"
             "--\n\n"
+            "get_range(self) -> Tuple[int, int]\n"
             "Get the range of elements (tuple) contained in the handle, return ``None`` if not indexable."
         )
     },
@@ -1052,6 +1077,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)iterate, METH_VARARGS, PyDoc_STR(
             "iterate($self, mode, /)\n"
             "--\n\n"
+            "iterate(self, mode: int) -> cocotb.simulator.gpi_iterator_hdl\n"
             "Get an iterator handle to loop over all members in an object."
         )
     },
@@ -1081,6 +1107,7 @@ static PyMethodDef gpi_cb_hdl_methods[] = {
         (PyCFunction)deregister, METH_NOARGS, PyDoc_STR(
             "deregister($self)\n"
             "--\n\n"
+            "deregister(self) -> None\n"
             "De-register this callback."
         )},
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -1089,6 +1089,9 @@ template<>
 PyTypeObject gpi_hdl_Object<gpi_sim_hdl>::py_type = []() -> PyTypeObject {
     auto type = fill_common_slots<gpi_sim_hdl>();
     type.tp_name = "cocotb.simulator.gpi_sim_hdl";
+    type.tp_doc = "GPI object handle\n"
+        "\n"
+        "Contains methods for getting and setting the value of a GPI object, and introspection.";
     type.tp_methods = gpi_sim_hdl_methods;
     return type;
 }();
@@ -1097,6 +1100,7 @@ template<>
 PyTypeObject gpi_hdl_Object<gpi_iterator_hdl>::py_type = []() -> PyTypeObject {
     auto type = fill_common_slots<gpi_iterator_hdl>();
     type.tp_name = "cocotb.simulator.gpi_iterator_hdl";
+    type.tp_doc = "GPI iterator handle.";
     type.tp_iter = PyObject_SelfIter;
     type.tp_iternext = (iternextfunc)next;
     return type;
@@ -1117,6 +1121,7 @@ template<>
 PyTypeObject gpi_hdl_Object<gpi_cb_hdl>::py_type = []() -> PyTypeObject {
     auto type = fill_common_slots<gpi_cb_hdl>();
     type.tp_name = "cocotb.simulator.gpi_cb_hdl";
+    type.tp_doc = "GPI callback handle";
     type.tp_methods = gpi_cb_hdl_methods;
     return type;
 }();

--- a/cocotb/share/lib/simulator/simulatormodule.h
+++ b/cocotb/share/lib/simulator/simulatormodule.h
@@ -69,56 +69,73 @@ static PyObject *get_simulator_version(PyObject *self, PyObject *args);
 
 static PyObject *log_level(PyObject *self, PyObject *args);
 
+/* NOTE: in the following docstrings we are specifying the parameters twice, but this is necessary.
+ * The first docstring before the long '--' line specifies the __text_signature__ that is used
+ * by the help() function. And the second after the '--' line contains type annotations used by
+ * the `autodoc_docstring_signature` setting of sphinx.ext.autodoc for generating documentation
+ * because type annotations are not supported in __text_signature__.
+ */
+
 static PyMethodDef SimulatorMethods[] = {
     {"log_msg", log_msg, METH_VARARGS, PyDoc_STR(
         "log_msg(name, path, funcname, lineno, msg, /)\n"
         "--\n\n"
+        "log_msg(name: str, path: str, funcname: str, lineno: int, msg: str) -> None\n"
         "Log a message."
     )},
     {"get_root_handle", get_root_handle, METH_VARARGS, PyDoc_STR(
         "get_root_handle(name, /)\n"
         "--\n\n"
+        "get_root_handle(name: str) -> cocotb.simulator.gpi_sim_hdl\n"
         "Get the root handle."
     )},
     {"register_timed_callback", register_timed_callback, METH_VARARGS, PyDoc_STR(
         "register_timed_callback(time, func, /, *args)\n"
         "--\n\n"
+        "register_timed_callback(time: int, func: Callable[..., None], *args: Any) -> cocotb.simulator.gpi_cb_hdl\n"
         "Register a timed callback."
     )},
     {"register_value_change_callback", register_value_change_callback, METH_VARARGS, PyDoc_STR(
         "register_value_change_callback(signal, func, edge, /, *args)\n"
         "--\n\n"
+        "register_value_change_callback(signal: cocotb.simulator.gpi_sim_hdl, func: Callable[..., None], edge: int, *args: Any) -> cocotb.simulator.gpi_cb_hdl\n"
         "Register a signal change callback."
     )},
     {"register_readonly_callback", register_readonly_callback, METH_VARARGS, PyDoc_STR(
         "register_readonly_callback(func, /, *args)\n"
         "--\n\n"
+        "register_readonly_callback(func: Callable[..., None], *args: Any) -> cocotb.simulator.gpi_cb_hdl\n"
         "Register a callback for the read-only section."
     )},
     {"register_nextstep_callback", register_nextstep_callback, METH_VARARGS, PyDoc_STR(
         "register_nextstep_callback(func, /, *args)\n"
         "--\n\n"
+        "register_nextstep_callback(func: Callable[..., None], *args: Any) -> cocotb.simulator.gpi_cb_hdl\n"
         "Register a callback for the NextSimTime callback."
     )},
     {"register_rwsynch_callback", register_rwsynch_callback, METH_VARARGS, PyDoc_STR(
         "register_rwsynch_callback(func, /, *args)\n"
         "--\n\n"
+        "register_rwsynch_callback(func: Callable[..., None], *args: Any) -> cocotb.simulator.gpi_cb_hdl\n"
         "Register a callback for the read-write section."
     )},
     {"stop_simulator", stop_simulator, METH_VARARGS, PyDoc_STR(
         "stop_simulator()\n"
         "--\n\n"
+        "stop_simulator() -> None\n"
         "Instruct the attached simulator to stop. Users should not call this function."
     )},
     {"log_level", log_level, METH_VARARGS, PyDoc_STR(
         "log_level(level, /)\n"
         "--\n\n"
+        "log_level(level: int) -> None\n"
         "Set the log level for GPI."
     )},
 
     {"get_sim_time", get_sim_time, METH_NOARGS, PyDoc_STR(
         "get_sim_time()\n"
         "--\n\n"
+        "get_sim_time() -> Tuple[int, int]\n"
         "Get the current simulation time.\n"
         "\n"
         "Time is represented as a tuple of 32 bit integers ([low32, high32]) comprising a single 64 bit integer."
@@ -126,6 +143,7 @@ static PyMethodDef SimulatorMethods[] = {
     {"get_precision", get_precision, METH_NOARGS, PyDoc_STR(
         "get_precision()\n"
         "--\n\n"
+        "get_precision() -> int\n"
         "Get the precision of the simulator in powers of 10.\n"
         "\n"
         "For example, if ``-12`` is returned, the simulator's time precision is 10**-12 or 1 ps."
@@ -133,11 +151,13 @@ static PyMethodDef SimulatorMethods[] = {
     {"get_simulator_product", get_simulator_product, METH_NOARGS, PyDoc_STR(
         "get_simulator_product()\n"
         "--\n\n"
+        "get_simulator_product() -> str\n"
         "Get the simulator's product string."
     )},
     {"get_simulator_version", get_simulator_version, METH_NOARGS, PyDoc_STR(
         "get_simulator_version()\n"
         "--\n\n"
+        "get_simulator_version() -> str\n"
         "Get the simulator's product version string."
     )},
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/cocotb/share/lib/simulator/simulatormodule.h
+++ b/cocotb/share/lib/simulator/simulatormodule.h
@@ -73,68 +73,72 @@ static PyMethodDef SimulatorMethods[] = {
     {"log_msg", log_msg, METH_VARARGS, PyDoc_STR(
         "log_msg(name, path, funcname, lineno, msg, /)\n"
         "--\n\n"
-        "Log a message"
+        "Log a message."
     )},
     {"get_root_handle", get_root_handle, METH_VARARGS, PyDoc_STR(
         "get_root_handle(name, /)\n"
         "--\n\n"
-        "Get the root handle"
+        "Get the root handle."
     )},
     {"register_timed_callback", register_timed_callback, METH_VARARGS, PyDoc_STR(
         "register_timed_callback(time, func, /, *args)\n"
         "--\n\n"
-        "Register a timed callback"
+        "Register a timed callback."
     )},
     {"register_value_change_callback", register_value_change_callback, METH_VARARGS, PyDoc_STR(
         "register_value_change_callback(signal, func, edge, /, *args)\n"
         "--\n\n"
-        "Register a signal change callback"
+        "Register a signal change callback."
     )},
     {"register_readonly_callback", register_readonly_callback, METH_VARARGS, PyDoc_STR(
         "register_readonly_callback(func, /, *args)\n"
         "--\n\n"
-        "Register a callback for the read-only section"
+        "Register a callback for the read-only section."
     )},
     {"register_nextstep_callback", register_nextstep_callback, METH_VARARGS, PyDoc_STR(
         "register_nextstep_callback(func, /, *args)\n"
         "--\n\n"
-        "Register a callback for the NextSimTime callback"
+        "Register a callback for the NextSimTime callback."
     )},
     {"register_rwsynch_callback", register_rwsynch_callback, METH_VARARGS, PyDoc_STR(
         "register_rwsynch_callback(func, /, *args)\n"
         "--\n\n"
-        "Register a callback for the read-write section"
+        "Register a callback for the read-write section."
     )},
     {"stop_simulator", stop_simulator, METH_VARARGS, PyDoc_STR(
         "stop_simulator()\n"
         "--\n\n"
-        "Instruct the attached simulator to stop"
+        "Instruct the attached simulator to stop. Users should not call this function."
     )},
     {"log_level", log_level, METH_VARARGS, PyDoc_STR(
         "log_level(level, /)\n"
         "--\n\n"
-        "Set the log level for GPI"
+        "Set the log level for GPI."
     )},
 
     {"get_sim_time", get_sim_time, METH_NOARGS, PyDoc_STR(
         "get_sim_time()\n"
         "--\n\n"
-        "Get the current simulation time as an int tuple"
+        "Get the current simulation time.\n"
+        "\n"
+        "Time is represented as a tuple of 32 bit integers ([low32, high32]) comprising a single 64 bit integer."
     )},
     {"get_precision", get_precision, METH_NOARGS, PyDoc_STR(
         "get_precision()\n"
         "--\n\n"
-        "Get the precision of the simulator"
+        "Get the precision of the simulator in powers of 10.\n"
+        "\n"
+        "For example, if ``-12`` is returned, the simulator's time precision is 10**-12 or 1 ps."
     )},
     {"get_simulator_product", get_simulator_product, METH_NOARGS, PyDoc_STR(
         "get_simulator_product()\n"
         "--\n\n"
-        "Simulator product information"
+        "Get the simulator's product string."
     )},
     {"get_simulator_version", get_simulator_version, METH_NOARGS, PyDoc_STR(
         "get_simulator_version()\n"
         "--\n\n"
-        "Simulator product version information"
+        "Get the simulator's product version string."
     )},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -15,12 +15,22 @@ BUILDDIR      = build
 # Put it first so that "make" without argument is like "make help".
 help: .venv
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo "Other targets"
+	@echo "  .venv             Create virtual environment used to generate documentation"
+	@echo "  rebuild_cocotb    Rebuilds the cocotb package and installs in the virtual environment"
+	@echo "  clean             Deletes Sphinx-build artifacts"
+	@echo "  distclean         Deletes the virtual environment and Sphinx-build artifacts"
+	@echo "  help              Prints this help message"
 
 .venv: requirements.txt
 	@echo Creating Python venv for Sphinx build
 	python3 -m venv .venv
 	.venv/bin/pip -q install --upgrade pip
 	.venv/bin/pip -q install -r requirements.txt
+	.venv/bin/pip -q install -e ..
+
+.PHONY: rebuild_cocotb
+rebuild_cocotb:
 	.venv/bin/pip -q install -e ..
 
 .PHONY: clean
@@ -41,4 +51,4 @@ distclean:
 # We hack around that by calling the target explicitly.
 	make .venv
 
-	source .venv/bin/activate; $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	. .venv/bin/activate; $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
Improves the documentation of the simulator by improving the general clarity of docstrings, referencing Python types rather than C types, adding type annotations to the documentation, and adding class docstrings to the `gpi_hdl_Object` types.