### PR TITLE
Add references to terms in glossary

### DIFF
--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -26,7 +26,7 @@ Make Phases
 -----------
 
 Typically the makefiles provided with cocotb for various simulators use a separate ``compile`` and ``run`` target.
-This allows for a rapid re-running of a simulator if none of the RTL source files have changed and therefore the simulator does not need to recompile the RTL.
+This allows for a rapid re-running of a simulator if none of the :term:`RTL` source files have changed and therefore the simulator does not need to recompile the :term:`RTL`.
 
 
 Variables
@@ -42,7 +42,7 @@ Cocotb
 
 .. envvar:: TOPLEVEL
 
-    Use this to indicate the instance in the hierarchy to use as the DUT.
+    Use this to indicate the instance in the hierarchy to use as the :term:`DUT`.
     If this isn't defined then the first root instance is used.
 
 .. envvar:: RANDOM_SEED
@@ -167,7 +167,7 @@ Regression Manager
 
 .. envvar:: COVERAGE
 
-    Enable to report Python coverage data. For some simulators, this will also report HDL coverage.
+    Enable to report Python coverage data. For some simulators, this will also report :term:`HDL` coverage.
 
     This needs the :mod:`coverage` Python module to be installed.
 
@@ -192,7 +192,7 @@ GPI
 
     A comma-separated list of extra libraries that are dynamically loaded at runtime.
     A function from each of these libraries will be called as an entry point prior to elaboration, allowing these libraries to register
-    system functions and callbacks. Note that HDL objects cannot be accessed at this time.
+    system functions and callbacks. Note that :term:`HDL` objects cannot be accessed at this time.
     The function name defaults to ``{library_name}_entry_point``, but a custom name can be specified using a ``:``, which follows an existing simulator convention.
 
     For example:
@@ -223,9 +223,9 @@ Makefile-based Test Scripts
 
 .. make:var:: TOPLEVEL_LANG
 
-    Used to inform the makefile scripts which HDL language the top-level design element is written in.
+    Used to inform the makefile scripts which :term:`HDL` language the top-level design element is written in.
     Currently it supports the values ``verilog`` for Verilog or SystemVerilog tops, and ``vhdl`` for VHDL tops.
-    This is used by simulators that support more than one interface (VPI, VHPI, or FLI) to select the appropriate interface to start cocotb.
+    This is used by simulators that support more than one interface (:term:`VPI`, :term:`VHPI`, or :term:`FLI`) to select the appropriate interface to start cocotb.
 
     The variable is also made available to cocotb tests conveniently as :data:`cocotb.LANGUAGE`.
 
@@ -292,7 +292,7 @@ Makefile-based Test Scripts
 
 .. make:var:: CUSTOM_COMPILE_DEPS
 
-      Use to add additional dependencies to the compilation target; useful for defining additional rules to run pre-compilation or if the compilation phase depends on files other than the RTL sources listed in :make:var:`VERILOG_SOURCES` or :make:var:`VHDL_SOURCES`.
+      Use to add additional dependencies to the compilation target; useful for defining additional rules to run pre-compilation or if the compilation phase depends on files other than the :term:`RTL` sources listed in :make:var:`VERILOG_SOURCES` or :make:var:`VHDL_SOURCES`.
 
 .. make:var:: CUSTOM_SIM_DEPS
 

--- a/documentation/source/endian_swapper.rst
+++ b/documentation/source/endian_swapper.rst
@@ -16,12 +16,12 @@ You can run this example from a fresh checkout::
 Design
 ======
 
-We have a relatively simplistic RTL block called the ``endian_swapper``.
-The DUT has three interfaces, all conforming to the Avalon standard:
+We have a relatively simplistic :term:`RTL` block called the ``endian_swapper``.
+The :term:`DUT` has three interfaces, all conforming to the Avalon standard:
 
 .. image:: diagrams/svg/endian_swapper_design.svg
 
-The DUT will swap the endianness of packets on the Avalon-ST bus if a configuration bit is set.
+The :term:`DUT` will swap the endianness of packets on the Avalon-ST bus if a configuration bit is set.
 For every packet arriving on the ``stream_in`` interface the entire packet will be endian swapped
 if the configuration bit is set, otherwise the entire packet will pass through unmodified.
 
