### PR TITLE
Deprecating cocotb.generators and Scoreboard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ jobs:
       after_success: *travis_linux_post
 
     - stage: SimTests
-      python: 3.7
       os: windows
       language: shell
       before_install:

--- a/cocotb/generators/__init__.py
+++ b/cocotb/generators/__init__.py
@@ -31,7 +31,18 @@
 import math
 import random
 import itertools
+import warnings
+
 from cocotb.decorators import public
+
+
+warnings.warn(
+    "The contents of the cocotb.generators package will soon be removed.\n"
+    "Most of the functionality can be replaced with utilities provided "
+    "by other packages or the standard library.\n Alternatively, you can "
+    "copy this package or individual functions into your project, if you "
+    "follow cocotb's license agreement.",
+    DeprecationWarning)
 
 
 @public
@@ -41,6 +52,8 @@ def repeat(obj, nrepeat=None):
     Args:
         obj (any): The object to yield
         nrepeat (int, optional): The number of times to repeatedly yield *obj*
+
+    .. deprecated:: 1.4.1
     """
     if nrepeat is None:
         return itertools.repeat(obj)
@@ -55,6 +68,8 @@ def combine(generators):
 
     Args:
         generators (iterable): Generators to combine together
+
+    .. deprecated:: 1.4.1
     """
     return itertools.chain.from_iterable(generators)
 
@@ -68,6 +83,8 @@ def gaussian(mean, sigma):
         mean (int/float): mean value
 
         sigma (int/float): Standard deviation
+
+    .. deprecated:: 1.4.1
     """
     while True:
         yield random.gauss(mean, sigma)
@@ -85,6 +102,8 @@ def sine_wave(amplitude, w, offset=0):
 
     Yields:
         floats that form a sine wave
+
+    .. deprecated:: 1.4.1
     """
     twoPiF_DIV_sampleRate = math.pi * 2
     while True:
@@ -97,5 +116,7 @@ def get_generators(module):
 
     Args:
         module (python module): The module to get the generators from
+
+    .. deprecated:: 1.4.1
     """
     return (getattr(module, gen) for gen in module.__all__)

--- a/cocotb/generators/bit.py
+++ b/cocotb/generators/bit.py
@@ -44,6 +44,8 @@ def bit_toggler(gen_on, gen_off):
     Args:
         gen_on (generator): generator that yields number of cycles on
         gen_off (generator): generator that yields number of cycles off
+
+    .. deprecated:: 1.4.1
     """
     for n_on, n_off in zip(gen_on, gen_off):
         yield int(abs(n_on)), int(abs(n_off))
@@ -56,6 +58,8 @@ def intermittent_single_cycles(mean=10, sigma=None):
     Args:
         mean (int, optional): Average number of cycles in between single cycle gaps
         sigma (int, optional): Standard deviation of gaps.  mean/4 if sigma is None
+
+    .. deprecated:: 1.4.1
     """
     if sigma is None:
         sigma = mean / 4.0
@@ -70,6 +74,8 @@ def random_50_percent(mean=10, sigma=None):
     Args:
         mean (int, optional): Average number of cycles on/off
         sigma (int, optional): Standard deviation of gaps.  mean/4 if sigma is None
+
+    .. deprecated:: 1.4.1
     """
     if sigma is None:
         sigma = mean / 4.0
@@ -84,6 +90,8 @@ def wave(on_ampl=30, on_freq=200, off_ampl=10, off_freq=100):
 
     TODO:
         Adjust args so we just specify a repeat duration and overall throughput
