### PR TITLE
Cleanup documentation for Trigger __init__ parameters.

### DIFF
--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -28,6 +28,7 @@
 """Collection of handy functions."""
 
 import ctypes
+import inspect
 import math
 import os
 import sys
@@ -458,6 +459,10 @@ class ParametrizedSingleton(type):
             self = super(ParametrizedSingleton, cls).__call__(*args, **kwargs)
             cls.__instances[key] = self
             return self
+
+    @property
+    def __signature__(cls):
+        return inspect.signature(cls.__singleton_key__)
 
 
 def reject_remaining_kwargs(name, kwargs):

--- a/documentation/source/triggers.rst
+++ b/documentation/source/triggers.rst
@@ -22,11 +22,11 @@ Simulator Triggers
 Signals
 -------
 
-.. autoclass:: cocotb.triggers.Edge
+.. autoclass:: cocotb.triggers.Edge(signal)
 
-.. autoclass:: cocotb.triggers.RisingEdge
+.. autoclass:: cocotb.triggers.RisingEdge(signal)
 
-.. autoclass:: cocotb.triggers.FallingEdge
+.. autoclass:: cocotb.triggers.FallingEdge(signal)
 
 .. autoclass:: cocotb.triggers.ClockCycles
 
@@ -36,11 +36,11 @@ Timing
 
 .. autoclass:: cocotb.triggers.Timer
 
-.. autoclass:: cocotb.triggers.ReadOnly
+.. autoclass:: cocotb.triggers.ReadOnly()
 
-.. autoclass:: cocotb.triggers.ReadWrite
+.. autoclass:: cocotb.triggers.ReadWrite()
 
-.. autoclass:: cocotb.triggers.NextTimeStep
+.. autoclass:: cocotb.triggers.NextTimeStep()
 
 
 Python Triggers
@@ -50,7 +50,7 @@ Python Triggers
 
 .. autoclass:: cocotb.triggers.First
 
-.. autoclass:: cocotb.triggers.Join
+.. autoclass:: cocotb.triggers.Join(coroutine)
     :members: retval
 
 


### PR DESCRIPTION
The parameters generated by `autodoc`'s `.. autoclass::` directive  don't match the source.

https://cocotb--2011.org.readthedocs.build/en/2011/triggers.html#simulator-triggers

https://docs.cocotb.org/en/latest/triggers.html#simulator-triggers

