### PR TITLE
Collect coverage for code paths containing cocotb

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -115,7 +115,9 @@ class RegressionManager:
 
         if coverage is not None:
             self.log.info("Enabling coverage collection of Python code")
-            self._cov = coverage.coverage(branch=True, omit=["*cocotb*"])
+            # Exclude cocotb itself from coverage collection.
+            cocotb_package_dir = os.path.dirname(__file__)
+            self._cov = coverage.coverage(branch=True, omit=["{}/*".format(cocotb_package_dir)])
             self._cov.start()
 
         # Test Discovery


### PR DESCRIPTION
The Python coverage collection (enabled with `COVERAGE=1`)
excludes all paths containing `cocotb` in any form. For example, users
put their code in in `/home/joe/myproject/cocotb-tests`, no coverage
would be collected for their code.

Unfortunately, restricting coverage collection to "user code" doesn't
seem to be as easy as one would hope. This commit goes for a similar
workaround as before, just hopefully slightly more useful: installed
code is identified by looking for the `site-packages` path component,
and then excluded.

I'm not convinced that this exclusion is worth it, maybe we should
either find a correct solution, or don't exclude cocotb code (which is
"ugly", but at least correct).


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->