### PR TITLE
Remove Python dependency from gpilog library

### DIFF
--- a/cocotb/share/include/py_gpi_logging.h
+++ b/cocotb/share/include/py_gpi_logging.h
@@ -1,0 +1,31 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef PY_GPI_LOGGING_H
+#define PY_GPI_LOGGING_H
+
+#include <exports.h>
+#ifdef PYGPILOG_EXPORTS
+#define PYGPILOG_EXPORT COCOTB_EXPORT
+#else
+#define PYGPILOG_EXPORT COCOTB_IMPORT
+#endif
+
+#define PY_GPI_LOG_SIZE 1024
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+PYGPILOG_EXPORT void py_gpi_set_log_level(int level);
+
+PYGPILOG_EXPORT void py_gpi_initialize(PyObject * handler, PyObject * filter);
+
+PYGPILOG_EXPORT void py_gpi_finalize();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -31,6 +31,8 @@
 
 #include <Python.h>
 #include <cocotb_utils.h>
+#include <gpi_logging.h>        // LOG_* macros
+#include <py_gpi_logging.h>     // set_log_handler, set_log_filter, clear_log_handler, clear_log_filter
 #include "embed.h"
 #include "locale.h"
 #include <cassert>
@@ -181,8 +183,7 @@ extern "C" void embed_sim_cleanup(void)
         PyGILState_Ensure();    // Don't save state as we are calling Py_Finalize
         Py_DecRef(pEventFn);
         pEventFn = NULL;
-        clear_log_handler();
-        clear_log_filter();
+        py_gpi_finalize();
         Py_Finalize();
         to_simulator();
     }
@@ -228,7 +229,8 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
 
     PyObject *cocotb_module, *cocotb_init, *cocotb_retval;
     PyObject *cocotb_log_module = NULL;
-    PyObject *simlog_func;
+    PyObject *log_func;
+    PyObject *filter_func;
     PyObject *argv_list;
 
     cocotb_module = NULL;
@@ -248,24 +250,23 @@ extern "C" int embed_sim_init(int argc, char const * const * argv)
     }
 
     // Obtain the function to use when logging from C code
