### PR TITLE
Support coroutines in First and Combine

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -29,6 +29,7 @@
 
 import abc
 from collections.abc import Awaitable
+import inspect
 
 from cocotb import simulator
 from cocotb.log import SimLog
@@ -655,17 +656,23 @@ class _AggregateWaitable(Waitable):
     __slots__ = ('triggers',)
 
     def __init__(self, *triggers):
-        self.triggers = tuple(triggers)
+        usable_triggers = []
 
         # Do some basic type-checking up front, rather than waiting until we
         # await them.
         allowed_types = (Trigger, Waitable, cocotb.decorators.RunningTask)
-        for trigger in self.triggers:
-            if not isinstance(trigger, allowed_types):
+        for trigger in triggers:
+            if inspect.iscoroutine(trigger):
+                usable_triggers.append(cocotb.decorators.RunningTask(trigger))
+            elif isinstance(trigger, allowed_types):
+                usable_triggers.append(trigger)
+            else:
                 raise TypeError(
-                    "All triggers must be instances of Trigger! Got: {}"
+                    "All triggers must be awaitable! Got: {}"
                     .format(type(trigger).__qualname__)
                 )
+
+        self.triggers = tuple(usable_triggers)
 
     def __repr__(self):
         # no _pointer_str here, since this is not a trigger, so identity
@@ -815,7 +822,7 @@ async def with_timeout(trigger, timeout_time, timeout_unit=None):
         await with_timeout(First(coro, event.wait()), 100, 'ns')
 
     Args:
-        trigger (:class:`~cocotb.triggers.Trigger` or :class:`~cocotb.triggers.Waitable` or :class:`~cocotb.decorators.RunningTask`):
+        trigger (:class:`~cocotb.triggers.Trigger` or :class:`~cocotb.triggers.Waitable` or :class:`~cocotb.decorators.RunningTask` or :class:`types.CoroutineType`):
             A single object that could be right of an :keyword:`await` expression in cocotb.
         timeout_time (numbers.Real or decimal.Decimal):
             Simulation time duration before timeout occurs.

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -80,8 +80,6 @@ async def test_first_does_not_kill(dut):
     """ Test that `First` does not kill coroutines that did not finish first """
     ran = False
 
-    # decorating `async def` is required to use `First`
-    @cocotb.coroutine
     async def coro():
         nonlocal ran
         await Timer(2, units='ns')

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -218,7 +218,6 @@ async def test_nulltrigger_reschedule(dut):
 
     last_fork = None
 
-    @cocotb.coroutine   # TODO: Remove once Combine accepts bare coroutines
     async def reschedule(n):
         nonlocal last_fork
         for i in range(4):
@@ -273,14 +272,12 @@ async def test_last_scheduled_write_wins(dut):
     e = Event()
     dut.stream_in_data.setimmediatevalue(0)
 
-    @cocotb.coroutine   # TODO: Remove once Combine accepts bare coroutines
     async def first():
         await Timer(1)
         dut._log.info("scheduling stream_in_data <= 1")
         dut.stream_in_data <= 1
         e.set()
 
-    @cocotb.coroutine   # TODO: Remove once Combine accepts bare coroutines
     async def second():
         await Timer(1)
         await e.wait()


### PR DESCRIPTION
Add support for Python coroutines to `First` and `Combine` triggers.
