### PR TITLE
Fix typo 'seqfault'

### DIFF
--- a/tests/designs/close_module/Makefile
+++ b/tests/designs/close_module/Makefile
@@ -49,7 +49,7 @@ ifneq ($(SIM),vcs)
 include $(shell cocotb-config --makefiles)/Makefile.sim
 else
 all:
-	@echo "Skipping test as system call overrides seqfault VCS"
+	@echo "Skipping test as system call overrides segfault VCS"
 endif
 
 endif


### PR DESCRIPTION
Grepping the code for "segfault" might happen and then we should find this occurrence.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
