### PR TITLE
Fixup documentation for global  variables.

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies to build the documentation
 
-Sphinx ~= 3.1
+Sphinx ~= 3.4
 breathe
 sphinx-rtd-theme
 cairosvg

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -361,18 +361,25 @@ Other Runtime Information
 -------------------------
 
 .. autodata:: cocotb.argv
+   :no-value:
 
 .. autodata:: cocotb.SIM_NAME
+   :no-value:
 
 .. autodata:: cocotb.SIM_VERSION
+   :no-value:
 
 .. autodata:: cocotb.RANDOM_SEED
+   :no-value:
 
 .. autodata:: cocotb.plusargs
+   :no-value:
 
 .. autodata:: cocotb.LANGUAGE
+   :no-value:
 
 .. autodata:: cocotb.top
+   :no-value:
 
 
 Signal Tracer for WaveDrom
@@ -397,6 +404,7 @@ The Scheduler
 .. currentmodule:: cocotb.scheduler
 
 .. autodata:: cocotb.scheduler
+   :no-value:
 
 .. autoclass:: Scheduler
     :members:
@@ -408,6 +416,7 @@ The Regression Manager
 .. currentmodule:: cocotb.regression
 
 .. autodata:: cocotb.regression_manager
+   :no-value:
 
 .. autoclass:: RegressionManager
     :members:


### PR DESCRIPTION
Documentation for globals in the cocotb module show "= None" because the
autodata directive tries to get the value by default.
A blank annotation option overrides the default to show no value.

Looks like it also removes type info: https://cocotb--2069.org.readthedocs.build/en/2069/library_reference.html#cocotb.scheduler
