### PR TITLE
Add TOPLEVEL_LANG to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ jobs:
 
     - stage: SimTests
       python: 3.7
-      env: SIM=ghdl
+      env: SIM=ghdl TOPLEVEL_LANG=vhdl
       before_install:
         - sudo apt-get install gnat
         - git clone https://github.com/ghdl/ghdl.git --depth=1 --branch v0.36
@@ -132,4 +132,4 @@ jobs:
   allow_failures:
     - stage: SimTests
       python: 3.7
-      env: SIM=ghdl
+      env: SIM=ghdl TOPLEVEL_LANG=vhdl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ Running tests locally
 
 Our tests are managed by `tox`, which runs both `pytest` and our system of makefiles.
 This exercises the contents of both the `tests` and `examples` directories.
+`tox` supports the usage of the environment variables `SIM` and `TOPLEVEL_LANG` to direct how to run the regression.
 
 
 Managing of Issues and Pull Requests

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ setenv =
     CXXFLAGS = -Werror
 passenv =
     SIM
+    TOPLEVEL_LANG
     ALDEC_LICENSE_FILE
     SYNOPSYS_LICENSE_FILE
     LM_LICENSE_FILE


### PR DESCRIPTION
Add `TOPLEVEL_LANG` passthrough to tox and add it to GHDL CI run where it is currently missing (that might explain some of the failures).