### PR TITLE
cleanup usage of LOG_CRITICAL in GPI and implementations

### DIFF
--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -53,10 +53,7 @@ enum gpi_log_levels {
 #define LOG_INFO(...)      gpi_log("cocotb.gpi", GPIInfo,          __FILE__, __func__, __LINE__, __VA_ARGS__);
 #define LOG_WARN(...)      gpi_log("cocotb.gpi", GPIWarning,       __FILE__, __func__, __LINE__, __VA_ARGS__);
 #define LOG_ERROR(...)     gpi_log("cocotb.gpi", GPIError,         __FILE__, __func__, __LINE__, __VA_ARGS__);
-#define LOG_CRITICAL(...)  do { \
-    gpi_log("cocotb.gpi", GPICritical,      __FILE__, __func__, __LINE__, __VA_ARGS__); \
-    exit(1); \
-} while (0)
+#define LOG_CRITICAL(...)  gpi_log("cocotb.gpi", GPICritical,      __FILE__, __func__, __LINE__, __VA_ARGS__);
 
 void set_log_handler(void *handler);
 void clear_log_handler(void);

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -1016,6 +1016,8 @@ void handle_fli_callback(void *data)
 
     if (!cb_hdl) {
         LOG_CRITICAL("FLI: Callback data corrupted: ABORTING");
+        gpi_embed_end();
+        return;
     }
 
     gpi_cb_state_e old_state = cb_hdl->get_call_state();

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -83,7 +83,7 @@ int FliObjHdl::initialise(std::string &name, std::string &fq_name)
             m_num_elems = 1;
             break;
         default:
-            LOG_CRITICAL("Invalid object type for FliObjHdl. (%s (%s))", name.c_str(), get_type_str());
+            LOG_ERROR("Invalid object type for FliObjHdl. (%s (%s))", name.c_str(), get_type_str());
             return -1;
     }
 
@@ -228,7 +228,7 @@ long FliEnumObjHdl::get_signal_value_long()
 int FliEnumObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
-        LOG_CRITICAL("Force or release action not supported for FLI.");
+        LOG_ERROR("Force or release action not supported for FLI.");
         return -1;
     }
 
@@ -269,7 +269,7 @@ int FliLogicObjHdl::initialise(std::string &name, std::string &fq_name)
             }
             break;
         default:
-            LOG_CRITICAL("Object type is not 'logic' for %s (%d)", name.c_str(), m_fli_type);
+            LOG_ERROR("Object type is not 'logic' for %s (%d)", name.c_str(), m_fli_type);
             return -1;
     }
 
@@ -306,7 +306,7 @@ const char* FliLogicObjHdl::get_signal_value_binstr()
             }
             break;
         default:
-            LOG_CRITICAL("Object type is not 'logic' for %s (%d)", m_name.c_str(), m_fli_type);
+            LOG_ERROR("Object type is not 'logic' for %s (%d)", m_name.c_str(), m_fli_type);
             return NULL;
     }
 
@@ -318,7 +318,7 @@ const char* FliLogicObjHdl::get_signal_value_binstr()
 int FliLogicObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
-        LOG_CRITICAL("Force or release action not supported for FLI.");
+        LOG_ERROR("Force or release action not supported for FLI.");
         return -1;
     }
 
