### PR TITLE
Add Python 3.9 to Linux Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,15 @@ jobs:
       after_success: *travis_linux_post
 
     - stage: SimTests
+      python: 3.9-dev
+      before_install: *travis_linx_prep
+      script:
+        - echo 'Running cocotb tests with Python 3.9-dev ...' && echo -en 'travis_fold:start:cocotb_py39'
+        - tox -e py39
+        - echo 'travis_fold:end:cocotb_py39'
+      after_success: *travis_linux_post
+
+    - stage: SimTests
       python: 3.7
       os: windows
       language: shell

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -131,7 +131,6 @@ extern "C" void embed_init_python(void)
     set_program_name_in_venv();
     Py_Initialize();                    /* Initialize the interpreter */
     PySys_SetArgvEx(1, argv, 0);
-    PyEval_InitThreads();               /* Create (and acquire) the interpreter lock */
 
     /* Swap out and return current thread state and release the GIL */
     gtstate = PyEval_SaveThread();

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: BSD License",
         "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
     ],


### PR DESCRIPTION
Adds Python 3.9 (currently dev) to Linux Travis CI. Makes a single fix to support Python 3.9. Closes #1911.

Justification[https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads] for removing the call to `PyEval_InitThreads()`.