### PR TITLE
Deprecate GPI_PARAMETER and remove it from VPI

### DIFF
--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -160,7 +160,7 @@ typedef enum gpi_objtype_e {
     GPI_MEMORY = 1,
     GPI_MODULE = 2,
     GPI_NET = 3,
-    GPI_PARAMETER = 4,
+    // GPI_PARAMETER = 4,  // Deprecated
     GPI_REGISTER = 5,
     GPI_ARRAY = 6,
     GPI_ENUM = 7,

--- a/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -57,7 +57,7 @@ const char * GpiObjHdl::get_type_str()
         CASE_OPTION(GPI_MEMORY);
         CASE_OPTION(GPI_MODULE);
         CASE_OPTION(GPI_NET);
-        CASE_OPTION(GPI_PARAMETER);
+        // CASE_OPTION(GPI_PARAMETER);  // Deprecated
         CASE_OPTION(GPI_REGISTER);
         CASE_OPTION(GPI_ARRAY);
         CASE_OPTION(GPI_ENUM);

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -920,7 +920,7 @@ static int add_module_constants(PyObject* simulator)
         PyModule_AddIntConstant(simulator, "MEMORY",    GPI_MEMORY    ) < 0 ||
         PyModule_AddIntConstant(simulator, "MODULE",    GPI_MODULE    ) < 0 ||
         PyModule_AddIntConstant(simulator, "NET",       GPI_NET       ) < 0 ||
-        PyModule_AddIntConstant(simulator, "PARAMETER", GPI_PARAMETER ) < 0 ||
+        // PyModule_AddIntConstant(simulator, "PARAMETER", GPI_PARAMETER ) < 0 ||  // Deprecated
         PyModule_AddIntConstant(simulator, "REG",       GPI_REGISTER  ) < 0 ||
         PyModule_AddIntConstant(simulator, "NETARRAY",  GPI_ARRAY     ) < 0 ||
         PyModule_AddIntConstant(simulator, "ENUM",      GPI_ENUM      ) < 0 ||

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -37,7 +37,11 @@ typedef struct packed
 } test_if;
 `endif
 
-module sample_module (
+module sample_module #(
+    parameter INT_PARAM = 12,
+    parameter REAL_PARAM = 3.14,
+    parameter STRING_PARAM = "Test"
+)(
     input                                       clk,
 
     output reg                                  stream_in_ready,

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -461,7 +461,7 @@ def type_check_verilog(dut):
     test_handles = [
         (dut.stream_in_ready, "GPI_REGISTER"),
         (dut.register_array, "GPI_ARRAY"),
-        (dut.NUM_OF_MODULES, "GPI_PARAMETER"),
+        (dut.NUM_OF_MODULES, "GPI_INTEGER"),
         (dut.temp, "GPI_REGISTER"),
         (dut.and_output, "GPI_NET"),
         (dut.stream_in_data, "GPI_NET"),

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -461,12 +461,14 @@ def type_check_verilog(dut):
     test_handles = [
         (dut.stream_in_ready, "GPI_REGISTER"),
         (dut.register_array, "GPI_ARRAY"),
-        (dut.NUM_OF_MODULES, "GPI_INTEGER"),
         (dut.temp, "GPI_REGISTER"),
         (dut.and_output, "GPI_NET"),
         (dut.stream_in_data, "GPI_NET"),
         (dut.logic_b, "GPI_REGISTER"),
         (dut.logic_c, "GPI_REGISTER"),
+        (dut.INT_PARAM, "GPI_INTEGER"),
+        (dut.REAL_PARAM, "GPI_REAL"),
+        (dut.STRING_PARAM, "GPI_STRING")
     ]
 
     if cocotb.SIM_NAME.lower().startswith(("icarus")):


### PR DESCRIPTION
GPI_PARAMETER represents a parameter or a constant in VHDL, but it
doesn't say anything about what *kind* of constant value it is. VHPI and
FLI already don't support GPI_PARAMETER because of this issue, but the
VPI does. This commit implements the small amount of features necessary
to map parameters to the correct GPI type. Constness is handled in the
VpiSignalObj class. It also deprecates the GPI_PARAMETER constant in
both C and Python.

Following https://github.com/cocotb/cocotb/pull/1949#discussion_r447365438.