@@ -97,7 +97,7 @@ We do the same to create the :class:`monitor <cocotb.monitors.avalon.AvalonSTPkt
             self.scoreboard.add_interface(self.stream_out, self.expected_output)
 
 The above lines create a :class:`.Scoreboard` instance and attach it to the ``stream_out`` monitor instance.
-The scoreboard is used to check that the DUT behavior is correct.
+The scoreboard is used to check that the :term:`DUT` behavior is correct.
 The call to :meth:`.add_interface()` takes a Monitor instance as the first argument and
 the second argument is a mechanism for describing the expected output for that interface.
 This could be a callable function but in this example a simple list of expected transactions is sufficient.
@@ -108,7 +108,7 @@ This could be a callable function but in this example a simple list of expected 
             self.stream_in_recovered = AvalonSTMonitor(dut, "stream_in", dut.clk, callback=self.model)
 
 Finally we create another Monitor instance, this time connected to the ``stream_in`` interface.
-This is to reconstruct the transactions being driven into the DUT.
+This is to reconstruct the transactions being driven into the :term:`DUT`.
 It's good practice to use a monitor to reconstruct the transactions from the pin interactions
 rather than snooping them from a higher abstraction layer as we can gain confidence that our drivers and monitors are functioning correctly.
 
@@ -177,7 +177,7 @@ To generate backpressure on the ``stream_out`` interface we use the :class:`.Bit
         raise tb.scoreboard.result
 
 We can see that this test function creates an instance of the testbench,
-resets the DUT by running the coroutine ``tb.reset()`` and then starts off any optional coroutines passed in using the keyword arguments.
+resets the :term:`DUT` by running the coroutine ``tb.reset()`` and then starts off any optional coroutines passed in using the keyword arguments.
 We then send in all the packets from ``data_in``, ensure that all the packets have been received by waiting 2 cycles at the end.
 We read the packet count and compare this with the number of packets.
 Finally we use the :any:`tb.scoreboard.result <cocotb.scoreboard.Scoreboard.result>` to determine the status of the test.

--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -9,7 +9,7 @@ the directory :file:`cocotb/examples/` contains some more smaller modules you ma
 Adder
 =====
 
-The directory :file:`cocotb/examples/adder/` contains an ``adder`` RTL in both Verilog and VHDL,
+The directory :file:`cocotb/examples/adder/` contains an ``adder`` :term:`RTL` in both Verilog and VHDL,
 an ``adder_model`` implemented in Python,
 and the cocotb testbench with two defined tests ­ a simple :func:`adder_basic_test` and
 a slightly more advanced :func:`adder_randomised_test`.
@@ -22,7 +22,7 @@ D Flip-Flop
 
 The directory :file:`cocotb/examples/dff/` contains a simple D flip-flop, implemented in both VDHL and Verilog.
 
-The HDL has the data input port ``d``, the clock port ``c``, and the data output ``q`` with an initial state of ``0``.
+The :term:`HDL` has the data input port ``d``, the clock port ``c``, and the data output ``q`` with an initial state of ``0``.
 No reset port exists.
 
 The cocotb testbench checks the initial state first, then applies random data to the data input.
@@ -52,7 +52,7 @@ feed a :class:`.Scoreboard` with the collected transactions on input bus ``i``.
 Mixed Language
 ==============
 
-The directory :file:`cocotb/examples/mixed_language/` contains two toplevel HDL files,
+The directory :file:`cocotb/examples/mixed_language/` contains two toplevel :term:`HDL` files,
 one in VHDL, one in SystemVerilog, that each instantiate the ``endian_swapper`` in
 SystemVerilog and VHDL in parallel and chains them together so that the endianness is swapped twice.
 

--- a/documentation/source/glossary.rst
+++ b/documentation/source/glossary.rst
@@ -32,6 +32,9 @@ Glossary
    GPI
       General Procedural Interface, cocotb's abstraction over :term:`VPI`, :term:`VHPI`, and :term:`FLI`.
 
+   HAL
+      Hardware Abstraction Layer
+
    HDL
       Hardware Description Language
 

