### PR TITLE
Use std::initializer_list in place of GpiIteratorMapping

### DIFF
--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -418,7 +418,6 @@ private:
 class FliIterator : public GpiIterator {
 public:
     enum OneToMany {
-        OTM_END = 0,
         OTM_CONSTANTS,  // include Generics
         OTM_SIGNALS,
         OTM_REGIONS,
@@ -434,7 +433,7 @@ private:
     void populate_handle_list(OneToMany childType);
 
 private:
-    static GpiIteratorMapping<int, OneToMany> iterate_over;      /* Possible mappings */
+    static std::map<int, std::vector<OneToMany>> iterate_over;   /* Possible mappings */
     std::vector<OneToMany> *selected;                            /* Mapping currently in use */
     std::vector<OneToMany>::iterator one2many;
 

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -224,40 +224,6 @@ protected:
     GpiObjHdl *m_parent;
 };
 
-template <class Ti, class Tm> class GpiIteratorMapping {
-public:
-    GpiIteratorMapping(void(*populate)(GpiIteratorMapping<Ti, Tm>&)) {
-        populate(*this);
-    }
-public:
-    std::vector<Tm>* get_options(Ti type);
-    void add_to_options(Ti type, Tm *options);
-private:
-    std::map<Ti, std::vector<Tm> > options_map;
-};
-
-template <class Ti, class Tm> void GpiIteratorMapping<Ti, Tm>::add_to_options(Ti type, Tm *options)
-{
-    std::vector<Tm> option_vec;
-    Tm *ptr = options;
-    while (*ptr) {
-        option_vec.push_back(*ptr);
-        ptr++;
-    }
-    options_map[type] = option_vec;
-}
-
-template <class Ti, class Tm> std::vector<Tm> * GpiIteratorMapping<Ti, Tm>::get_options(Ti type)
-{
-    typename std::map<Ti, std::vector<Tm> >::iterator valid = options_map.find(type);
-
-    if (options_map.end() == valid) {
-        return NULL;
-    } else {
-        return &valid->second;
-    }
-}
-
 
 class GpiImplInterface {
 public:

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -916,81 +916,64 @@ VhpiNextPhaseCbHdl::VhpiNextPhaseCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
     cb_data.time = &vhpi_time;
 }
 
-void vhpi_mappings(GpiIteratorMapping<vhpiClassKindT, vhpiOneToManyT> &map)
-{
-    /* vhpiRootInstK */
-    vhpiOneToManyT root_options[] = {
-        vhpiInternalRegions,
-        vhpiSigDecls,
-        vhpiVarDecls,
-        vhpiPortDecls,
-        vhpiGenericDecls,
-        vhpiConstDecls,
-        //    vhpiIndexedNames,
-        vhpiCompInstStmts,
-        vhpiBlockStmts,
-        (vhpiOneToManyT)0,
+decltype(VhpiIterator::iterate_over) VhpiIterator::iterate_over = []{
+    /* for reused lists */
+    std::initializer_list<vhpiOneToManyT> root_options;
+    std::initializer_list<vhpiOneToManyT> sig_options;
+    std::initializer_list<vhpiOneToManyT> simplesig_options;
+    std::initializer_list<vhpiOneToManyT> gen_options;
+
+    return decltype(VhpiIterator::iterate_over) {
+        {vhpiRootInstK, root_options = {
+            vhpiInternalRegions,
+            vhpiSigDecls,
+            vhpiVarDecls,
+            vhpiPortDecls,
+            vhpiGenericDecls,
+            vhpiConstDecls,
+            //    vhpiIndexedNames,
+            vhpiCompInstStmts,
+            vhpiBlockStmts,
+        }},
+        {vhpiCompInstStmtK, root_options},
+
+        {vhpiGenericDeclK, sig_options = {
+            vhpiIndexedNames,
+            vhpiSelectedNames,
+        }},
+        {vhpiSigDeclK, sig_options},
+        {vhpiSelectedNameK, sig_options},
+        {vhpiIndexedNameK, sig_options},
+        {vhpiPortDeclK, sig_options},
+
+        {vhpiCondSigAssignStmtK, simplesig_options = {
+            vhpiDecls,
+            vhpiInternalRegions,
+            vhpiSensitivitys,
+            vhpiStmts,
+        }},
+        {vhpiSimpleSigAssignStmtK, simplesig_options},
+        {vhpiSelectSigAssignStmtK, simplesig_options},
+
+        {vhpiForGenerateK, gen_options = {
+            vhpiDecls,
+            vhpiInternalRegions,
+            vhpiSigDecls,
+            vhpiVarDecls,
+            vhpiConstDecls,
+            vhpiCompInstStmts,
+            vhpiBlockStmts,
+        }},
+        {vhpiIfGenerateK, gen_options},
+        {vhpiBlockStmtK, gen_options},
+
+        {vhpiConstDeclK, {
+            vhpiAttrSpecs,
+            vhpiIndexedNames,
+            vhpiSelectedNames,
+        }},
     };
-    map.add_to_options(vhpiRootInstK, &root_options[0]);
-
-    /* vhpiSigDeclK */
-    vhpiOneToManyT sig_options[] = {
-        vhpiIndexedNames,
-        vhpiSelectedNames,
-        (vhpiOneToManyT)0,
-    };
-    map.add_to_options(vhpiGenericDeclK, &sig_options[0]);
-    map.add_to_options(vhpiSigDeclK, &sig_options[0]);
-
-    /* vhpiIndexedNameK */
-    map.add_to_options(vhpiSelectedNameK, &sig_options[0]);
-    map.add_to_options(vhpiIndexedNameK, &sig_options[0]);
-
-    /* vhpiCompInstStmtK */
-    map.add_to_options(vhpiCompInstStmtK, &root_options[0]);
-
-    /* vhpiSimpleSigAssignStmtK */
-    vhpiOneToManyT simplesig_options[] = {
-        vhpiDecls,
-        vhpiInternalRegions,
-        vhpiSensitivitys,
-        vhpiStmts,
-        (vhpiOneToManyT)0,
-    };
-    map.add_to_options(vhpiCondSigAssignStmtK, &simplesig_options[0]);
-    map.add_to_options(vhpiSimpleSigAssignStmtK, &simplesig_options[0]);
-    map.add_to_options(vhpiSelectSigAssignStmtK, &simplesig_options[0]);
-
-    /* vhpiPortDeclK */
-    map.add_to_options(vhpiPortDeclK, &sig_options[0]);
-
-    /* vhpiForGenerateK */
-    vhpiOneToManyT gen_options[] = {
-        vhpiDecls,
-        vhpiInternalRegions,
-        vhpiSigDecls,
-        vhpiVarDecls,
-        vhpiConstDecls,
-        vhpiCompInstStmts,
-        vhpiBlockStmts,
-        (vhpiOneToManyT)0,
-    };
-    map.add_to_options(vhpiForGenerateK, &gen_options[0]);
-    map.add_to_options(vhpiIfGenerateK, &gen_options[0]);
-    map.add_to_options(vhpiBlockStmtK, &gen_options[0]);
-
-    /* vhpiConstDeclK */
-    vhpiOneToManyT const_options[] = {
-        vhpiAttrSpecs,
-        vhpiIndexedNames,
-        vhpiSelectedNames,
-        (vhpiOneToManyT)0,
-    };
-    map.add_to_options(vhpiConstDeclK, &const_options[0]);
-
-}
-
-GpiIteratorMapping<vhpiClassKindT, vhpiOneToManyT> VhpiIterator::iterate_over(vhpi_mappings);
+}();
 
 VhpiIterator::VhpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiIterator(impl, hdl),
                                                                      m_iterator(NULL),
@@ -1000,9 +983,13 @@ VhpiIterator::VhpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiIterator
     vhpiHandleT vhpi_hdl = m_parent->get_handle<vhpiHandleT>();
 
     vhpiClassKindT type = (vhpiClassKindT)vhpi_get(vhpiKindP, vhpi_hdl);
-    if (NULL == (selected = iterate_over.get_options(type))) {
+    try {
+        selected = &iterate_over.at(type);
+    }
+    catch (std::out_of_range const&) {
         LOG_WARN("VHPI: Implementation does not know how to iterate over %s(%d)",
                  vhpi_get_str(vhpiKindStrP, vhpi_hdl), type);
+        selected = nullptr;
         return;
     }
 

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -232,7 +232,7 @@ public:
 private:
     vhpiHandleT m_iterator;
     vhpiHandleT m_iter_obj;
-    static GpiIteratorMapping<vhpiClassKindT, vhpiOneToManyT> iterate_over;      /* Possible mappings */
+    static std::map<vhpiClassKindT, std::vector<vhpiOneToManyT>> iterate_over;      /* Possible mappings */
     std::vector<vhpiOneToManyT> *selected; /* Mapping currently in use */
     std::vector<vhpiOneToManyT>::iterator one2many;
 };

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -552,117 +552,94 @@ VpiNextPhaseCbHdl::VpiNextPhaseCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
     cb_data.reason = cbNextSimTime;
 }
 
-void vpi_mappings(GpiIteratorMapping<int32_t, int32_t> &map)
-{
-    /* vpiModule */
-    int32_t module_options[] = {
-        //vpiModule,            // Aldec SEGV on mixed language
-        //vpiModuleArray,       // Aldec SEGV on mixed language
-        //vpiIODecl,            // Don't care about these
-        vpiNet,
-        vpiNetArray,
-        vpiReg,
-        vpiRegArray,
-        vpiMemory,
-        vpiIntegerVar,
-        vpiRealVar,
-        vpiRealNet,
-        vpiStructVar,
-        vpiStructNet,
-        //vpiVariables          // Aldec SEGV on plain Verilog
-        vpiNamedEvent,
-        vpiNamedEventArray,
-        vpiParameter,
-        //vpiSpecParam,         // Don't care
-        //vpiParamAssign,       // Aldec SEGV on mixed language
-        //vpiDefParam,          // Don't care
-        vpiPrimitive,
-        vpiPrimitiveArray,
-        //vpiContAssign,        // Don't care
-        vpiProcess,             // Don't care
-        vpiModPath,
-        vpiTchk,
-        vpiAttribute,
-        vpiPort,
-        vpiInternalScope,
-        //vpiInterface,         // Aldec SEGV on mixed language
-        //vpiInterfaceArray,    // Aldec SEGV on mixed language
-        0
-    };
-    map.add_to_options(vpiModule, &module_options[0]);
-    map.add_to_options(vpiGenScope, &module_options[0]);
+decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = []{
+    /* for reused lists */
+    std::initializer_list<int32_t> module_options;
+    std::initializer_list<int32_t> struct_options;
 
-    int32_t struct_options[] = {
-        vpiNet,
+    return decltype(VpiIterator::iterate_over) {
+        {vpiModule, module_options = {
+            //vpiModule,            // Aldec SEGV on mixed language
+            //vpiModuleArray,       // Aldec SEGV on mixed language
+            //vpiIODecl,            // Don't care about these
+            vpiNet,
+            vpiNetArray,
+            vpiReg,
+            vpiRegArray,
+            vpiMemory,
+            vpiIntegerVar,
+            vpiRealVar,
+            vpiRealNet,
+            vpiStructVar,
+            vpiStructNet,
+            //vpiVariables          // Aldec SEGV on plain Verilog
+            vpiNamedEvent,
+            vpiNamedEventArray,
+            vpiParameter,
+            //vpiSpecParam,         // Don't care
+            //vpiParamAssign,       // Aldec SEGV on mixed language
+            //vpiDefParam,          // Don't care
+            vpiPrimitive,
+            vpiPrimitiveArray,
+            //vpiContAssign,        // Don't care
+            vpiProcess,             // Don't care
+            vpiModPath,
+            vpiTchk,
+            vpiAttribute,
+            vpiPort,
+            vpiInternalScope,
+            //vpiInterface,         // Aldec SEGV on mixed language
+            //vpiInterfaceArray,    // Aldec SEGV on mixed language
+        }},
+        {vpiGenScope, module_options},
+
+        {vpiStructVar, struct_options = {
+            vpiNet,
 #ifndef IUS
-        vpiNetArray,
+            vpiNetArray,
 #endif
-        vpiReg,
-        vpiRegArray,
-        vpiMemory,
-        vpiParameter,
-        vpiPrimitive,
-        vpiPrimitiveArray,
-        vpiAttribute,
-        vpiMember,
-        0
-    };
-    map.add_to_options(vpiStructVar, &struct_options[0]);
-    map.add_to_options(vpiStructNet, &struct_options[0]);
+            vpiReg,
+            vpiRegArray,
+            vpiMemory,
+            vpiParameter,
+            vpiPrimitive,
+            vpiPrimitiveArray,
+            vpiAttribute,
+            vpiMember,
+        }},
+        {vpiStructNet, struct_options},
 
-    /* vpiNet */
-    int32_t net_options[] = {
-        //vpiContAssign,        // Driver and load handled separately
-        //vpiPrimTerm,
-        //vpiPathTerm,
-        //vpiTchkTerm,
-        //vpiDriver,
-        //vpiLocalDriver,
-        //vpiLoad,
-        //vpiLocalLoad,
-        vpiNetBit,
-        0
+        {vpiNet, {
+            //vpiContAssign,        // Driver and load handled separately
+            //vpiPrimTerm,
+            //vpiPathTerm,
+            //vpiTchkTerm,
+            //vpiDriver,
+            //vpiLocalDriver,
+            //vpiLoad,
+            //vpiLocalLoad,
+            vpiNetBit,
+        }},
+        {vpiNetArray, {
+            vpiNet,
+        }},
+        {vpiRegArray, {
+            vpiReg,
+        }},
+        {vpiMemory, {
+            vpiMemoryWord,
+        }},
+        {vpiPort, {
+            vpiPortBit,
+        }},
+        {vpiGate, {
+            vpiPrimTerm,
+            vpiTableEntry,
+            vpiUdpDefn,
+        }},
     };
-    map.add_to_options(vpiNet, &net_options[0]);
+}();
 
-    /* vpiNetArray */
-    int32_t netarray_options[] = {
-        vpiNet,
-        0
-    };
-    map.add_to_options(vpiNetArray, &netarray_options[0]);
-
-    /* vpiRegArray */
-    int32_t regarray_options[] = {
-        vpiReg,
-        0
-    };
-    map.add_to_options(vpiRegArray, &regarray_options[0]);
-
-    /* vpiMemory */
-    int32_t memory_options[] = {
-        vpiMemoryWord,
-        0
-    };
-    map.add_to_options(vpiMemory, &memory_options[0]);
-
-    /* vpiPort */
-    int32_t port_options[] = {
-        vpiPortBit,
-        0
-    };
-    map.add_to_options(vpiPort, &port_options[0]);
-
-    int32_t gate_options[] = {
-        vpiPrimTerm,
-        vpiTableEntry,
-        vpiUdpDefn,
-        0
-    };
-    map.add_to_options(vpiGate, &gate_options[0]);
-}
-
-GpiIteratorMapping<int32_t, int32_t> VpiIterator::iterate_over(vpi_mappings);
 
 VpiIterator::VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiIterator(impl, hdl),
                                                                    m_iterator(NULL)
@@ -671,9 +648,13 @@ VpiIterator::VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiIterator(i
     vpiHandle vpi_hdl = m_parent->get_handle<vpiHandle>();
 
     int type = vpi_get(vpiType, vpi_hdl);
-    if (NULL == (selected = iterate_over.get_options(type))) {
+    try {
+        selected = &iterate_over.at(type);
+    }
+    catch (std::out_of_range const&) {
         LOG_WARN("VPI: Implementation does not know how to iterate over %s(%d)",
                   vpi_get_str(vpiType, vpi_hdl), type);
+        selected = nullptr;
         return;
     }
 

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -201,7 +201,7 @@ public:
 
 private:
     vpiHandle m_iterator;
-    static GpiIteratorMapping<int32_t, int32_t> iterate_over;      /* Possible mappings */
+    static std::map<int32_t, std::vector<int32_t>> iterate_over;  /* Possible mappings */
     std::vector<int32_t> *selected; /* Mapping currently in use */
     std::vector<int32_t>::iterator one2many;
 };


### PR DESCRIPTION
The helper functions this type provided are subsumed by C++11 syntax in the standard library.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
