### PR TITLE
Wait for license on private CI

### DIFF
--- a/.azp-private.yml
+++ b/.azp-private.yml
@@ -22,6 +22,7 @@ resources:
     type: github
     endpoint: cocotb
     name: cocotb/cocotb-private-ci
+    ref: refs/heads/wait-for-license
 
 extends:
   template: jobs.yml@cocotb-private-ci

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ passenv =
     ALDEC_LICENSE_FILE
     SYNOPSYS_LICENSE_FILE
     LM_LICENSE_FILE
+    LICENSE_QUEUE
 
 deps =
     coverage


### PR DESCRIPTION
Running multiple regressions on the private CI at the same time breaks right now. When the simulator tries to get license when another is using it, it just fails. This change enables the simulator to wait until a license is available.