### PR TITLE
Provide better user experience for setting log levels

### DIFF
--- a/documentation/source/newsfragments/1843.change.rst
+++ b/documentation/source/newsfragments/1843.change.rst
@@ -1,1 +1,1 @@
-Certain methods on the :mod:`cocotb.simulator` Python module now throw a :exc`RuntimeError` when no simulator is present, making it safe to use :mod:`cocotb` without a simulator present.
+Certain methods on the :mod:`cocotb.simulator` Python module now throw a :exc:`RuntimeError` when no simulator is present, making it safe to use :mod:`cocotb` without a simulator present.

--- a/documentation/source/newsfragments/1898.change.rst
+++ b/documentation/source/newsfragments/1898.change.rst
@@ -1,0 +1,2 @@
+Invalid values of the environment variable :envvar:`COCOTB_LOG_LEVEL` are no longer ignored.
+They now raise an exception with instructions how to fix the problem.


### PR DESCRIPTION
The log level for the "cocotb" logger can be set with the environment
variable COCOTB_LOG_LEVEL. This variable is documented to accept only
uppercase log level names, and that works.

However, the checking code was slightly fragile. If the `logging` module
happened to have an attribute named like a value of COCOTB_LOG_LEVEL, the
error checking wouldn't catch it and instead a TypeError would be
thrown. See #1888 for a full stacktrace. Hitting this behavior is quite
easy by passing in `debug` instead of `DEBUG`, for example.

This patch improves this behavior by:
- Always converting log level names passed in through the environment
  variable to upper case. That's a convenience function which is
  intentionally not documented to encourage our users to do the right
  thing (TM). It's tested, however.
- Strengthening the error checking by explicitly checking for valid
  values. (Unfortunately, the `logging` class is missing an essential
  piece of functionality here to avoid code duplication.)
- Making the error message more actionable by mentioning (a) where the
  invalid value is coming from, (b) showing which value is used instead,
  and (c) giving other valid options to select from.
- Adding a test.

Fixes #1888


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->