### PR TITLE
Fix build with gcc 10

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -29,6 +29,7 @@
 #include "VhpiImpl.h"
 #include <limits>     // numeric_limits
 #include <cinttypes>  // fixed-size int types and format strings
+#include <stdexcept>
 
 namespace {
     using bufSize_type = decltype(vhpiValueT::bufSize);

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -29,6 +29,7 @@
 
 #include <assert.h>
 #include "VpiImpl.h"
+#include <stdexcept>
 
 extern "C" int32_t handle_vpi_callback(p_cb_data cb_data);
 


### PR DESCRIPTION
Compiling with gcc 10 fails:
```
    cocotb/share/lib/vpi/VpiCbHdl.cpp: In constructor 'VpiIterator::VpiIterator(GpiImplInterface*, GpiObjHdl*)':
    cocotb/share/lib/vpi/VpiCbHdl.cpp:661:17: error: 'out_of_range' in namespace 'std' does not name a type
      661 |     catch (std::out_of_range const&) {
          |                 ^~~~~~~~~~~~
    cocotb/share/lib/vpi/VpiCbHdl.cpp:661:29: error: expected ')' before 'const'
      661 |     catch (std::out_of_range const&) {
          |           ~                 ^~~~~~
          |                             )
    cocotb/share/lib/vpi/VpiCbHdl.cpp:661:30: error: expected '{' before 'const'
      661 |     catch (std::out_of_range const&) {
          |                              ^~~~~
    cocotb/share/lib/vpi/VpiCbHdl.cpp:661:36: error: expected unqualified-id before ')' token
      661 |     catch (std::out_of_range const&) {
          |                                    ^
```
Fix by including `#include <stdexcept>`
