### PR TITLE
Added checks for detecting when coroutine functions are passed into functions that expect coroutine objects.

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -93,6 +93,11 @@ class RunningTask:
             self._natively_awaitable = True
         elif inspect.isgenerator(inst):
             self._natively_awaitable = False
+        elif inspect.iscoroutinefunction(inst):
+            raise TypeError(
+                "Coroutine function {} should be called prior to being "
+                "scheduled."
+                .format(inst))
         elif sys.version_info >= (3, 6) and inspect.isasyncgen(inst):
             raise TypeError(
                 "{} is an async generator, not a coroutine. "

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -638,6 +638,13 @@ class Scheduler:
         Just a wrapper around self.schedule which provides some debug and
         useful error messages in the event of common gotchas.
         """
+
+        if inspect.iscoroutinefunction(coroutine):
+            raise TypeError(
+                "Coroutine function {} should be called prior to being "
+                "scheduled."
+                .format(coroutine))
+
         if isinstance(coroutine, cocotb.decorators.coroutine):
             raise TypeError(
                 "Attempt to schedule a coroutine that hasn't started: {}.\n"

--- a/documentation/source/newsfragments/1593.feature.rst
+++ b/documentation/source/newsfragments/1593.feature.rst
@@ -1,0 +1,1 @@
+:meth:`cocotb.fork` will now raise a descriptive :class:`TypeError` if a coroutine function is passed into them.

--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -45,10 +45,13 @@ def _check_traceback(running_coro, exc_type, pattern):
 
 
 @contextmanager
-def assert_raises(exc_type):
+def assert_raises(exc_type, pattern=None):
     try:
         yield
-    except exc_type:
+    except exc_type as e:
+        if pattern:
+            assert re.match(pattern, str(e)), \
+                "Correct exception type caught, but message did not match pattern"
         pass
     else:
         raise AssertionError("{} was not raised".format(exc_type.__name__))

--- a/tests/test_cases/test_cocotb/test_async_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_async_coroutines.py
@@ -8,6 +8,7 @@ Test function and substitutablility of async coroutines
 import cocotb
 from cocotb.triggers import Timer
 from cocotb.outcomes import Value, Error
+from common import assert_raises
 
 
 class produce:
@@ -135,3 +136,25 @@ def test_undecorated_coroutine_yield(dut):
 
     yield example()
     assert ran
+
+
+@cocotb.test()
+async def test_fork_coroutine_function_exception(dut):
+    async def coro():
+        pass
+
+    pattern = "Coroutine function {} should be called " \
+        "prior to being scheduled.".format(coro)
+    with assert_raises(TypeError, pattern):
+        cocotb.fork(coro)
+
+
+@cocotb.test()
+async def test_task_coroutine_function_exception(dut):
+    async def coro(dut):
+        pass
+
+    pattern = "Coroutine function {} should be called " \
+        "prior to being scheduled.".format(coro)
+    with assert_raises(TypeError, pattern):
+        cocotb.decorators.RunningTask(coro)


### PR DESCRIPTION
Hello,

This PR closes #1593.

In all places where a coroutine object is expected, I added a check that determines whether or not the argument is a coroutine function, and if it is, a `TypeError` exception is raised with message indicating a coroutine object should be used. The code of concern is the following.

- `cocotb.scheduler.Scheduler.add()`
- `cocotb.decorators.RunningTask()`


The tests themselves are written such that they intentionally pass coroutine functions directly into the calls to trigger the exception. The exceptions are caught and asserted to ensure the correct exception is thrown.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
