### PR TITLE
Deprecate Scoreboard and generators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ jobs:
       after_success: *travis_linux_post
 
     - stage: SimTests
-      python: 3.7
       os: windows
       language: shell
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ jobs:
         - if [[ ! -e "./iverilog/README.txt" ]]; then rm -rf iverilog; git clone https://github.com/steveicarus/iverilog.git --depth=1 --branch v10_3; fi
         - cd iverilog && autoconf && ./configure && make -j2 && sudo make install && cd ..
         - pip install --upgrade tox virtualenv codecov
-        - pyenv global system $TRAVIS_PYTHON_VERSION
       script:
         - echo 'Running cocotb tests with Python 3.7 ...' && echo -en 'travis_fold:start:cocotb_py37'
         - tox -e py37
@@ -124,7 +123,6 @@ jobs:
         - git clone https://github.com/ghdl/ghdl.git --depth=1 --branch v0.36
         - cd ghdl && ./configure && make -j2 && sudo make install && cd ..
         - pip install tox
-        - pyenv global system $TRAVIS_PYTHON_VERSION
       script:
         - tox -e py37
 

--- a/cocotb/generators/__init__.py
+++ b/cocotb/generators/__init__.py
@@ -40,9 +40,7 @@ def repeat(obj, nrepeat=None):
 
     Args:
         obj (any): The object to yield
-
-    Kwargs:
-        nrepeat (int): The number of times to repeatedly yield obj
+        nrepeat (int, optional): The number of times to repeatedly yield *obj*
     """
     if nrepeat is None:
         return itertools.repeat(obj)
@@ -69,7 +67,7 @@ def gaussian(mean, sigma):
     Args:
         mean (int/float): mean value
 
-        signma (int/float): Standard deviation
+        sigma (int/float): Standard deviation
     """
     while True:
         yield random.gauss(mean, sigma)
@@ -81,7 +79,7 @@ def sine_wave(amplitude, w, offset=0):
     Generates a sine wave that repeats forever
 
     Args:
-        amplitude (int/float):  peak deviation of the function from zero
+        amplitude (int/float): peak deviation of the function from zero
 
         w (int/float): is the rate of change of the function argument
 
@@ -95,7 +93,7 @@ def sine_wave(amplitude, w, offset=0):
 
 
 def get_generators(module):
-    """Return an iterator which yields  all the generators in a module
+    """Return an iterator which yields all the generators in a module
 
     Args:
         module (python module): The module to get the generators from

--- a/cocotb/generators/bit.py
+++ b/cocotb/generators/bit.py
@@ -32,7 +32,7 @@
     cycles onto a bus.
 
     These yield a tuple which is intended to be interpreted as a number of
-    cycles (ON,OFF)
+    cycles ``(ON,OFF)``
 """
 from cocotb.decorators import public
 from cocotb.generators import gaussian, sine_wave, repeat
@@ -43,7 +43,6 @@ def bit_toggler(gen_on, gen_off):
 
     Args:
         gen_on (generator): generator that yields number of cycles on
-
         gen_off (generator): generator that yields number of cycles off
     """
     for n_on, n_off in zip(gen_on, gen_off):
@@ -54,10 +53,9 @@ def bit_toggler(gen_on, gen_off):
 def intermittent_single_cycles(mean=10, sigma=None):
     """Generator to intermittently insert a single cycle pulse
 
-    Kwargs:
-        mean (int):     Average number of cycles in between single cycle gaps
-
-        sigma (int):    Standard deviation of gaps.  mean/4 if sigma is None
+    Args:
+        mean (int, optional): Average number of cycles in between single cycle gaps
+        sigma (int, optional): Standard deviation of gaps.  mean/4 if sigma is None
     """
     if sigma is None:
         sigma = mean / 4.0
