### PR TITLE
Add support to GPI to determine if a handle is a port

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -104,6 +104,24 @@ class SimHandleBase:
         :meta public:
         """
 
+    @property
+    def _is_port(self):
+        """
+        Whether the GPI object is a port or not.
+
+        :meta public:
+        """
+        return self._handle.is_port()
+
+    @property
+    def _port_direction(self):
+        """
+        The directionality of the port, if the object is a port, otherwise ``GPI_UNDEFINED``.
+
+        :meta public:
+        """
+        return self._handle.get_port_direction()
+
     def get_definition_name(self):
         return self._def_name
 

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -228,6 +228,29 @@ int gpi_is_constant(gpi_sim_hdl gpi_hdl);
 // Determine whether an object is indexable
 int gpi_is_indexable(gpi_sim_hdl gpi_hdl);
 
+/** Determine whether an object is a port
+ *  @returns 1 if object is a port, 0 otherwise
+ */
+int gpi_is_port(gpi_sim_hdl gpi_hdl);
+
+/** Enumerates possible port types */
+typedef enum gpi_port_direction_e {
+    GPI_PORT_UNHANDLED = -1,    ///< unknown and unhandled port type
+    GPI_NOT_A_PORT = 0,         ///< definitely not a port
+    GPI_PORT_INPUT = 1,         ///< input port
+    GPI_PORT_OUTPUT = 2,        ///< output port
+    GPI_PORT_INOUT = 3,         ///< inout port
+    GPI_PORT_MIXEDIO = 4,       ///< ??? (Verilog only)
+    GPI_PORT_NO_DIRECTION = 5,  ///< ??? (Verilog only)
+    GPI_PORT_BUFFER = 6,        ///< ??? (VHDL only)
+    GPI_PORT_LINKAGE = 7,       ///< ??? (VHDL only)
+} gpi_port_direction_t;
+
+/** The direction of a port
+ *  @returns the direction of a port, GPI_NOT_A_PORT if the object is not a port
+ */
+gpi_port_direction_t gpi_port_direction(gpi_sim_hdl gpi_hdl);
+
 // Functions for setting the properties of a handle
 void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value, gpi_set_action_t action);
 void gpi_set_signal_value_long(gpi_sim_hdl gpi_hdl, long value, gpi_set_action_t action);

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -173,7 +173,8 @@ public:
         GpiObjHdl(impl, hdl, objtype, is_const),
         FliObj(acc_type, acc_full_type) { }
 
-
+    bool is_port() const override;
+    gpi_port_direction_t get_port_direction() const override;
     int initialise(std::string &name, std::string &fq_name) override;
 };
 

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -98,6 +98,22 @@ int FliObjHdl::initialise(std::string &name, std::string &fq_name)
     return GpiObjHdl::initialise(name, fq_name);
 }
 
+gpi_port_direction_t FliSignalObjHdl::get_port_direction() const
+{
+    mtiDirectionT dir_raw =  mti_GetSignalMode(static_cast<mtiSignalIdT>(hdl));
+    switch (dir_raw) {
+        case MTI_DIR_IN:
+            return GPI_PORT_INPUT;
+        case MTI_DIR_OUT:
+            return GPI_PORT_OUTPUT;
+        case MTI_DIR_INOUT:
+            return GPI_PORT_INOUT;
+        case MTI_INTERNAL:
+            return GPI_NOT_A_PORT;
+    }
+    LOG_ERROR("Unable to map FLI port direction type '%d' to GPI port direction type", dir_raw);
+    return GPI_PORT_UNHANDLED;
+}
 
 int FliSignalObjHdl::initialise(std::string &name, std::string &fq_name)
 {

--- a/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -91,6 +91,23 @@ int GpiObjHdl::initialise(std::string &name, std::string &fq_name)
     return 0;
 }
 
+bool GpiObjHdl::is_port() const
+{
+    switch (get_port_direction()) {
+        case GPI_NOT_A_PORT:
+        case GPI_UNHANDLED:
+            return false;
+        default:
+            return true;
+    }
+}
+
+gpi_port_direction_t GpiObjHdl::get_port_direction() const
+{
+    LOG_ERROR("get_port_direction not implemented for %s", m_impl->get_name_c());
+    return GPI_UNHANDLED;
+}
+
 int GpiCbHdl::run_callback()
 {
     LOG_DEBUG("Generic run_callback");

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -509,6 +509,16 @@ int gpi_is_indexable(gpi_sim_hdl obj_hdl)
     return 0;
 }
 
+int gpi_is_port(gpi_sim_hdl obj_hdl)
+{
+    return obj_hdl->is_port();
+}
+
+gpi_port_direction_t gpi_port_direction(gpi_sim_hdl obj_hdl)
+{
+    return obj_hdl->get_port_direction();
+}
+
 void gpi_set_signal_value_long(gpi_sim_hdl sig_hdl, long value, gpi_set_action_t action)
 {
     GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl*>(sig_hdl);

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -104,6 +104,8 @@ public:
     int get_range_left() { return m_range_left; }
     int get_range_right() { return m_range_right; }
     int get_indexable() { return m_indexable; }
+    virtual bool is_port() const;
+    virtual gpi_port_direction_t get_port_direction() const;
 
     const std::string & get_name();
     const std::string & get_fullname();

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -211,6 +211,35 @@ int VpiArrayObjHdl::initialise(std::string &name, std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
+bool VpiArrayObjHdl::is_port() const
+{
+    return get_port_direction() != GPI_NOT_A_PORT;
+}
+
+gpi_port_direction_t VpiArrayObjHdl::get_port_direction() const
+{
+    vpiHandle self = GpiObjHdl::get_handle<vpiHandle>();
+    vpiHandle module = vpi_handle(vpiModule, self);
+    vpiHandle port_iter = vpi_iterate(vpiPort, module);
+    if (!port_iter) {
+        return GPI_NOT_A_PORT;
+    }
+    for (vpiHandle port; port = vpi_scan(port_iter); ) {
+        if (vpi_compare_objects(port, self)) {
+            vpi_free_object(port_iter);
+            switch (vpi_get(vpiDirection, port)) {
+                case vpiInput: return GPI_PORT_INPUT;
+                case vpiOutput: return GPI_PORT_OUTPUT;
+                case vpiInout: return GPI_PORT_INOUT;
+                case vpiMixedIO: return GPI_PORT_MIXEDIO;
+                case vpiNoDirection: return GPI_PORT_NO_DIRECTION;
+                default: return GPI_PORT_UNHANDLED;
+            }
+        }
+    }
+    return GPI_NOT_A_PORT;
+}
+
 int VpiObjHdl::initialise(std::string &name, std::string &fq_name) {
     char * str;
     vpiHandle hdl = GpiObjHdl::get_handle<vpiHandle>();
@@ -222,6 +251,35 @@ int VpiObjHdl::initialise(std::string &name, std::string &fq_name) {
         m_definition_file = str;
 
     return GpiObjHdl::initialise(name, fq_name);
+}
+
+bool VpiObjHdl::is_port() const
+{
+    return get_port_direction() != GPI_NOT_A_PORT;
+}
+
+gpi_port_direction_t VpiObjHdl::get_port_direction() const
+{
+    vpiHandle self = GpiObjHdl::get_handle<vpiHandle>();
+    vpiHandle module = vpi_handle(vpiModule, self);
+    vpiHandle port_iter = vpi_iterate(vpiPort, module);
+    if (!port_iter) {
+        return GPI_NOT_A_PORT;
+    }
+    for (vpiHandle port; port = vpi_scan(port_iter); ) {
+        if (vpi_compare_objects(port, self)) {
+            vpi_free_object(port_iter);
+            switch (vpi_get(vpiDirection, port)) {
+                case vpiInput: return GPI_PORT_INPUT;
+                case vpiOutput: return GPI_PORT_OUTPUT;
+                case vpiInout: return GPI_PORT_INOUT;
+                case vpiMixedIO: return GPI_PORT_MIXEDIO;
+                case vpiNoDirection: return GPI_PORT_NO_DIRECTION;
+                default: return GPI_PORT_UNHANDLED;
+            }
+        }
+    }
+    return GPI_NOT_A_PORT;
 }
 
 int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
@@ -286,6 +344,35 @@ int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
     }
     LOG_DEBUG("VPI: %s initialized with %d elements", name.c_str(), m_num_elems);
     return GpiObjHdl::initialise(name, fq_name);
+}
+
+bool VpiSignalObjHdl::is_port() const
+{
+    return get_port_direction() != GPI_NOT_A_PORT;
+}
+
+gpi_port_direction_t VpiSignalObjHdl::get_port_direction() const
+{
+    vpiHandle self = GpiObjHdl::get_handle<vpiHandle>();
+    vpiHandle module = vpi_handle(vpiModule, self);
+    vpiHandle port_iter = vpi_iterate(vpiPort, module);
+    if (!port_iter) {
+        return GPI_NOT_A_PORT;
+    }
+    for (vpiHandle port; port = vpi_scan(port_iter); ) {
+        if (vpi_compare_objects(port, self)) {
+            vpi_free_object(port_iter);
+            switch (vpi_get(vpiDirection, port)) {
+                case vpiInput: return GPI_PORT_INPUT;
+                case vpiOutput: return GPI_PORT_OUTPUT;
+                case vpiInout: return GPI_PORT_INOUT;
+                case vpiMixedIO: return GPI_PORT_MIXEDIO;
+                case vpiNoDirection: return GPI_PORT_NO_DIRECTION;
+                default: return GPI_PORT_UNHANDLED;
+            }
+        }
+    }
+    return GPI_NOT_A_PORT;
 }
 
 const char* VpiSignalObjHdl::get_signal_value_binstr()

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -146,17 +146,21 @@ public:
 class VpiArrayObjHdl : public GpiObjHdl {
 public:
     VpiArrayObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype) :
-                                                             GpiObjHdl(impl, hdl, objtype) { }
+        GpiObjHdl(impl, hdl, objtype) { }
 
     int initialise(std::string &name, std::string &fq_name) override;
+    bool is_port() const override;
+    gpi_port_direction_t get_port_direction() const override;
 };
 
 class VpiObjHdl : public GpiObjHdl {
 public:
     VpiObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype) :
-                                                             GpiObjHdl(impl, hdl, objtype) { }
+        GpiObjHdl(impl, hdl, objtype) { }
 
     int initialise(std::string &name, std::string &fq_name) override;
+    bool is_port() const override;
+    gpi_port_direction_t get_port_direction() const override;
 };
 
 class VpiSignalObjHdl : public GpiSignalObjHdl {
@@ -180,6 +184,8 @@ public:
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(int edge) override;
     int initialise(std::string &name, std::string &fq_name) override;
+    bool is_port() const override;
+    gpi_port_direction_t get_port_direction() const override;
 
 private:
     int set_signal_value(s_vpi_value value, gpi_set_action_t action);


### PR DESCRIPTION
Supercedes #1128. Implements the same features a slightly different way that 1. works, 2. works with the use of `SINGLETON_HANDLES`.

### Differences
The previous implementation set a port direction on the constructor, which in combination with the `SINGLETON_HANDLES` cache, caused handles to not be recorded as ports. This is handled by adding a method to determine portness after creation, rather make that decision during construction. This will prevent the original issue and allow lazy evaluation on a likely uncommonly used property.

Additionally, *how* the detection of portness is done is suspect, running `vpi_get(vpiType, handle)` can return multiple types given the same object depending on the type of handle to that object there is. And there is no way to test an object for portness in the VPI. Instead, the safest and most consistent way to check this is:
1. obtain the module using `vpi_get(vpiModule, handle)`.
2. `vpi_iterate(vpiPort, module)` to check all ports.
3. see if any ports in the module have the same name as you.

### Alternatives

One can get ports associated with objects using `vpi_get(vpiPorts, object)`. But the LRM doesn't say what ports are returned... Are they ports connected to the object? Are they all ports in a module? What does that say about the object's name? It's not very clear.

### WIP

- [ ] Check if individual bits get counted as ports
- [ ] Check if struct members get counted as ports
- [ ] Implement VPI
    - [X] ~~I'm not sure how well `vpiFullName` works in context of mixedlanguage but it's probably necessary to check if we have the same object. For instance you can have two separate object with the same name that have the same module, if they are in different scopes.~~ Use `vpi_compare_objects`. Funnily, this is not support by *any* of the FOSS simulators.
    - [ ] If all the implementations in VPI truly are the same, move implementation to function
    - [ ] running `vpi_iterate(vpiPort, module)` iff the module handle was obtained from a port via `vpi_get(vpiModule, port)` returns NULL on both Riviera and Questa. I'm not entirely sure why...
- [x] Implement reasonable default implementation of is_port in GpiObjHdl
- [X] Implement FLI
- [ ] Implement VHPI
- [ ] Add caching for performance reasons?