### PR TITLE
Deal with failing tests in Riviera-PRO

### DIFF
--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -357,7 +357,7 @@ def test_discover_all(dut):
             pass_total = 803
         elif cocotb.SIM_VERSION.startswith(("2016.06", "2016.10", "2017.02")):
             pass_total = 813
-        elif cocotb.SIM_VERSION.startswith(("2016.02")):
+        elif cocotb.SIM_VERSION.startswith(("2016.02", "2019.10")):
             pass_total = 947
         else:
             pass_total = 1038

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -341,7 +341,7 @@ def test_discover_all(dut):
         dummy = dut.sig_rec
         dummy = dut.port_rec_out
 
-    # Riviera-Pro's VHPI implementation does not fine signal declarations when iterating
+    # Riviera-Pro's VHPI implementation does not find signal declarations when iterating
     if cocotb.LANGUAGE in ["vhdl"] and cocotb.SIM_NAME.lower().startswith(("riviera")):
         for hdl in dut.asc_gen:
             dummy = hdl.sig

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -274,7 +274,7 @@ def access_string_vhdl(dut):
 
 # TODO: add tests for Verilog "string_input_port" and "STRING_LOCALPARAM" (see issue #802)
 
-@cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"] or cocotb.SIM_NAME.lower().startswith("icarus"),
+@cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"] or cocotb.SIM_NAME.lower().startswith(("icarus", "riviera")),
              expect_error=cocotb.result.TestFailure if cocotb.SIM_NAME.lower().startswith(("xmsim", "ncsim", "modelsim", "chronologic simulation vcs")) else False)
 def access_const_string_verilog(dut):
     """Access to a const Verilog string."""

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -115,5 +115,5 @@ def test_n_dimension_array(dut):
             inner_count += 1
         outer_count += 1
 
-    if inner_count != 14 or outer_count != 2:
-        raise TestFailure("dut.inst_ram_ctrl.config should have a total of 14 elems over 2 loops")
+    assert outer_count == 2, outer_count
+    assert inner_count == 14, inner_count

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -101,7 +101,7 @@ def get_clock(dut):
         raise TestFailure("dut.aclk is not what we expected (got %d)" % int(dut.aclk))
 
 
-@cocotb.test()
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("riviera") and cocotb.SIM_VERSION.startswith("2019.10"))
 def test_n_dimension_array(dut):
     tlog = logging.getLogger("cocotb.test")
     inner_count = 0

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -30,11 +30,14 @@ from cocotb.triggers import Timer
 from cocotb.result import TestFailure
 
 
-@cocotb.test()
+# This test crashes Riviera-PRO 2019.10 (at least); skip to avoid hanging the
+# tests. See issue #1854 for details.
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("riviera") and cocotb.SIM_VERSION.startswith("2019.10"))
 def recursive_discovery(dut):
     """
     Recursively discover every single object in the design
     """
+
     if (cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim", "modelsim")) or
        (cocotb.SIM_NAME.lower().startswith("riviera") and not cocotb.SIM_VERSION.startswith("2016.02"))):
         # Finds regions, signal, generics, constants, varibles and ports.

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -95,7 +95,9 @@ def check_objects(dut):
         raise TestFailure("%d Failures during the test" % fails)
 
 
-@cocotb.test()
+# This test crashes Riviera-PRO 2019.10 (at least); skip to avoid hanging the
+# tests. See issue #1857 for details.
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("riviera") and cocotb.SIM_VERSION.startswith("2019.10"))
 def port_not_hierarchy(dut):
     """
     Test for issue raised by Luke - iteration causes a toplevel port type to


### PR DESCRIPTION
Riviera-PRO 2019.10 fails some tests in various ways, see the individual commits for details.
This PR doesn't fix any of the issues, only disables tests in different ways. Individual bugs have been filed to debug issues where possible.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->