### PR TITLE
Fix typo in scoreboard error message

### DIFF
--- a/cocotb/scoreboard.py
+++ b/cocotb/scoreboard.py
@@ -161,7 +161,7 @@ class Scoreboard:
                     pass
             log.warning("Difference:\n%s" % hexdiffs(strexp, strgot))
             if self._imm:
-                raise TestFailure("Received transaction differed from expected"
+                raise TestFailure("Received transaction differed from expected "
                                   "transaction")
         else:
             # Don't want to fail the test


### PR DESCRIPTION
Scoreboard use to report message as :
cocotb.result.TestFailure: Received transaction differed from expectedtransaction
with as missing space.
Just correcting adding a space.

First pull request, very basic fix, think good way to test the contribution flow.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
