### PR TITLE
Detection of TOPLEVEL_LANG

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -111,6 +111,17 @@ $(SIM_BUILD):
 .PHONY: regression
 regression: $(COCOTB_RESULTS_FILE)
 
+# Attempt to detect TOPLEVEL_LANG based on available sources if not set
+ifeq ($(TOPLEVEL_LANG),)
+
+ifneq ($(and $(VHDL_SOURCES),$(if $(VERILOG_SOURCES),,1),)
+	TOPLEVEL_LANG := vhdl
+else ifneq ($(and $(VERILOG_SOURCES),$(if $(VHDL_SOURCES),,1),)
+	TOPLEVEL_LANG := verilog
+endif
+
+endif
+
 else
     $(warning Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.)
 endif # COCOTB_MAKEFILE_INC_INCLUDED

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -26,12 +26,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+TOPLEVEL_LANG ?= vhdl
+
 include $(shell cocotb-config --makefiles)/Makefile.inc
 
-ifneq ($(VERILOG_SOURCES),)
+ifneq ($(or $(filter-out $(TOPLEVEL_LANG),vhdl),$(VERILOG_SOURCES)),)
 
 $(COCOTB_RESULTS_FILE):
-	@echo "Skipping simulation as Verilog is not supported on simulator=$(SIM)"
+	@echo "Skipping simulation as only VHDL is supported on simulator=$(SIM)"
 clean::
 
 else

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -27,12 +27,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+TOPLEVEL_LANG ?= verilog
+
 include $(shell cocotb-config --makefiles)/Makefile.inc
 
-ifneq ($(VHDL_SOURCES),)
+ifneq ($(or $(filter-out $(TOPLEVEL_LANG),verilog),$(VHDL_SOURCES)),)
 
 $(COCOTB_RESULTS_FILE):
-	@echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
+	@echo "Skipping simulation as only Verilog is supported on simulator=$(SIM)"
 debug: $(COCOTB_RESULTS_FILE)
 clean::
 

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -2,12 +2,14 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
+TOPLEVEL_LANG ?= verilog
+
 include $(shell cocotb-config --makefiles)/Makefile.inc
 
-ifneq ($(VHDL_SOURCES),)
+ifneq ($(or $(filter-out $(TOPLEVEL_LANG),verilog),$(VHDL_SOURCES)),)
 
 results.xml:
-	@echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
+	@echo "Skipping simulation as only Verilog is supported on simulator=$(SIM)"
 debug: results.xml
 clean::
 


### PR DESCRIPTION
Adds support for the automatic detection of an appropriate `TOPLEVEL_LANG` value based on the value of `VERILOG_SOURCES` and `VHDL_SOURCES`. This PR also adds detection of invalid `TOPLEVEL_LANG` values in simulators that only support one language like Verilator, Icarus, and GHDL. Closes #1893.