### PR TITLE
Github Actions

### DIFF
--- a/.github/workflows/cocotb-ci.yml
+++ b/.github/workflows/cocotb-ci.yml
@@ -1,0 +1,178 @@
+name: Regression Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  lint-whitespace:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: whitespace
+      run: |
+        ! git --no-pager grep --color --line-number --full-name --extended-regexp -I '\\s+$'
+
+  lint-flake8:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.5, '3.9.0-alpha - 3.9']
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: flake8
+      run: |
+        pip install flake8
+        flake8
+
+  test-python:
+
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        sim: ['icarus']
+        lang: ['verilog']
+        python-version: [3.5, 3.6, 3.7, 3.8, '3.9.0-alpha - 3.9']
+        os: ['ubuntu-latest']
+    env:
+      SIM: ${{matrix.sim}}
+      TOPLEVEL_LANG: ${{matrix.lang}}
+      PYTHON: ${{matrix.python-version}}
+      OS: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Icarus
+      run: |
+        sudo apt-get install -y gperf
+        git clone https://github.com/steveicarus/iverilog.git --depth=1
+        cd iverilog && autoconf && ./configure && make -j2 && sudo make install && cd ..
+    - name: Install Python testing dependencies
+      run: |
+        sudo apt install swig
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: |
+        tox
+
+  test-ghdl:
+
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        sim: ['ghdl']
+        lang: ['vhdl']
+        python-version: [3.7]
+        os: ['ubuntu-latest']
+    env:
+      SIM: ${{matrix.sim}}
+      TOPLEVEL_LANG: ${{matrix.lang}}
+      PYTHON: ${{matrix.python-version}}
+      OS: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ghdl/setup-ghdl-ci@nightly
+      with:
+        backend: mcode
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Python testing dependencies
+      run: |
+        sudo apt install swig
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      continue-on-error: true
+      run: |
+        tox
+
+  test-verilator:
+
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        sim: ['verilator']
+        lang: ['verilog']
+        python-version: [3.7]
+        os: ['ubuntu-latest']
+    env:
+      SIM: ${{matrix.sim}}
+      TOPLEVEL_LANG: ${{matrix.lang}}
+      PYTHON: ${{matrix.python-version}}
+      OS: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Verilator
+      run: |
+        sudo apt install libfl-dev zlib1g-dev
+        git clone https://github.com/verilator/verilator.git --depth=1
+        cd verilator && autoconf && ./configure && make -j2 && sudo make install && cd ..
+    - name: Install Python testing dependencies
+      run: |
+        sudo apt install swig
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      continue-on-error: true
+      run: |
+        tox
+
+  test-macos:
+
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        sim: ['icarus']
+        lang: ['verilog']
+        python-version: [3.7]
+        os: ['macos-latest']
+    env:
+      SIM: ${{matrix.sim}}
+      TOPLEVEL_LANG: ${{matrix.lang}}
+      PYTHON: ${{matrix.python-version}}
+      OS: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Icarus
+      run: |
+        brew install icarus-verilog --HEAD
+    - name: Install Python testing dependencies
+      run: |
+        brew install swig
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: |
+        tox

--- a/tests/test_cases/issue_1279/Makefile
+++ b/tests/test_cases/issue_1279/Makefile
@@ -1,3 +1,17 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+ifeq ($(SIM),verilator)
+
+all:
+	@echo "Skipping test due to Verilator hanging when prematurely shutting down"  # gh-2008
+clean::
+
+else
+
 include ../../designs/sample_module/Makefile
 
 MODULE = issue_1279
+
+endif

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -108,8 +108,6 @@ def access_signal(dut):
 
 
 @cocotb.test(
-    # Icarus 10.3 doesn't support bit-selects, see https://github.com/steveicarus/iverilog/issues/323
-    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("icarus") else False,
     skip=cocotb.LANGUAGE in ["vhdl"])
 def access_single_bit(dut):
     """Access a single bit in a vector of the DUT"""
@@ -126,8 +124,6 @@ def access_single_bit(dut):
 
 
 @cocotb.test(
-    # Icarus 10.3 doesn't support bit-selects, see https://github.com/steveicarus/iverilog/issues/323
-    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("icarus") else False,
     skip=cocotb.LANGUAGE in ["vhdl"])
 def access_single_bit_assignment(dut):
     """Access a single bit in a vector of the DUT using the assignment mechanism"""

--- a/tests/test_cases/test_exit_error/Makefile
+++ b/tests/test_cases/test_exit_error/Makefile
@@ -25,6 +25,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+ifeq ($(SIM),verilator)
+
+all:
+	@echo "Skipping test due to Verilator hanging when prematurely shutting down"  # gh-2008
+clean::
+
+else
+
 # detecting an expected failure has to happen here, as the python code is invalid
 .PHONY: override_for_this_test
 override_for_this_test:
@@ -33,3 +41,5 @@ override_for_this_test:
 include ../../designs/sample_module/Makefile
 
 MODULE = test_exit
+
+endif

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py{35,36,37,38,39}
 # for the requires key
 minversion = 3.2.0
 # virtualenv is used by tox; versions below 16.1.0 cause a DeprecationWarning
@@ -50,3 +50,11 @@ description = invoke sphinx-build to build the HTML docs
 deps = -rdocumentation/requirements.txt
 commands = sphinx-build -d "{toxworkdir}/docs_doctree" ./documentation/source "{toxworkdir}/docs_out" --color -bhtml {posargs}
            python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+
+[gh-actions]
+python =
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39


### PR DESCRIPTION
Reimplemented some of the CI tests in Github Actions. All of the tests build the FOSS simulators from source off HEAD. GHDL offers a Github Action, Icarus and Verilator don't (yet). Verilator's nightly docker image isn't compatible with GHA.
This was a learning experience for me, so I wouldn't be devastated if it was rejected. [See the results in my fork.](https://github.com/ktbarrett/cocotb/pull/4)

Missing
- [ ] code coverage upload
- [ ] Windows
- [ ] PyPi upload

Some observations
- Doesn't support anchors? Seriously? The most basic and only reuse tool in YAML not available?
- YAMLs aren't a great tool. For example, matrix combinations of simulator and OS have identical simulator setup steps, but there is no way to describe that, so you have to repeat yourself.
- feature set seems identical to Travis (for our needs) besides:
  - longer timeout
  - can see individual all tests in PR
  - reusable steps (!)