### PR TITLE
Fix lexer name for doctest examples

### DIFF
--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -181,11 +181,10 @@ Accessing the :attr:`~cocotb.handle.NonHierarchyObject.value` property of a hand
 Any unresolved bits are preserved and can be accessed using the :attr:`~cocotb.binary.BinaryValue.binstr` attribute,
 or a resolved integer value can be accessed using the :attr:`~cocotb.binary.BinaryValue.integer` attribute.
 
-.. code-block:: python3
+.. code-block:: pycon
 
     >>> # Read a value back from the DUT
     >>> count = dut.counter.value
-    >>>
     >>> print(count.binstr)
     1X1010
     >>> # Resolve the value to an integer (X or Z treated as 0)
@@ -197,7 +196,7 @@ or a resolved integer value can be accessed using the :attr:`~cocotb.binary.Bina
 
 We can also cast the signal handle directly to an integer:
 
-.. code-block:: python3
+.. code-block:: pycon
 
     >>> print(int(dut.counter))
     42


### PR DESCRIPTION
See https://pygments.org/docs/lexers/#pygments.lexers.python.PythonConsoleLexer

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
