### PR TITLE
Fix warning introduced by recent change

### DIFF
--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -577,16 +577,20 @@ GpiIterator *FliImpl::iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type
 }
 
 decltype(FliIterator::iterate_over) FliIterator::iterate_over = []{
-    std::initializer_list<FliIterator::OneToMany> region_options;
-    std::initializer_list<FliIterator::OneToMany> signal_options;
-    std::initializer_list<FliIterator::OneToMany> variable_options;
+    std::initializer_list<FliIterator::OneToMany> region_options = {
+        FliIterator::OTM_CONSTANTS,
+        FliIterator::OTM_SIGNALS,
+        FliIterator::OTM_REGIONS,
+    };
+    std::initializer_list<FliIterator::OneToMany> signal_options = {
+        FliIterator::OTM_SIGNAL_SUB_ELEMENTS,
+    };
+    std::initializer_list<FliIterator::OneToMany> variable_options = {
+        FliIterator::OTM_VARIABLE_SUB_ELEMENTS,
+    };
 
     return decltype(FliIterator::iterate_over) {
-        {accArchitecture, region_options = {
-            FliIterator::OTM_CONSTANTS,
-            FliIterator::OTM_SIGNALS,
-            FliIterator::OTM_REGIONS,
-        }},
+        {accArchitecture, region_options},
         {accEntityVitalLevel0, region_options},
         {accArchVitalLevel0, region_options},
         {accArchVitalLevel1, region_options},
@@ -612,16 +616,12 @@ decltype(FliIterator::iterate_over) FliIterator::iterate_over = []{
         {accForGenerate, region_options},
         {accConfiguration, region_options},
 
-        {accSignal, signal_options = {
-            FliIterator::OTM_SIGNAL_SUB_ELEMENTS,
-        }},
+        {accSignal, signal_options},
         {accSignalBit, signal_options},
         {accSignalSubComposite, signal_options},
         {accAliasSignal, signal_options},
 
-        {accVariable, variable_options = {
-            FliIterator::OTM_VARIABLE_SUB_ELEMENTS,
-        }},
+        {accVariable, variable_options},
         {accGeneric, variable_options},
         {accGenericConstant, variable_options},
         {accAliasConstant, variable_options},

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -921,52 +921,52 @@ VhpiNextPhaseCbHdl::VhpiNextPhaseCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
 
 decltype(VhpiIterator::iterate_over) VhpiIterator::iterate_over = []{
     /* for reused lists */
-    std::initializer_list<vhpiOneToManyT> root_options;
-    std::initializer_list<vhpiOneToManyT> sig_options;
-    std::initializer_list<vhpiOneToManyT> simplesig_options;
-    std::initializer_list<vhpiOneToManyT> gen_options;
+    std::initializer_list<vhpiOneToManyT> root_options = {
+        vhpiInternalRegions,
+        vhpiSigDecls,
+        vhpiVarDecls,
+        vhpiPortDecls,
+        vhpiGenericDecls,
+        vhpiConstDecls,
+        //    vhpiIndexedNames,
+        vhpiCompInstStmts,
+        vhpiBlockStmts,
+    };
+    std::initializer_list<vhpiOneToManyT> sig_options = {
+        vhpiIndexedNames,
+        vhpiSelectedNames,
+    };
+    std::initializer_list<vhpiOneToManyT> simplesig_options = {
+        vhpiDecls,
+        vhpiInternalRegions,
+        vhpiSensitivitys,
+        vhpiStmts,
+    };
+    std::initializer_list<vhpiOneToManyT> gen_options = {
+        vhpiDecls,
+        vhpiInternalRegions,
+        vhpiSigDecls,
+        vhpiVarDecls,
+        vhpiConstDecls,
+        vhpiCompInstStmts,
+        vhpiBlockStmts,
+    };
 
     return decltype(VhpiIterator::iterate_over) {
-        {vhpiRootInstK, root_options = {
-            vhpiInternalRegions,
-            vhpiSigDecls,
-            vhpiVarDecls,
-            vhpiPortDecls,
-            vhpiGenericDecls,
-            vhpiConstDecls,
-            //    vhpiIndexedNames,
-            vhpiCompInstStmts,
-            vhpiBlockStmts,
-        }},
+        {vhpiRootInstK, root_options},
         {vhpiCompInstStmtK, root_options},
 
-        {vhpiGenericDeclK, sig_options = {
-            vhpiIndexedNames,
-            vhpiSelectedNames,
-        }},
+        {vhpiGenericDeclK, sig_options},
         {vhpiSigDeclK, sig_options},
         {vhpiSelectedNameK, sig_options},
         {vhpiIndexedNameK, sig_options},
         {vhpiPortDeclK, sig_options},
 
-        {vhpiCondSigAssignStmtK, simplesig_options = {
-            vhpiDecls,
-            vhpiInternalRegions,
-            vhpiSensitivitys,
-            vhpiStmts,
-        }},
+        {vhpiCondSigAssignStmtK, simplesig_options},
         {vhpiSimpleSigAssignStmtK, simplesig_options},
         {vhpiSelectSigAssignStmtK, simplesig_options},
 
-        {vhpiForGenerateK, gen_options = {
-            vhpiDecls,
-            vhpiInternalRegions,
-            vhpiSigDecls,
-            vhpiVarDecls,
-            vhpiConstDecls,
-            vhpiCompInstStmts,
-            vhpiBlockStmts,
-        }},
+        {vhpiForGenerateK, gen_options},
         {vhpiIfGenerateK, gen_options},
         {vhpiBlockStmtK, gen_options},
 

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -561,59 +561,59 @@ VpiNextPhaseCbHdl::VpiNextPhaseCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
 
 decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = []{
     /* for reused lists */
-    std::initializer_list<int32_t> module_options;
-    std::initializer_list<int32_t> struct_options;
+    std::initializer_list<int32_t> module_options = {
+        //vpiModule,            // Aldec SEGV on mixed language
+        //vpiModuleArray,       // Aldec SEGV on mixed language
+        //vpiIODecl,            // Don't care about these
+        vpiNet,
+        vpiNetArray,
+        vpiReg,
+        vpiRegArray,
+        vpiMemory,
+        vpiIntegerVar,
+        vpiRealVar,
+        vpiRealNet,
+        vpiStructVar,
+        vpiStructNet,
+        //vpiVariables          // Aldec SEGV on plain Verilog
+        vpiNamedEvent,
+        vpiNamedEventArray,
+        vpiParameter,
+        //vpiSpecParam,         // Don't care
+        //vpiParamAssign,       // Aldec SEGV on mixed language
+        //vpiDefParam,          // Don't care
+        vpiPrimitive,
+        vpiPrimitiveArray,
+        //vpiContAssign,        // Don't care
+        vpiProcess,             // Don't care
+        vpiModPath,
+        vpiTchk,
+        vpiAttribute,
+        vpiPort,
+        vpiInternalScope,
+        //vpiInterface,         // Aldec SEGV on mixed language
+        //vpiInterfaceArray,    // Aldec SEGV on mixed language
+    };
+    std::initializer_list<int32_t> struct_options = {
+        vpiNet,
+#ifndef IUS
+        vpiNetArray,
+#endif
+        vpiReg,
+        vpiRegArray,
+        vpiMemory,
+        vpiParameter,
+        vpiPrimitive,
+        vpiPrimitiveArray,
+        vpiAttribute,
+        vpiMember,
+    };
 
     return decltype(VpiIterator::iterate_over) {
-        {vpiModule, module_options = {
-            //vpiModule,            // Aldec SEGV on mixed language
-            //vpiModuleArray,       // Aldec SEGV on mixed language
-            //vpiIODecl,            // Don't care about these
-            vpiNet,
-            vpiNetArray,
-            vpiReg,
-            vpiRegArray,
-            vpiMemory,
-            vpiIntegerVar,
-            vpiRealVar,
-            vpiRealNet,
-            vpiStructVar,
-            vpiStructNet,
-            //vpiVariables          // Aldec SEGV on plain Verilog
-            vpiNamedEvent,
-            vpiNamedEventArray,
-            vpiParameter,
-            //vpiSpecParam,         // Don't care
-            //vpiParamAssign,       // Aldec SEGV on mixed language
-            //vpiDefParam,          // Don't care
-            vpiPrimitive,
-            vpiPrimitiveArray,
-            //vpiContAssign,        // Don't care
-            vpiProcess,             // Don't care
-            vpiModPath,
-            vpiTchk,
-            vpiAttribute,
-            vpiPort,
-            vpiInternalScope,
-            //vpiInterface,         // Aldec SEGV on mixed language
-            //vpiInterfaceArray,    // Aldec SEGV on mixed language
-        }},
+        {vpiModule, module_options},
         {vpiGenScope, module_options},
 
-        {vpiStructVar, struct_options = {
-            vpiNet,
-#ifndef IUS
-            vpiNetArray,
-#endif
-            vpiReg,
-            vpiRegArray,
-            vpiMemory,
-            vpiParameter,
-            vpiPrimitive,
-            vpiPrimitiveArray,
-            vpiAttribute,
-            vpiMember,
-        }},
+        {vpiStructVar, struct_options},
         {vpiStructNet, struct_options},
 
         {vpiNet, {


### PR DESCRIPTION
Fixes #1974. The clever hack used to improve readability in #1906 invokes UB relating to the lifetime of the initializer_list. This causes GCC to throw a warning. Which fails due to `-Werror`.