--- a/documentation/source/hal_cosimulation.rst
+++ b/documentation/source/hal_cosimulation.rst
@@ -34,20 +34,20 @@ Calling the HAL from a test
 ---------------------------
 
 Typically the software component (often referred to as a Hardware Abstraction
-Layer or HAL) is written in C.  We need to call this software from our test
+Layer or :term:`HAL`) is written in C.  We need to call this software from our test
 written in Python.  There are multiple ways to call C code from Python, in
-this tutorial we'll use `SWIG`_ to generate Python bindings for our HAL.
+this tutorial we'll use `SWIG`_ to generate Python bindings for our :term:`HAL`.
 
 
 Blocking in the driver
 ----------------------
 
-Another difficulty to overcome is the fact that the HAL is expecting to call
+Another difficulty to overcome is the fact that the :term:`HAL` is expecting to call
 a low-level function to access the hardware, often something like ``ioread32``.
 We need this call to block while simulation time advances and a value is
-either read or written on the bus.  To achieve this we link the HAL against
+either read or written on the bus.  To achieve this we link the :term:`HAL` against
 a C library that provides the low level read/write functions.  These functions
-in turn call into cocotb and perform the relevant access on the DUT.
+in turn call into cocotb and perform the relevant access on the :term:`DUT`.
 
 
 Cocotb infrastructure
@@ -87,8 +87,8 @@ The endian swapper has a very simple register map:
 HAL
 ---
 
-To keep things simple we use the same RTL from the :doc:`endian_swapper`. We
-write a simplistic HAL which provides the following functions:
+To keep things simple we use the same :term:`RTL` from the :doc:`endian_swapper`. We
+write a simplistic :term:`HAL` which provides the following functions:
 
 .. code-block:: c
 
@@ -104,8 +104,8 @@ NIOS framework.
 IO Module
 ---------
 
-This module acts as the bridge between the C HAL and the Python testbench.  It
-exposes the ``IORD`` and ``IOWR`` calls to link the HAL against, but also
+This module acts as the bridge between the C :term:`HAL` and the Python testbench.  It
+exposes the ``IORD`` and ``IOWR`` calls to link the :term:`HAL` against, but also
 provides a Python interface to allow the read/write bindings to be dynamically
 set (through ``set_write_function`` and ``set_read_function`` module functions).
 
@@ -118,9 +118,9 @@ Testbench
 ---------
 
 First of all we set up a clock, create an :class:`Avalon Master <cocotb.drivers.avalon.AvalonMaster>`
-interface and reset the DUT.
+interface and reset the :term:`DUT`.
 Then we create two functions that are wrapped with the :class:`cocotb.function` decorator
-to be called when the HAL attempts to perform a read or write.
+to be called when the :term:`HAL` attempts to perform a read or write.
 These are then passed to the `IO Module`_:
 
 
@@ -144,7 +144,7 @@ These are then passed to the `IO Module`_:
     io_module.set_read_function(read)
 
 
-We can then initialize the HAL and call functions, using the :class:`cocotb.external`
+We can then initialize the :term:`HAL` and call functions, using the :class:`cocotb.external`
 decorator to turn the normal function into a blocking coroutine that we can
 :keyword:`yield`:
 
@@ -154,7 +154,7 @@ decorator to turn the normal function into a blocking coroutine that we can
     yield cocotb.external(hal.endian_swapper_enable)(state)
 
 
-The HAL will perform whatever calls it needs, accessing the DUT through the
+The :term:`HAL` will perform whatever calls it needs, accessing the :term:`DUT` through the
 :class:`Avalon-MM driver <cocotb.drivers.avalon.AvalonMM>`,
 and control will return to the testbench when the function returns.
 

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -15,11 +15,11 @@ Welcome to cocotb's documentation!
 What is cocotb?
 ***************
 
-**cocotb** is a *COroutine* based *COsimulation* *TestBench* environment for verifying VHDL and SystemVerilog RTL using `Python <https://www.python.org>`_.
+**cocotb** is a *COroutine* based *COsimulation* *TestBench* environment for verifying VHDL and SystemVerilog :term:`RTL` using `Python <https://www.python.org>`_.
 
 cocotb is completely free, open source (under the `BSD License <https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_(%22BSD_License_2.0%22,_%22Revised_BSD_License%22,_%22New_BSD_License%22,_or_%22Modified_BSD_License%22)>`_) and hosted on `GitHub <https://github.com/cocotb/cocotb>`_.
 