@@ -68,10 +66,10 @@ def intermittent_single_cycles(mean=10, sigma=None):
 @public
 def random_50_percent(mean=10, sigma=None):
     """50% duty cycle with random width
-    Kwargs:
-        mean (int):     Average number of cycles on/off
 
-        sigma (int):    Standard deviation of gaps.  mean/4 if sigma is None
+    Args:
+        mean (int, optional): Average number of cycles on/off
+        sigma (int, optional): Standard deviation of gaps.  mean/4 if sigma is None
     """
     if sigma is None:
         sigma = mean / 4.0

--- a/cocotb/generators/byte.py
+++ b/cocotb/generators/byte.py
@@ -29,7 +29,7 @@
 
 
 """
-    Collection of generators for creating byte streams
+    Collection of generators for creating byte streams.
 
     Note that on Python 3, individual bytes are represented with integers.
 """
@@ -44,7 +44,7 @@ def get_bytes(nbytes: int, generator: Iterator[int]) -> bytes:
     """Get nbytes from generator
 
     .. versionchanged:: 1.4.0
-        This now returns :type:`bytes` not :type:`str`. """
+        This now returns :class:`bytes`, not :class:`str`. """
     return bytes(next(generator) for i in range(nbytes))
 
 
@@ -53,7 +53,7 @@ def random_data() -> Iterator[int]:
     r"""Random bytes
 
     .. versionchanged:: 1.4.0
-        This now returns integers not single-character :type:`str`\ s. """
+        This now returns integers, not single-character :class:`str`\ s. """
     while True:
         yield random.randrange(256)
 
@@ -63,7 +63,7 @@ def incrementing_data(increment=1) -> Iterator[int]:
     r"""Incrementing bytes
 
     .. versionchanged:: 1.4.0
-        This now returns integers not single-character :type:`str`\ s. """
+        This now returns integers, not single-character :class:`str`\ s. """
     val = 0
     while True:
         yield val

--- a/cocotb/generators/byte.py
+++ b/cocotb/generators/byte.py
@@ -41,29 +41,41 @@ from typing import Iterator
 
 @public
 def get_bytes(nbytes: int, generator: Iterator[int]) -> bytes:
-    """Get nbytes from generator
+    """
+    Get nbytes from generator
 
     .. versionchanged:: 1.4.0
-        This now returns :class:`bytes`, not :class:`str`. """
+        This now returns :class:`bytes`, not :class:`str`.
+
+    .. deprecated:: 1.4.1
+    """
     return bytes(next(generator) for i in range(nbytes))
 
 
 @public
 def random_data() -> Iterator[int]:
-    r"""Random bytes
+    r"""
+    Random bytes
 
     .. versionchanged:: 1.4.0
-        This now returns integers, not single-character :class:`str`\ s. """
+        This now returns integers, not single-character :class:`str`\ s.
+
+    .. deprecated:: 1.4.1
+    """
     while True:
         yield random.randrange(256)
 
 
 @public
 def incrementing_data(increment=1) -> Iterator[int]:
-    r"""Incrementing bytes
+    r"""
+    Incrementing bytes
 
     .. versionchanged:: 1.4.0
-        This now returns integers, not single-character :class:`str`\ s. """
+        This now returns integers, not single-character :class:`str`\ s.
+
+    .. deprecated:: 1.4.1
+    """
     val = 0
     while True:
         yield val
@@ -72,6 +84,10 @@ def incrementing_data(increment=1) -> Iterator[int]:
 
 
 @public
-def repeating_bytes(pattern : bytes = b"\x00") -> Iterator[int]:
-    """Repeat a pattern of bytes"""
+def repeating_bytes(pattern: bytes = b"\x00") -> Iterator[int]:
+    """
+    Repeat a pattern of bytes
+
+    .. deprecated:: 1.4.1
+    """
     return itertools.cycle(pattern)

--- a/cocotb/scoreboard.py
+++ b/cocotb/scoreboard.py
@@ -30,6 +30,7 @@
 """Common scoreboarding capability."""
 
 import logging
+import warnings
 
 from cocotb.utils import hexdump, hexdiffs
 from cocotb.log import SimLog
@@ -57,6 +58,8 @@ class Scoreboard:
         fail_immediately (bool, optional): Raise :any:`TestFailure`
             immediately when something is wrong instead of just
             recording an error. Default is ``True``.
+
+    .. deprecated:: 1.4.1
     """
 
     def __init__(self, dut, reorder_depth=0, fail_immediately=True):  # FIXME: reorder_depth needed here?
