### PR TITLE
Collect coverage information for the pytest tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,14 @@ jobs:
         - sudo apt-get -y install gperf swig
         - if [[ ! -e "./iverilog/README.txt" ]]; then rm -rf iverilog; git clone https://github.com/steveicarus/iverilog.git --depth=1 --branch v10_3; fi
         - cd iverilog && autoconf && ./configure && make -j2 && sudo make install && cd ..
-        - pip install --upgrade tox virtualenv
+        - pip install --upgrade tox virtualenv codecov
         - pyenv global system $TRAVIS_PYTHON_VERSION
       script:
         - echo 'Running cocotb tests with Python 3.7 ...' && echo -en 'travis_fold:start:cocotb_py37'
         - tox -e py37
         - echo 'travis_fold:end:cocotb_py37'
+      after_success: &travis_linux_post
+        - codecov
 
     - stage: SimTests
       python: 3.8
@@ -59,6 +61,7 @@ jobs:
         - echo 'Running cocotb tests with Python 3.8 ...' && echo -en 'travis_fold:start:cocotb_py38'
         - tox -e py38
         - echo 'travis_fold:end:cocotb_py38'
+      after_success: *travis_linux_post
 
     - stage: SimTests
       python: 3.6.7
@@ -67,6 +70,7 @@ jobs:
         - echo 'Running cocotb tests with Python 3.6.7 ...' && echo -en 'travis_fold:start:cocotb_py36'
         - tox -e py36
         - echo 'travis_fold:end:cocotb_py36'
+      after_success: *travis_linux_post
 
     - stage: SimTests
       python: 3.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,13 @@ All changes which should go into the main codebase of cocotb must follow this se
   # SPDX-License-Identifier: CC0-1.0
   ```
 
+Running tests locally
+---------------------
+
+Our tests are managed by `tox`, which runs both `pytest` and our system of makefiles.
+This exercises the contents of both the `tests` and `examples` directories.
+
+
 Managing of Issues and Pull Requests
 ------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://travis-ci.org/cocotb/cocotb.svg?branch=master)](https://travis-ci.org/cocotb/cocotb)
 [![PyPI](https://img.shields.io/pypi/dm/cocotb.svg?label=PyPI%20downloads)](https://pypi.org/project/cocotb/)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cocotb/cocotb)
+[![codecov](https://codecov.io/gh/cocotb/cocotb/branch/master/graph/badge.svg)](https://codecov.io/gh/cocotb/cocotb)
 
 * Read the [documentation](https://docs.cocotb.org)
 * Get involved:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ ignore =
     W504  # line break after binary operator
 
 [tool:pytest]
-addopts = -v
+addopts = -v --cov=cocotb --cov-branch
 testpaths = tests/pytest
 confcutdir = tests/pytest
 # log_cli = true

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,9 @@ commands =
 whitelist_externals =
     make
 
+# needed for coverage to work
+usedevelop=True
+
 [testenv:py3_mingw]
 install_command =
     python -m pip install  --global-option build_ext --global-option --compiler=mingw32 {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     coverage
     xunitparser
     pytest
+    pytest-cov
 
 commands =
     pytest


### PR DESCRIPTION
This does not attempt to collect coverage for the simulator tests, as gh-1909 handles that.

@ktbarrett, since your PR is running into some weird python environment issues, maybe we should merge this first?
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
