### PR TITLE
Add template for GitHub issues

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,11 @@
+<!--
+In case you are reporting a problem with running cocotb,
+please remember to add relevant information about your environment, such as
+* the cocotb version used,
+* the operating system and version (32/64 bit),
+* the simulator and version (32/64 bit),
+* the Python version, and where it's coming from (e.g. system, Anaconda, self-installed, ...),
+* (part of) the log file (cleaned of proprietary information).
+If you are unsure about any of the above items, open the issue anyway and we will figure it out together.
+Thanks for helping improve cocotb!
+-->


### PR DESCRIPTION
Next try, this time following the instructions at https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository (which I still feel are a bit ambiguous).

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