@@ -65,6 +68,12 @@ class Scoreboard:
         self.errors = 0
         self.expected = {}
         self._imm = fail_immediately
+
+        warnings.warn(
+            "This Scoreboard implementation has been deprecated and will be removed soon.\n"
+            "If this implementation works for you, copy the implementation into your project, "
+            "while following cocotb's license agreement.",
+            DeprecationWarning)
 
     @property
     def result(self):

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -130,6 +130,45 @@ Scoreboard
     :show-inheritance:
     :synopsis: Class for scoreboards.
 
+Generators
+----------
+
+.. currentmodule:: cocotb.generators
+
+.. automodule:: cocotb.generators
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+    :synopsis: Class for generators.
+
+Bit
+^^^
+
+.. automodule:: cocotb.generators.bit
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+
+Byte
+^^^^
+
+.. automodule:: cocotb.generators.byte
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+..
+   Needs scapy
+
+   Packet
+   ^^^^^^
+
+   .. automodule:: cocotb.generators.packet
+       :members:
+       :member-order: bysource
+       :show-inheritance:
+
 Clock
 -----
 

--- a/examples/dff/tests/dff_cocotb.py
+++ b/examples/dff/tests/dff_cocotb.py
@@ -1,7 +1,7 @@
 # ==============================================================================
-# Authors:		Martin Zabel
+# Authors:              Martin Zabel
 #
-# Cocotb Testbench:	For D flip-flop
+# Cocotb Testbench:     For D flip-flop
 #
 # Description:
 # ------------------------------------
@@ -26,6 +26,7 @@
 # ==============================================================================
 
 import random
+import warnings
 
 import cocotb
 from cocotb.clock import Clock
@@ -93,7 +94,9 @@ class DFF_TB(object):
 
         # Create a scoreboard on the outputs
         self.expected_output = [init_val]  # a list with init_val as the first element
-        self.scoreboard = Scoreboard(dut)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.scoreboard = Scoreboard(dut)
         self.scoreboard.add_interface(self.output_mon, self.expected_output)
 
         # Use the input monitor to reconstruct the transactions from the pins

--- a/examples/endian_swapper/tests/generators/__init__.py
+++ b/examples/endian_swapper/tests/generators/__init__.py
@@ -31,18 +31,8 @@
 import math
 import random
 import itertools
-import warnings
 
 from cocotb.decorators import public
-
-
-warnings.warn(
-    "The contents of the cocotb.generators package will soon be removed.\n"
-    "Most of the functionality can be replaced with utilities provided "
-    "by other packages or the standard library.\n Alternatively, you can "
-    "copy this package or individual functions into your project, if you "
-    "follow cocotb's license agreement.",
-    DeprecationWarning)
 
 
 @public
@@ -51,9 +41,9 @@ def repeat(obj, nrepeat=None):
 
     Args:
         obj (any): The object to yield
-        nrepeat (int, optional): The number of times to repeatedly yield *obj*
 
-    .. deprecated:: 1.4.1
+    Kwargs:
+        nrepeat (int): The number of times to repeatedly yield obj
     """
     if nrepeat is None:
         return itertools.repeat(obj)
@@ -68,8 +58,6 @@ def combine(generators):
 
     Args:
         generators (iterable): Generators to combine together
-
-    .. deprecated:: 1.4.1
     """
     return itertools.chain.from_iterable(generators)
 
@@ -82,9 +70,7 @@ def gaussian(mean, sigma):
     Args:
         mean (int/float): mean value
 
