### PR TITLE
Add Python debugging support for VSCode and GitPod

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -55,7 +55,7 @@ jobs:
         echo "::add-path::C:\iverilog\bin"
     - name: Install Python testing dependencies
       run: |
-        pip install coverage xunitparser pytest pytest-cov
+        pip install coverage xunitparser pytest pytest-cov debugpy
     - name: Install cocotb
       run: |
         python -m pip install  --global-option build_ext --global-option --compiler=mingw32 -e .

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,7 @@ image:
 tasks:
   - before: >
       pip3 install -e . &&
+      pip3 install debugpy &&
       export COCOTB_REDUCED_LOG_FMT=1
     init: >
       gp preview https://docs.cocotb.org/ &&
@@ -18,6 +19,7 @@ tasks:
       history -s make SIM=ghdl TOPLEVEL_LANG=vhdl &&
       history -s make SIM=verilator &&
       history -s make SIM=icarus
+      history -s COCOTB_PY_ATTACH=localhost:5678 make SIM=icarus
 
 vscode:
   extensions:

--- a/.theia/launch.json
+++ b/.theia/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "name": "Python: attach cocotb",
+          "type": "python",
+          "request": "attach",
+          "host": "localhost",
+          "port": 5678
+      }
+  ]
+}

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -67,6 +67,7 @@ def help_vars_text():
     COCOTB_ANSI_OUTPUT        Force cocotb to print or not print in color
     COCOTB_REDUCED_LOG_FMT    Display log lines shorter
     COCOTB_ATTACH             Pause time value in seconds before the simulator start
+    COCOTB_PY_ATTACH          On Python init, listen for debugger attach at 'host:port'
     COCOTB_ENABLE_PROFILING   Performance analysis of the Python portion of cocotb
     COCOTB_LOG_LEVEL          Default logging level (default INFO)
     COCOTB_RESOLVE_X          How to resolve X, Z, U, W on integer conversion

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -91,6 +91,21 @@ Cocotb
     If set, cocotb will print the process ID (PID) to attach to and wait the specified time before
     actually letting the simulator run.
 
+.. envvar:: COCOTB_PY_ATTACH
+
+    To attach a feature-full Python debugger (VSCode, GitPod/Theia, etc)
+    and enable stepping through tests and cocotb internals, viewing local variables, and more,
+    install the `debugpy <https://pypi.org/project/debugpy/>`_ package alongside cocotb.
+
+    Set :envvar:`COCOTB_PY_ATTACH` to a ``host:port`` value that cocotb will listen on
+    (i.e., ``localhost:5678``).
+    During initialization, cocotb will print the host and port it is listening on,
+    and wait for a debugger to attach.
+
+    Attach Python debugger using the provided host and port.
+    After attach, cocotb will immediately break into the debugger as if a breakpoint was set.
+    Set breakpoints in tests or other Python code and start debugging.
+
 .. envvar:: COCOTB_ENABLE_PROFILING
 
     Enable performance analysis of the Python portion of cocotb. When set, a file :file:`test_profile.pstat`

--- a/tests/pytest/test_debug_attach.py
+++ b/tests/pytest/test_debug_attach.py
@@ -1,0 +1,57 @@
+import logging
+import os
+import sys
+import threading
+from unittest.mock import patch
+
+import pytest
+
+import cocotb
+from cocotb import check_debug_attach
+
+
+def test_check_debug_attach_errors():
+    """Test error cases for check_debug_attach."""
+    try:
+        del os.environ["COCOTB_PY_ATTACH"]
+    except KeyError:
+        pass
+
+    check_debug_attach()
+    assert 'debugpy' not in sys.modules
+
+    os.environ["COCOTB_PY_ATTACH"] = 'invalidformat'
+    with pytest.raises(RuntimeError, match=r"Failure to parse COCOTB_PY_ATTACH.*"):
+        check_debug_attach()
+
+    os.environ["COCOTB_PY_ATTACH"] = 'localhost:not_a_number'
+    with pytest.raises(RuntimeError, match=r"Failure to parse COCOTB_PY_ATTACH.*"):
+        check_debug_attach()
+
+    os.environ["COCOTB_PY_ATTACH"] = 'fakehost:5678'
+    with patch.dict(sys.modules, {'debugpy': None}):
+        with pytest.raises(RuntimeError, match=r".* debugpy package is not importable.*"):
+            check_debug_attach()
+
+    with pytest.raises(RuntimeError, match=r"COCOTB_PY_ATTACH failure using.*"):
+        check_debug_attach()
+
+
+def test_check_debug_attach(caplog):
+    caplog.set_level(logging.DEBUG)
+    os.environ["COCOTB_PY_ATTACH"] = 'localhost:3456'
+    cocotb.log = logging.getLogger('cocotb')
+
+    def cancel_wait():
+        import debugpy
+        debugpy.wait_for_client.cancel()
+
+    # Cancel debugpy.wait_for_client() from another thread
+    cancel_timer = threading.Timer(5.0, cancel_wait)
+    cancel_timer.start()
+
+    check_debug_attach()
+
+    cancel_timer.join()
+
+    assert "Waiting for Python debugger attach on 127.0.0.1:3456" in caplog.messages

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     xunitparser
     pytest
     pytest-cov
+    debugpy
 
 commands =
     pytest


### PR DESCRIPTION
During Python initialization, if the `COCOTB_PY_ATTACH` environment
variable is set to a valid 'host:port' value, cocotb will wait for
debugger attach and then break into the debugger.

Here's a GitPod snapshot: https://gitpod.io/#snapshot/3073329c-b771-4c8b-a6ca-50562a816331

Run `COCOTB_PY_ATTACH=localhost:5678 make SIM=icarus` then attach using the **Python: attach cocotb** configuration.