### PR TITLE
Use logger.warning() instead of logger.warn()

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -846,4 +846,4 @@ class Scheduler:
             raise Exception("Cleanup() called outside of the main thread")
 
         for ext in self._pending_threads:
-            self.log.warn("Waiting for %s to exit", ext.thread)
+            self.log.warning("Waiting for %s to exit", ext.thread)

--- a/cocotb/scoreboard.py
+++ b/cocotb/scoreboard.py
@@ -82,8 +82,8 @@ class Scoreboard:
                                "than a list" % str(monitor))
                 continue
             if len(expected_output):
-                self.log.warn("Still expecting %d transactions on %s" %
-                              (len(expected_output), str(monitor)))
+                self.log.warning("Still expecting %d transactions on %s" %
+                                 (len(expected_output), str(monitor)))
                 for index, transaction in enumerate(expected_output):
                     self.log.info("Expecting %d:\n%s" %
                                   (index, hexdump(str(transaction))))


### PR DESCRIPTION
`.warn()` is deprecated and leads to deprecation warnings, see
https://docs.python.org/3/library/logging.html#logging.Logger.warning.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->