-cocotb requires a simulator to simulate the HDL design
+cocotb requires a simulator to simulate the :term:`HDL` design
 and has been used with a variety of simulators on Linux, Windows and macOS.
 Please check the :ref:`simulator-support` page for specifics.
 
@@ -56,9 +56,9 @@ All verification is done using Python which has various advantages over using Sy
 How does cocotb work?
 *********************
 
-A typical cocotb testbench requires no additional RTL code.
-The Design Under Test (DUT) is instantiated as the toplevel in the simulator without any wrapper code.
-cocotb drives stimulus onto the inputs to the DUT (or further down the hierarchy) and monitors the outputs directly from Python.
+A typical cocotb testbench requires no additional :term:`RTL` code.
+The Design Under Test (:term:`DUT`) is instantiated as the toplevel in the simulator without any wrapper code.
+cocotb drives stimulus onto the inputs to the :term:`DUT` (or further down the hierarchy) and monitors the outputs directly from Python.
 
 
 .. image:: diagrams/svg/cocotb_overview.svg

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -20,7 +20,7 @@ Cocotb has the following requirements:
 * Python-dev packages
 * GCC 4.8.1+ or Clang 3.3+ and associated development packages
 * GNU Make
-* A Verilog or VHDL simulator, depending on your RTL source code
+* A Verilog or VHDL simulator, depending on your :term:`RTL` source code
 
 .. versionchanged:: 1.4 Dropped Python 2 support
 

--- a/documentation/source/ping_tun_tap.rst
+++ b/documentation/source/ping_tun_tap.rst
@@ -4,7 +4,7 @@ Tutorial: Ping
 
 One of the benefits of Python is the ease with which interfacing is possible.
 In this tutorial we'll look at interfacing the standard GNU `ping`_ command
-to the simulator. Using Python we can ping our DUT with fewer than 50 lines of
+to the simulator. Using Python we can ping our :term:`DUT` with fewer than 50 lines of
 code.
 
 For the impatient this tutorial is provided as an example with cocotb. You can
@@ -22,13 +22,13 @@ run this example from a fresh checkout:
 Architecture
 ============
 
-We have a simple RTL block that takes ICMP echo requests and generates an ICMP
+We have a simple :term:`RTL` block that takes ICMP echo requests and generates an ICMP
 echo response.  To verify this behavior we want to run the `ping`_ utility
-against our RTL running in the simulator.
+against our :term:`RTL` running in the simulator.
 
 In order to achieve this we need to capture the packets that are created by
-ping, drive them onto the pins of our DUT in simulation, monitor the output of
-the DUT and send any responses back to the ping process.
+ping, drive them onto the pins of our :term:`DUT` in simulation, monitor the output of
+the :term:`DUT` and send any responses back to the ping process.
 
 Linux has a `TUN/TAP`_ virtual network device which we can use for this
 purpose, allowing `ping`_ to run unmodified and unaware that it is
@@ -63,7 +63,7 @@ we write a function that will create our virtual interface:
 
 Now we can get started on the actual test.  First of all we'll create a clock
 signal and connect up the :class:`Avalon driver <cocotb.drivers.avalon.AvalonSTPkts>` and
-:class:`monitor <cocotb.monitors.avalon.AvalonSTPkts>` to the DUT.  To help debug
+:class:`monitor <cocotb.monitors.avalon.AvalonSTPkts>` to the :term:`DUT`.  To help debug
 the testbench we'll enable verbose debug on the drivers and monitors by setting
 the log level to ``logging.DEBUG``.
 
@@ -86,7 +86,7 @@ the log level to ``logging.DEBUG``.
         stream_out.log.setLevel(logging.DEBUG)
 
 
-We also need to reset the DUT and drive some default values onto some of the
+We also need to reset the :term:`DUT` and drive some default values onto some of the
 bus signals.  Note that we'll need to import the :class:`~.triggers.Timer`
 and :class:`~.triggers.RisingEdge` triggers.
 

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -36,10 +36,10 @@ but selecting a different simulator is as easy as:
 Running the same example as VHDL
 --------------------------------
 
