### PR TITLE
Improve Active-HDL makefile

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -46,7 +46,7 @@ endif
 
 # Create a DO script (Tcl-like but not fully compatible) based on the list of $(VERILOG_SOURCES)
 $(SIM_BUILD)/runsim.do : $(VERILOG_SOURCES) $(VHDL_SOURCES) $(SIM_BUILD)
-	@echo "alib $(RTL_LIBRARY)" >> $@
+	@echo "alib $(RTL_LIBRARY)" > $@
 	@echo "set worklib $(RTL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)
 	@echo "acom $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@


### PR DESCRIPTION
Cleanup/bugfix for Active-HDL:

1. Overwrite `runsim.do` instead of appending when it already exists
~~2. Always re-create `runsim.do` to account for variable changes~~
