### PR TITLE
Including the top-level Makefiles is outdated

### DIFF
--- a/makefiles/Makefile.inc
+++ b/makefiles/Makefile.inc
@@ -2,13 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-COCOTB_CONFIG_CMD := $(shell :; command -v cocotb-config)
-ifeq ($(COCOTB_CONFIG_CMD),)
-    $(error 'cocotb-config not found! Cocotb is not installed (or is installed but not on the PATH). \
-             Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#installing-cocotb \
-             for installation instructions.')
-endif
-
-$(error 'Deprecated cocotb file structure detected. \
-         Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#creating-a-makefile \
-         for instructions.')
+$(error Outdated use of cocotb detected. \
+        Please install cocotb, and modify your makefile to \
+        "include $$(shell cocotb-config --makefile)/Makefile.sim" instead. \
+        Please refer to the documentation at https://docs.cocotb.org.)

--- a/makefiles/Makefile.sim
+++ b/makefiles/Makefile.sim
@@ -2,14 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-COCOTB_CONFIG_CMD := $(shell :; command -v cocotb-config)
-ifeq ($(COCOTB_CONFIG_CMD),)
-    $(error 'cocotb-config not found! Cocotb is not installed (or is installed but not on the PATH). \
-             Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#installing-cocotb \
-             for installation instructions.')
-endif
-
-$(error 'Deprecated cocotb file structure detected. \
-         Use "include $$(shell cocotb-config --makefile)/Makefile.sim" instead. \
-         Please refer to https://cocotb.readthedocs.io/en/latest/quickstart.html#creating-a-makefile \
-         for instructions.')
+$(error Outdated use of cocotb detected. \
+        Please install cocotb, and modify your makefile to \
+        "include $$(shell cocotb-config --makefile)/Makefile.sim" instead. \
+        Please refer to the documentation at https://docs.cocotb.org.)


### PR DESCRIPTION
Including these makefiles doesn't work any more -- this functionality
isn't deprecated, it's outdated. Users need to take action. Point them
to the documentation to get that fixed on their side, which often
also involves installing cocotb (instead of running it directly from the
source tree).

This also removes the fragile check for cocotb-config, which was used as
a proxy for "is cocotb installed". The intention is to gently push such
users towards the documentation, since they really need to read up on
the updated installation instructions and cannot simply move along by
going from error message to error message.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->