+
+    .. deprecated:: 1.4.1
     """
     return bit_toggler(sine_wave(on_ampl, on_freq),
                        sine_wave(off_ampl, off_freq))

--- a/cocotb/generators/byte.py
+++ b/cocotb/generators/byte.py
@@ -41,29 +41,41 @@ from typing import Iterator
 
 @public
 def get_bytes(nbytes: int, generator: Iterator[int]) -> bytes:
-    """Get nbytes from generator
+    """
+    Get nbytes from generator
 
     .. versionchanged:: 1.4.0
-        This now returns :class:`bytes`, not :class:`str`. """
+        This now returns :class:`bytes`, not :class:`str`.
+
+    .. deprecated:: 1.4.1
+    """
     return bytes(next(generator) for i in range(nbytes))
 
 
 @public
 def random_data() -> Iterator[int]:
-    r"""Random bytes
+    r"""
+    Random bytes
 
     .. versionchanged:: 1.4.0
-        This now returns integers, not single-character :class:`str`\ s. """
+        This now returns integers, not single-character :class:`str`\ s.
+
+    .. deprecated:: 1.4.1
+    """
     while True:
         yield random.randrange(256)
 
 
 @public
 def incrementing_data(increment=1) -> Iterator[int]:
-    r"""Incrementing bytes
+    r"""
+    Incrementing bytes
 
     .. versionchanged:: 1.4.0
-        This now returns integers, not single-character :class:`str`\ s. """
+        This now returns integers, not single-character :class:`str`\ s.
+
+    .. deprecated:: 1.4.1
+    """
     val = 0
     while True:
         yield val
@@ -72,6 +84,10 @@ def incrementing_data(increment=1) -> Iterator[int]:
 
 
 @public
-def repeating_bytes(pattern : bytes = b"\x00") -> Iterator[int]:
-    """Repeat a pattern of bytes"""
+def repeating_bytes(pattern: bytes = b"\x00") -> Iterator[int]:
+    """
+    Repeat a pattern of bytes
+
+    .. deprecated:: 1.4.1
+    """
     return itertools.cycle(pattern)

--- a/cocotb/generators/packet.py
+++ b/cocotb/generators/packet.py
@@ -51,7 +51,11 @@ _default_payload = random_data
 # UDP packet generators
 @public
 def udp_all_sizes(max_size=1500, payload=_default_payload()):
-    """UDP packets of every supported size"""
+    """
+    UDP packets of every supported size
+
+    .. deprecated:: 1.4.1
+    """
     header = Ether() / IP() / UDP()
 
     for size in range(0, max_size - len(header)):
@@ -60,7 +64,11 @@ def udp_all_sizes(max_size=1500, payload=_default_payload()):
 
 @public
 def udp_random_sizes(npackets=100, payload=_default_payload()):
-    """UDP packets with random sizes"""
+    """
+    UDP packets with random sizes
+
+    .. deprecated:: 1.4.1
+    """
     header = Ether() / IP() / UDP()
     max_size = 1500 - len(header)
 
@@ -71,6 +79,10 @@ def udp_random_sizes(npackets=100, payload=_default_payload()):
 # IPV4 generator
 @public
 def ipv4_small_packets(npackets=100, payload=_default_payload()):
-    """Small (<100bytes payload) IPV4 packets"""
+    """
+    Small (<100bytes payload) IPV4 packets
+
+    .. deprecated:: 1.4.1
+    """
     for pkt in range(npackets):
         yield Ether() / IP() / get_bytes(random.randint(0, 100), payload)

--- a/cocotb/scoreboard.py
+++ b/cocotb/scoreboard.py
@@ -30,6 +30,7 @@
 """Common scoreboarding capability."""
 
 import logging
+import warnings
 
 from cocotb.utils import hexdump, hexdiffs
 from cocotb.log import SimLog
@@ -57,6 +58,8 @@ class Scoreboard:
         fail_immediately (bool, optional): Raise :any:`TestFailure`
             immediately when something is wrong instead of just
             recording an error. Default is ``True``.
+
+    .. deprecated:: 1.4.1
     """
 
     def __init__(self, dut, reorder_depth=0, fail_immediately=True):  # FIXME: reorder_depth needed here?
@@ -65,6 +68,12 @@ class Scoreboard:
         self.errors = 0
         self.expected = {}
         self._imm = fail_immediately
+
+        warnings.warn(
+            "This Scoreboard implementation has been deprecated and will be removed soon.\n"
+            "If this implementation works for you, copy the implementation into your project, "
+            "while following cocotb's license agreement.",
+            DeprecationWarning)
 
     @property
     def result(self):

--- a/documentation/source/newsfragments/2047.removal.rst
+++ b/documentation/source/newsfragments/2047.removal.rst
@@ -1,0 +1,1 @@
+:class:`~cocotb.scoreboard.Scoreboard` and all contents of :mod:`cocotb.generators` have been deprecated.

