### PR TITLE
Support vpiConstant, which is used by GHDL

### DIFF
--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -127,6 +127,7 @@ gpi_objtype_t to_gpi_objtype(int32_t vpitype)
         case vpiIntegerNet:
             return GPI_INTEGER;
 
+        case vpiConstant:
         case vpiParameter:
             return GPI_PARAMETER;
 
@@ -186,6 +187,7 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiInterconnectNet:
             new_obj = new VpiSignalObjHdl(this, new_hdl, to_gpi_objtype(type), false);
             break;
+        case vpiConstant:
         case vpiParameter:
             new_obj = new VpiSignalObjHdl(this, new_hdl, to_gpi_objtype(type), true);
             break;


### PR DESCRIPTION
From https://github.com/cocotb/cocotb/issues/1942#issuecomment-651453987. For some reason GHDL is returning the type of constants as `vpiConstant` sometimes and `vpiParameter` other times. `vpiConstant` is synonymous with `vpiParameter` so this is not a problem.