### PR TITLE
Update the verilator main control loop.

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -22,6 +22,13 @@ ifeq ($(shell which $(CMD) 2>/dev/null),)
 $(error Cannot find verilator.)
 endif
 
+VLT_MIN := 4.106
+VLT_VERSION := $(shell $(CMD) --version | cut -d " " -f 2)
+MIN_VERSION := $(shell printf "%s\n%s\n" "$(VLT_MIN)" "$(VLT_VERSION)" | sort -g | head -1)
+ifneq ($(MIN_VERSION),$(VLT_MIN))
+  $(error cocotb requires Verilator $(VLT_MIN) or later, but using $(VLT_VERSION))
+endif
+
 ifeq ($(VERILATOR_SIM_DEBUG), 1)
   COMPILE_ARGS += --debug
   PLUSARGS += +verilator+debug

--- a/documentation/source/newsfragments/2105.change.rst
+++ b/documentation/source/newsfragments/2105.change.rst
@@ -1,0 +1,1 @@
+Improved support and performance for :ref:`sim-verilator` (version 4.106 or later now required).

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -79,21 +79,19 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
 
     make SIM=verilator
 
-cocotb supports Verilator 4.020 and above.
 Verilator converts Verilog code to C++ code that is compiled.
 It does not support VHDL.
 One major limitation compared to standard Verilog simulators is that it does not support delayed assignments.
 
 To run cocotb with Verilator, you need ``verilator`` in your PATH.
 
-Finally, cocotb currently generates a Verilator toplevel C++ simulation loop which is timed at the highest precision.
-If your design's clocks vary in precision, the performance of the simulation can be improved in the same order of magnitude by adjusting the precision in the Makefile, e.g.,
+.. note::
 
-.. code-block:: makefile
-
-    COCOTB_HDL_TIMEPRECISION = 1us # Set precision to 10^-6s
+    cocotb requires Verilator 4.106 or later.
 
 .. versionadded:: 1.3
+
+.. versionchanged:: 1.5 Improved cocotb support and greatly improved performance when using a higher time precision. Verilator 4.106 or later is required.
 
 Coverage
 --------

--- a/tests/test_cases/issue_1279/Makefile
+++ b/tests/test_cases/issue_1279/Makefile
@@ -2,16 +2,6 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-ifeq ($(SIM),verilator)
-
-all:
-	@echo "Skipping test due to Verilator hanging when prematurely shutting down"  # gh-2008
-clean::
-
-else
-
 include ../../designs/sample_module/Makefile
 
 MODULE = issue_1279
-
-endif

--- a/tests/test_cases/test_exit_error/Makefile
+++ b/tests/test_cases/test_exit_error/Makefile
@@ -25,14 +25,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-ifeq ($(SIM),verilator)
-
-all:
-	@echo "Skipping test due to Verilator hanging when prematurely shutting down"  # gh-2008
-clean::
-
-else
-
 # detecting an expected failure has to happen here, as the python code is invalid
 .PHONY: override_for_this_test
 override_for_this_test:
@@ -41,5 +33,3 @@ override_for_this_test:
 include ../../designs/sample_module/Makefile
 
 MODULE = test_exit
-
-endif


### PR DESCRIPTION
After some discussion in #2096, here's a stab at improving the verilator main control loop.

Closes #2008. 

Uses solutions for verilator/verilator#2536 and verilator/verilator#2589, so this will bump the minimum supported version of Verilator to 4.106.

- [x] Update supported version in docs
- [x] Newsfragment for better support and version bump

---

- Don't call eval() on every time step, instead skip ahead to the next
registered Timer trigger.

    - All values should be settled after the inner loop, and verilator ignores delays (#) in SystemVerilog files, so the only thing that can cause additional stimulus is a `Timer` trigger. There's no use in iterating over each time step and calling eval(), etc.

    - This should fix some of the "freeze" issues people have seen which are really just *very* long waits filled with useless calls into Verilator.

- If there are no more Timer triggers registered but we end up back in
the loop, end the simulation so we don't get stuck in an infinite loop.

    - I don't know if this is the cause of some of the lockups people like @ktbarrett have seen, but there are cases where cocotb can return to the simulator with no future `Timer` triggers.

- Move the cbAfterDelay callbacks (for Timer triggers) to the beginning of
the time step (Pre-Active region).

    - SystemVerilog standard IEEE 1800-2012 section 4.4 and 4.10 detail when `cbAfterDelay` callbacks should be called, which is before the iterative regions, in the same Pre-Active region as `cbNextSimTime`