### PR TITLE
Add the RegressionManager and cocotb module vars to documentation

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -37,6 +37,7 @@ import threading
 import random
 import time
 import warnings
+from typing import Dict, List, Union
 
 import cocotb._os_compat  # must appear first, before the first import of cocotb.simulator
 import cocotb.handle
@@ -95,13 +96,35 @@ def _setup_logging():
 # so that cocotb.scheduler gives you the singleton instance and not the
 # scheduler package
 
-scheduler = None
+scheduler = None  # type: cocotb.scheduler.Scheduler
 """The global scheduler instance."""
 
-regression_manager = None
+regression_manager = None  # type: cocotb.regression.RegressionManager
+"""The global regression manager instance."""
 
-plusargs = {}
-"""A dictionary of "plusargs" handed to the simulation."""
+argv = None  # type: List[str]
+"""The argument list as seen by the simulator"""
+
+argc = None  # type: int
+"""The length of :data:`cocotb.argv`"""
+
+plusargs = None  # type: Dict[str, Union[bool, str]]
+"""A dictionary of "plusargs" handed to the simulation. See :make:var:`PLUSARGS` for details."""
+
+LANGUAGE = os.getenv("TOPLEVEL_LANG")  # type: str
+"""The value of :make:var:`TOPLEVEL_LANG`"""
+
+SIM_NAME = None  # type: str
+"""The running simulator product information. ``None`` if :mod:`cocotb` was not loaded from a simulator"""
+
+SIM_VERSION = None  # type: str
+"""The version of the running simulator. ``None`` if :mod:`cocotb` was not loaded from a simulator"""
+
+RANDOM_SEED = None  # type: int
+"""
+The value passed to the Python default random number generator.
+See :envvar:`RANDOM_SEED` for details on how the value is computed.
+"""
 
 
 def fork(coro):
@@ -111,8 +134,6 @@ def fork(coro):
 
 # FIXME is this really required?
 _rlock = threading.RLock()
-
-LANGUAGE = os.getenv("TOPLEVEL_LANG")
 
 
 def mem_debug(port):

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -61,7 +61,7 @@ Cocotb
 
        make RANDOM_SEED=1377424946
 
-    See also: :envvar:`PLUSARGS`
+    See also: :make:var:`PLUSARGS`
 
 .. envvar:: COCOTB_ANSI_OUTPUT
 

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -326,22 +326,32 @@ Signal Tracer for WaveDrom
     :synopsis: A signal tracer for WaveDrom.
 
 
-Developer-focused
-=================
+Implementation Details
+======================
+
+.. note::
+    In general, nothing in this section should be interacted with directly -
+    these components work mostly behind the scenes.
 
 The Scheduler
 -------------
-
-.. note::
-    The scheduler object should generally not be interacted with directly -
-    the only part of it that a user will need is encapsulated in :func:`~cocotb.fork`,
-    everything else works behind the scenes.
 
 .. currentmodule:: cocotb.scheduler
 
 .. autodata:: cocotb.scheduler
 
 .. autoclass:: Scheduler
+    :members:
+    :member-order: bysource
+
+The Regression Manager
+----------------------
+
+.. currentmodule:: cocotb.regression
+
+.. autodata:: cocotb.regression_manager
+
+.. autoclass:: RegressionManager
     :members:
     :member-order: bysource
 

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -141,8 +141,6 @@ Clock
 Utilities
 =========
 
-.. autodata:: cocotb.plusargs
-
 .. automodule:: cocotb.utils
     :members:
     :member-order: bysource
@@ -316,6 +314,22 @@ XGMII
 
 Miscellaneous
 =============
+
+Other Runtime Information
+-------------------------
+
+.. autodata:: cocotb.argv
+
+.. autodata:: cocotb.SIM_NAME
+
+.. autodata:: cocotb.SIM_VERSION
+
+.. autodata:: cocotb.RANDOM_SEED
+
+.. autodata:: cocotb.plusargs
+
+.. autodata:: cocotb.LANGUAGE
+
 
 Signal Tracer for WaveDrom
 --------------------------


### PR DESCRIPTION
`Scheduler` and `cocotb.scheduler` are documented, but `RegressionManager` and `cocotb.regression_manager` were not. None of the cocotb module level variables were either. This fixes #1724. This PR also contains a small bugfix in the documentation of `RANDOM_SEED`.

Note: the link to `TOPLEVEL_LANG` in the docs for `LANGUAGE` are broken because of #1847.