--- a/examples/dff/tests/dff_cocotb.py
+++ b/examples/dff/tests/dff_cocotb.py
@@ -1,7 +1,7 @@
 # ==============================================================================
-# Authors:		Martin Zabel
+# Authors:              Martin Zabel
 #
-# Cocotb Testbench:	For D flip-flop
+# Cocotb Testbench:     For D flip-flop
 #
 # Description:
 # ------------------------------------
@@ -26,6 +26,7 @@
 # ==============================================================================
 
 import random
+import warnings
 
 import cocotb
 from cocotb.clock import Clock
@@ -93,7 +94,9 @@ class DFF_TB(object):
 
         # Create a scoreboard on the outputs
         self.expected_output = [init_val]  # a list with init_val as the first element
-        self.scoreboard = Scoreboard(dut)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.scoreboard = Scoreboard(dut)
         self.scoreboard.add_interface(self.output_mon, self.expected_output)
 
         # Use the input monitor to reconstruct the transactions from the pins

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -27,6 +27,7 @@
 
 import random
 import logging
+import warnings
 
 import cocotb
 
@@ -81,7 +82,9 @@ class EndianSwapperTB(object):
         # Create a scoreboard on the stream_out bus
         self.pkts_sent = 0
         self.expected_output = []
-        self.scoreboard = Scoreboard(dut)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.scoreboard = Scoreboard(dut)
         self.scoreboard.add_interface(self.stream_out, self.expected_output)
 
         # Reconstruct the input transactions from the pins

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -42,9 +42,10 @@ from cocotb.scoreboard import Scoreboard
 from cocotb.result import TestFailure
 
 # Data generators
-from cocotb.generators.byte import random_data, get_bytes
-from cocotb.generators.bit import (wave, intermittent_single_cycles,
-                                   random_50_percent)
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    from cocotb.generators.byte import random_data, get_bytes
+    from cocotb.generators.bit import wave, intermittent_single_cycles, random_50_percent
 
 
 async def stream_out_config_setter(dut, stream_out, stream_in):

--- a/examples/mean/tests/test_mean.py
+++ b/examples/mean/tests/test_mean.py
@@ -8,6 +8,7 @@ from cocotb.monitors import BusMonitor
 from cocotb.scoreboard import Scoreboard
 
 import random
+import warnings
 
 CLK_PERIOD_NS = 100
 
@@ -90,7 +91,9 @@ async def mean_randomised_test(dut):
     dut_out = StreamBusMonitor(dut, "o", dut.clk)
 
     exp_out = []
-    scoreboard = Scoreboard(dut)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        scoreboard = Scoreboard(dut)
     scoreboard.add_interface(dut_out, exp_out)
 
     DATA_WIDTH = int(dut.DATA_WIDTH.value)

--- a/tests/test_cases/test_avalon_stream/test_avalon_stream.py
+++ b/tests/test_cases/test_avalon_stream/test_avalon_stream.py
@@ -3,6 +3,7 @@
 
 import random
 import struct
+import warnings
 
 import cocotb
 from cocotb.drivers import BitDriver
@@ -24,7 +25,9 @@ class AvalonSTTB(object):
 
         self.stream_in = AvalonSTDriver(self.dut, "asi", dut.clk)
         self.stream_out = AvalonSTMonitor(self.dut, "aso", dut.clk)
-        self.scoreboard = Scoreboard(self.dut, fail_immediately=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.scoreboard = Scoreboard(self.dut, fail_immediately=True)
 
         self.expected_output = []
         self.scoreboard.add_interface(self.stream_out, self.expected_output)

--- a/tests/test_cases/test_avalon_stream/test_avalon_stream.py
+++ b/tests/test_cases/test_avalon_stream/test_avalon_stream.py
@@ -12,7 +12,10 @@ from cocotb.monitors.avalon import AvalonST as AvalonSTMonitor
 from cocotb.triggers import RisingEdge
 from cocotb.clock import Clock
 from cocotb.scoreboard import Scoreboard
-from cocotb.generators.bit import wave
+
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    from cocotb.generators.bit import wave
 
 
 class AvalonSTTB(object):


### PR DESCRIPTION
This rebases #2041 on master. It deprecates everything in the `cocotb.generators` package, and the `cocotb.scoreboard.Scoreboard`. It must also update the tests and examples that use the deprecated feature.