### PR TITLE
Prevent segfaults when using simulatormodule without a simulator

### DIFF
--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -113,6 +113,13 @@ typedef enum gpi_event_e {
 
 // Functions for controlling/querying the simulation state
 
+/**
+ * Returns 1 if there is a registered GPI implementation, 0 otherwise.
+ *
+ * Useful for checking if a simulator is running.
+ */
+bool gpi_has_registered_impl(void);
+
 // Stop the simulator
 void gpi_sim_end(void);
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -123,6 +123,11 @@ int gpi_register_impl(GpiImplInterface *func_tbl)
     return 0;
 }
 
+bool gpi_has_registered_impl()
+{
+    return registered_impls.size() > 0;
+}
+
 void gpi_embed_init(int argc, char const* const* argv)
 {
     if (embed_sim_init(argc, argv))

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -749,6 +749,14 @@ static PyObject *get_type_string(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *ar
 }
 
 
+static PyObject *is_running(PyObject *self, PyObject *args)
+{
+    COCOTB_UNUSED(self);
+    COCOTB_UNUSED(args);
+
+    return PyBool_FromLong(gpi_has_registered_impl());
+}
+
 // Returns a high, low, tuple of simulator time
 // Note we can never log from this function since the logging mechanism calls this to annotate
 // log messages with the current simulation time

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -255,6 +255,7 @@ err:
 static PyObject *log_msg(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
+
     const char *name;
     const char *path;
     const char *msg;
@@ -295,6 +296,11 @@ static PyObject *register_readonly_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
 
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
+
     Py_ssize_t numargs = PyTuple_Size(args);
 
     if (numargs < 1) {
@@ -332,6 +338,11 @@ static PyObject *register_readonly_callback(PyObject *self, PyObject *args)
 static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
+
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -371,6 +382,11 @@ static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args)
 static PyObject *register_nextstep_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
+
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -414,6 +430,11 @@ static PyObject *register_nextstep_callback(PyObject *self, PyObject *args)
 static PyObject *register_timed_callback(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
+
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -472,6 +493,11 @@ static PyObject *register_timed_callback(PyObject *self, PyObject *args)
 static PyObject *register_value_change_callback(PyObject *self, PyObject *args) //, PyObject *keywds)
 {
     COCOTB_UNUSED(self);
+
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
 
     Py_ssize_t numargs = PyTuple_Size(args);
 
@@ -675,6 +701,11 @@ static PyObject *get_root_handle(PyObject *self, PyObject *args)
     COCOTB_UNUSED(self);
     const char *name;
 
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
+
     if (!PyArg_ParseTuple(args, "z:get_root_handle", &name)) {
         return NULL;
     }
@@ -725,6 +756,12 @@ static PyObject *get_sim_time(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
     COCOTB_UNUSED(args);
+
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
+
     struct sim_time local_time;
 
     if (is_python_context) {
@@ -744,6 +781,15 @@ static PyObject *get_precision(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
     COCOTB_UNUSED(args);
+
+    if (!gpi_has_registered_impl()) {
+        char const * msg = "Simulator is not available! Defaulting precision to 1 fs.";
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, msg, 1) < 0) {
+            return NULL;
+        }
+        return PyLong_FromLong(-15);  // preserves old behavior
+    }
+
     int32_t precision;
 
     gpi_get_sim_precision(&precision);
@@ -755,6 +801,12 @@ static PyObject *get_simulator_product(PyObject *m, PyObject *args)
 {
     COCOTB_UNUSED(m);
     COCOTB_UNUSED(args);
+
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
+
     return PyUnicode_FromString(gpi_get_simulator_product());
 }
 
@@ -762,6 +814,12 @@ static PyObject *get_simulator_version(PyObject *m, PyObject *args)
 {
     COCOTB_UNUSED(m);
     COCOTB_UNUSED(args);
+
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
+
     return PyUnicode_FromString(gpi_get_simulator_version());
 }
 
@@ -792,6 +850,12 @@ static PyObject *stop_simulator(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
     COCOTB_UNUSED(args);
+
+    if (!gpi_has_registered_impl()) {
+        PyErr_SetString(PyExc_RuntimeError, "No simulator available!");
+        return NULL;
+    }
+
     gpi_sim_end();
     sim_ending = 1;
     Py_RETURN_NONE;
@@ -810,6 +874,7 @@ static PyObject *deregister(gpi_hdl_Object<gpi_cb_hdl> *self, PyObject *args)
 static PyObject *log_level(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
+
     long l_level;
 
     if (!PyArg_ParseTuple(args, "l:log_level", &l_level)) {

--- a/cocotb/share/lib/simulator/simulatormodule.h
+++ b/cocotb/share/lib/simulator/simulatormodule.h
@@ -61,7 +61,7 @@ static PyObject *register_rwsynch_callback(PyObject *self, PyObject *args);
 
 static PyObject *get_root_handle(PyObject *self, PyObject *args);
 static PyObject *stop_simulator(PyObject *self, PyObject *args);
-
+static PyObject *is_running(PyObject *self, PyObject *args);
 static PyObject *get_sim_time(PyObject *self, PyObject *args);
 static PyObject *get_precision(PyObject *self, PyObject *args);
 static PyObject *get_simulator_product(PyObject *self, PyObject *args);
@@ -115,7 +115,14 @@ static PyMethodDef SimulatorMethods[] = {
         "--\n\n"
         "Set the log level for GPI"
     )},
-
+    {"is_running", is_running, METH_NOARGS, PyDoc_STR(
+        "is_running()\n"
+        "--\n\n"
+        "is_running() -> bool\n"
+        "Returns ``True`` if the caller is running within a simulator.\n"
+        "\n"
+        ".. versionadded:: 1.4"
+    )},
     {"get_sim_time", get_sim_time, METH_NOARGS, PyDoc_STR(
         "get_sim_time()\n"
         "--\n\n"

--- a/documentation/source/newsfragments/1843.change.rst
+++ b/documentation/source/newsfragments/1843.change.rst
@@ -1,0 +1,1 @@
+Certain methods on the :mod:`cocotb.simulator` Python module now throw a :exc`RuntimeError` when no simulator is present, making it safe to use :mod:`cocotb` without a simulator present.

--- a/documentation/source/newsfragments/1843.feature.rst
+++ b/documentation/source/newsfragments/1843.feature.rst
@@ -1,0 +1,1 @@
+The :func:`cocotb.simulator.is_running` function was added so a user of cocotb could determine if they are running within a simulator.


### PR DESCRIPTION
A more permanent fix to #1839. When accessing the simulator module without a simulator present, all methods will throw an exception to prevent a possible segfault. `get_sim_precision` is an exception, previous to #1717, this defaulted to `-15`, this behavior has been restored.

@tpoikela