### PR TITLE
Add doc for accessing names starting w/ underscore

### DIFF
--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -13,3 +13,16 @@ It may not be clear when to raise an exception and when to use ``log.error()``.
 Even if you do eventually throw an exception (if you weren't able to do it immediately), you should also ``log.error()`` so that the simulation time of when things went wrong is recorded.
 
 TL;DR: ``log.error()`` is for humans only, ``raise`` is for both humans and code.
+
+
+Accessing Identifiers Starting with an Underscore
+=================================================
+
+The attribute syntax of ``dut._some_signal`` cannot be used to access
+an identifier that starts with an underscore (``_``, as is valid in Verilog)
+because we reserve such names for cocotb-internals,
+thus the access will raise an :exc:`AttributeError`.
+
+A workaround is to use indirect access using
+:meth:`~cocotb.handle.HierarchyObject._id` like in the following example:
+``dut._id("_some_signal", extended=False)``.


### PR DESCRIPTION
Closes #1315.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
