### PR TITLE
Fix VHPI cast issue

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -789,7 +789,7 @@ long VhpiSignalObjHdl::get_signal_value_long()
         LOG_ERROR("VHPI: Failed to get value of type long");
     }
 
-    return value.value.intg;
+    return static_cast<int32_t>(value.value.intg);
 }
 
 

--- a/documentation/source/newsfragments/2129.bugfix.rst
+++ b/documentation/source/newsfragments/2129.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue on Mac OS and Linux where negative integers were returned as large positive values.

--- a/documentation/source/newsfragments/2129.bugfix.rst
+++ b/documentation/source/newsfragments/2129.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed issue on Mac OS and Linux where negative integers were returned as large positive values.
+Fixed an issue with VHPI on Mac OS and Linux where negative integers were returned as large positive values.


### PR DESCRIPTION
Closes #2126.

`vhpiIntT` before the 2008 standard was defined as an unsigned integer in
vhpi_user.h. However, the standard states that all integers are 32-bit
integers with two's complement representation.

The issue occurs when `vhpiIntT` is defined as `uint32_t` and `long` is a
signed 64 bit integer. Negative values are represented as large unsigned
values in two's complement. When this value is returned as a long, it is
implicitly converted ("safely") to the larger signed representation.

To prevent this issue we convert the `vhpiIntT` into a 32-bit two's
complement integer type (`int32_t`) before allowing the conversion to
take place.