### PR TITLE
Fix flake8 F841 reports for core code

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -252,7 +252,7 @@ def _initialise_testbench(argv_):
 
 def _sim_event(level, message):
     """Function that can be called externally to signal an event."""
-    SIM_INFO = 0
+    # SIM_INFO = 0
     SIM_TEST_FAIL = 1
     SIM_FAIL = 2
     from cocotb.result import TestFailure, SimFailure

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -157,7 +157,7 @@ def main():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    args = parser.parse_args()
+    parser.parse_args()
 
 
 if __name__ == "__main__":

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -292,6 +292,7 @@ class AXI4Slave(BusDriver):
                     "AWLEN   %d\n" % _awlen +
                     "AWSIZE  %d\n" % _awsize +
                     "AWBURST %d\n" % _awburst +
+                    "AWPROT %d\n" % _awprot +
                     "BURST_LENGTH %d\n" % burst_length +
                     "Bytes in beat %d\n" % bytes_in_beat)
 
@@ -341,6 +342,7 @@ class AXI4Slave(BusDriver):
                     "ARLEN   %d\n" % _arlen +
                     "ARSIZE  %d\n" % _arsize +
                     "ARBURST %d\n" % _arburst +
+                    "ARPROT %d\n" % _arprot +
                     "BURST_LENGTH %d\n" % burst_length +
                     "Bytes in beat %d\n" % bytes_in_beat)
 

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -213,7 +213,7 @@ class AvalonMaster(AvalonMM):
 
         # Wait for waitrequest to be low
         if hasattr(self.bus, "waitrequest"):
-            count = yield self._wait_for_nsignal(self.bus.waitrequest)
+            yield self._wait_for_nsignal(self.bus.waitrequest)
 
         # Deassert write
         yield RisingEdge(self.clock)

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -763,7 +763,7 @@ class Scheduler:
                 self.log.debug("Coroutine %s yielded %s (mode %d)" %
                                (coroutine.__qualname__, str(result), self._mode))
 
-        except cocotb.decorators.CoroutineComplete as exc:
+        except cocotb.decorators.CoroutineComplete:
             if _debug:
                 self.log.debug("Coroutine {} completed with {}".format(
                     coroutine, coroutine._outcome

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -347,7 +347,6 @@ def hexdiffs(x: bytes, y: bytes) -> str:
     doy = 0
     l = len(backtrackx)
     while i < l:
-        separate = 0
         linex = backtrackx[i:i+16]
         liney = backtracky[i:i+16]
         xx = sum(len(k) for k in linex)

--- a/cocotb/xunit_reporter.py
+++ b/cocotb/xunit_reporter.py
@@ -112,12 +112,12 @@ class XUnitReporter:
     def add_failure(self, testcase=None, **kwargs):
         if testcase is None:
             testcase = self.last_testcase
-        log = SubElement(testcase, "failure", **kwargs)
+        SubElement(testcase, "failure", **kwargs)
 
     def add_skipped(self, testcase=None, **kwargs):
         if testcase is None:
             testcase = self.last_testcase
-        log = SubElement(testcase, "skipped", **kwargs)
+        SubElement(testcase, "skipped", **kwargs)
 
     def indent(self, elem, level=0):
         i = "\n" + level*"  "

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ exclude =
     documentation
     makefiles
     venv
+    .tox
     examples/endian_swapper/cosim
 
 ignore =
@@ -19,8 +20,12 @@ ignore =
     E501  # line too long (... > 79 characters)
     E741  # ambiguous variable name 'l'
     F405  # ... may be undefined, or defined from star
-    F841  # local variable ... is assigned to but never used
     W504  # line break after binary operator
+
+per-file-ignores =
+    # F841 - local variable ... is assigned to but never used
+    tests/*: F841
+    examples/*: F841
 
 [tool:pytest]
 addopts = -v --cov=cocotb --cov-branch


### PR DESCRIPTION
Ignore this ("local variable ... is assigned to but never used")
for tests and examples where names are useful for didactic purposes.

Refs #1547.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
