### PR TITLE
add share/lib/verilator/verilator.cpp to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,8 @@ setup(
         'cocotb': (
             package_files('cocotb/share/makefiles') +   # noqa: W504
             package_files('cocotb/share/include') +     # noqa: W504
-            package_files('cocotb/share/def')
+            package_files('cocotb/share/def') +
+            package_files('cocotb/share/lib/verilator')
         )
     },
     ext_modules=get_ext(),


### PR DESCRIPTION
The file was removed in #1853 but it is actually needed. Without it, you get an error like:

```
make[1]: *** No rule to make target '.../lib/python3.7/site-packages/cocotb/share/lib/verilator/verilator.cpp', needed by 'verilator.o'.  Stop.
```

We probably should add a verilator test to avoid a regression.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
