### PR TITLE
Add private CI trigger

### DIFF
--- a/.azp-private.yml
+++ b/.azp-private.yml
@@ -1,0 +1,27 @@
+# Private CI trigger.  Used to run tooling that can't currently be shared
+# publicly.
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - '*'
+  tags:
+    include:
+    - "*"
+pr:
+  branches:
+    include:
+    - '*'
+
+# The runner used for private CI enforces the use of the template below. All
+# build steps need to be placed into the template.
+resources:
+  repositories:
+  - repository: cocotb-private-ci
+    type: github
+    endpoint: cocotb
+    name: cocotb/cocotb-private-ci
+
+extends:
+  template: jobs.yml@cocotb-private-ci


### PR DESCRIPTION
This Azure Pipelines configuration triggers a private CI run. The
configuration for the private CI is contained in a non-public
repository, as we cannot share the tools or their output publicly due to
licensing restrictions.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->