### PR TITLE
Provide <SimName>Version classes to compare simulator versions

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -95,7 +95,6 @@ jobs:
             lang: verilog
             python-version: 3.8
             os: ubuntu-20.04
-            may_fail: true
 
             # Test GHDL on Ubuntu
 
@@ -136,7 +135,6 @@ jobs:
             lang: verilog
             python-version: 3.8
             os: macos-latest
-            may_fail: true
 
           - sim: icarus             # Icarus homebrew stable
             sim-version: homebrew
@@ -149,7 +147,6 @@ jobs:
             lang: verilog
             python-version: 3.8
             os: windows-latest
-            may_fail: true
 
           - sim: icarus             # Icarus windows 10.3 from source
             sim-version: v10_3

--- a/cocotb/_sim_versions.py
+++ b/cocotb/_sim_versions.py
@@ -6,7 +6,9 @@
 Classes to compare simulation versions.
 
 These are for cocotb-internal use only.
-Warning: these classes silently allow comparing versions of different simulators.
+
+.. warning::
+    These classes silently allow comparing versions of different simulators.
 """
 
 from distutils.version import LooseVersion

--- a/cocotb/_sim_versions.py
+++ b/cocotb/_sim_versions.py
@@ -1,0 +1,117 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Classes to compare simulation versions.
+
+These are for cocotb-internal use only.
+Warning: these classes silently allow comparing versions of different simulators.
+"""
+
+from distutils.version import LooseVersion
+
+
+class ActivehdlVersion(LooseVersion):
+    """Version numbering class for Aldec Active-HDL.
+
+    NOTE: unsupported versions exist, e.g.
+    ActivehdlVersion("10.5a.12.6914") > ActivehdlVersion("10.5.216.6767")
+    """
+    pass
+
+
+class CvcVersion(LooseVersion):
+    """Version numbering class for Tachyon DA CVC.
+
+    Example:
+        >>> CvcVersion("OSS_CVC_7.00b-x86_64-rhel6x of 07/07/14 (Linux-elf)") > CvcVersion("OSS_CVC_7.00a-x86_64-rhel6x of 07/07/14 (Linux-elf)")
+        True
+    """
+    pass
+
+
+class GhdlVersion(LooseVersion):
+    """Version numbering class for GHDL."""
+    pass
+
+
+class IcarusVersion(LooseVersion):
+    """Version numbering class for Icarus Verilog.
+
+    Example:
+        >>> IcarusVersion("11.0 (devel)") > IcarusVersion("10.3 (stable)")
+        True
+        >>> IcarusVersion("10.3 (stable)") <= IcarusVersion("10.3 (stable)")
+        True
+    """
+    pass
+
+
+class ModelsimVersion(LooseVersion):
+    """Version numbering class for Mentor ModelSim."""
+    pass
+
+
+class QuestaVersion(LooseVersion):
+    """Version numbering class for Mentor Questa.
+
+    Example:
+        >>> QuestaVersion("10.7c 2018.08") > QuestaVersion("10.7b 2018.06")
+        True
+        >>> QuestaVersion("2020.1 2020.01") > QuestaVersion("10.7c 2018.08")
+        True
+    """
+    pass
+
+
+class RivieraVersion(LooseVersion):
+    """Version numbering class for Aldec Riviera-PRO.
+
+    Example:
+        >>> RivieraVersion("2019.10.138.7537") == RivieraVersion("2019.10.138.7537")
+        True
+    """
+    pass
+
+
+class VcsVersion(LooseVersion):
+    """Version numbering class for Synopsys VCS.
+
+    Example:
+        >>> VcsVersion("Q-2020.03-1_Full64") > VcsVersion("K-2015.09_Full64")
+        True
+    """
+    pass
+
+
+class VerilatorVersion(LooseVersion):
+    """Version numbering class for Verilator.
+
+    Example:
+        >>> VerilatorVersion("4.032 2020-04-04") > VerilatorVersion("4.031 devel")
+        True
+    """
+    pass
+
+
+class XceliumVersion(LooseVersion):
+    """Version numbering class for Cadence Xcelium.
+
+    Example:
+        >>> XceliumVersion("20.06-g183") > XceliumVersion("20.03-s002")
+        True
+        >>> XceliumVersion("20.07-e501") > XceliumVersion("20.06-g183")
+        True
+    """
+    pass
+
+
+class IusVersion(XceliumVersion):  # inherit everything from Xcelium
+    """Version numbering class for Cadence IUS.
+
+    Example:
+        >>> IusVersion("15.20-s050") > IusVersion("15.20-s049")
+        True
+    """
+    pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,5 +33,6 @@ testpaths =
     tests/pytest
     cocotb/utils.py
     cocotb/binary.py
+    cocotb/_sim_versions.py
 # log_cli = true
 # log_cli_level = DEBUG

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -30,6 +30,7 @@ import logging
 from cocotb.triggers import Timer
 from cocotb.result import TestError, TestFailure
 from cocotb.handle import IntegerObject, ConstantObject, HierarchyObject, StringObject
+from cocotb._sim_versions import IcarusVersion
 
 
 @cocotb.test()
@@ -89,8 +90,8 @@ async def access_signal(dut):
 
 
 @cocotb.test(
-    # Icarus 10.3 doesn't support bit-selects, see https://github.com/steveicarus/iverilog/issues/323
-    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("icarus") else False,
+    # Icarus up to (including) 10.3 doesn't support bit-selects, see https://github.com/steveicarus/iverilog/issues/323
+    expect_error=IndexError if (cocotb.SIM_NAME.lower().startswith("icarus") and (IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"))) else False,
     skip=cocotb.LANGUAGE in ["vhdl"])
 async def access_single_bit(dut):
     """Access a single bit in a vector of the DUT"""
@@ -107,8 +108,8 @@ async def access_single_bit(dut):
 
 
 @cocotb.test(
-    # Icarus 10.3 doesn't support bit-selects, see https://github.com/steveicarus/iverilog/issues/323
-    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("icarus") else False,
+    # Icarus up to (including) 10.3 doesn't support bit-selects, see https://github.com/steveicarus/iverilog/issues/323
+    expect_error=IndexError if (cocotb.SIM_NAME.lower().startswith("icarus") and (IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"))) else False,
     skip=cocotb.LANGUAGE in ["vhdl"])
 async def access_single_bit_assignment(dut):
     """Access a single bit in a vector of the DUT using the assignment mechanism"""


### PR DESCRIPTION
Currently, these are directly using `distutils.version.LooseVersion`.
Intended use case is for setting `expect_errors` for testcases.

Closes #1951

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
