### PR TITLE
drivers: Move type information from docstrings to annotations

### DIFF
--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -107,24 +107,26 @@ class AXI4LiteMaster(BusDriver):
         self.write_data_busy.release()
 
     @cocotb.coroutine
-    def write(self, address, value, byte_enable=0xf, address_latency=0,
-              data_latency=0, sync=True):
+    def write(
+        self, address: int, value: int, byte_enable: int = 0xf,
+        address_latency: int = 0, data_latency: int = 0, sync: bool = True
+    ) -> BinaryValue:
         """Write a value to an address.
 
         Args:
-            address (int): The address to write to.
-            value (int): The data value to write.
-            byte_enable (int, optional): Which bytes in value to actually write.
+            address: The address to write to.
+            value: The data value to write.
+            byte_enable: Which bytes in value to actually write.
                 Default is to write all bytes.
-            address_latency (int, optional): Delay before setting the address (in clock cycles).
+            address_latency: Delay before setting the address (in clock cycles).
                 Default is no delay.
-            data_latency (int, optional): Delay before setting the data value (in clock cycles).
+            data_latency: Delay before setting the data value (in clock cycles).
                 Default is no delay.
-            sync (bool, optional): Wait for rising edge on clock initially.
+            sync: Wait for rising edge on clock initially.
                 Defaults to True.
 
         Returns:
-            BinaryValue: The write response value.
+            The write response value.
 
         Raises:
             AXIProtocolError: If write response from AXI is not ``OKAY``.
@@ -160,16 +162,16 @@ class AXI4LiteMaster(BusDriver):
         return result
 
     @cocotb.coroutine
-    def read(self, address, sync=True):
+    def read(self, address: int, sync: bool = True) -> BinaryValue:
         """Read from an address.
 
         Args:
-            address (int): The address to read from.
-            sync (bool, optional): Wait for rising edge on clock initially.
+            address: The address to read from.
+            sync: Wait for rising edge on clock initially.
                 Defaults to True.
 
         Returns:
-            BinaryValue: The read data value.
+            The read data value.
 
         Raises:
             AXIProtocolError: If read response from AXI is not ``OKAY``.

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -33,6 +33,7 @@ NB Currently we only support a very small subset of functionality
 """
 
 import random
+from typing import Iterable, Union, Optional
 
 import cocotb
 from cocotb.decorators import coroutine
@@ -116,19 +117,19 @@ class AvalonMaster(AvalonMM):
         self.busy_event.set()
 
     @coroutine
-    def read(self, address, sync=True):
+    def read(self, address: int, sync: bool = True) -> BinaryValue:
         """Issue a request to the bus and block until this comes back.
 
         Simulation time still progresses
         but syntactically it blocks.
 
         Args:
-            address (int): The address to read from.
-            sync (bool, optional): Wait for rising edge on clock initially.
+            address: The address to read from.
+            sync: Wait for rising edge on clock initially.
                 Defaults to True.
 
         Returns:
-            BinaryValue: The read data value.
+            The read data value.
 
         Raises:
             :any:`TestError`: If master is write-only.
@@ -183,13 +184,13 @@ class AvalonMaster(AvalonMM):
         return data
 
     @coroutine
-    def write(self, address, value):
+    def write(self, address: int, value: int) -> None:
         """Issue a write to the given address with the specified
         value.
 
         Args:
-            address (int): The address to write to.
-            value (int): The data value to write.
+            address: The address to write to.
+            value: The data value to write.
 
         Raises:
             :any:`TestError`: If master is read-only.
@@ -671,10 +672,10 @@ class AvalonSTPkts(ValidatedBusDriver):
             yield ReadOnly()
 
     @coroutine
-    def _send_string(self, string, sync=True, channel=None):
+    def _send_string(self, string: bytes, sync: bool = True, channel: Optional[int] = None) -> None:
         """Args:
-            string (bytes): A string of bytes to send over the bus.
-            channel (int): Channel to send the data on.
+            string: A string of bytes to send over the bus.
+            channel: Channel to send the data on.
         """
         # Avoid spurious object creation by recycling
         clkedge = RisingEdge(self.clock)
@@ -774,9 +775,9 @@ class AvalonSTPkts(ValidatedBusDriver):
             self.bus.channel <= channel_value
 
     @coroutine
-    def _send_iterable(self, pkt, sync=True):
+    def _send_iterable(self, pkt: Iterable, sync: bool = True) -> None:
         """Args:
-            pkt (iterable): Will yield objects with attributes matching the
+            pkt: Will yield objects with attributes matching the
                 signal names for each individual bus cycle.
         """
         clkedge = RisingEdge(self.clock)
@@ -815,12 +816,12 @@ class AvalonSTPkts(ValidatedBusDriver):
         self.bus.valid <= 0
 
     @coroutine
-    def _driver_send(self, pkt, sync=True, channel=None):
+    def _driver_send(self, pkt: Union[bytes, Iterable], sync: bool = True, channel: Optional[int] = None):
         """Send a packet over the bus.
 
         Args:
-            pkt (str or iterable): Packet to drive onto the bus.
-            channel (None or int): Channel attributed to the packet.
+            pkt: Packet to drive onto the bus.
+            channel: Channel attributed to the packet.
 
         If ``pkt`` is a string, we simply send it word by word
 

--- a/cocotb/drivers/opb.py
+++ b/cocotb/drivers/opb.py
@@ -33,6 +33,7 @@ NOTE: Currently we only support a very small subset of functionality.
 import cocotb
 from cocotb.triggers import RisingEdge, ReadOnly, Event
 from cocotb.drivers import BusDriver
+from cocotb.binary import BinaryValue
 
 
 class OPBException(Exception):
@@ -65,18 +66,18 @@ class OPBMaster(BusDriver):
         self.busy_event.set()
 
     @cocotb.coroutine
-    def read(self, address, sync=True):
+    def read(self, address: int, sync: bool = True) -> BinaryValue:
         """Issue a request to the bus and block until this comes back.
 
         Simulation time still progresses but syntactically it blocks.
 
         Args:
-            address (int): The address to read from.
-            sync (bool, optional): Wait for rising edge on clock initially.
+            address: The address to read from.
+            sync: Wait for rising edge on clock initially.
                 Defaults to True.
 
         Returns:
-            BinaryValue: The read data value.
+            The read data value.
 
         Raises:
             OPBException: If read took longer than 16 cycles.
@@ -110,13 +111,13 @@ class OPBMaster(BusDriver):
         return data
 
     @cocotb.coroutine
-    def write(self, address, value, sync=True):
+    def write(self, address: int, value: int, sync: bool = True) -> None:
         """Issue a write to the given address with the specified value.
 
         Args:
-            address (int): The address to read from.
-            value (int): The data value to write.
-            sync (bool, optional): Wait for rising edge on clock initially.
+            address: The address to read from.
+            value: The data value to write.
+            sync: Wait for rising edge on clock initially.
                 Defaults to True.
 
         Raises:


### PR DESCRIPTION
Only the functions which had typesin their docstrings are touched here.
Some instances of `str` were corrected to `bytes`, since those were my fault in a previous PR.
Everything else is left as in the docstring.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
