### PR TITLE
Don't install unneeded objects with python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,13 @@ setup(
     install_requires=[],
     python_requires='>=3.5',
     packages=find_packages(),
-    include_package_data=True,
-    package_data={'cocotb': package_files('cocotb/share')},
+    package_data={
+        'cocotb': (
+            package_files('cocotb/share/makefiles') +   # noqa: W504
+            package_files('cocotb/share/include') +     # noqa: W504
+            package_files('cocotb/share/def')
+        )
+    },
     ext_modules=get_ext(),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
We remove `include_package_data` option and instead depend on detecting the cocotb package and specifying the makefiles as cocotb package data.

Previously, this installed everything under cocotb/, but now it only installs the python files and the makefiles.

I don't know much about packaging, so I might be totally off base here.