### PR TITLE
Added latency example with brief note in documentation.

### DIFF
--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -34,6 +34,15 @@ to start and stop generation of input data.
 
 A :class:`.TestFactory` is used to generate the random tests.
 
+Latency
+=======
+
+The directory :file:`cocotb/examples/simple_latency/` contains a simple testbench to demonstrate how to implementat latency in python similar to Verilog, e.g. `assign #(delay) output_sig = input_sig;`.
+To do so 3 outputs from :term:`RTL` design are looped back with different delay values.
+This example uses 4 flip-flops based on the D flip-flop model in :term:`RTL`, one to register the original signal from testbench, and 3 to register the looped back signals.
+Origianl signal value is saved for the 2 previous cycles to verify the registerd signal values. Also waveform is generated for better visualization.
+
+This example does not use any :class:`.Driver`, :class:`.Monitor`, or :class:`.Scoreboard`.
 
 .. _matrix_multiplier:
 

--- a/examples/simple_latency/.gitignore
+++ b/examples/simple_latency/.gitignore
@@ -1,0 +1,46 @@
+# Python
+__pycache__
+
+# Waveforms
+*.vcd
+*.fst
+
+# Results
+results.xml
+sim_build
+
+# VCS files
+*.tab
+ucli.key
+
+# Cadence Incisive/Xcelium
+*.elog
+irun.log
+xrun.log
+irun.key
+xrun.key
+irun.history
+xrun.history
+INCA_libs
+xcelium.d
+ncelab_*.err
+xmelab_*.err
+ncsim_*.err
+xmsim_*.err
+bpad_*.err
+.bpad/
+.simvision/
+waves.shm/
+
+# Mentor Modelsim/Questa
+modelsim.ini
+transcript
+*.wlf
+
+# Riviera
+library.cfg
+dataset.asdb
+compile
+library.cfg
+dataset.asdb
+compile

--- a/examples/simple_latency/Makefile
+++ b/examples/simple_latency/Makefile
@@ -1,0 +1,16 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+TOPLEVEL_LANG ?= verilog
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+  VERILOG_SOURCES = $(shell pwd)/dffs.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+  VHDL_SOURCES = $(shell pwd)/dffs.vhdl
+endif
+
+MODULE = test_latency
+TOPLEVEL = dffs
+PLUSARGS+=-fst
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/examples/simple_latency/dffs.sv
+++ b/examples/simple_latency/dffs.sv
@@ -1,0 +1,26 @@
+// This file is public domain, it can be freely copied without restrictions.
+// SPDX-License-Identifier: CC0-1.0
+
+`timescale 1us/1us
+
+module dffs (
+  input  logic clk, 
+  input  logic d,
+  output logic q,
+
+  input  logic [2:0] delayed_d,
+  output logic [2:0] delayed_q
+);
+
+always @(posedge clk) begin
+  q <= d;
+  delayed_q <= delayed_d;
+end
+  
+initial begin
+  $dumpfile ("sim_results.fst");
+  $dumpvars (0, dffs);
+  #1;
+end
+
+endmodule

--- a/examples/simple_latency/test_latency.py
+++ b/examples/simple_latency/test_latency.py
@@ -1,0 +1,52 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+import random
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import FallingEdge, Edge
+from cocotb.clock import Timer
+
+async def delayed_wire (output_sig, input_sig, latency):
+  while (1):
+    await Edge(input_sig)
+    cocotb.fork(delayer(output_sig, input_sig.value, latency))
+ 
+async def delayer(output_sig, val, latency, unit="us"):
+  await Timer(latency, units=unit)
+  output_sig <= val
+
+@cocotb.test()
+async def test_dff_simple(dut):
+    """ Test that d propagates to q """
+
+    clock = Clock(dut.clk, 10, units="us")  # Create a 10us period clock on port clk
+    cocotb.fork(clock.start())  # Start the clock
+    cocotb.fork(delayed_wire(dut.delayed_d[0], dut.q, 2))
+    cocotb.fork(delayed_wire(dut.delayed_d[1], dut.q, 8))
+    cocotb.fork(delayed_wire(dut.delayed_d[2], dut.q, 14))
+
+    await FallingEdge(dut.clk)  # Synchronize with the clock
+
+    # To hold singal value during two previous clock
+    old_val1 = 0
+    old_val2 = 0
+
+    for i in range(20):
+        val = random.randint(0, 1)
+        dut.d <= val  # Assign the random value val to the input port d
+        await FallingEdge(dut.clk)
+        assert dut.q == val, "output q was incorrect on the {}th cycle".format(i)
+
+        # check output of delayed signals 
+        if (dut.delayed_q[0].value): # Avoid X/Z, expected 1 cycle delay
+          assert dut.delayed_q[0] == old_val1, "output delayed_q[0] was incorrect on the {}th cycle".format(i)
+        if (dut.delayed_q[1].value): # Avoid X/Z, expected 1 cycle delay
+          assert dut.delayed_q[1] == old_val1, "output delayed_q[1] was incorrect on the {}th cycle".format(i)
+        if (dut.delayed_q[2].value): # Avoid X/Z, expected 2 cycles delay
+          assert dut.delayed_q[2] == old_val2, "output delayed_q[2] was incorrect on the {}th cycle".format(i)
+
+        # update value of previous cycle signal
+        old_val2 = old_val1
+        old_val1 = val
+


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

This is an example for how to implement Verilog style latency in Python, discussed in Gitter chat with Colin Marquardt. 