### PR TITLE
Use absolute path for VCS and compile as VHDL-93 for Xcelium

### DIFF
--- a/tests/test_cases/test_fatal/Makefile
+++ b/tests/test_cases/test_fatal/Makefile
@@ -7,10 +7,15 @@ TOPLEVEL_LANG ?= verilog
 TOPLEVEL := fatal
 MODULE := test_fatal
 
+PWD=$(shell pwd)
+
 ifeq ($(TOPLEVEL_LANG),verilog)
-	VERILOG_SOURCES := fatal.sv
+    VERILOG_SOURCES := $(PWD)/fatal.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-	VHDL_SOURCES := fatal.vhd
+    VHDL_SOURCES := $(PWD)/fatal.vhd
+    ifneq ($(filter $(SIM),ius xcelium),)
+        SIM_ARGS += -v93
+    endif
 endif
 
 # squash error code from simulator and ensure the cocotb test passed


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
