### PR TITLE
Add newsfragments for PRs that should have them

### DIFF
--- a/documentation/source/newsfragments/1982.feature.rst
+++ b/documentation/source/newsfragments/1982.feature.rst
@@ -1,0 +1,2 @@
+Makefiles now automatically deduce :make:var:`TOPLEVEL_LANG` based on the value of :make:var:`VERILOG_SOURCES` and :make:var:`VHDL_SOURCES`.
+Makefiles also detect incorrect usage of :make:var:`TOPLEVEL_LANG` for simulators that only support one language.

--- a/documentation/source/newsfragments/2022.change.rst
+++ b/documentation/source/newsfragments/2022.change.rst
@@ -1,0 +1,1 @@
+Updated :class:`~cocotb.drivers.Driver`, :class:`~cocotb.monitors.Monitor`, and all their subclasses to use the :keyword:`async`/:keyword:`await` syntax instead of the :keyword:`yield` syntax.

--- a/documentation/source/newsfragments/2038.bugfix.rst
+++ b/documentation/source/newsfragments/2038.bugfix.rst
@@ -1,0 +1,1 @@
+Fix GHDL's library search path, allowing libraries other than *work* to be used in simulation.


### PR DESCRIPTION
I looked through all the changes between the 1.4.0 release and the current master and added a newsfragment for everything I thought should have one, but didn't get merged with one. #1982, #2038, and #2022 are included. I asked @garmin-mjames to comment on whether #1805 should have one. I'm open to other suggestions, rewording, dropping, etc.