### PR TITLE
Enable assertion rewriting with pytest

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -240,6 +240,23 @@ def _initialise_testbench(argv_):
 
     dut = cocotb.handle.SimHandle(handle)
 
+    try:
+        import pytest
+    except ImportError:
+        log.warning("Pytest not found, assertion rewriting will not occur")
+    else:
+        try:
+            # Install the assertion rewriting hook, which must be done before we
+            # import the test modules.
+            from _pytest.config import Config
+            from _pytest.assertion import install_importhook
+            pytest_conf = Config.fromdictargs([], {})
+            install_importhook(pytest_conf)
+        except Exception:
+            log.exception(
+                "Configuring the assertion rewrite hook using pytest {} failed. "
+                "Please file a bug report!".format(pytest.__version__))
+
     # start Regression Manager
     global regression_manager
     regression_manager = RegressionManager.from_discovery(dut)

--- a/documentation/source/newsfragments/2028.feature.rst
+++ b/documentation/source/newsfragments/2028.feature.rst
@@ -1,0 +1,2 @@
+If ``pytest`` is installed, its assertion-rewriting framework will be used to
+produce more informative tracebacks from the :keyword:`assert` statement.

--- a/tests/test_cases/test_cocotb/Makefile
+++ b/tests/test_cases/test_cocotb/Makefile
@@ -18,6 +18,7 @@ MODULE := "\
 	test_async_coroutines,\
 	test_handle,\
 	test_logging,\
+	test_pytest,\
 	"
 
 ifeq ($(shell python -c "import sys; print(sys.version_info >= (3, 6))"), "True")

--- a/tests/test_cases/test_cocotb/test_pytest.py
+++ b/tests/test_cases/test_cocotb/test_pytest.py
@@ -1,0 +1,22 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+""" Tests relating to pytest integration """
+
+import cocotb
+
+# pytest is an option dependency
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+
+@cocotb.test(skip=pytest is None)
+async def test_assertion_rewriting(dut):
+    """ Test that assertion rewriting hooks take effect in cocotb tests """
+    try:
+        assert 1 != 42
+    except AssertionError as e:
+        assert "42" in str(e), (
+            "Assertion rewriting seems not to work, message was {}".format(e))

--- a/tests/test_cases/test_cocotb/test_pytest.py
+++ b/tests/test_cases/test_cocotb/test_pytest.py
@@ -5,7 +5,7 @@
 
 import cocotb
 
-# pytest is an option dependency
+# pytest is an optional dependency
 try:
     import pytest
 except ImportError:


### PR DESCRIPTION
This means that code like `assert dut.signal.value == 3` will now show the actual signal value when the assertion fails.

I think by default this only applies to files called `test_*.py` or `*_test.py`.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

Close #2027. Close #1449.
