### PR TITLE
Add test for the .loads() iterator

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -624,11 +624,17 @@ class NonConstantObject(NonHierarchyIndexableObject):
     # FIXME: what is the difference to ModifiableObject? Explain in docstring.
 
     def drivers(self):
-        """An iterator for gathering all drivers for a signal."""
+        """An iterator for gathering all drivers for a signal.
+
+        Few simulators implement this.
+        """
         return self._handle.iterate(simulator.DRIVERS)
 
     def loads(self):
-        """An iterator for gathering all loads on a signal."""
+        """An iterator for gathering all loads on a signal.
+
+        Few simulators implement this.
+        """
         return self._handle.iterate(simulator.LOADS)
 
 

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -45,39 +45,33 @@ def recursive_dump(parent, log):
 
 
 @cocotb.test(expect_fail=True)
-def test_drivers(dut):
-    """
-    Try iterating over drivers of a signal.
+async def test_drivers(dut):
+    """Try iterating over drivers of a signal.
 
-    Seems that few simulators implement vpiDriver
+    Seems that few simulators implement ``vpiDriver``.
     """
     tlog = logging.getLogger("cocotb.test")
-    yield Timer(100)
-    for driver in dut.i_verilog.uart1.uart_rx_1.rx_data.drivers():
+    drivers = list(dut.i_verilog.uart1.uart_rx_1.rx_data.drivers())
+    assert drivers, "No drivers found for dut.i_verilog.uart1.uart_rx_1.rx_data"
+    for driver in drivers:
         tlog.info("Found %s" % repr(driver))
-        break
-    else:
-        raise TestFailure("No drivers found for dut.i_verilog.uart1.uart_rx_1.rx_data")
 
 
 @cocotb.test(expect_fail=True)
-def test_loads(dut):
-    """
-    Try iterating over loads of a signal.
+async def test_loads(dut):
+    """Try iterating over loads of a signal.
 
-    Seems that few simulators implement vpiLoad
+    Seems that few simulators implement ``vpiLoad``.
     """
     tlog = logging.getLogger("cocotb.test")
-    yield Timer(100)
-    for load in dut.i_verilog.uart1.ser_in.loads():
+    loads = list(dut.i_verilog.uart1.ser_in.loads())
+    assert loads, "No loads found for dut.i_verilog.uart1.ser_in"
+    for load in loads:
         tlog.info("Found %s" % repr(load))
-        break
-    else:
-        raise TestFailure("No loads found for dut.i_verilog.uart1.ser_in")
 
 
 @cocotb.test()
-def recursive_discovery(dut):
+async def recursive_discovery(dut):
     """
     Recursively discover every single object in the design
     """
@@ -90,7 +84,6 @@ def recursive_discovery(dut):
         pass_total = 1024
 
     tlog = logging.getLogger("cocotb.test")
-    yield Timer(100)
     total = recursive_dump(dut, tlog)
 
     if pass_total != total:
@@ -105,9 +98,9 @@ def recursive_discovery(dut):
 
 
 @cocotb.test()
-def recursive_discovery_boundary(dut):
+async def recursive_discovery_boundary(dut):
     """
-    Iteration though the boundary works but this just double checks
+    Iteration through the boundary works but this just double checks
     """
     if cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
         pass_total = 462
@@ -115,7 +108,6 @@ def recursive_discovery_boundary(dut):
         pass_total = 478
 
     tlog = logging.getLogger("cocotb.test")
-    yield Timer(100)
     total = recursive_dump(dut.i_vhdl, tlog)
     tlog.info("Found a total of %d things", total)
     if total != pass_total:

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -60,6 +60,22 @@ def test_drivers(dut):
         raise TestFailure("No drivers found for dut.i_verilog.uart1.uart_rx_1.rx_data")
 
 
+@cocotb.test(expect_fail=True)
+def test_loads(dut):
+    """
+    Try iterating over loads of a signal.
+
+    Seems that few simulators implement vpiLoad
+    """
+    tlog = logging.getLogger("cocotb.test")
+    yield Timer(100)
+    for load in dut.i_verilog.uart1.ser_in.loads():
+        tlog.info("Found %s" % repr(load))
+        break
+    else:
+        raise TestFailure("No loads found for dut.i_verilog.uart1.ser_in")
+
+
 @cocotb.test()
 def recursive_discovery(dut):
     """

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -26,8 +26,6 @@
 import logging
 
 import cocotb
-from cocotb.triggers import Timer
-from cocotb.result import TestFailure
 
 
 def recursive_dump(parent, log):
@@ -72,9 +70,7 @@ async def test_loads(dut):
 
 @cocotb.test()
 async def recursive_discovery(dut):
-    """
-    Recursively discover every single object in the design
-    """
+    """Recursively discover every single object in the design."""
     if cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
         # vpiAlways = 31 and vpiStructVar = 2 do not show up in IUS/Xcelium
         pass_total = 917
@@ -86,22 +82,17 @@ async def recursive_discovery(dut):
     tlog = logging.getLogger("cocotb.test")
     total = recursive_dump(dut, tlog)
 
-    if pass_total != total:
-        raise TestFailure("Expected %d but found %d" % (pass_total, total))
-    else:
-        tlog.info("Found a total of %d things", total)
+    assert pass_total == total, "Expected %d but found %d" % (pass_total, total)
+    tlog.info("Found a total of %d things", total)
 
-    if not isinstance(dut.i_verilog.uart1.baud_gen_1.baud_freq, cocotb.handle.ModifiableObject):
-        tlog.error("Expected dut.i_verilog.uart1.baud_gen_1.baud_freq to be modifiable")
-        tlog.error("but it was %s" % type(dut.i_verilog.uart1.baud_gen_1.baud_freq).__name__)
-        raise TestFailure()
+    assert isinstance(dut.i_verilog.uart1.baud_gen_1.baud_freq, cocotb.handle.ModifiableObject), \
+        ("Expected dut.i_verilog.uart1.baud_gen_1.baud_freq to be modifiable"
+         " but it was %s" % type(dut.i_verilog.uart1.baud_gen_1.baud_freq).__name__)
 
 
 @cocotb.test()
 async def recursive_discovery_boundary(dut):
-    """
-    Iteration through the boundary works but this just double checks
-    """
+    """Iteration through the boundary works but this just double checks."""
     if cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
         pass_total = 462
     else:
@@ -110,5 +101,4 @@ async def recursive_discovery_boundary(dut):
     tlog = logging.getLogger("cocotb.test")
     total = recursive_dump(dut.i_vhdl, tlog)
     tlog.info("Found a total of %d things", total)
-    if total != pass_total:
-        raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
+    assert total == pass_total, "Expected %d objects but found %d" % (pass_total, total)


### PR DESCRIPTION
The test itself is only for completeness' sake, as it doesn't seem to be implemented in most (any?) of our supported simulators.
Add a comment about this to the docstrings.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
