### PR TITLE
Fix SSL cert error in Travis builds on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,8 @@ jobs:
         - export CONDA_PATH="\$env:Path = ';C:\miniconda3;C:\miniconda3\Library\mingw-w64\bin;C:\miniconda3\Library\usr\bin;C:\miniconda3\Library\bin;C:\miniconda3\Scripts;C:\miniconda3\bin;C:\miniconda3\condabin;C:\iverilog\bin;' + \$env:Path"
         - powershell "$CONDA_PATH; conda install --yes -c msys2 m2-base m2-make m2w64-toolchain libpython"
         - powershell "$CONDA_PATH; conda install --yes virtualenv"
+        - powershell "$CONDA_PATH; conda update --yes pip"
+        - powershell "$CONDA_PATH; conda info; conda list --show-channel-urls"
         # needed to make the builtin sqlite3 module (used by coverage) work - see gh-1909
         - powershell '$CONDA_PATH; cp C:\miniconda3\Library\bin\sqlite3.dll C:\miniconda3\DLLs\'
         - powershell "$CONDA_PATH; pip install tox"

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ jobs:
         - powershell "$CONDA_PATH; conda update --yes pip"
         - powershell "$CONDA_PATH; conda info; conda list --show-channel-urls"
         # needed to make the builtin sqlite3 module (used by coverage) work - see gh-1909
-        - powershell '$CONDA_PATH; cp C:\miniconda3\Library\bin\sqlite3.dll C:\miniconda3\DLLs\'
+        - powershell 'cp C:\miniconda3\Library\bin\sqlite3.dll C:\miniconda3\DLLs\sqlite3.dll'
         - powershell "$CONDA_PATH; pip install tox"
       script:
         # TODO[gh-1372]: the default compiler on windows, msvc, is not supported


### PR DESCRIPTION
In Travis builds on Windows we get the following error.

```
    ERROR: Command errored out with exit status 1:
     command: 'C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\Scripts\python.EXE' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\travis\\AppData\\Local\\Temp\\pip-install-7zlcuzsx\\py\\setup.py'"'"'; __file__='"'"'C:\\Users\\travis\\AppData\\Local\\Temp\\pip-install-7zlcuzsx\\py\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: C:\Users\travis\AppData\Local\Temp\pip-install-7zlcuzsx\py\
    Complete output (85 lines):
    Traceback (most recent call last):
      File "c:\miniconda3\Lib\urllib\request.py", line 1319, in do_open
        encode_chunked=req.has_header('Transfer-encoding'))
      File "c:\miniconda3\Lib\http\client.py", line 1252, in request
        self._send_request(method, url, body, headers, encode_chunked)
      File "c:\miniconda3\Lib\http\client.py", line 1298, in _send_request
        self.endheaders(body, encode_chunked=encode_chunked)
      File "c:\miniconda3\Lib\http\client.py", line 1247, in endheaders
        self._send_output(message_body, encode_chunked=encode_chunked)
      File "c:\miniconda3\Lib\http\client.py", line 1026, in _send_output
        self.send(msg)
      File "c:\miniconda3\Lib\http\client.py", line 966, in send
        self.connect()
      File "c:\miniconda3\Lib\http\client.py", line 1422, in connect
        server_hostname=server_hostname)
      File "c:\miniconda3\Lib\ssl.py", line 423, in wrap_socket
        session=session
      File "c:\miniconda3\Lib\ssl.py", line 870, in _create
        self.do_handshake()
      File "c:\miniconda3\Lib\ssl.py", line 1139, in do_handshake
        self._sslobj.do_handshake()
    ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 766, in open_url
        return open_with_auth(url, self.opener)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 961, in _socket_timeout
        return func(*args, **kwargs)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 1080, in open_with_auth
        fp = opener(request)
      File "c:\miniconda3\Lib\urllib\request.py", line 222, in urlopen
        return opener.open(url, data, timeout)
      File "c:\miniconda3\Lib\urllib\request.py", line 525, in open
        response = self._open(req, data)
      File "c:\miniconda3\Lib\urllib\request.py", line 543, in _open
        '_open', req)
      File "c:\miniconda3\Lib\urllib\request.py", line 503, in _call_chain
        result = func(*args)
      File "c:\miniconda3\Lib\urllib\request.py", line 1362, in https_open
        context=self._context, check_hostname=self._check_hostname)
      File "c:\miniconda3\Lib\urllib\request.py", line 1321, in do_open
        raise URLError(err)
    urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)>

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\travis\AppData\Local\Temp\pip-install-7zlcuzsx\py\setup.py", line 41, in <module>
        main()
      File "C:\Users\travis\AppData\Local\Temp\pip-install-7zlcuzsx\py\setup.py", line 37, in main
        zip_safe=False,
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\__init__.py", line 144, in setup
        _install_setup_requires(attrs)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\__init__.py", line 139, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\dist.py", line 719, in fetch_build_eggs
        replace_conflicting=True,
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\pkg_resources\__init__.py", line 782, in resolve
        replace_conflicting=replace_conflicting
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\pkg_resources\__init__.py", line 1065, in best_match
        return self.obtain(req, installer)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\pkg_resources\__init__.py", line 1077, in obtain
        return installer(requirement)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\dist.py", line 786, in fetch_build_egg
        return cmd.easy_install(req)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\command\easy_install.py", line 667, in easy_install
        not self.always_copy, self.local_index
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 655, in fetch_distribution
        dist = find(requirement)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 635, in find
        loc = self.download(dist.location, tmpdir)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 579, in download
        found = self._download_url(scheme.group(1), spec, tmpdir)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 824, in _download_url
        return self._attempt_download(url, filename)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 830, in _attempt_download
        headers = self._download_to(url, filename)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 729, in _download_to
        fp = self.open_url(url)
      File "C:\Users\travis\build\cocotb\cocotb\.tox\py3_mingw\lib\site-packages\setuptools\package_index.py", line 780, in open_url
        % (url, v.reason))
    distutils.errors.DistutilsError: Download error for https://files.pythonhosted.org/packages/ad/d3/e54f8b4cde0f6fb4f231629f570c1a33ded18515411dee6df6fe363d976f/setuptools_scm-4.1.2-py2.py3-none-any.whl#sha256=69258e2eeba5f7ce1ed7a5f109519580fa3578250f8e4d6684859f86d1b15826: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)
```


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->