### PR TITLE
Skip mixed_language example if TOPLEVEL_LANG is not Verilog.

### DIFF
--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -6,6 +6,10 @@ else ifeq ($(shell echo $(SIM) | tr A-Z a-z),icarus)
 all:
 	@echo "Skipping example mixed_language since Icarus doesn't support this"
 clean::
+else ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),verilog)
+all:
+	@echo "Skipping example mixed_language since only Verilog toplevel implemented"
+clean::
 else
 
 # Override this variable to use a VHDL toplevel instead of SystemVerilog


### PR DESCRIPTION
Skip mixed_language example if toplevel_lang  is not Verilog. It fails VHDL regression.

