### PR TITLE
GPI: iterate over parent if VPI gen scope array not found

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -257,10 +257,6 @@ class HierarchyObject(RegionObject):
         except KeyError:
             pass
 
-        if not self._discovered:
-            self._discover_all()
-            return self.__get_sub_handle_by_name(name)
-
         # Cache to avoid a call to the simulator if we already know the name is
         # invalid. Unclear if we care, but we had this before.
         if name in self._invalid_sub_handles:

--- a/documentation/source/newsfragments/2079.bugfix.rst
+++ b/documentation/source/newsfragments/2079.bugfix.rst
@@ -1,4 +1,4 @@
-Generate blocks are now accessible directly via lookup without having to iterate over parent handle. (:pr:`2079`)
+In :ref:`Icarus Verilog <sim-icarus>`, generate blocks are now accessible directly via lookup without having to iterate over parent handle. (:pr:`2079`, :pr:`2143`)
 
   .. code-block:: python3
 


### PR DESCRIPTION
Follow-up to #2079. This brings the VPI code in-line with VHPI/FLI.

The underlying problem in #497 (as re-opened):
Icarus does not support `vpiGenScopeArray`, only `vpiGenScope`. So when trying to access a pseudo-region by name, `vpi_handle_by_name` lookup fails.

For both FLI and VHPI, the GPI code will fall-back to iterating over the parent handle to check if a generate statement can be found whose name starts with the pseudo-region name, and creates the pseudo-region if so. This matches that behavior when using VPI.

For example,
if searching for `dut.genblk` by name in Icarus, no handle will be found. However, `dut.genblk[0]` is discovered by iteration so the
pseudo-region can be inferred.
