### PR TITLE
Change newsfragment category and link mixed signal example

### DIFF
--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -120,6 +120,8 @@ The directory :file:`cocotb/examples/axi_lite_slave/` contains ...
     Write documentation, see :file:`README.md`
 
 
+.. _mixed_signal:
+
 Mixed-signal (analog/digital)
 =============================
 

--- a/documentation/source/newsfragments/1051.doc.rst
+++ b/documentation/source/newsfragments/1051.doc.rst
@@ -1,3 +1,3 @@
-The ``mixed_signal`` example has been added,
+The  :ref:`mixed_signal` example has been added,
 showing how to use HDL helper modules in cocotb testbenches that exercise
 two mixed-signal (i.e. analog and digital) designs.


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