@@ -351,7 +351,7 @@ int FliLogicObjHdl::set_signal_value(const long value, const gpi_set_action_t ac
 int FliLogicObjHdl::set_signal_value_binstr(std::string &value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
-        LOG_CRITICAL("Force or release action not supported for FLI.");
+        LOG_ERROR("Force or release action not supported for FLI.");
         return -1;
     }
 
@@ -435,7 +435,7 @@ long FliIntObjHdl::get_signal_value_long()
 int FliIntObjHdl::set_signal_value(const long value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
-        LOG_CRITICAL("Force or release action not supported for FLI.");
+        LOG_ERROR("Force or release action not supported for FLI.");
         return -1;
     }
 
@@ -474,7 +474,7 @@ double FliRealObjHdl::get_signal_value_real()
 int FliRealObjHdl::set_signal_value(const double value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
-        LOG_CRITICAL("Force or release action not supported for FLI.");
+        LOG_ERROR("Force or release action not supported for FLI.");
         return -1;
     }
 
@@ -522,7 +522,7 @@ const char* FliStringObjHdl::get_signal_value_str()
 int FliStringObjHdl::set_signal_value_str(std::string &value, const gpi_set_action_t action)
 {
     if (action != GPI_DEPOSIT) {
-        LOG_CRITICAL("Force or release action not supported for FLI.");
+        LOG_ERROR("Force or release action not supported for FLI.");
         return -1;
     }
 

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -932,8 +932,11 @@ void handle_vhpi_callback(const vhpiCbDataT *cb_data)
 {
     VhpiCbHdl *cb_hdl = (VhpiCbHdl*)cb_data->user_data;
 
-    if (!cb_hdl)
-        LOG_CRITICAL("VHPI: Callback data corrupted");
+    if (!cb_hdl) {
+        LOG_CRITICAL("VHPI: Callback data corrupted: ABORTING");
+        gpi_embed_end();
+        return;
+    }
 
     gpi_cb_state_e old_state = cb_hdl->get_call_state();
 

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -164,7 +164,8 @@ int VpiArrayObjHdl::initialise(std::string &name, std::string &fq_name) {
         }
 
         if (rangeHdl == NULL) {
-            LOG_CRITICAL("Unable to get range for indexable object");
+            LOG_ERROR("Unable to get range for indexable object");
+            return -1;
         } else {
             vpi_free_object(iter); // Need to free iterator since exited early
 
@@ -185,7 +186,8 @@ int VpiArrayObjHdl::initialise(std::string &name, std::string &fq_name) {
         check_vpi_error();
         m_range_right = val.value.integer;
     } else {
-        LOG_CRITICAL("Unable to get range for indexable object");
+        LOG_ERROR("Unable to get range for indexable object");
+        return -1;
     }
 
     /* vpiSize will return a size that is incorrect for multi-dimensional arrays so use the range
@@ -260,7 +262,8 @@ int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
                         check_vpi_error();
                         m_range_right = val.value.integer;
                     } else {
-                        LOG_CRITICAL("Unable to get range for indexable object");
+                        LOG_ERROR("Unable to get range for indexable object");
+                        return -1;
                     }
                 }
                 else {

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -96,11 +96,13 @@ int VpiCbHdl::cleanup_callback()
 
     if (m_state == GPI_PRIMED) {
         if (!m_obj_hdl) {
-            LOG_CRITICAL("VPI: passed a NULL pointer : ABORTING");
+            LOG_ERROR("VPI: passed a NULL pointer");
+            return -1;
         }
 
         if (!(vpi_remove_cb(get_handle<vpiHandle>()))) {
-            LOG_CRITICAL("VPI: unable to remove callback : ABORTING");
+            LOG_ERROR("VPI: unable to remove callback");
+            return -1;
         }
 
         check_vpi_error();
@@ -108,7 +110,8 @@ int VpiCbHdl::cleanup_callback()
 #ifndef MODELSIM
         /* This is disabled for now, causes a small leak going to put back in */
         if (!(vpi_free_object(get_handle<vpiHandle>()))) {
-            LOG_CRITICAL("VPI: unable to free handle : ABORTING");
+            LOG_ERROR("VPI: unable to free handle");
+            return -1;
         }
 #endif
     }
@@ -461,7 +464,8 @@ int VpiValueCbHdl::cleanup_callback()
     /* This is a recurring callback so just remove when
      * not wanted */
     if (!(vpi_remove_cb(get_handle<vpiHandle>()))) {
-        LOG_CRITICAL("VPI: unbale to remove callback : ABORTING");
+        LOG_ERROR("VPI: unable to remove callback");
+        return -1;
     }
 
     m_obj_hdl = NULL;

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -572,6 +572,8 @@ int32_t handle_vpi_callback(p_cb_data cb_data)
 
     if (!cb_hdl) {
         LOG_CRITICAL("VPI: Callback data corrupted: ABORTING");
+        gpi_embed_end();
+        return -1;
     }
 
     gpi_cb_state_e old_state = cb_hdl->get_call_state();

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -543,8 +543,7 @@ GpiCbHdl *VpiImpl::register_nexttime_callback()
 
 int VpiImpl::deregister_callback(GpiCbHdl *gpi_hdl)
 {
-    gpi_hdl->cleanup_callback();
-    return 0;
+    return gpi_hdl->cleanup_callback();
 }
 
 // If the Python world wants things to shut down then unregister
@@ -587,13 +586,15 @@ int32_t handle_vpi_callback(p_cb_data cb_data)
 
         /* We have re-primed in the handler */
         if (new_state != GPI_PRIMED)
-            if (cb_hdl->cleanup_callback())
+            if (cb_hdl->cleanup_callback()) {
                 delete cb_hdl;
+            }
 
     } else {
         /* Issue #188: This is a work around for a modelsim */
-        if (cb_hdl->cleanup_callback())
+        if (cb_hdl->cleanup_callback()) {
             delete cb_hdl;
+        }
     }
 
     return rv;


### PR DESCRIPTION
xref #1844. Should fix #1476.

`LOG_CRITICAL` calls `exit`. On Questa 2019 and 2020, `exit` calls the registered shutdown callback immediately. This causes GPI re-entrance from the simulator. The re-entrant call shuts down cocotb and finalizes the interpreter, but the original caller of `exit` might return through now invalid Python code. `LOG_CRITICAL` is *never* a good idea in user-called code. To remedy this, all calls to `LOG_CRITICAL` in user-called code were replaced with `LOG_ERROR` and a error code returned.

For simulator-called function that use `LOG_CRITICAL`, it should be safe. However, some simulator do not call the shutdown callback when `exit` is called, so they don't exit cleanly. Instead we should replace all instances of `LOG_CRITICAL` with `LOG_ERROR` and then call `gpi_embed_end` to cleanup cocotb gracefully.

The one outlier is the `LOG_CRITICAL`s in `cleanup_callback`s. This can be called by either the user (`deregister_callback`) or the simulator (in `handle_(vpi/vhpi/fli)_callback`). This could be solved by replacing `LOG_CRITICAL` with `LOG_ERROR` and returning an error code. If it returns to simulator control, it would *then* call `gpi_embed_end`. However, the current usage of `clenaup_callback` stomps on the return code and just returns 0, so this will require some work.