### PR TITLE
Mean Verilator

### DIFF
--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -713,10 +713,10 @@ VpiIterator::VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiIterator(i
         return;
     }
 
-    LOG_DEBUG("Created iterator working from type %d %s (%s)",
-              *one2many,
+    LOG_DEBUG("Created iterator working from '%s' with type %s(%d)",
               vpi_get_str(vpiFullName, vpi_hdl),
-              vpi_get_str(vpiType, vpi_hdl));
+              vpi_get_str(vpiType, vpi_hdl),
+              type);
 
     m_iterator = iterator;
 }

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -241,7 +241,7 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
 
     new_obj->initialise(name, fq_name);
 
-    LOG_DEBUG("VPI: Created object with type was %s(%d)",
+    LOG_DEBUG("VPI: Created GPI object from type %s(%d)",
               vpi_get_str(vpiType, new_hdl), type);
 
     return new_obj;

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -65,9 +65,8 @@ static inline int __check_vpi_error(const char *file, const char *func, long lin
             loglevel = GPIWarning;
     }
 
-    gpi_log("cocotb.gpi", loglevel, file, func, line,
-            "VPI Error %s\nPROD %s\nCODE %s\nFILE %s",
-            info.message, info.product, info.code, info.file);
+    gpi_log("cocotb.gpi", loglevel, file, func, line, "VPI error");
+    gpi_log("cocotb.gpi", loglevel, info.file, info.product, info.line, info.message);
 
 #endif
     return level;

--- a/examples/mean/hdl/mean.sv
+++ b/examples/mean/hdl/mean.sv
@@ -7,10 +7,16 @@
 
 `timescale 1ns/1ps
 
+`ifdef VERILATOR  // make parameter readable from VPI
+  `define VL_RD /*verilator public_flat_rd*/
+`else
+  `define VL_RD
+`endif
+
 
 module mean #(
-  parameter int BUS_WIDTH = 4,
-  parameter int DATA_WIDTH = 6
+  parameter int BUS_WIDTH  `VL_RD = 4,
+  parameter int DATA_WIDTH `VL_RD = 6
 ) (
   input  logic                  clk,
   input  logic                  rst,
@@ -60,13 +66,17 @@ module mean #(
   assign o_data = s_sum >> $clog2(BUS_WIDTH);
 
 
+`ifndef VERILATOR
   initial begin
     int idx;
     $dumpfile("dump.vcd");
     $dumpvars(0, mean);
-    for (idx = 0; idx < BUS_WIDTH; idx++)
+  `ifdef __ICARUS__
+    for (idx = 0; idx < BUS_WIDTH; idx++) begin
         $dumpvars(0, i_data[idx]);
-    #1;
+    end
+  `endif
   end
+`endif
 
 endmodule

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -21,4 +21,8 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
+ifeq ($(SIM),verilator)
+    EXTRA_ARGS += $(PWD)/verilator_waiver.vlt
+endif
+
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/examples/mean/tests/verilator_waiver.vlt
+++ b/examples/mean/tests/verilator_waiver.vlt
@@ -1,0 +1,7 @@
+// This file is public domain, it can be freely copied without restrictions.
+// SPDX-License-Identifier: CC0-1.0
+
+// waivers for verilator
+
+`verilator_config
+lint_off -rule WIDTH


### PR DESCRIPTION
- Fix some logging issues that surfaced in #1851 . 
- Add a waiver to mean example for Verilator linting warnings.
- Add /*verilator public_flat_rd*/ to mean example parameter declarations to make them visible in Verilator.