### PR TITLE
Fix Windows SSL issue

### DIFF
--- a/pip.ini
+++ b/pip.ini
@@ -1,0 +1,2 @@
+[global]
+trusted-host = pypi.python.org files.pythonhosted.org pypi.org


### PR DESCRIPTION
The SSL certificate for pythonhosted.org isn't verifying. Strangely, this is only happening once tox is building it's virtualenv, and not when installing packages. Supposedly, this can be fixed by [upgrading pip](https://files.pythonhosted.org/packages/ad/d3/e54f8b4cde0f6fb4f231629f570c1a33ded18515411dee6df6fe363d976f/setuptools_scm-4.1.2-py2.py3-none-any.whl#sha256=69258e2eeba5f7ce1ed7a5f109519580fa3578250f8e4d6684859f86d1b15826).