### PR TITLE
Print object type info in VpiSingleIterator

### DIFF
--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -223,7 +223,8 @@ public:
         vpiHandle vpi_hdl = m_parent->get_handle<vpiHandle>();
         m_iterator = vpi_iterate(vpitype, vpi_hdl);
         if (NULL == m_iterator) {
-            LOG_WARN("vpi_iterate returned NULL for %d", vpitype);
+            LOG_WARN("vpi_iterate returned NULL for type %d for object %s(%d)",
+                     vpitype, vpi_get_str(vpiType, vpi_hdl), vpi_get(vpiType, vpi_hdl));
             return;
         }
     }


### PR DESCRIPTION
Some small message improvement while looking at ``.drivers()``/``.loads()``.
Can we easily get the strings ``vpiLoad``/``vpiDriver`` from the raw ``vpitype`` (``91``/``93``) that is handed in?

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
