### PR TITLE
More simulators in Readme; Waveforms for GHDL in Simulator Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Cocotb requires:
 
 - Python 3.5+
 - A C++11 compiler
-- An HDL simulator (such as [Icarus Verilog](http://iverilog.icarus.com/))
+- An HDL simulator (such as [Icarus Verilog](http://iverilog.icarus.com/),
+[Verilator](https://www.veripool.org/wiki/verilator),
+[GHDL](http://ghdl.free.fr/) or a
+[Commercial Simulators](https://docs.cocotb.org/en/stable/simulator_support.html))
 
 After installing these dependencies, the latest stable version of cocotb can be installed with pip.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Cocotb requires:
 - A C++11 compiler
 - An HDL simulator (such as [Icarus Verilog](http://iverilog.icarus.com/),
 [Verilator](https://www.veripool.org/wiki/verilator),
-[GHDL](http://ghdl.free.fr/) or
+[GHDL](http://ghdl.free.fr/) or 
 [other simulator](https://docs.cocotb.org/en/stable/simulator_support.html))
 
 After installing these dependencies, the latest stable version of cocotb can be installed with pip.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Cocotb requires:
 
 - Python 3.5+
 - A C++11 compiler
-- An HDL simulator (such as [Icarus Verilog](http://iverilog.icarus.com/),
+- An HDL simulator (such as [Icarus Verilog](https://docs.cocotb.org/en/stable/simulator_support.html#icarus-verilog),
 [Verilator](https://docs.cocotb.org/en/stable/simulator_support.html#verilator),
 [GHDL](https://docs.cocotb.org/en/stable/simulator_support.html#ghdl) or
 [other simulator](https://docs.cocotb.org/en/stable/simulator_support.html))

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Cocotb requires:
 - An HDL simulator (such as [Icarus Verilog](http://iverilog.icarus.com/),
 [Verilator](https://www.veripool.org/wiki/verilator),
 [GHDL](http://ghdl.free.fr/) or a
-[Commercial Simulators](https://docs.cocotb.org/en/stable/simulator_support.html))
+[commercial simulator](https://docs.cocotb.org/en/stable/simulator_support.html))
 
 After installing these dependencies, the latest stable version of cocotb can be installed with pip.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Cocotb requires:
 - A C++11 compiler
 - An HDL simulator (such as [Icarus Verilog](http://iverilog.icarus.com/),
 [Verilator](https://www.veripool.org/wiki/verilator),
-[GHDL](http://ghdl.free.fr/) or a
-[commercial simulator](https://docs.cocotb.org/en/stable/simulator_support.html))
+[GHDL](http://ghdl.free.fr/) or
+[other simulator](https://docs.cocotb.org/en/stable/simulator_support.html))
 
 After installing these dependencies, the latest stable version of cocotb can be installed with pip.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Cocotb requires:
 - Python 3.5+
 - A C++11 compiler
 - An HDL simulator (such as [Icarus Verilog](http://iverilog.icarus.com/),
-[Verilator](https://www.veripool.org/wiki/verilator),
-[GHDL](http://ghdl.free.fr/) or 
+[Verilator](https://docs.cocotb.org/en/stable/simulator_support.html#verilator),
+[GHDL](https://docs.cocotb.org/en/stable/simulator_support.html#ghdl) or
 [other simulator](https://docs.cocotb.org/en/stable/simulator_support.html))
 
 After installing these dependencies, the latest stable version of cocotb can be installed with pip.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -256,27 +256,6 @@ Support is preliminary.
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the VPI interface.
 
 
-.. _sim-ghdl-waveforms:
-
-Waveforms
----------
-
-To get waveforms in VCD format, set the :make:var:`SIM_ARGS` option to ``--vcd=anyname.vcd``, 
-for example in a Makefile:
-
-  .. code-block:: make
-
-    SIM_ARGS=--vcd=anyname.vcd
-
-The option can be set on the command line, as shown in the following example.
-
-  .. code-block:: bash
-
-    make SIM=ghdl SIM_ARGS=--vcd=anyname.vcd
-    
-A VCD file named ``anyname.vcd`` will be generated in the current directory.
-
-
 .. _sim-cvc:
 
 Tachyon DA CVC


### PR DESCRIPTION
This readme change mentions Verilator, GHDL and commercial simulators in the readme file. The intent is to make it a little more clear to Design and DV engineers that cocotb supports open source and commercial tools that they frequently used.
