### PR TITLE
Cleanup MANIFEST and include LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-recursive-include cocotb/share *.c* *.h *.def Makefile.* Makefile
-recursive-include examples *.v *.py Makefile *.tcl *.cfg
-include version
+recursive-include cocotb/share *
+recursive-include examples *
 include README.md
+include LICENSE
 include cocotb_build_libs.py


### PR DESCRIPTION
Cleanup the MANIFEST.in file.

We didn't include the LICENSE file, the version file no longer exists, and the patterns on the inclusion of example was out of date and the examples wouldn't run.