### PR TITLE
Prevent AXI Lite tests from running when TOPLEVEL_LANG isn't verilog

### DIFF
--- a/examples/axi_lite_slave/tests/Makefile
+++ b/examples/axi_lite_slave/tests/Makefile
@@ -1,5 +1,13 @@
 
 TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+all:
+	@echo "Skipping; this example does not support VHDL at the top-level"
+clean::
+
+else
+
 PWD=$(shell pwd)
 TOPDIR=$(PWD)/..
 PYTHONPATH := ./model:$(PYTHONPATH)
@@ -31,3 +39,4 @@ MODULE=test_axi_lite_slave
 
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
+endif


### PR DESCRIPTION
Only Verilog sources are available, so `TOPLEVEL_LANG=vhdl` doesn't work. Without this protection the Questa regression stack traces.