### PR TITLE
Initial library / CI coverage support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,8 @@ jobs:
         - export CONDA_PATH="\$env:Path = ';C:\miniconda3;C:\miniconda3\Library\mingw-w64\bin;C:\miniconda3\Library\usr\bin;C:\miniconda3\Library\bin;C:\miniconda3\Scripts;C:\miniconda3\bin;C:\miniconda3\condabin;C:\iverilog\bin;' + \$env:Path"
         - powershell "$CONDA_PATH; conda install --yes -c msys2 m2-base m2-make m2w64-toolchain libpython"
         - powershell "$CONDA_PATH; conda install --yes virtualenv"
+        # needed to make the builtin sqlite3 module (used by coverage) work - see gh-1909
+        - powershell '$CONDA_PATH; cp C:\miniconda3\Library\bin\sqlite3.dll C:\miniconda3\DLLs\'
         - powershell "$CONDA_PATH; pip install tox"
       script:
         # TODO[gh-1372]: the default compiler on windows, msvc, is not supported

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -126,6 +126,9 @@ The value passed to the Python default random number generator.
 See :envvar:`RANDOM_SEED` for details on how the value is computed.
 """
 
+_library_coverage = None
+""" used for cocotb library coverage """
+
 
 def fork(coro):
     """ Schedule a coroutine to be run concurrently. See :ref:`coroutines` for details on its use. """
@@ -154,6 +157,16 @@ def _initialise_testbench(argv_):
     comma-separated list of modules to be executed before the first test.
     """
     _rlock.acquire()
+
+    if "COCOTB_LIBRARY_COVERAGE" in os.environ:
+        import coverage
+
+        global _library_coverage
+        _library_coverage = coverage.coverage(
+            data_file=".coverage.cocotb",
+            branch=True,
+            include=["{}/*".format(os.path.dirname(__file__))])
+        _library_coverage.start()
 
     global argc, argv
     argv = argv_

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -261,6 +261,10 @@ class RegressionManager:
             self.log.info("Writing coverage data")
             self._cov.save()
             self._cov.html_report()
+        if cocotb._library_coverage is not None:
+            # TODO: move this once we have normal shutdown behavior to _sim_event
+            cocotb._library_coverage.stop()
+            cocotb._library_coverage.save()
 
         # Setup simulator finalization
         simulator.stop_simulator()

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py3
 setenv =
     CFLAGS = -Werror
     CXXFLAGS = -Werror
+    COCOTB_LIBRARY_COVERAGE = 1
 passenv =
     SIM
     TOPLEVEL_LANG
@@ -21,9 +22,11 @@ deps =
 commands =
     pytest
     make test
+    bash -c 'find . -type f -name "\.coverage\.cocotb" | xargs coverage combine --append'
 
 whitelist_externals =
     make
+    bash
 
 # needed for coverage to work
 usedevelop=True


### PR DESCRIPTION
Initial addition of cocotb library coverage support for regressions.

I started the collection in `__init__.py`, therefor there no collection in the root of that file.Ideally, we would start coverage before we imported cocotb the first time. This would probably be best living near the code that will also do custom entry point loading.

Total coverage was obtained with the following commands:
```bash
make LIBRARY_COVERAGE=1
find . -name ".library_coverage" | xargs coverage combine
coverage report  # or coverage html
```

I attached the [current coverage file for Icarus](https://github.com/cocotb/cocotb/files/4734146/coverage.zip) for your reading pleasure. Total coverage isn't great, at 63%.

### TODO
- [x] Figure out how to combine the results between CI runs?
- [ ] Move coverage start and stop farther out past the first import and last use of the cocotb module
- [x] Add badge to README