-    simlog_func = PyObject_GetAttrString(cocotb_log_module, "_log_from_c");      // New reference
-    if (simlog_func == NULL) {
+    log_func = PyObject_GetAttrString(cocotb_log_module, "_log_from_c");      // New reference
+    if (log_func == NULL) {
         PyErr_Print();
         LOG_ERROR("Failed to get the _log_from_c function");
         goto cleanup;
     }
 
-    set_log_handler(simlog_func);                                       // Note: This function steals a reference to simlog_func.
-
     // Obtain the function to check whether to call log function
-    simlog_func = PyObject_GetAttrString(cocotb_log_module, "_filter_from_c");   // New reference
-    if (simlog_func == NULL) {
+    filter_func = PyObject_GetAttrString(cocotb_log_module, "_filter_from_c");   // New reference
+    if (filter_func == NULL) {
+        Py_DECREF(log_func);
         PyErr_Print();
         LOG_ERROR("Failed to get the _filter_from_c method");
         goto cleanup;
     }
 
-    set_log_filter(simlog_func);                                        // Note: This function steals a reference to simlog_func.
+    py_gpi_initialize(log_func, filter_func);                           // Note: This function steals a reference to simlog_func.
 
     pEventFn = PyObject_GetAttrString(cocotb_module, "_sim_event");     // New reference
     if (pEventFn == NULL) {

--- a/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
+++ b/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
@@ -1,0 +1,167 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <Python.h>         // all things Python
+#include <gpi_logging.h>    // all things GPI logging
+#include <py_gpi_logging.h> // PY_GPI_LOG_SIZE
+#include <cstdarg>          // va_list, va_copy, va_end
+#include <cstdio>           // fprintf, vsnprintf
+
+
+static PyObject *pLogHandler = nullptr;
+
+static PyObject *pLogFilter = nullptr;
+
+static int py_gpi_log_level = GPIInfo;
+
+
+/**
+ * @name    GPI logging
+ * @brief   Write a log message using cocotb SimLog class
+ * @ingroup python_c_api
+ *
+ * GILState before calling: Unknown
+ *
+ * GILState after calling: Unknown
+ *
+ * Makes one call to PyGILState_Ensure and one call to PyGILState_Release
+ *
+ * If the Python logging mechanism is not initialised, dumps to `stderr`.
+ *
+ */
+static void py_gpi_log_handler(
+    void *userdata,
+    const char *name,
+    int level,
+    const char *pathname,
+    const char *funcname,
+    long lineno,
+    const char *msg,
+    va_list argp)
+{
+    (void)userdata;
+
+    if (!pLogHandler) {
+        gpi_native_logger_vlog(name, level, pathname, funcname, lineno, msg, argp);
+        return;
+    }
+
+    if (level < py_gpi_log_level) {
+        return;
+    }
+
+    va_list argp_copy;
+    va_copy(argp_copy, argp);
+
+    PyGILState_STATE gstate = PyGILState_Ensure();
+
+    // Declared here in order to be initialized before any goto statements and refcount cleanup
+    PyObject *logger_name_arg = NULL, *filename_arg = NULL, *lineno_arg = NULL, *msg_arg = NULL, *function_arg = NULL;
+
+    PyObject *level_arg = PyLong_FromLong(level);                  // New reference
+    if (level_arg == NULL) {
+        goto error;
+    }
+
+    logger_name_arg = PyUnicode_FromString(name);      // New reference
+    if (logger_name_arg == NULL) {
+        goto error;
+    }
+
+    {
+        // check if log level is enabled
+        PyObject *filter_ret = PyObject_CallFunctionObjArgs(pLogFilter, logger_name_arg, level_arg, NULL);
+        if (filter_ret == NULL) {
+            goto error;
+        }
+
+        int is_enabled = PyObject_IsTrue(filter_ret);
+        Py_DECREF(filter_ret);
+        if (is_enabled < 0) {
+            /* A python exception occured while converting `filter_ret` to bool */
+            goto error;
+        }
+
+        if (!is_enabled) {
+            goto ok;
+        }
+    }
+
+    static char log_buff[PY_GPI_LOG_SIZE];
+
+    // Ignore truncation
+    {
+        int n = vsnprintf(log_buff, sizeof(log_buff), msg, argp);
+        if (n < 0 || n >= (int)sizeof(log_buff)) {
+            fprintf(stderr, "Log message construction failed\n");
+        }
+    }
+
+    filename_arg = PyUnicode_FromString(pathname);      // New reference
+    if (filename_arg == NULL) {
+        goto error;
+    }
+
+    lineno_arg = PyLong_FromLong(lineno);               // New reference
+    if (lineno_arg == NULL) {
+        goto error;
+    }
+
+    msg_arg = PyUnicode_FromString(log_buff);           // New reference
+    if (msg_arg == NULL) {
+        goto error;
+    }
+
+    function_arg = PyUnicode_FromString(funcname);      // New reference
+    if (function_arg == NULL) {
+        goto error;
+    }
+
+    {
+        // Log function args are logger_name, level, filename, lineno, msg, function
+        PyObject *handler_ret = PyObject_CallFunctionObjArgs(pLogHandler, logger_name_arg, level_arg, filename_arg, lineno_arg, msg_arg, function_arg, NULL);
+        if (handler_ret == NULL) {
+            goto error;
+        }
+        Py_DECREF(handler_ret);
+    }
+
+    goto ok;
+error:
+    /* Note: don't call the LOG_ERROR macro because that might recurse */
+    gpi_native_logger_vlog(name, level, pathname, funcname, lineno, msg, argp_copy);
+    gpi_native_logger_log("cocotb.gpi", GPIError, __FILE__, __func__, __LINE__, "Error calling Python logging function from C while logging the above");
+    PyErr_Print();
+ok:
+    va_end(argp_copy);
+    Py_XDECREF(logger_name_arg);
+    Py_XDECREF(level_arg);
+    Py_XDECREF(filename_arg);
+    Py_XDECREF(lineno_arg);
+    Py_XDECREF(msg_arg);
+    Py_XDECREF(function_arg);
+    PyGILState_Release(gstate);
+}
+
+
+extern "C" void py_gpi_set_log_level(int level)
+{
+    py_gpi_log_level = level;
+}
+
+
+extern "C" void py_gpi_initialize(PyObject * handler, PyObject * filter)
+{
+    pLogHandler = handler;
+    pLogFilter = filter;
+    gpi_set_log_handler(py_gpi_log_handler, nullptr);
+}
+
+
+extern "C" void py_gpi_finalize()
+{
+    gpi_clear_log_handler();
+    Py_XDECREF(pLogHandler);
+    Py_XDECREF(pLogFilter);
+}

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -39,10 +39,11 @@ static int releases = 0;
 
 static int sim_ending = 0;
 
-#include <cocotb_utils.h>     // COCOTB_UNUSED
+#include <cocotb_utils.h>       // COCOTB_UNUSED
 #include <type_traits>
 #include <Python.h>
-#include "gpi_logging.h"
+#include <gpi_logging.h>        // LOG_* macros
+#include <py_gpi_logging.h>     // py_gpi_set_log_level
 #include "gpi.h"
 
 // This file defines the routines available to Python
@@ -897,17 +898,18 @@ static PyObject *deregister(gpi_hdl_Object<gpi_cb_hdl> *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+
 static PyObject *log_level(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
 
-    long l_level;
+    int l_level;
 
-    if (!PyArg_ParseTuple(args, "l:log_level", &l_level)) {
+    if (!PyArg_ParseTuple(args, "i:log_level", &l_level)) {
         return NULL;
     }
 
-    set_log_level((enum gpi_log_levels)l_level);
+    py_gpi_set_log_level(l_level);
 
     Py_RETURN_NONE;
 }

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -344,11 +344,28 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         libgpilog_sources += ["libgpilog.rc"]
     libgpilog = Extension(
         os.path.join("cocotb", "libs", "libgpilog"),
-        define_macros=[("GPILOG_EXPORTS", "")]  + _extra_defines,
+        define_macros=[("GPILOG_EXPORTS", "")] + _extra_defines,
         include_dirs=[include_dir],
-        library_dirs=python_lib_dirs,
         sources=libgpilog_sources,
         extra_link_args=_extra_link_args(lib_name="libgpilog", rpaths=["$ORIGIN"]),
+        extra_compile_args=_extra_cxx_compile_args,
+    )
+
+    #
+    #  libpygpilog
+    #
+    libpygpilog_sources = [
+        os.path.join(share_lib_dir, "py_gpi_log", "py_gpi_logging.cpp")
+    ]
+    if os.name == "nt":
+        libpygpilog_sources += ["libpygpilog.rc"]
+    libpygpilog = Extension(
+        os.path.join("cocotb", "libs", "libpygpilog"),
+        define_macros=[("PYGPILOG_EXPORTS", "")] + _extra_defines,
+        include_dirs=[include_dir],
+        libraries=["gpilog"],
+        sources=libpygpilog_sources,
+        extra_link_args=_extra_link_args(lib_name="libpygpilog", rpaths=["$ORIGIN"]),
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -364,7 +381,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         os.path.join("cocotb", "libs", "libcocotb"),
         define_macros=[("COCOTB_EMBED_EXPORTS", ""), ("PYTHON_SO_LIB", _get_python_lib())] + _extra_defines,
         include_dirs=[include_dir],
-        libraries=[_get_python_lib_link(), "gpilog", "cocotbutils"],
+        libraries=[_get_python_lib_link(), "gpilog", "cocotbutils", "pygpilog"],
         library_dirs=python_lib_dirs,
         sources=libcocotb_sources,
         extra_link_args=_extra_link_args(lib_name="libcocotb", rpaths=["$ORIGIN"] + python_lib_dirs),
@@ -402,7 +419,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         os.path.join("cocotb", "simulator"),
         define_macros=_extra_defines,
         include_dirs=[include_dir],
-        libraries=["cocotbutils", "gpilog", "gpi"],
+        libraries=["cocotbutils", "gpilog", "gpi", "pygpilog"],
         library_dirs=python_lib_dirs,
         sources=simulator_sources,
         extra_compile_args=_extra_cxx_compile_args,
@@ -412,7 +429,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     # The libraries in this list are compiled in order of their appearance.
     # If there is a linking dependency on one library to another,
     # the linked library must be built first.
-    return [libgpilog, libcocotbutils, libcocotb, libgpi, libsim]
+    return [libgpilog, libpygpilog, libcocotbutils, libcocotb, libgpi, libsim]
 
 
 def _get_vpi_lib_ext(


### PR DESCRIPTION
Closes #1993. This change moves the Python logger into the gpi_embed library and refactors the gpilog interface to handle *registering* the Python logger once it's ready to use. As explained in the aforementioned issue, this removes the dependency on Python from the gpilog library. Now, nothing in the actual GPI depends upon Python. This will allow other wrappers in potentially other languages to use the GPI.

I followed @eric-wieser's advice to maintain the current behavior of requiring custom log handlers to call the native logger manually if they fail to log themselves. This is more flexible, allowing the user to try other fallbacks if possible, and allows the user to print an additional diagnostic.

The best way to read these changes is to recognize that:
* gpi_logging.h was rewritten for clarity and a lot more documentation
* The Python logger and the two private static variables used by the logger were moved to gpi_embed
* The calls that set up and tear down the Python logger in gpi_embed have been updated
* gpi_embed now calls `gpi_set_log_handler` to register that Python logger implementation with the GPI
* All the support functions in gpi_logging were re-written
* The native logger implementation is still the same, save one bugfix regarding the level at which to log messages