### PR TITLE
combine_results.py: xml.etree.cElementTree removed in Python 3.9

### DIFF
--- a/bin/combine_results.py
+++ b/bin/combine_results.py
@@ -8,7 +8,7 @@ Useful for Jenkins.
 import os
 import sys
 import argparse
-from xml.etree import cElementTree as ET
+from xml.etree import ElementTree as ET
 
 
 def find_all(name, path):


### PR DESCRIPTION
The ```combine_results``` script imports xml.etree.cElementTree; this module was deprecated in Python 3.3 and finally removed in Python 3.9. According to the [3.9 release notes](https://docs.python.org/3.9/whatsnew/3.9.html#removed), xml.etree.ElementTree should now be used instead.

Since we currently require Python 3.5+, and this change was first made in Python 3.3, I think there should be no problem switching the import to use xml.etree.ElementTree.
