### PR TITLE
Convert most examples to async/await

### DIFF
--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -19,7 +19,7 @@ def setup_dut(dut):
 
 # Write to address 0 and verify that value got through
 @cocotb.test()
-def write_address_0(dut):
+async def write_address_0(dut):
     """Write to the register at address 0, verify the value has changed.
 
     Test ID: 0
@@ -34,14 +34,14 @@ def write_address_0(dut):
     dut.test_id <= 0
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
     ADDRESS = 0x00
     DATA = 0xAB
 
-    yield axim.write(ADDRESS, DATA)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    await axim.write(ADDRESS, DATA)
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
 
     value = dut.dut.r_temp_0
     if value != DATA:
@@ -54,7 +54,7 @@ def write_address_0(dut):
 
 # Read back a value at address 0x01
 @cocotb.test()
-def read_address_1(dut):
+async def read_address_1(dut):
     """Use cocotb to set the value of the register at address 0x01.
     Use AXIML to read the contents of that register and
     compare the values.
@@ -69,17 +69,17 @@ def read_address_1(dut):
     dut.test_id <= 1
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
-    yield Timer(CLK_PERIOD_NS, units='ns')
+    await Timer(CLK_PERIOD_NS, units='ns')
     ADDRESS = 0x01
     DATA = 0xCD
 
     dut.dut.r_temp_1 <= DATA
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
 
-    value = yield axim.read(ADDRESS)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    value = await axim.read(ADDRESS)
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
 
     if value != DATA:
         # Fail
@@ -90,7 +90,7 @@ def read_address_1(dut):
 
 
 @cocotb.test()
-def write_and_read(dut):
+async def write_and_read(dut):
     """Write to the register at address 0.
     Read back from that register and verify the value is the same.
 
@@ -105,19 +105,19 @@ def write_and_read(dut):
     dut.test_id <= 2
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
     ADDRESS = 0x00
     DATA = 0xAB
 
     # Write to the register
-    yield axim.write(ADDRESS, DATA)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    await axim.write(ADDRESS, DATA)
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
 
     # Read back the value
-    value = yield axim.read(ADDRESS)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    value = await axim.read(ADDRESS)
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
 
     value = dut.dut.r_temp_0
     if value != DATA:
@@ -129,7 +129,7 @@ def write_and_read(dut):
 
 
 @cocotb.test()
-def write_fail(dut):
+async def write_fail(dut):
     """Attempt to write data to an address that doesn't exist. This test
     should fail.
 
@@ -144,15 +144,15 @@ def write_fail(dut):
     dut.test_id <= 3
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
     ADDRESS = 0x02
     DATA = 0xAB
 
     try:
-        yield axim.write(ADDRESS, DATA)
-        yield Timer(CLK_PERIOD_NS * 10, units='ns')
+        await axim.write(ADDRESS, DATA)
+        await Timer(CLK_PERIOD_NS * 10, units='ns')
     except AXIProtocolError as e:
         print("Exception: %s" % str(e))
         dut._log.info("Bus successfully raised an error")
@@ -162,7 +162,7 @@ def write_fail(dut):
 
 
 @cocotb.test()
-def read_fail(dut):
+async def read_fail(dut):
     """Attempt to read data from an address that doesn't exist. This test
     should fail.
 
@@ -177,15 +177,15 @@ def read_fail(dut):
     dut.test_id <= 4
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
-    yield Timer(CLK_PERIOD_NS * 10, units='ns')
+    await Timer(CLK_PERIOD_NS * 10, units='ns')
     dut.rst <= 0
 
     ADDRESS = 0x02
     DATA = 0xAB
 
     try:
-        yield axim.read(ADDRESS, DATA)
-        yield Timer(CLK_PERIOD_NS * 10, units='ns')
+        await axim.read(ADDRESS, DATA)
+        await Timer(CLK_PERIOD_NS * 10, units='ns')
     except AXIProtocolError as e:
         print("Exception: %s" % str(e))
         dut._log.info("Bus Successfully Raised an Error")

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -4,9 +4,9 @@ from cocotb.result import TestFailure
 
 
 @cocotb.test()
-def mixed_language_test(dut):
+async def mixed_language_test(dut):
     """Try accessing handles and setting values in a mixed language environment."""
-    yield Timer(100, units='ns')
+    await Timer(100, units='ns')
 
     verilog = dut.i_swapper_sv
     dut._log.info("Got: %s" % repr(verilog._name))
@@ -15,10 +15,10 @@ def mixed_language_test(dut):
     dut._log.info("Got: %s" % repr(vhdl._name))
 
     verilog.reset_n <= 1
-    yield Timer(100, units='ns')
+    await Timer(100, units='ns')
 
     vhdl.reset_n <= 1
-    yield Timer(100, units='ns')
+    await Timer(100, units='ns')
 
     if int(verilog.reset_n) == int(vhdl.reset_n):
         dut._log.info("Both signals read as %d" % int(vhdl.reset_n))


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
Most of the rest of #1730 

Since this was easy, I think it's valuable to have these examples in `async` form for people learning from them in the next release.