### PR TITLE
Backport #1882 to 1.3 branch

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -39,9 +39,12 @@ VhpiArrayObjHdl::~VhpiArrayObjHdl()
 
 VhpiObjHdl::~VhpiObjHdl()
 {
-    LOG_DEBUG("Releasing VhpiObjHdl handle at %p\n", (void *)get_handle<vhpiHandleT>());
-    if (vhpi_release_handle(get_handle<vhpiHandleT>()))
-        check_vhpi_error();
+    /* Don't release handles for pseudo-regions, as they borrow the handle of the containing region */
+    if (m_type != GPI_GENARRAY) {
+        LOG_DEBUG("Releasing VhpiObjHdl handle at %p\n", (void *)get_handle<vhpiHandleT>());
+        if (vhpi_release_handle(get_handle<vhpiHandleT>()))
+            check_vhpi_error();
+    }
 }
 
 VhpiSignalObjHdl::~VhpiSignalObjHdl()

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -4,6 +4,15 @@ Release Notes
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
+cocotb 1.3.2
+============
+
+Notable changes and bug fixes
+-----------------------------
+
+- Iterating over ``for generate`` statements using VHPI has been fixed.
+  This bug caused some simulators to crash, and was a regression in version 1.3.1. (:pr:`1882`)
+
 cocotb 1.3.1
 ============
 


### PR DESCRIPTION
Closes #1939. Backports just the fix from PR #1882 to the 1.3 branch and moves the release notes to the correct place.