### PR TITLE
Update recursive_discovery for Questa newly found objects

### DIFF
--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -75,7 +75,7 @@ async def recursive_discovery(dut):
         # vpiAlways = 31 and vpiStructVar = 2 do not show up in IUS/Xcelium
         pass_total = 975
     elif cocotb.SIM_NAME.lower().startswith(("modelsim")):
-        pass_total = 933
+        pass_total = 991
     else:
         pass_total = 1024
 


### PR DESCRIPTION
#2079 and later #2143 caused the number of objects found to increase.

Found the following new paths.
```
verilog_toplevel.bus_verilog
verilog_toplevel.bus_verilog.address
verilog_toplevel.bus_verilog.address[0]
verilog_toplevel.bus_verilog.address[10]
verilog_toplevel.bus_verilog.address[11]
verilog_toplevel.bus_verilog.address[12]
verilog_toplevel.bus_verilog.address[13]
verilog_toplevel.bus_verilog.address[14]
verilog_toplevel.bus_verilog.address[15]
verilog_toplevel.bus_verilog.address[1]
verilog_toplevel.bus_verilog.address[2]
verilog_toplevel.bus_verilog.address[3]
verilog_toplevel.bus_verilog.address[4]
verilog_toplevel.bus_verilog.address[5]
verilog_toplevel.bus_verilog.address[6]
verilog_toplevel.bus_verilog.address[7]
verilog_toplevel.bus_verilog.address[8]
verilog_toplevel.bus_verilog.address[9]
verilog_toplevel.bus_verilog.read
verilog_toplevel.bus_verilog.wr_data
verilog_toplevel.bus_verilog.wr_data[0]
verilog_toplevel.bus_verilog.wr_data[1]
verilog_toplevel.bus_verilog.wr_data[2]
verilog_toplevel.bus_verilog.wr_data[3]
verilog_toplevel.bus_verilog.wr_data[4]
verilog_toplevel.bus_verilog.wr_data[5]
verilog_toplevel.bus_verilog.wr_data[6]
verilog_toplevel.bus_verilog.wr_data[7]
verilog_toplevel.bus_verilog.write
verilog_toplevel.bus_vhdl
verilog_toplevel.bus_vhdl.address
verilog_toplevel.bus_vhdl.address[0]
verilog_toplevel.bus_vhdl.address[10]
verilog_toplevel.bus_vhdl.address[11]
verilog_toplevel.bus_vhdl.address[12]
verilog_toplevel.bus_vhdl.address[13]
verilog_toplevel.bus_vhdl.address[14]
verilog_toplevel.bus_vhdl.address[15]
verilog_toplevel.bus_vhdl.address[1]
verilog_toplevel.bus_vhdl.address[2]
verilog_toplevel.bus_vhdl.address[3]
verilog_toplevel.bus_vhdl.address[4]
verilog_toplevel.bus_vhdl.address[5]
verilog_toplevel.bus_vhdl.address[6]
verilog_toplevel.bus_vhdl.address[7]
verilog_toplevel.bus_vhdl.address[8]
verilog_toplevel.bus_vhdl.address[9]
verilog_toplevel.bus_vhdl.read
verilog_toplevel.bus_vhdl.wr_data
verilog_toplevel.bus_vhdl.wr_data[0]
verilog_toplevel.bus_vhdl.wr_data[1]
verilog_toplevel.bus_vhdl.wr_data[2]
verilog_toplevel.bus_vhdl.wr_data[3]
verilog_toplevel.bus_vhdl.wr_data[4]
verilog_toplevel.bus_vhdl.wr_data[5]
verilog_toplevel.bus_vhdl.wr_data[6]
verilog_toplevel.bus_vhdl.wr_data[7]
verilog_toplevel.bus_vhdl.write
```