### PR TITLE
Define TOPLEVEL_LANG before checking it

### DIFF
--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -1,3 +1,6 @@
+# Override this variable to use a VHDL toplevel instead of SystemVerilog
+TOPLEVEL_LANG ?= verilog
+
 ifeq ($(SIM),)
 all:
 	@echo "Skipping example mixed_language since Icarus doesn't support this"
@@ -11,9 +14,6 @@ all:
 	@echo "Skipping example mixed_language since only Verilog toplevel implemented"
 clean::
 else
-
-# Override this variable to use a VHDL toplevel instead of SystemVerilog
-TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL = endian_swapper_mixed
 


### PR DESCRIPTION
Without this change, leaving TOPLEVEL_LANG unset would lead to an error.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