-        sigma (int/float): Standard deviation
-
-    .. deprecated:: 1.4.1
+        signma (int/float): Standard deviation
     """
     while True:
         yield random.gauss(mean, sigma)
@@ -96,14 +82,12 @@ def sine_wave(amplitude, w, offset=0):
     Generates a sine wave that repeats forever
 
     Args:
-        amplitude (int/float): peak deviation of the function from zero
+        amplitude (int/float):  peak deviation of the function from zero
 
         w (int/float): is the rate of change of the function argument
 
     Yields:
         floats that form a sine wave
-
-    .. deprecated:: 1.4.1
     """
     twoPiF_DIV_sampleRate = math.pi * 2
     while True:
@@ -112,11 +96,9 @@ def sine_wave(amplitude, w, offset=0):
 
 
 def get_generators(module):
-    """Return an iterator which yields all the generators in a module
+    """Return an iterator which yields  all the generators in a module
 
     Args:
         module (python module): The module to get the generators from
-
-    .. deprecated:: 1.4.1
     """
     return (getattr(module, gen) for gen in module.__all__)

--- a/examples/endian_swapper/tests/generators/bit.py
+++ b/examples/endian_swapper/tests/generators/bit.py
@@ -32,7 +32,7 @@
     cycles onto a bus.
 
     These yield a tuple which is intended to be interpreted as a number of
-    cycles ``(ON,OFF)``
+    cycles (ON,OFF)
 """
 from cocotb.decorators import public
 from cocotb.generators import gaussian, sine_wave, repeat
@@ -43,9 +43,8 @@ def bit_toggler(gen_on, gen_off):
 
     Args:
         gen_on (generator): generator that yields number of cycles on
-        gen_off (generator): generator that yields number of cycles off
 
-    .. deprecated:: 1.4.1
+        gen_off (generator): generator that yields number of cycles off
     """
     for n_on, n_off in zip(gen_on, gen_off):
         yield int(abs(n_on)), int(abs(n_off))
@@ -55,11 +54,10 @@ def bit_toggler(gen_on, gen_off):
 def intermittent_single_cycles(mean=10, sigma=None):
     """Generator to intermittently insert a single cycle pulse
 
-    Args:
-        mean (int, optional): Average number of cycles in between single cycle gaps
-        sigma (int, optional): Standard deviation of gaps.  mean/4 if sigma is None
+    Kwargs:
+        mean (int):     Average number of cycles in between single cycle gaps
 
-    .. deprecated:: 1.4.1
+        sigma (int):    Standard deviation of gaps.  mean/4 if sigma is None
     """
     if sigma is None:
         sigma = mean / 4.0
@@ -70,12 +68,10 @@ def intermittent_single_cycles(mean=10, sigma=None):
 @public
 def random_50_percent(mean=10, sigma=None):
     """50% duty cycle with random width
+    Kwargs:
+        mean (int):     Average number of cycles on/off
 
-    Args:
-        mean (int, optional): Average number of cycles on/off
-        sigma (int, optional): Standard deviation of gaps.  mean/4 if sigma is None
-
-    .. deprecated:: 1.4.1
+        sigma (int):    Standard deviation of gaps.  mean/4 if sigma is None
     """
     if sigma is None:
         sigma = mean / 4.0
@@ -90,8 +86,6 @@ def wave(on_ampl=30, on_freq=200, off_ampl=10, off_freq=100):
 
     TODO:
         Adjust args so we just specify a repeat duration and overall throughput
-
-    .. deprecated:: 1.4.1
     """
     return bit_toggler(sine_wave(on_ampl, on_freq),
                        sine_wave(off_ampl, off_freq))

--- a/examples/endian_swapper/tests/generators/packet.py
+++ b/examples/endian_swapper/tests/generators/packet.py
@@ -51,11 +51,7 @@ _default_payload = random_data
 # UDP packet generators
 @public
 def udp_all_sizes(max_size=1500, payload=_default_payload()):
-    """
-    UDP packets of every supported size
-
-    .. deprecated:: 1.4.1
-    """
+    """UDP packets of every supported size"""
     header = Ether() / IP() / UDP()
 
     for size in range(0, max_size - len(header)):
