### PR TITLE
Fix #1519 newsfragment to correctly display str

### DIFF
--- a/documentation/source/newsfragments/1519.removal.rst
+++ b/documentation/source/newsfragments/1519.removal.rst
@@ -1,1 +1,1 @@
-Passing :type:`str` instances to :func:`cocotb.utils.hexdump` and :func:`cocotb.utils.hexdiffs` is deprecated. :class:`bytes` objects should be passed instead.
+Passing :class:`str` instances to :func:`cocotb.utils.hexdump` and :func:`cocotb.utils.hexdiffs` is deprecated. :class:`bytes` objects should be passed instead.


### PR DESCRIPTION
`str` is not displayed correctly on master:

![image](https://user-images.githubusercontent.com/47790688/82247718-b8a11880-98fb-11ea-960b-eb704dcf5486.png)

https://docs.cocotb.org/en/latest/release_notes.html