### PR TITLE
Make Marlon maintainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,7 @@ Most maintainers are experts in part of the cocotb codebase, and are primarily r
 
 - Kaleb Barrett (@ktbarrett)
 - Tomasz Hemperek (@themperek)
+- Marlon James (@garmin-mjames)
 - Colin Marquardt (@cmarqu)
 - Philipp Wagner (@imphil)
 - Eric Wieser (@eric-wieser)


### PR DESCRIPTION
We are happy that Marlon has accepted the invitation to become cocotb
maintainer. This commit adds him to the list.

Thank you Marlon for your great work so far, and we're looking forward
to more of it!


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->