### PR TITLE
Fix type annotations on simulatormodule

### DIFF
--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -933,7 +933,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_signal_val_long, METH_NOARGS, PyDoc_STR(
             "get_signal_val_long($self)\n"
             "--\n\n"
-            "get_signal_val_long(self) -> int\n"
+            "get_signal_val_long() -> int\n"
             "Get the value of a signal as an integer."
         )
     },
@@ -941,7 +941,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_signal_val_str, METH_NOARGS, PyDoc_STR(
             "get_signal_val_str($self)\n"
             "--\n\n"
-            "get_signal_val_str(self) -> bytes\n"
+            "get_signal_val_str() -> bytes\n"
             "Get the value of a signal as a byte string."
         )
     },
@@ -949,7 +949,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_signal_val_binstr, METH_NOARGS, PyDoc_STR(
             "get_signal_val_binstr($self)\n"
             "--\n\n"
-            "get_signal_val_binstr(self) -> str\n"
+            "get_signal_val_binstr() -> str\n"
             "Get the value of a logic vector signal as a string of (``0``, ``1``, ``X``, etc.), one element per character."
         )
     },
@@ -957,7 +957,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_signal_val_real, METH_NOARGS, PyDoc_STR(
             "get_signal_val_real($self)\n"
             "--\n\n"
-            "get_signal_val_real(self) -> float\n"
+            "get_signal_val_real() -> float\n"
             "Get the value of a signal as a float."
         )
     },
@@ -965,7 +965,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)set_signal_val_long, METH_VARARGS, PyDoc_STR(
             "set_signal_val_long($self, action, value, /)\n"
             "--\n\n"
-            "set_signal_val_long(self, action: int, value: int) -> None\n"
+            "set_signal_val_long(action: int, value: int) -> None\n"
             "Set the value of a signal using an integer.\n"
         )
     },
@@ -973,7 +973,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)set_signal_val_str, METH_VARARGS, PyDoc_STR(
             "set_signal_val_str($self, action, value, /)\n"
             "--\n\n"
-            "set_signal_val_str(self, action: int, value: bytes) -> None\n"
+            "set_signal_val_str(action: int, value: bytes) -> None\n"
             "Set the value of a signal using a user-encoded string."
         )
     },
@@ -981,7 +981,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)set_signal_val_binstr, METH_VARARGS, PyDoc_STR(
             "set_signal_val_binstr($self, action, value, /)\n"
             "--\n\n"
-            "set_signal_val_binstr(self, action: int, value: str) -> None\n"
+            "set_signal_val_binstr(action: int, value: str) -> None\n"
             "Set the value of a logic vector signal using a string of (``0``, ``1``, ``X``, etc.), one element per character."
         )
     },
@@ -989,7 +989,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)set_signal_val_real, METH_VARARGS, PyDoc_STR(
             "set_signal_val_real($self, action, value, /)\n"
             "--\n\n"
-            "set_signal_val_real(self, action: int, value: float) -> None\n"
+            "set_signal_val_real(action: int, value: float) -> None\n"
             "Set the value of a signal using a float."
         )
     },
@@ -997,7 +997,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_definition_name, METH_NOARGS, PyDoc_STR(
             "get_definition_name($self)\n"
             "--\n\n"
-            "get_definition_name(self) -> str\n"
+            "get_definition_name() -> str\n"
             "Get the name of a GPI object's definition."
         )
     },
@@ -1005,7 +1005,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_definition_file, METH_NOARGS, PyDoc_STR(
             "get_definition_file($self)\n"
             "--\n\n"
-            "get_definition_file(self) -> str\n"
+            "get_definition_file() -> str\n"
             "Get the file that sources the object's definition."
         )
     },
@@ -1013,7 +1013,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_handle_by_name, METH_VARARGS, PyDoc_STR(
             "get_handle_by_name($self, name, /)\n"
             "--\n\n"
-            "get_handle_by_name(self, name: str) -> cocotb.simulator.gpi_sim_hdl\n"
+            "get_handle_by_name(name: str) -> cocotb.simulator.gpi_sim_hdl\n"
             "Get a handle to a child object by name."
         )
     },
@@ -1021,7 +1021,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_handle_by_index, METH_VARARGS, PyDoc_STR(
             "get_handle_by_index($self, index, /)\n"
             "--\n\n"
-            "get_handle_by_index(self, index: int) -> cocotb.simulator.gpi_sim_hdl\n"
+            "get_handle_by_index(index: int) -> cocotb.simulator.gpi_sim_hdl\n"
             "Get a handle to a child object by index."
         )
     },
@@ -1029,7 +1029,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_name_string, METH_NOARGS, PyDoc_STR(
             "get_name_string($self)\n"
             "--\n\n"
-            "get_name_string(self) -> str\n"
+            "get_name_string() -> str\n"
             "Get the name of an object as a string."
         )
     },
@@ -1037,7 +1037,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_type_string, METH_NOARGS, PyDoc_STR(
             "get_type_string($self)\n"
             "--\n\n"
-            "get_type_string(self) -> str\n"
+            "get_type_string() -> str\n"
             "Get the GPI type of an object as a string."
         )
     },
@@ -1045,7 +1045,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_type, METH_NOARGS, PyDoc_STR(
             "get_type($self)\n"
             "--\n\n"
-            "get_type(self) -> int\n"
+            "get_type() -> int\n"
             "Get the GPI type of an object as an enum."
         )
     },
@@ -1053,7 +1053,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_const, METH_NOARGS, PyDoc_STR(
             "get_const($self)\n"
             "--\n\n"
-            "get_const(self) -> bool\n"
+            "get_const() -> bool\n"
             "Return ``True`` if the object is a constant."
         )
     },
@@ -1061,7 +1061,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_num_elems, METH_NOARGS, PyDoc_STR(
             "get_num_elems($self)\n"
             "--\n\n"
-            "get_num_elems(self) -> int\n"
+            "get_num_elems() -> int\n"
             "Get the number of elements contained in the handle."
         )
     },
@@ -1069,7 +1069,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)get_range, METH_NOARGS, PyDoc_STR(
             "get_range($self)\n"
             "--\n\n"
-            "get_range(self) -> Tuple[int, int]\n"
+            "get_range() -> Tuple[int, int]\n"
             "Get the range of elements (tuple) contained in the handle, return ``None`` if not indexable."
         )
     },
@@ -1077,7 +1077,7 @@ static PyMethodDef gpi_sim_hdl_methods[] = {
         (PyCFunction)iterate, METH_VARARGS, PyDoc_STR(
             "iterate($self, mode, /)\n"
             "--\n\n"
-            "iterate(self, mode: int) -> cocotb.simulator.gpi_iterator_hdl\n"
+            "iterate(mode: int) -> cocotb.simulator.gpi_iterator_hdl\n"
             "Get an iterator handle to loop over all members in an object."
         )
     },
@@ -1111,7 +1111,7 @@ static PyMethodDef gpi_cb_hdl_methods[] = {
         (PyCFunction)deregister, METH_NOARGS, PyDoc_STR(
             "deregister($self)\n"
             "--\n\n"
-            "deregister(self) -> None\n"
+            "deregister() -> None\n"
             "De-register this callback."
         )},
     {NULL, NULL, 0, NULL}        /* Sentinel */


### PR DESCRIPTION
From https://github.com/cocotb/cocotb/pull/1842#discussion_r428065895.

The type annotations on the `gpi_hdl_Object`s shouldn't have include `self`.