### PR TITLE
Reflect renaming of status:on-hold to status:blocked

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ The `type` labels define the type of issue or PR:
 
 The `status` labels give a quick impression of the current status of the issue or PR:
 - `status:worksforme`: the issue it not reproducible, or intended behavior (i.e. not a bug)
-- `status:on-hold`: further progress is blocked by a dependency, e.g. other code which must be commited first.
+- `status:blocked`: further progress is blocked by a dependency, e.g. other code which must be commited first.
 - `status:needinfo`: feedback from someone is required. The issue/PR text gives more details.
 - `status:duplicate`: the same issue is already being handled in another issue/PR.
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