-The ``simple_dff`` example includes both a VHDL and a Verilog RTL implementation.
-The cocotb testbench can execute against either implementation using VPI for
-Verilog and VHPI/FLI for VHDL.  To run the test suite against the VHDL
-implementation, use the following command (a VHPI or FLI capable simulator must
+The ``simple_dff`` example includes both a VHDL and a Verilog :term:`RTL` implementation.
+The cocotb testbench can execute against either implementation using :term:`VPI` for
+Verilog and :term:`VHPI`/:term:`FLI` for VHDL.  To run the test suite against the VHDL
+implementation, use the following command (a :term:`VHPI` or :term:`FLI` capable simulator must
 be used):
 
 .. code-block:: bash
@@ -50,10 +50,10 @@ be used):
 Using cocotb
 ============
 
-A typical cocotb testbench requires no additional HDL code (though nothing prevents you from adding testbench helper code).
-The Design Under Test (DUT) is instantiated as the toplevel in the simulator
+A typical cocotb testbench requires no additional :term:`HDL` code (though nothing prevents you from adding testbench helper code).
+The Design Under Test (:term:`DUT`) is instantiated as the toplevel in the simulator
 without any wrapper code.
-Cocotb drives stimulus onto the inputs to the DUT and monitors the outputs
+Cocotb drives stimulus onto the inputs to the :term:`DUT` and monitors the outputs
 directly from Python.
 
 
@@ -84,7 +84,7 @@ Creating a test
 The test is written in Python. Cocotb wraps your top level with the handle you
 pass it. In this documentation, and most of the examples in the project, that
 handle is ``dut``, but you can pass your own preferred name in instead. The
-handle is used in all Python files referencing your RTL project. Assuming we
+handle is used in all Python files referencing your :term:`RTL` project. Assuming we
 have a toplevel port called ``clk`` we could create a test file containing the
 following:
 
@@ -147,7 +147,7 @@ or using direct assignment while traversing the hierarchy.
 
 
 The syntax ``sig <= new_value`` is a short form of ``sig.value = new_value``.
-It not only resembles HDL syntax, but also has the same semantics:
+It not only resembles :term:`HDL` syntax, but also has the same semantics:
 writes are not applied immediately, but delayed until the next write cycle.
 Use ``sig.setimmediatevalue(new_val)`` to set a new value immediately
 (see :meth:`~cocotb.handle.NonHierarchyObject.setimmediatevalue`).

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -98,7 +98,7 @@ If your design's clocks vary in precision, the performance of the simulation can
 Coverage
 --------
 
-To enable HDL code coverage, add Verilator's coverage option(s) to the :make:var:`EXTRA_ARGS` make variable, for example:
+To enable :term:`HDL` code coverage, add Verilator's coverage option(s) to the :make:var:`EXTRA_ARGS` make variable, for example:
 
  .. code-block:: make
 
@@ -140,7 +140,7 @@ In order to use this simulator, set :make:var:`SIM` to ``vcs``:
 
     make SIM=vcs
 
-cocotb currently only supports VPI for Synopsys VCS, not VHPI.
+cocotb currently only supports :term:`VPI` for Synopsys VCS, not :term:`VHPI`.
 
 .. _sim-vcs-issues:
 
@@ -244,17 +244,17 @@ In order to use this simulator, set :make:var:`SIM` to ``modelsim``:
 
 .. note::
 
-   In order to use FLI (for VHDL), a ``vdbg`` executable from the simulator installation directory needs to be available on the ``PATH`` during cocotb installation.
+   In order to use :term:`FLI` (for VHDL), a ``vdbg`` executable from the simulator installation directory needs to be available on the ``PATH`` during cocotb installation.
    This is needed to access the proprietary ``mti.h`` header file.
 
-Any ModelSim PE or ModelSim PE derivatives (like the ModelSim Microsemi, Intel, Lattice Editions) do not support the VHDL FLI feature.
-If you try to use them with FLI, you will see a ``vsim-FLI-3155`` error:
+Any ModelSim PE or ModelSim PE derivatives (like the ModelSim Microsemi, Intel, Lattice Editions) do not support the VHDL :term:`FLI` feature.
+If you try to use them with :term:`FLI`, you will see a ``vsim-FLI-3155`` error:
 
 .. code-block:: bash
 
     ** Error (suppressible): (vsim-FLI-3155) The FLI is not enabled in this version of ModelSim.
 
