### PR TITLE
Document generators in Python library reference

### DIFF
--- a/cocotb/generators/__init__.py
+++ b/cocotb/generators/__init__.py
@@ -40,9 +40,7 @@ def repeat(obj, nrepeat=None):
 
     Args:
         obj (any): The object to yield
-
-    Kwargs:
-        nrepeat (int): The number of times to repeatedly yield obj
+        nrepeat (int, optional): The number of times to repeatedly yield *obj*
     """
     if nrepeat is None:
         return itertools.repeat(obj)
@@ -69,7 +67,7 @@ def gaussian(mean, sigma):
     Args:
         mean (int/float): mean value
 
-        signma (int/float): Standard deviation
+        sigma (int/float): Standard deviation
     """
     while True:
         yield random.gauss(mean, sigma)
@@ -81,7 +79,7 @@ def sine_wave(amplitude, w, offset=0):
     Generates a sine wave that repeats forever
 
     Args:
-        amplitude (int/float):  peak deviation of the function from zero
+        amplitude (int/float): peak deviation of the function from zero
 
         w (int/float): is the rate of change of the function argument
 
@@ -95,7 +93,7 @@ def sine_wave(amplitude, w, offset=0):
 
 
 def get_generators(module):
-    """Return an iterator which yields  all the generators in a module
+    """Return an iterator which yields all the generators in a module
 
     Args:
         module (python module): The module to get the generators from

--- a/cocotb/generators/bit.py
+++ b/cocotb/generators/bit.py
@@ -32,7 +32,7 @@
     cycles onto a bus.
 
     These yield a tuple which is intended to be interpreted as a number of
-    cycles (ON,OFF)
+    cycles ``(ON,OFF)``
 """
 from cocotb.decorators import public
 from cocotb.generators import gaussian, sine_wave, repeat
@@ -43,7 +43,6 @@ def bit_toggler(gen_on, gen_off):
 
     Args:
         gen_on (generator): generator that yields number of cycles on
-
         gen_off (generator): generator that yields number of cycles off
     """
     for n_on, n_off in zip(gen_on, gen_off):
@@ -54,10 +53,9 @@ def bit_toggler(gen_on, gen_off):
 def intermittent_single_cycles(mean=10, sigma=None):
     """Generator to intermittently insert a single cycle pulse
 
-    Kwargs:
-        mean (int):     Average number of cycles in between single cycle gaps
-
-        sigma (int):    Standard deviation of gaps.  mean/4 if sigma is None
+    Args:
+        mean (int, optional): Average number of cycles in between single cycle gaps
+        sigma (int, optional): Standard deviation of gaps.  mean/4 if sigma is None
     """
     if sigma is None:
         sigma = mean / 4.0
@@ -68,10 +66,10 @@ def intermittent_single_cycles(mean=10, sigma=None):
 @public
 def random_50_percent(mean=10, sigma=None):
     """50% duty cycle with random width
-    Kwargs:
-        mean (int):     Average number of cycles on/off
 
-        sigma (int):    Standard deviation of gaps.  mean/4 if sigma is None
+    Args:
+        mean (int, optional): Average number of cycles on/off
+        sigma (int, optional): Standard deviation of gaps.  mean/4 if sigma is None
     """
     if sigma is None:
         sigma = mean / 4.0

--- a/cocotb/generators/byte.py
+++ b/cocotb/generators/byte.py
@@ -29,7 +29,7 @@
 
 
 """
-    Collection of generators for creating byte streams
+    Collection of generators for creating byte streams.
 
     Note that on Python 3, individual bytes are represented with integers.
 """
@@ -44,7 +44,7 @@ def get_bytes(nbytes: int, generator: Iterator[int]) -> bytes:
     """Get nbytes from generator
 
     .. versionchanged:: 1.4.0
-        This now returns :type:`bytes` not :type:`str`. """
+        This now returns :class:`bytes`, not :class:`str`. """
     return bytes(next(generator) for i in range(nbytes))
 
 
@@ -53,7 +53,7 @@ def random_data() -> Iterator[int]:
     r"""Random bytes
 
     .. versionchanged:: 1.4.0
-        This now returns integers not single-character :type:`str`\ s. """
+        This now returns integers, not single-character :class:`str`\ s. """
     while True:
         yield random.randrange(256)
 
@@ -63,7 +63,7 @@ def incrementing_data(increment=1) -> Iterator[int]:
     r"""Incrementing bytes
 
     .. versionchanged:: 1.4.0
-        This now returns integers not single-character :type:`str`\ s. """
+        This now returns integers, not single-character :class:`str`\ s. """
     val = 0
     while True:
         yield val

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -130,6 +130,45 @@ Scoreboard
     :show-inheritance:
     :synopsis: Class for scoreboards.
 
+Generators
+----------
+
+.. currentmodule:: cocotb.generators
+
+.. automodule:: cocotb.generators
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+    :synopsis: Class for generators.
+
+Bit
+^^^
+
+.. automodule:: cocotb.generators.bit
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+
+Byte
+^^^^
+
+.. automodule:: cocotb.generators.byte
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+..
+   Needs scapy
+
+   Packet
+   ^^^^^^
+
+   .. automodule:: cocotb.generators.packet
+       :members:
+       :member-order: bysource
+       :show-inheritance:
+
 Clock
 -----
 


### PR DESCRIPTION
I fixed some small docstring problems but didn't polish it all the way since these will be deprecated anyway with #2041.
I also left out ``packet`` since that depends on ``scapy`` and IMHO doesn't warrant adding that dependency for doc building.