### PR TITLE
imlement FST support for verilator

### DIFF
--- a/cocotb/share/lib/verilator/verilator.cpp
+++ b/cocotb/share/lib/verilator/verilator.cpp
@@ -8,6 +8,11 @@
 
 #include <memory>
 
+#ifndef VM_TRACE_FST
+    //emulate new verilator behavior for legacy versions
+    #define VM_TRACE_FST 0
+#endif
+
 #if VM_TRACE
 #if VM_TRACE_FST
 #include <verilated_fst_c.h>

--- a/cocotb/share/lib/verilator/verilator.cpp
+++ b/cocotb/share/lib/verilator/verilator.cpp
@@ -9,7 +9,7 @@
 #include <memory>
 
 #if VM_TRACE
-#if TRACE_FST
+#if VM_TRACE_FST
 #include <verilated_fst_c.h>
 #else
 #include <verilated_vcd_c.h>
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
 
 #if VM_TRACE
     Verilated::traceEverOn(true);
-#if TRACE_FST
+#if VM_TRACE_FST
     std::unique_ptr<VerilatedFstC> tfp(new VerilatedFstC);
     top->trace(tfp.get(), 99);
     tfp->open("dump.fst");

--- a/cocotb/share/lib/verilator/verilator.cpp
+++ b/cocotb/share/lib/verilator/verilator.cpp
@@ -9,7 +9,11 @@
 #include <memory>
 
 #if VM_TRACE
-# include <verilated_vcd_c.h>
+#if TRACE_FST
+#include <verilated_fst_c.h>
+#else
+#include <verilated_vcd_c.h>
+#endif
 #endif
 
 vluint64_t main_time = 0;       // Current simulation time
@@ -36,10 +40,15 @@ int main(int argc, char** argv) {
 
 #if VM_TRACE
     Verilated::traceEverOn(true);
-
+#if TRACE_FST
+    std::unique_ptr<VerilatedFstC> tfp(new VerilatedFstC);
+    top->trace(tfp.get(), 99);
+    tfp->open("dump.fst");
+#else
     std::unique_ptr<VerilatedVcdC> tfp(new VerilatedVcdC);
     top->trace(tfp.get(), 99);
     tfp->open("dump.vcd");
+#endif
 #endif
 
     while (!Verilated::gotFinish()) {

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -66,6 +66,6 @@ debug: $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS)
 clean::
 	@rm -rf $(SIM_BUILD)
 	@rm -f dump.vcd
-    @rm -f dump.fst
+	@rm -f dump.fst
 
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -66,5 +66,6 @@ debug: $(SIM_BUILD)/$(TOPLEVEL) $(CUSTOM_SIM_DEPS)
 clean::
 	@rm -rf $(SIM_BUILD)
 	@rm -f dump.vcd
+    @rm -f dump.fst
 
 endif

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -129,7 +129,7 @@ For Verilator 4.102 and above, the `-CFLAGS -DVM_TRACE_FST=1` argument is no lon
 
   .. code-block:: make
 
-    EXTRA_ARGS += --trace-fst --trace-structs -CFLAGS -DVM_TRACE_FST
+    EXTRA_ARGS += --trace-fst --trace-structs -CFLAGS -DVM_TRACE_FST=1
 
 The resulting file will be ``dump.fst`` and can be opened by ``gtkwave dump.fst``.
 Note only the most recent versions of gtkwave and verilator support the FST format.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -131,9 +131,8 @@ For Verilator 4.102 and above, the `-CFLAGS -DVM_TRACE_FST=1` argument is no lon
 
     EXTRA_ARGS += --trace-fst --trace-structs -CFLAGS -DVM_TRACE_FST
 
-instead. The resulting file will be ``dump.fst`` and can be opened by ``gtkwave dump.fst``.
-Please note that you should use the most recent versions of verilator and gtkwave for FST to be
-properly supported with acceptable performance.
+The resulting file will be ``dump.fst`` and can be opened by ``gtkwave dump.fst``.
+Note only the most recent versions of gtkwave and verilator support the FST format.
 
 .. _sim-verilator-issues:
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -132,7 +132,6 @@ For Verilator 4.102 and above, the `-CFLAGS -DVM_TRACE_FST=1` argument is no lon
     EXTRA_ARGS += --trace-fst --trace-structs -CFLAGS -DVM_TRACE_FST=1
 
 The resulting file will be ``dump.fst`` and can be opened by ``gtkwave dump.fst``.
-Note only the most recent versions of gtkwave and verilator support the FST format.
 
 .. _sim-verilator-issues:
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -125,7 +125,7 @@ If you wish to use FST-Tracing (much smaller file size), which is supported by G
 
   .. code-block:: make
 
-    EXTRA_ARGS += --trace-fst --trace-structs -CFLAGS -DTRACE_FST
+    EXTRA_ARGS += --trace-fst --trace-structs -CFLAGS -DVM_TRACE_FST
 
 instead. The resulting file will be ``dump.fst`` and can be opened by ``gtkwave dump.fst``.
 Please note that you should use the most recent versions of verilator and gtkwave for FST to be

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -121,7 +121,11 @@ To get waveforms in VCD format, add Verilator's trace option(s) to the
 To set the same options on the command line, use ``EXTRA_ARGS="--trace --trace-structs" make ...``.
 A VCD file named ``dump.vcd`` will be generated in the current directory.
 
-If you wish to use FST-Tracing (much smaller file size), which is supported by GTKWAVE, then use
+Verilator can produce waveform traces in the FST format, the native format of GTKWave. 
+FST traces are much smaller and more efficient to write, but require the use of GTKWave.
+
+To enable FST tracing, add `--trace-fst -CFLAGS -DVM_TRACE_FST=1` to `EXTRA_ARGS` as shown below.
+For Verilator 4.102 and above, the `-CFLAGS -DVM_TRACE_FST=1` argument is no longer necessary.
 
   .. code-block:: make
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -121,6 +121,16 @@ To get waveforms in VCD format, add Verilator's trace option(s) to the
 To set the same options on the command line, use ``EXTRA_ARGS="--trace --trace-structs" make ...``.
 A VCD file named ``dump.vcd`` will be generated in the current directory.
 
+If you wish to use FST-Tracing (much smaller file size), which is supported by GTKWAVE, then use
+
+  .. code-block:: make
+
+    EXTRA_ARGS += --trace-fst --trace-structs -CFLAGS -DTRACE_FST
+
+instead. The resulting file will be ``dump.fst`` and can be opened by ``gtkwave dump.fst``.
+Please note that you should use the most recent versions of verilator and gtkwave for FST to be
+properly supported with acceptable performance.
+
 .. _sim-verilator-issues:
 
 Issues for this simulator


### PR DESCRIPTION
This addresses Ticket #1709 

The VM_TRACE define is set by verilator and its value cannot be modified.
Cleanest solution seems to be to add another orthogonal define via CFLAGS.

Documentation is also adapted, because verilator also needs to be called via --trace-fst instead of --trace

I have checked their docs and there is no seperate define being set when FST option is selected, so
we have to do it by ourselves for now.

Closes #2131.