### PR TITLE
Show Timer object reuse instead of re-creation

### DIFF
--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -164,9 +164,10 @@ including triggers like :class:`~cocotb.triggers.Timer`.
     @cocotb.coroutine
     def simple_clock(signal, half_period, half_period_units):
         signal <= 0
+        timer = Timer(half_period, half_period_units)
         while True:
             # in generator-based coroutines triggers are yielded
-            yield Timer(half_period, half_period_units)
+            yield timer
             signal <= ~signal
 
 Likewise, any place that will accept async coroutines will also accept generator-based coroutines;


### PR DESCRIPTION
I didn't comment the reason for creating the Timer outside the loop here since that would distract from the purpose of this section, but we shouldn't advertise code we know could be better.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
