### PR TITLE
Iterate over handle if sub-handle lookup fails

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -249,6 +249,10 @@ class HierarchyObject(RegionObject):
         except KeyError:
             pass
 
+        if not self._discovered:
+            self._discover_all()
+            return self.__get_sub_handle_by_name(name)
+
         # Cache to avoid a call to the simulator if we already know the name is
         # invalid. Unclear if we care, but we had this before.
         if name in self._invalid_sub_handles:

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -576,7 +576,7 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = []{
         vpiRealNet,
         vpiStructVar,
         vpiStructNet,
-        //vpiVariables          // Aldec SEGV on plain Verilog
+        vpiVariables,
         vpiNamedEvent,
         vpiNamedEventArray,
         vpiParameter,

--- a/documentation/source/newsfragments/2079.bugfix.rst
+++ b/documentation/source/newsfragments/2079.bugfix.rst
@@ -1,0 +1,8 @@
+Generate blocks are now accessible directly via lookup without having to iterate over parent handle. (:pr:`2079`)
+
+  .. code-block:: python3
+
+      # Example pseudo-region
+      dut.genblk1       #<class 'cocotb.handle.HierarchyArrayObject'>
+
+  .. consume the towncrier issue number on this line.

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -98,8 +98,8 @@ initial begin
     $dumpvars(0,sample_module);
 end
 
-reg[3:0] temp;
 parameter NUM_OF_MODULES = 4;
+reg[NUM_OF_MODULES-1:0] temp;
 genvar idx;
 generate
     for (idx = 0; idx < NUM_OF_MODULES; idx=idx+1) begin

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -107,7 +107,19 @@ architecture impl of sample_module is
     type twoDimArrayType is array (natural range <>) of unsignedArrayType(31 downto 28);
     signal array_2d         : twoDimArrayType(0 to 1);
 
+    constant NUM_OF_MODULES : natural := 4;
+    signal temp             : std_logic_vector(NUM_OF_MODULES-1 downto 0);
+
 begin
+
+    genblk1: for i in NUM_OF_MODULES - 1 downto 0 generate
+    begin
+        process (clk) begin
+            if rising_edge(clk) then
+                temp(i) <= '0';
+            end if;
+        end process;
+    end generate;
 
     process (clk) begin
         if rising_edge(clk) then

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -336,7 +336,7 @@ def test_discover_all(dut):
     # Modelsim/Questa VPI will not find a vpiStructVar from vpiModule so we set a dummy variable
     # to ensure the handle is in the dut "sub_handles" for iterating
     #
-    # DO NOT ADD FOR ALDEC.  Does not iterate over properly
+    # DO NOT ADD FOR ALDEC.  Older Versions do not iterate over properly
     if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(("modelsim", "ncsim", "xmsim")):
         dummy = dut.sig_rec
         dummy = dut.port_rec_out
@@ -353,12 +353,16 @@ def test_discover_all(dut):
     elif cocotb.LANGUAGE in ["vhdl"]:
         pass_total = 856
     elif cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(("riviera")):
+        # Numbers for versions before 2019.10 may be outdated
         if cocotb.SIM_VERSION.startswith(("2017.10.61")):
             pass_total = 803
         elif cocotb.SIM_VERSION.startswith(("2016.06", "2016.10", "2017.02")):
             pass_total = 813
-        elif cocotb.SIM_VERSION.startswith(("2016.02", "2019.10")):
+        elif cocotb.SIM_VERSION.startswith(("2016.02")):
             pass_total = 947
+        elif cocotb.SIM_VERSION.startswith(("2019.10")):
+            # vpiVariables finds port_rec_out and sig_rec
+            pass_total = 1006
         else:
             pass_total = 1038
     else:

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -35,6 +35,20 @@ from cocotb.handle import IntegerObject, ConstantObject, HierarchyObject, String
 
 
 @cocotb.test()
+async def pseudo_region_access(dut):
+    """Test that pseudo-regions are accessible before iteration"""
+
+    # Ensure pseudo-region lookup will fail
+    if len(dut._sub_handles) != 0:
+        dut._sub_handles = {}
+
+    pseudo_region = dut.genblk1
+    dut._log.info("Found %s (%s)", pseudo_region._name, type(pseudo_region))
+    first_generate_instance = pseudo_region[0]
+    dut._log.info("Found %s (%s)", first_generate_instance._name, type(first_generate_instance))
+
+
+@cocotb.test()
 def recursive_discover(dut):
     """Discover absolutely everything in the DUT"""
     yield Timer(0)

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -71,7 +71,7 @@ def recursive_discovery(dut):
     elif cocotb.SIM_NAME.lower().startswith(("modelsim")):
         pass_total = 933
     else:
-        pass_total = 966
+        pass_total = 1024
 
     tlog = logging.getLogger("cocotb.test")
     yield Timer(100)


### PR DESCRIPTION
Fixes #497. 

Pseudo-region lookup may fail, so iterate over sub-handles using `_discover_all` and try lookup again.

Once this was added, it uncovered another issue where iterating on a module would find the vpiPort for
a variable and create a `HierarchyObject` rather than the underlying variable itself which becomes a
`ModifiableObject` or subclass.

---
Todo:
- [x] Test
- [x] Newsfragment?