@@ -64,11 +60,7 @@ def udp_all_sizes(max_size=1500, payload=_default_payload()):
 
 @public
 def udp_random_sizes(npackets=100, payload=_default_payload()):
-    """
-    UDP packets with random sizes
-
-    .. deprecated:: 1.4.1
-    """
+    """UDP packets with random sizes"""
     header = Ether() / IP() / UDP()
     max_size = 1500 - len(header)
 
@@ -79,10 +71,6 @@ def udp_random_sizes(npackets=100, payload=_default_payload()):
 # IPV4 generator
 @public
 def ipv4_small_packets(npackets=100, payload=_default_payload()):
-    """
-    Small (<100bytes payload) IPV4 packets
-
-    .. deprecated:: 1.4.1
-    """
+    """Small (<100bytes payload) IPV4 packets"""
     for pkt in range(npackets):
         yield Ether() / IP() / get_bytes(random.randint(0, 100), payload)

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -27,6 +27,7 @@
 
 import random
 import logging
+import warnings
 
 import cocotb
 
@@ -81,7 +82,9 @@ class EndianSwapperTB(object):
         # Create a scoreboard on the stream_out bus
         self.pkts_sent = 0
         self.expected_output = []
-        self.scoreboard = Scoreboard(dut)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.scoreboard = Scoreboard(dut)
         self.scoreboard.add_interface(self.stream_out, self.expected_output)
 
         # Reconstruct the input transactions from the pins

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -42,9 +42,8 @@ from cocotb.scoreboard import Scoreboard
 from cocotb.result import TestFailure
 
 # Data generators
-from cocotb.generators.byte import random_data, get_bytes
-from cocotb.generators.bit import (wave, intermittent_single_cycles,
-                                   random_50_percent)
+from generators.byte import random_data, get_bytes
+from generators.bit import wave, intermittent_single_cycles, random_50_percent
 
 
 async def stream_out_config_setter(dut, stream_out, stream_in):

--- a/examples/mean/tests/test_mean.py
+++ b/examples/mean/tests/test_mean.py
@@ -8,6 +8,7 @@ from cocotb.monitors import BusMonitor
 from cocotb.scoreboard import Scoreboard
 
 import random
+import warnings
 
 CLK_PERIOD_NS = 100
 
@@ -90,7 +91,9 @@ async def mean_randomised_test(dut):
     dut_out = StreamBusMonitor(dut, "o", dut.clk)
 
     exp_out = []
-    scoreboard = Scoreboard(dut)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        scoreboard = Scoreboard(dut)
     scoreboard.add_interface(dut_out, exp_out)
 
     DATA_WIDTH = int(dut.DATA_WIDTH.value)

--- a/tests/test_cases/test_avalon_stream/test_avalon_stream.py
+++ b/tests/test_cases/test_avalon_stream/test_avalon_stream.py
@@ -3,6 +3,7 @@
 
 import random
 import struct
+import warnings
 
 import cocotb
 from cocotb.drivers import BitDriver
@@ -24,7 +25,9 @@ class AvalonSTTB(object):
 
         self.stream_in = AvalonSTDriver(self.dut, "asi", dut.clk)
         self.stream_out = AvalonSTMonitor(self.dut, "aso", dut.clk)
-        self.scoreboard = Scoreboard(self.dut, fail_immediately=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.scoreboard = Scoreboard(self.dut, fail_immediately=True)
 
         self.expected_output = []
         self.scoreboard.add_interface(self.stream_out, self.expected_output)


### PR DESCRIPTION
Fixes #2017. I don't have a test, seeing as we aren't currently testing the scoreboard, and may move it out of repo soon, I'm not sure if that's necessary. I will make one if it is desired.

@hjwmedenblik This should fix the issue you were seeing with hexdiff.
@bluecmd This should remove the DeprecationWarning you are seeing.

Could you both please test it?