### PR TITLE
Tox: Whitelist common license file variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ setenv =
     CXXFLAGS = -Werror
 passenv =
     SIM
+    ALDEC_LICENSE_FILE
+    SYNOPSYS_LICENSE_FILE
+    LM_LICENSE_FILE
 
 deps =
     coverage


### PR DESCRIPTION
Proprietary EDA tools need a license which is typically provided through
FlexLM. The correct license file is found through an environment
variable which we need to pass through to the tool.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->