### PR TITLE
Various makefile cleanups

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -43,7 +43,7 @@ sim:
 SHELL := bash
 
 # Directory containing the cocotb Python module (realpath for Windows compatibility)
-COCOTB_PY_DIR := $(realpath $(shell cocotb-config --prefix))
+COCOTB_PY_DIR := $(realpath $(shell $(COCOTB_CONFIG_CMD) --prefix))
 
 # Directory containing all support files required to build cocotb-based
 # simulations: Makefile fragments, and the simulator libraries.
@@ -59,7 +59,7 @@ export OS
 
 # this ensures we use the same python as the one cocotb was installed into
 # realpath to convert windows paths to unix paths, like cygpath -u
-PYTHON_BIN ?= $(realpath $(shell cocotb-config --python-bin))
+PYTHON_BIN ?= $(realpath $(shell $(COCOTB_CONFIG_CMD) --python-bin))
 
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.deprecations
 

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -36,7 +36,7 @@ COCOTB_MAKEFILE_INC_INCLUDED = 1
 # and RTL compilation phases are still evaluated by makefile dependencies)
 .PHONY: sim
 sim:
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 	$(MAKE) $(COCOTB_RESULTS_FILE)
 
 # Make sure to use bash for the pipefail option used in many simulator Makefiles

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -79,7 +79,7 @@ ifeq ($(MAKECMDGOALS),help)
     help_vars := $(subst %,${newline},$(shell cocotb-config --help-vars | tr \\n %))
     $(info ${help_vars})
     # is there a cleaner way to exit here?
-    $(error "Stopping after printing help")
+    $(error Stopping after printing help)
 endif
 
 # Safety net to bail out early if users go into this Makefile without making
