### PR TITLE
Fix flake8 in 1.3 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
     - stage: PythonLint
       os: linux
       python: 3.5
-      install: pip install flake8
+      install: pip install "flake8>=3.7,<3.8"
       script: flake8
 
     - stage: SimTests


### PR DESCRIPTION
Flake8 3.7.9 was used in the 1.3.1 release and checks passed, with flake8 3.8 a behavior changed that cause the checks to fail. Instead of updating the source in a released version, we pin flake8 to the old version.