-ModelSim DE and SE (and Questa, of course) support the FLI.
+ModelSim DE and SE (and Questa, of course) support the :term:`FLI`.
 
 .. _sim-modelsim-issues:
 
@@ -296,7 +296,7 @@ In order to use this simulator, set :make:var:`SIM` to ``xcelium``:
 
     make SIM=xcelium
 
-The simulator automatically loads VPI even when only VHPI is requested.
+The simulator automatically loads :term:`VPI` even when only :term:`VHPI` is requested.
 
 .. _sim-xcelium-issues:
 
@@ -318,7 +318,7 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
     make SIM=ghdl
 
 Support is preliminary.
-Noteworthy is that despite GHDL being a VHDL simulator, it implements the VPI interface.
+Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.
 
 .. _sim-ghdl-issues:
 

--- a/documentation/source/testbench_tools.rst
+++ b/documentation/source/testbench_tools.rst
@@ -6,11 +6,11 @@ Logging
 =======
 
 Cocotb uses the builtin :mod:`logging` library, with some configuration described in :ref:`logging-reference-section` to provide some sensible defaults.
-Each DUT, monitor, driver, and scoreboard (as well as any other function using the coroutine decorator) holds a :class:`logging.Logger`, and each can be set to its own logging level.
-Within a DUT, each hierarchical object can also have individual logging levels set.
+Each :term:`DUT`, monitor, driver, and scoreboard (as well as any other function using the coroutine decorator) holds a :class:`logging.Logger`, and each can be set to its own logging level.
+Within a :term:`DUT`, each hierarchical object can also have individual logging levels set.
 
-When logging HDL objects, beware that ``_log`` is the preferred way to use
-logging. This helps minimize the change of name collisions with an HDL log
+When logging :term:`HDL` objects, beware that ``_log`` is the preferred way to use
+logging. This helps minimize the change of name collisions with an :term:`HDL` log
 component with the Python logging functionality.
 
 Log printing levels can also be set on a per-object basis.
@@ -131,9 +131,9 @@ Monitor class is a base class which you are expected to derive for your
 particular purpose. You must create a :any:`_monitor_recv()` function which is
 responsible for determining 1) at what points in simulation to call the
 :any:`_recv()` function, and 2) what transaction values to pass to be stored in the
-monitors receiving queue. Monitors are good for both outputs of the DUT for
-verification, and for the inputs of the DUT, to drive a test model of the DUT
-to be compared to the actual DUT. For this purpose, input monitors will often
+monitors receiving queue. Monitors are good for both outputs of the :term:`DUT` for
+verification, and for the inputs of the :term:`DUT`, to drive a test model of the :term:`DUT`
+to be compared to the actual :term:`DUT`. For this purpose, input monitors will often
 have a callback function passed that is a model. This model will often generate
 expected transactions, which are then compared using the :class:`.Scoreboard`
 class.

--- a/documentation/source/troubleshooting.rst
+++ b/documentation/source/troubleshooting.rst
@@ -12,7 +12,7 @@ i.e. without using :keyword:`await` or :keyword:`yield`?
 Increasing Verbosity
 ====================
 
-If things fail in the VPI/VHPI/FLI area, check your simulator's documentation to see if it has options to
+If things fail in the :term:`VPI`/:term:`VHPI`/:term:`FLI` area, check your simulator's documentation to see if it has options to
 increase its verbosity about what may be wrong. You can then set these options on the :command:`make` command line
 as :make:var:`COMPILE_ARGS`, :make:var:`SIM_ARGS` or :make:var:`EXTRA_ARGS` (see :doc:`building` for details).
 If things fail from within Python, or coroutines aren't being called when you expect, the
@@ -36,7 +36,7 @@ Python
 ------
 
 When executing the Makefile to run a cocotb test, a Python shell interpreter is called from within the
-VPI/VHPI/FLI library.
+:term:`VPI`/:term:`VHPI`/:term:`FLI` library.
 Hence it is not possible to directly attach a Python debugger to the Python process being part of the simulator that uses the aforementioned library.
 Using ``import pdb; pdb.set_trace()`` directly is also frequently not possible, due to the way that simulators interfere with stdin.
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