@@ -109,7 +109,8 @@ HAVE_SIMULATOR = $(shell if [ -f $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.$(S
 AVAILABLE_SIMULATORS = $(patsubst .%,%,$(suffix $(wildcard $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.*)))
 
 ifeq ($(HAVE_SIMULATOR),0)
-    $(error "Couldn't find makefile for simulator: "$(SIM_LOWERCASE)"! Available simulators: $(AVAILABLE_SIMULATORS)")
+    $(error Couldn't find makefile for simulator: "$(SIM_LOWERCASE)"! \
+            Available simulators: $(AVAILABLE_SIMULATORS))
 endif
 
 include $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.$(SIM_LOWERCASE)

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -82,6 +82,18 @@ ifeq ($(MAKECMDGOALS),help)
     $(error "Stopping after printing help")
 endif
 
+# Safety net to bail out early if users go into this Makefile without making
+# cocotb-config available in their PATH.
+# Use override to prevent users from overriding COCOTB_CONFIG_CMD, which is not
+# supported. (Modify PATH instead.)
+override COCOTB_CONFIG_CMD := $(shell :; command -v cocotb-config)
+ifeq ($(COCOTB_CONFIG_CMD),)
+    $(error cocotb-config not found! Cocotb is not installed (or is installed \
+            but not on the PATH). \
+            Please refer to https://docs.cocotb.org/en/latest/install.html \
+            for installation instructions.)
+endif
+
 # Default to Icarus if no simulator is defined
 SIM ?= icarus
 
@@ -89,7 +101,7 @@ SIM ?= icarus
 SIM_LOWERCASE := $(shell echo $(SIM) | tr A-Z a-z)
 
 # Directory containing the cocotb Makfiles (realpath for Windows compatibility)
-COCOTB_MAKEFILES_DIR := $(realpath $(shell cocotb-config --makefiles))
+COCOTB_MAKEFILES_DIR := $(realpath $(shell $(COCOTB_CONFIG_CMD) --makefiles))
 
 include $(COCOTB_MAKEFILES_DIR)/Makefile.deprecations
 

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -59,7 +59,7 @@ endif
 	@echo "endsim" >> $@
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do | tee $(SIM_BUILD)/sim.log
@@ -67,6 +67,6 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(CUSTOM_COMPILE_DEPS) $(CUSTOM_S
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -rf work
-	@rm -rf wave.asdb
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r work
+	$(RM) wave.asdb

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -41,7 +41,7 @@ ifneq ($(VERILOG_SOURCES),)
     GPI_EXTRA = cocotbvpi_aldec:cocotbvpi_entry_point
 endif
 else
-   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+   $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 # Create a DO script (Tcl-like but not fully compatible) based on the list of $(VERILOG_SOURCES)

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -90,5 +90,5 @@ endif
 
 
 clean::
-	-@rm -rf $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -46,7 +46,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     CVC_BIN_DIR := $(shell dirname $(CMD))
     export CVC_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -46,7 +46,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     GHDL_BIN_DIR := $(shell dirname $(CMD))
     export GHDL_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -71,7 +71,7 @@ analyse: $(VHDL_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	$(CMD) -m $(GHDL_ARGS) $(COMPILE_ARGS) --workdir=$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL)
 
 $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) -r $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) --vpi=$(LIB_DIR)/libcocotbvpi_ghdl.$(LIB_EXT) $(SIM_ARGS) $(PLUSARGS)
@@ -79,5 +79,5 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	-@rm -rf $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -64,7 +64,7 @@ $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 # Execution phase
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
@@ -72,7 +72,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
@@ -80,5 +80,5 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	-@rm -rf $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -48,7 +48,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     ICARUS_BIN_DIR := $(shell dirname $(CMD))
     export ICARUS_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -41,7 +41,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     IUS_BIN_DIR := $(shell dirname $(CMD))
     export IUS_BIN_DIR
@@ -66,7 +66,7 @@ endif
 
 # IUS errors out if multiple timescales are specified on the command line.
 ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
-    $(error "Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.")
+    $(error Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.)
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
@@ -94,7 +94,7 @@ ifneq ($(VERILOG_SOURCES),)
     HDL_SOURCES += $(VERILOG_SOURCES)
 endif
 else
-   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+   $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -98,7 +98,7 @@ else
 endif
 
 $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
@@ -108,7 +108,7 @@ $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -rf irun.*
-	@rm -rf ncsim.*
-	@rm -rf gdb_cmd_ncsim
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r irun.*
+	$(RM) -r ncsim.*
+	$(RM) -r gdb_cmd_ncsim

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -39,7 +39,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 endif
 
 RTL_LIBRARY ?= work
@@ -89,7 +89,7 @@ ifneq ($(VHDL_SOURCES),)
 endif
 
 else
-   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+   $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -127,7 +127,7 @@ ifeq ($(PYTHON_ARCH),64bit)
 endif
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
@@ -136,4 +136,4 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do
 	$(call check_for_results_file)
 
 clean::
-	-rm -rf $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -45,7 +45,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     ALDEC_BIN_DIR := $(shell dirname $(CMD))
     export ALDEC_BIN_DIR
@@ -98,7 +98,7 @@ ifneq ($(VERILOG_SOURCES),)
 endif
 
 else
-   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+   $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 # Create a TCL script based on the list of $(VERILOG_SOURCES)

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -143,7 +143,7 @@ endif
 # Note it's the redirection of the output rather than the 'do' command
 # that turns on batch mode (i.e. exit on completion/error)
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.tcl | tee $(SIM_BUILD)/sim.log
@@ -151,7 +151,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(CUSTOM_COMPILE_DEPS) $(CUSTOM_
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -rf compile
-	@rm -rf library.cfg
-	@rm -rf dataset.asdb
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r compile
+	$(RM) library.cfg
+	$(RM) dataset.asdb

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -47,7 +47,7 @@ else
 endif
 
 ifeq (, $(CMD))
-     $(error "Unable to locate command >$(CMD_BIN)<")
+     $(error Unable to locate command >$(CMD_BIN)<)
 else
      VCS_BIN_DIR := $(shell dirname $(CMD))
      export VCS_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -79,7 +79,7 @@ $(SIM_BUILD)/simv: $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(CUSTOM_COMPILE_DEPS
 
 # Execution phase
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(SIM_BUILD)/simv +define+COCOTB_SIM=1 $(SIM_ARGS) $(EXTRA_ARGS)
@@ -88,9 +88,9 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)
 
 .PHONY: clean
 clean::
-	-@rm -rf $(SIM_BUILD)
-	-@rm -rf simv.daidir
-	-@rm -rf cm.log
-	-@rm -rf $(COCOTB_RESULTS_FILE)
-	-@rm -rf ucli.key
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r simv.daidir
+	$(RM) cm.log
+	$(RM) $(COCOTB_RESULTS_FILE)
+	$(RM) ucli.key
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -86,11 +86,9 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)
 
 	$(call check_for_results_file)
 
-.PHONY: clean
 clean::
 	$(RM) -r $(SIM_BUILD)
 	$(RM) -r simv.daidir
 	$(RM) cm.log
-	$(RM) $(COCOTB_RESULTS_FILE)
 	$(RM) ucli.key
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -46,7 +46,7 @@ $(SIM_BUILD)/$(TOPLEVEL): $(SIM_BUILD)/Vtop.mk
 	CPPFLAGS="$(SIM_BUILD_FLAGS)" make -C $(SIM_BUILD) -f Vtop.mk
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         $< $(PLUSARGS)
@@ -54,7 +54,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 debug: $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         gdb --args $< $(PLUSARGS)
@@ -62,7 +62,7 @@ debug: $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -f dump.vcd
+	$(RM) -r $(SIM_BUILD)
+	$(RM) dump.vcd
 
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -105,7 +105,7 @@ else
 endif
 
 $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
@@ -115,7 +115,7 @@ $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -rf xrun.*
-	@rm -rf xmsim.*
-	@rm -rf gdb_cmd_xmsim
+	$(RM) $(SIM_BUILD)
+	$(RM) -r xrun.*
+	$(RM) -r xmsim.*
+	$(RM) -r gdb_cmd_xmsim

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -41,7 +41,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     XCELIUM_BIN_DIR := $(shell dirname $(CMD))
     export XCELIUM_BIN_DIR
@@ -74,7 +74,7 @@ endif
 
 # Xcelium errors out if multiple timescales are specified on the command line.
 ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
-    $(error "Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.")
+    $(error Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.)
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
@@ -101,7 +101,7 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
         HDL_SOURCES += $(VERILOG_SOURCES)
     endif
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)


### PR DESCRIPTION
Small cleanups across our Makefiles, see the individual commit messages for details. Mostly non-functional changes, but a small functional change in the VCS makefile.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->