### PR TITLE
Make it possible to run skip=True tests by setting TESTCASE

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -510,7 +510,8 @@ class test(coroutine, metaclass=_decorator_helper):
             .. versionchanged:: 1.3
                 Specific exception types can be expected
         skip (bool, optional):
-            Don't execute this test as part of the regression.
+            Don't execute this test as part of the regression. Test can still be run
+            manually by setting :make:var:`TESTCASE`.
         stage (int, optional)
             Order tests logically into stages, where multiple tests can share a stage.
     """

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -196,7 +196,7 @@ class RegressionManager:
                                       test_name, module_name)
                         raise ImportError("Failed to find requested test %s" % test_name)
 
-                    # If we request a test manually, it should be ran even if skip=True is set.
+                    # If we request a test manually, it should be run even if skip=True is set.
                     test.skip = False
 
                     yield test

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -195,6 +195,10 @@ class RegressionManager:
                         _logger.error("Requested %s from module %s isn't a cocotb.test decorated coroutine",
                                       test_name, module_name)
                         raise ImportError("Failed to find requested test %s" % test_name)
+
+                    # If we request a test manually, it should be ran even if skip=True is set.
+                    test.skip = False
+
                     yield test
 
                 # only look in first module for all functions and don't complain if all functions are not found

--- a/documentation/source/newsfragments/2045.bugfix.rst
+++ b/documentation/source/newsfragments/2045.bugfix.rst
@@ -1,0 +1,1 @@
+Tests skipped by default (created with `skip=True`) can again be run manually by setting the :envvar:`TESTCASE` variable.

--- a/tests/test_cases/test_skipped/Makefile
+++ b/tests/test_cases/test_skipped/Makefile
@@ -1,0 +1,22 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+include ../../designs/sample_module/Makefile
+
+SKIPPED_TEST_FILE = ran_skipped_test~
+
+clean::
+	@rm -rf ${SKIPPED_TEST_FILE}
+
+# Override the default target. We need to run clean (to remove the cached test file)
+# and then test to make sure it is recreated.
+.DEFAULT_GOAL := override
+.PHONY: override
+override: clean all
+	 @test -f $(SKIPPED_TEST_FILE) || (echo "ERROR: skip=True test was not ran!" >&2 && exit 1)
+
+# Set TESTCASE; run test_skipped even though skip=True is set.
+TESTCASE = test_skipped
+
+MODULE = test_skipped

--- a/tests/test_cases/test_skipped/test_skipped.py
+++ b/tests/test_cases/test_skipped/test_skipped.py
@@ -1,0 +1,15 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pathlib
+
+import cocotb
+
+skipped_file_name = "ran_skipped_test~"
+
+
+@cocotb.test(skip=True)
+async def test_skipped(dut):
+    """ Touch a file so we can check that this test has ran."""
+    pathlib.Path(skipped_file_name).touch()

--- a/tests/test_cases/test_skipped/test_skipped.py
+++ b/tests/test_cases/test_skipped/test_skipped.py
@@ -11,5 +11,5 @@ skipped_file_name = "ran_skipped_test~"
 
 @cocotb.test(skip=True)
 async def test_skipped(dut):
-    """ Touch a file so we can check that this test has ran."""
+    """ Touch a file so we can check that this test has run."""
     pathlib.Path(skipped_file_name).touch()


### PR DESCRIPTION
The ```@cocotb.test()``` decorator takes an optional ```skip``` argument, which defaults to False. If skip is set to True, the
test will be skipped when tests are ran. However, in cocotb 1.3 (and earlier versions), these automatically skipped tests could still be ran explicitly by setting ```TESTCASE=``` on the command line.

As of cocotb 1.4+, that no longer appears to be possible. If a test has skip=True in its constructor, it cannot be ran even using the ```TESTCASE``` environment variable. It would be useful to have some supported way of overriding the skip setting and explicitly running a test, and restoring the pre-1.4 behavior seems like a reasonable way to do that.

This commit makes it so that setting ```TESTCASE``` on the command line sets ```test.skip = False```, meaning that the test will always be ran. If ```TESTCASE``` is not set, then nothing is changed-- the test will be ran or skipped depending on the value set in the test decorator.

I ran into this while upgrading a testbench to 1.4 which uses the skip setting to define tests which work but should not normally be ran-- e.g. a handful of longer tests that do more intense simulations that should only be run on demand have skip set to true, while the rest of the tests have skip set to false and run by default. Since this is a regression, I'd like to restore the previous behavior-- while we could implement some other way to run these tests (and I can always work around it by, for example, setting skip to ```os.getenv("SOME_OTHER_VAR")```) it seems like the simplest way to do this is through ```TESTCASE```.

This behavior can be tested by adding the following test to a project and trying to run it with ```make TESTCASE=test_skipped```. Using cocotb 1.4 (or master), the test below is skipped with the message "Skipping test 1/1: test_skipped". With this change, it will still be skipped by default, but will now run when ```TESTCASE=test_skipped``` is set.

```
import cocotb
from cocotb import triggers

@cocotb.test(skip=True)
def test_skipped(dut):
    yield triggers.NullTrigger()
    dut._log.info("Ran skipped test manually.")
```