### PR TITLE
XGMII Driver: Remove init value in helper class and use idle() function instead

### DIFF
--- a/cocotb/drivers/xgmii.py
+++ b/cocotb/drivers/xgmii.py
@@ -78,10 +78,6 @@ class _XGMIIBus:
         self._interleaved = interleaved
         self._nbytes = nbytes
 
-        # Default to idle
-        for i in range(nbytes):
-            self[i] = (0x07, True)
-
     def __setitem__(self, index, value):
         byte, ctrl = value
 
@@ -138,6 +134,7 @@ class XGMII(Driver):
         self.clock = clock
         self.bus = _XGMIIBus(len(signal)//9, interleaved=interleaved)
         Driver.__init__(self)
+        self.idle()
 
     @staticmethod
     def layer1(packet: bytes) -> bytes:

--- a/documentation/source/newsfragments/1905.bugfix.rst
+++ b/documentation/source/newsfragments/1905.bugfix.rst
@@ -1,0 +1,1 @@
+The :class:`~cocotb.drivers.xgmii.XGMII` driver no longer emits a corrupted word on the first transfer.


### PR DESCRIPTION
Fix candidate for #1904.
It also clears up the use of the helper class a bit, as the values are now only set by the main `XGMII(Driver)` which already has a function to set the IDLE value.