### PR TITLE
Replace yield with await in most of the monitors and drivers

### DIFF
--- a/cocotb/drivers/opb.py
+++ b/cocotb/drivers/opb.py
@@ -54,10 +54,9 @@ class OPBMaster(BusDriver):
         self.busy_event = Event("%s_busy" % name)
         self.busy = False
 
-    @cocotb.coroutine
-    def _acquire_lock(self):
+    async def _acquire_lock(self):
         if self.busy:
-            yield self.busy_event.wait()
+            await self.busy_event.wait()
         self.busy_event.clear()
         self.busy = True
 
@@ -66,7 +65,7 @@ class OPBMaster(BusDriver):
         self.busy_event.set()
 
     @cocotb.coroutine
-    def read(self, address: int, sync: bool = True) -> BinaryValue:
+    async def read(self, address: int, sync: bool = True) -> BinaryValue:
         """Issue a request to the bus and block until this comes back.
 
         Simulation time still progresses but syntactically it blocks.
@@ -82,11 +81,11 @@ class OPBMaster(BusDriver):
         Raises:
             OPBException: If read took longer than 16 cycles.
         """
-        yield self._acquire_lock()
+        await self._acquire_lock()
 
         # Apply values for next clock edge
         if sync:
-            yield RisingEdge(self.clock)
+            await RisingEdge(self.clock)
         self.bus.ABus <= address
         self.bus.select <= 1
         self.bus.RNW <= 1
@@ -94,8 +93,8 @@ class OPBMaster(BusDriver):
 
         count = 0
         while not int(self.bus.xferAck.value):
-            yield RisingEdge(self.clock)
-            yield ReadOnly()
+            await RisingEdge(self.clock)
+            await ReadOnly()
             if int(self.bus.toutSup.value):
                 count = 0
             else:
@@ -111,7 +110,7 @@ class OPBMaster(BusDriver):
         return data
 
     @cocotb.coroutine
-    def write(self, address: int, value: int, sync: bool = True) -> None:
+    async def write(self, address: int, value: int, sync: bool = True) -> None:
         """Issue a write to the given address with the specified value.
 
         Args:
@@ -123,10 +122,10 @@ class OPBMaster(BusDriver):
         Raises:
             OPBException: If write took longer than 16 cycles.
         """
-        yield self._acquire_lock()
+        await self._acquire_lock()
 
         if sync:
-            yield RisingEdge(self.clock)
+            await RisingEdge(self.clock)
         self.bus.ABus <= address
         self.bus.select <= 1
         self.bus.RNW <= 0
@@ -135,8 +134,8 @@ class OPBMaster(BusDriver):
 
         count = 0
         while not int(self.bus.xferAck.value):
-            yield RisingEdge(self.clock)
-            yield ReadOnly()
+            await RisingEdge(self.clock)
+            await ReadOnly()
             if int(self.bus.toutSup.value):
                 count = 0
             else:

--- a/cocotb/monitors/avalon.py
+++ b/cocotb/monitors/avalon.py
@@ -35,7 +35,6 @@ NB Currently we only support a very small subset of functionality.
 import warnings
 
 from cocotb.utils import hexdump
-from cocotb.decorators import coroutine
 from cocotb.monitors import BusMonitor
 from cocotb.triggers import RisingEdge, ReadOnly
 from cocotb.binary import BinaryValue
@@ -65,8 +64,7 @@ class AvalonST(BusMonitor):
             self.config[configoption] = value
             self.log.debug("Setting config option %s to %s", configoption, str(value))
 
-    @coroutine
-    def _monitor_recv(self):
+    async def _monitor_recv(self):
         """Watch the pins and reconstruct transactions."""
 
         # Avoid spurious object creation by recycling
@@ -78,10 +76,10 @@ class AvalonST(BusMonitor):
                 return self.bus.valid.value and self.bus.ready.value
             return self.bus.valid.value
 
-        # NB could yield on valid here more efficiently?
+        # NB could await on valid here more efficiently?
         while True:
-            yield clkedge
-            yield rdonly
+            await clkedge
+            await rdonly
             if valid():
                 vec = self.bus.data.value
                 vec.big_endian = self.config["firstSymbolInHighOrderBits"]
@@ -147,8 +145,7 @@ class AvalonSTPkts(BusMonitor):
                                      "(2**channel_width)-1=%d, channel_width=%d" %
                                      (self.name, self.config['maxChannel'], maxChannel, len(self.bus.channel)))
 
-    @coroutine
-    def _monitor_recv(self):
+    async def _monitor_recv(self):
         """Watch the pins and reconstruct transactions."""
 
         # Avoid spurious object creation by recycling
@@ -165,8 +162,8 @@ class AvalonSTPkts(BusMonitor):
             return self.bus.valid.value
 
         while True:
-            yield clkedge
-            yield rdonly
+            await clkedge
+            await rdonly
 
             if self.in_reset:
                 continue

--- a/cocotb/monitors/xgmii.py
+++ b/cocotb/monitors/xgmii.py
@@ -35,7 +35,6 @@ except ImportError:
 import struct
 import zlib
 
-import cocotb
 from cocotb.utils import hexdump
 from cocotb.monitors import Monitor
 from cocotb.triggers import RisingEdge
@@ -120,13 +119,12 @@ class XGMII(Monitor):
             self._pkt.append(byte)
         return True
 
-    @cocotb.coroutine
-    def _monitor_recv(self):
+    async def _monitor_recv(self):
         clk = RisingEdge(self.clock)
         self._pkt = bytearray()
 
         while True:
-            yield clk
+            await clk
             ctrl, bytes = self._get_bytes()
 
             if ctrl[0] and bytes[0] == _XGMII_START:
@@ -134,7 +132,7 @@ class XGMII(Monitor):
                 ctrl, bytes = ctrl[1:], bytes[1:]
 
                 while self._add_payload(ctrl, bytes):
-                    yield clk
+                    await clk
                     ctrl, bytes = self._get_bytes()
 
             elif self.bytes == 8 :
@@ -143,7 +141,7 @@ class XGMII(Monitor):
                     ctrl, bytes = ctrl[5:], bytes[5:]
 
                     while self._add_payload(ctrl, bytes):
-                        yield clk
+                        await clk
                         ctrl, bytes = self._get_bytes()
 
             if self._pkt:

--- a/documentation/source/testbench_tools.rst
+++ b/documentation/source/testbench_tools.rst
@@ -104,13 +104,13 @@ example:
             self.dut = dut
             self.stream_in = AvalonSTDriver(dut, "stream_in", dut.clk)
 
-    def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None,
+    async def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None,
                  backpressure_inserter=None):
 
         cocotb.fork(Clock(dut.clk, 5000).start())
         tb = EndianSwapperTB(dut)
 
-        yield tb.reset()
+        await tb.reset()
         dut.stream_out_ready <= 1
 
         if idle_inserter is not None:
@@ -118,7 +118,7 @@ example:
 
         # Send in the packets
         for transaction in data_in():
-            yield tb.stream_in.send(transaction)
+            await tb.stream_in.send(transaction)
 
 
 Monitoring Buses
@@ -149,13 +149,12 @@ class.
             self.clock = clock
             Monitor.__init__(self, callback, event)
 
-        @coroutine
-        def _monitor_recv(self):
+        async def _monitor_recv(self):
             clkedge = RisingEdge(self.clock)
 
             while True:
                 # Capture signal at rising edge of clock
-                yield clkedge
+                await clkedge
                 vec = self.signal.value
                 self._recv(vec)
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
This should give a small performance boost to a handful of drivers.

I've avoided the `amba` AXI drivers because that would create unhelpful conflicts with #1248.