### PR TITLE
Remove superfluous quotation marks from Makefile

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -118,5 +118,5 @@ $(SIM_BUILD):
 regression: $(COCOTB_RESULTS_FILE)
 
 else
-    $(warning "Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.")
+    $(warning Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.)
 endif # COCOTB_MAKEFILE_INC_INCLUDED


### PR DESCRIPTION
The `warning` function in Make doesn't need quotation marks; if they are
still present, they show up in the output.

Before:

```
$ make sim
a/b/c/Makefile.inc:121: "Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makef ...
```

After:
```
$ make sim
a/b/c/Makefile.inc:121: Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makef ...
```


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->