### PR TITLE
Adapt number of discovered objects for Cadence Xcelium

### DIFF
--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -67,7 +67,7 @@ def recursive_discovery(dut):
     """
     if cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
         # vpiAlways = 31 and vpiStructVar = 2 do not show up in IUS/Xcelium
-        pass_total = 917
+        pass_total = 975
     elif cocotb.SIM_NAME.lower().startswith(("modelsim")):
         pass_total = 933
     else:


### PR DESCRIPTION
Current master finds more objects.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
