### PR TITLE
Link to deprecations in roadmap section

### DIFF
--- a/documentation/source/roadmap.rst
+++ b/documentation/source/roadmap.rst
@@ -2,10 +2,17 @@
 Roadmap
 *******
 
-cocotb is in active development.
+cocotb is under development;
+however there is no "master plan".
+We depend upon users to contribute new features and improvements
+while maintainers focus mostly on reviewing PRs, project management, and bugfixes.
+Releases will occur approximately every 6 months.
 
 We use GitHub issues to track our pending tasks.
 Take a look at the `open feature list <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+is%3Aopen+label%3Atype%3Afeature>`_ to see the work that's lined up,
 or the `list of good first issues <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`_ to get your feet wet.
 
 If you have a GitHub account you can also `raise an enhancement request <https://github.com/cocotb/cocotb/issues/new>`_ to suggest new features.
+
+You may be interested in discussions about `planned deprecations <https://github.com/cocotb/cocotb/issues?q=is%3Aopen+label%3Atype%3Adeprecation>`_
+or review the `list of already applied deprecations <https://github.com/cocotb/cocotb/issues?q=is%3Aclosed+label%3Atype%3Adeprecation>`_.


### PR DESCRIPTION
https://cocotb--2087.org.readthedocs.build/en/2087/roadmap.html
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
