### PR TITLE
Improve contributors documentation on running tests locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,11 @@
-Cocotb Contribution Guidelines
-==============================
+# Cocotb Contribution Guidelines
 
 Welcome to the cocotb development!
 We are an inclusive community with the common goal of improving the cocotb, a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 This guide explains how to contribute to cocotb, and documents the processes we agreed on to manage the project.
 All processes in this document are designed to streamline the development effort, to avoid bottlenecks, and to ultimately give a pleasant experience to all involved.
 
-Architecture and Scope of Cocotb
---------------------------------
+## Architecture and Scope of Cocotb
 
 Cocotb has seen adoption in a wide variety of scenarios with sometimes conflicting requirements.
 To foster experimentation and to decentralize the development process the architecture of cocotb is highly modular.
@@ -24,8 +22,7 @@ However, none of these rules are set in stone.
 They can and should be challenged at times to ensure the project stays relevant to the majority of its users.
 
 
-How to Get Changes Merged
--------------------------
+## How to Get Changes Merged
 
 Have you fixed a bug in cocotb, or want to add new functionality to it?
 Cocotb follows the typical [GitHub flow](https://guides.github.com/introduction/flow/) and makes use of pull requests and reviews.
@@ -49,8 +46,7 @@ Follow the steps below to get your changes merged, i.e. integrated into the main
 8. Once your code has at least one positive review from a maintainer and no maintainer strongly objects it your code is ready to be merged into the `master` branch.
 
 
-Patch Requirements
-------------------
+## Patch Requirements
 
 All changes which should go into the main codebase of cocotb must follow this set of requirements.
 
@@ -85,16 +81,14 @@ All changes which should go into the main codebase of cocotb must follow this se
   # SPDX-License-Identifier: CC0-1.0
   ```
 
-Running tests locally
----------------------
+## Running tests locally
 
 Our tests are managed by `tox`, which runs both `pytest` and our system of makefiles.
 This exercises the contents of both the `tests` and `examples` directories.
 `tox` supports the usage of the environment variables `SIM` and `TOPLEVEL_LANG` to direct how to run the regression.
 
 
-Managing of Issues and Pull Requests
-------------------------------------
+## Managing of Issues and Pull Requests
 
 The cocotb project makes use of GitHub labels attached to issues and pull requests to structure the development process.
 Each issue and pull request can have multiple labels assigned.
@@ -160,15 +154,13 @@ cocotb explicitly uses no priority labels, as experience indicates that they pro
 
 Issues and pull requests which are invalid, or where feedback is lacking for four weeks, should be closed.
 
-Cocotb Releases
----------------
+## Cocotb Releases
 
 cocotb aims to keep the `master` branch always in a releasable state.
 At least four times a year an official release should be created.
 It is the job of the maintainers to find a suitable time for a release, to communicate it to the community, and to coordinate it.
 
-Maintainers
------------
+## Maintainers
 
 Cocotb uses a shared maintainer model.
 Most maintainers are experts in part of the cocotb codebase, and are primarily responsible for reviews in this area.
@@ -185,8 +177,7 @@ Founders
 - Chris Higgs (@chiggs)
 - Stuart Hodgson (@stuarthodgson)
 
-Code of Conduct
----------------
+## Code of Conduct
 
 The cocotb development community aims to be welcoming to everyone.
 The [FOSSi Foundation Code of Conduct](https://www.fossi-foundation.org/code-of-conduct) applies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,26 @@ We are an inclusive community with the common goal of improving the cocotb, a co
 This guide explains how to contribute to cocotb, and documents the processes we agreed on to manage the project.
 All processes in this document are designed to streamline the development effort, to avoid bottlenecks, and to ultimately give a pleasant experience to all involved.
 
+
+## Setting Up a Development Environment
+
+Assuming you have used cocotb prior to reading this guide, you will already have the cocotb [installation prerequisites](https://docs.cocotb.org/en/latest/install.html) and standard development tools (editor, shell, git, etc.) installed.
+
+Additionally, you will need [doxygen](https://www.doxygen.nl/index.html), for building documentation, and [tox](https://pypi.org/project/tox/), for building documentation and running regression tests.
+
+We recommend if you are using a Linux distribution to use your system package manager to install doxygen.
+Likewise, doxygen can be installed using the homebrew package manager on Mac OS.
+Windows contributors should download a binary distribution installer from the main website.
+
+tox is a Python project and can be installed with `pip`, like so.
+
+```command
+pip install tox
+```
+
+Now you are ready to contribute!
+
+
 ## Architecture and Scope of Cocotb
 
 Cocotb has seen adoption in a wide variety of scenarios with sometimes conflicting requirements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,8 @@ Windows contributors should download a binary distribution installer from the ma
 pip install tox
 ```
 
-Finally, you must download the cocotb source from Github if you have not already done so.
-
-```command
-git clone https://github.com/cocotb/cocotb
-```
+Finally, you should [fork and clone](https://guides.github.com/activities/forking/) the cocotb repo.
+This will allows you to make changes to cocotb source code, and run regressions and build documentation locally.
 
 Now you are ready to contribute!
 
@@ -36,7 +33,7 @@ Now you are ready to contribute!
 First, [set up your development environment](#setting-up-a-development-environment).
 
 Our tests are managed by `tox`, which runs both `pytest` tests and our system of makefiles.
-The regression does not end on the first failure, but continues until all tests in the `test` and `example` directories have been run.
+The regression does not end on the first failure, but continues until all tests in the `/tests` and `/examples` directories have been run.
 
 To run the tests locally with `tox`, you will need to select an appropriate test environment.
 Valid test environments are formatted as `{your python version}-{your OS}`.
@@ -58,10 +55,11 @@ tox -e py38-linux
 At the end of the regression, if there were any test failures, the tests that failed will be printed.
 Otherwise, tox will print a green `:)`.
 
-### Selecting a Regression Language and Simulator
+### Selecting a Language and Simulator for Regression
 
-`tox` supports the usage of the environment variables `SIM` and `TOPLEVEL_LANG` to select a simulator and language to run the regression.
+`tox` supports the usage of the environment variables [`SIM`](https://docs.cocotb.org/en/stable/building.html#var-SIM) and [`TOPLEVEL_LANG`](https://docs.cocotb.org/en/stable/building.html#var-TOPLEVEL_LANG) to select a simulator and language to run the regression.
 By default the tests will attempt to run with the Icarus Verilog simulator.
+
 For example, if you wanted to run tests with GHDL on Linux with Python 3.8, you would issue the following command.
 
 ```command
@@ -70,23 +68,23 @@ SIM=ghdl TOPLEVEL_LANG=vhdl tox -e py38-linux
 
 ### Running Individual Tests Locally
 
-Each test under `/tests/test_cases/*/` and `/examples/tests/` can be run individually.
+Each test under `/tests/test_cases/*/` and `/examples/*/tests/` can be run individually.
 This is particularly useful if you want to run a particular test that fails the regression.
 
-First you must install cocotb from source by navigating to the project root and issuing the following.
+First you must install cocotb from source by navigating to the project root directory and issuing the following.
 
 ```command
 python -m pip install .
 ```
 
-On Windows, you must install cocotb from source like so.
+On Windows, you must instead install cocotb from source like so.
 
 ```command
 python -m pip install --global-option build_ext --global-option --compiler=mingw32 .
 ```
 
 Once that has been done, you can navigate to the directory containing the test you wish to run.
-Then you may issue an [appropriate](https://docs.cocotb.org/en/stable/quickstart.html#running-your-first-example) `make` command.
+Then you may issue an [appropriate]https://docs.cocotb.org/en/stable/building.html#makefile-based-test-scripts) `make` command.
 
 ```command
 make SIM=icarus

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,99 @@ We recommend if you are using a Linux distribution to use your system package ma
 Likewise, doxygen can be installed using the homebrew package manager on Mac OS.
 Windows contributors should download a binary distribution installer from the main website.
 
-tox is a Python project and can be installed with `pip`, like so.
+`tox` is a Python project and can be installed with `pip`.
 
 ```command
 pip install tox
 ```
 
+Finally, you must download the cocotb source from Github if you have not already done so.
+
+```command
+git clone https://github.com/cocotb/cocotb
+```
+
 Now you are ready to contribute!
+
+
+## Running Tests Locally
+
+First, [set up your development environment](#setting-up-a-development-environment).
+
+Our tests are managed by `tox`, which runs both `pytest` tests and our system of makefiles.
+The regression does not end on the first failure, but continues until all tests in the `test` and `example` directories have been run.
+
+To run the tests locally with `tox`, you will need to select an appropriate test environment.
+Valid test environments are formatted as `{your python version}-{your OS}`.
+Valid python version values are `py35`, `py36`, `py37`, `py38`, or `py39`;
+and valid OS values are `linux`, `macos`, or `windows`.
+For example, a valid test environment is `py38-linux`.
+You can see the list of valid test environments by running the below command.
+
+```command
+tox -l
+```
+
+Once you know the test environment you wish to use, call `tox` .
+
+```command
+tox -e py38-linux
+```
+
+At the end of the regression, if there were any test failures, the tests that failed will be printed.
+Otherwise, tox will print a green `:)`.
+
+### Selecting a Regression Language and Simulator
+
+`tox` supports the usage of the environment variables `SIM` and `TOPLEVEL_LANG` to select a simulator and language to run the regression.
+By default the tests will attempt to run with the Icarus Verilog simulator.
+For example, if you wanted to run tests with GHDL on Linux with Python 3.8, you would issue the following command.
+
+```command
+SIM=ghdl TOPLEVEL_LANG=vhdl tox -e py38-linux
+```
+
+### Running Individual Tests Locally
+
+Each test under `/tests/test_cases/*/` and `/examples/tests/` can be run individually.
+This is particularly useful if you want to run a particular test that fails the regression.
+
+First you must install cocotb from source by navigating to the project root and issuing the following.
+
+```command
+python -m pip install .
+```
+
+On Windows, you must install cocotb from source like so.
+
+```command
+python -m pip install --global-option build_ext --global-option --compiler=mingw32 .
+```
+
+Once that has been done, you can navigate to the directory containing the test you wish to run.
+Then you may issue an [appropriate](https://docs.cocotb.org/en/stable/quickstart.html#running-your-first-example) `make` command.
+
+```command
+make SIM=icarus
+```
+
+
+## Building Documentation Locally
+
+First, [set up your development environment](#setting-up-a-development-environment).
+
+Documentation is built locally using `tox`.
+The last message in the output will contain a URL to the documentation you just built.
+Simply copy and paste the link into your browser to view it.
+The documentation will be built in the same location on your hard drive on every run, so you only have to refresh the page to see new changes.
+
+To build the documentation locally on Linux or Mac, issue the following command.
+
+```command
+tox -e docs
+```
+
+Building the documentation is not currently supported on Windows.
 
 
 ## Architecture and Scope of Cocotb
@@ -100,13 +186,6 @@ All changes which should go into the main codebase of cocotb must follow this se
   # This file is public domain, it can be freely copied without restrictions.
   # SPDX-License-Identifier: CC0-1.0
   ```
-
-## Running tests locally
-
-Our tests are managed by `tox`, which runs both `pytest` and our system of makefiles.
-This exercises the contents of both the `tests` and `examples` directories.
-`tox` supports the usage of the environment variables `SIM` and `TOPLEVEL_LANG` to direct how to run the regression.
-
 
 ## Managing of Issues and Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,14 +16,14 @@ We recommend if you are using a Linux distribution to use your system package ma
 Likewise, doxygen can be installed using the homebrew package manager on Mac OS.
 Windows contributors should download a binary distribution installer from the main website.
 
-`tox` is a Python project and can be installed with `pip`.
+`tox` is a Python project and can be installed with `pip`:
 
 ```command
 pip install tox
 ```
 
 Finally, you should [fork and clone](https://guides.github.com/activities/forking/) the cocotb repo.
-This will allows you to make changes to cocotb source code, and run regressions and build documentation locally.
+This will allow you to make changes to the cocotb source code, and run regressions and build documentation locally.
 
 Now you are ready to contribute!
 
@@ -40,13 +40,13 @@ Valid test environments are formatted as `{your python version}-{your OS}`.
 Valid python version values are `py35`, `py36`, `py37`, `py38`, or `py39`;
 and valid OS values are `linux`, `macos`, or `windows`.
 For example, a valid test environment is `py38-linux`.
-You can see the list of valid test environments by running the below command.
+You can see the list of valid test environments by running the below command:
 
 ```command
 tox -l
 ```
 
-Once you know the test environment you wish to use, call `tox` .
+Once you know the test environment you wish to use, call `tox`.
 
 ```command
 tox -e py38-linux
@@ -57,10 +57,10 @@ Otherwise, tox will print a green `:)`.
 
 ### Selecting a Language and Simulator for Regression
 
-`tox` supports the usage of the environment variables [`SIM`](https://docs.cocotb.org/en/stable/building.html#var-SIM) and [`TOPLEVEL_LANG`](https://docs.cocotb.org/en/stable/building.html#var-TOPLEVEL_LANG) to select a simulator and language to run the regression.
+`tox` supports the usage of the environment variables [`SIM`](https://docs.cocotb.org/en/latest/building.html#var-SIM) and [`TOPLEVEL_LANG`](https://docs.cocotb.org/en/latest/building.html#var-TOPLEVEL_LANG) to select a simulator and language to run the regression.
 By default the tests will attempt to run with the Icarus Verilog simulator.
 
-For example, if you wanted to run tests with GHDL on Linux with Python 3.8, you would issue the following command.
+For example, if you wanted to run tests with GHDL on Linux with Python 3.8, you would issue the following command:
 
 ```command
 SIM=ghdl TOPLEVEL_LANG=vhdl tox -e py38-linux
@@ -71,20 +71,20 @@ SIM=ghdl TOPLEVEL_LANG=vhdl tox -e py38-linux
 Each test under `/tests/test_cases/*/` and `/examples/*/tests/` can be run individually.
 This is particularly useful if you want to run a particular test that fails the regression.
 
-First you must install cocotb from source by navigating to the project root directory and issuing the following.
+First you must install cocotb from source by navigating to the project root directory and issuing the following command:
 
 ```command
 python -m pip install .
 ```
 
-On Windows, you must instead install cocotb from source like so.
+On Windows, you must instead install cocotb from source like so:
 
 ```command
 python -m pip install --global-option build_ext --global-option --compiler=mingw32 .
 ```
 
 Once that has been done, you can navigate to the directory containing the test you wish to run.
-Then you may issue an [appropriate]https://docs.cocotb.org/en/stable/building.html#makefile-based-test-scripts) `make` command.
+Then you may issue an [appropriate]https://docs.cocotb.org/en/latest/building.html#makefile-based-test-scripts) `make` command:
 
 ```command
 make SIM=icarus
@@ -100,7 +100,7 @@ The last message in the output will contain a URL to the documentation you just 
 Simply copy and paste the link into your browser to view it.
 The documentation will be built in the same location on your hard drive on every run, so you only have to refresh the page to see new changes.
 
-To build the documentation locally on Linux or Mac, issue the following command.
+To build the documentation locally on Linux or Mac, issue the following command:
 
 ```command
 tox -e docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,25 @@
 [tox]
-envlist = py{35,36,37,38,39}-{linux,macos,windows}
+envlist = py{35,36,37,38,39}-{linux,macos,windows},docs
+
 # for the requires key
 minversion = 3.2.0
+
 # virtualenv is used by tox; versions below 16.1.0 cause a DeprecationWarning
 # to be shown for all code which uses virtualenv, which is the case for all code
 # we run through tox. (https://github.com/pypa/virtualenv/pull/1064)
 requires = virtualenv >= 16.1
 
 [testenv]
+platform =
+    linux: linux|cygwin
+    macos: darwin
+    windows: win32
+
 setenv =
     CFLAGS = -Werror -Wno-deprecated-declarations
     CXXFLAGS = -Werror
     COCOTB_LIBRARY_COVERAGE = 1
+
 passenv =
     SIM
     TOPLEVEL_LANG
@@ -25,6 +33,10 @@ deps =
     pytest
     pytest-cov
 
+install_command =
+    windows: python -m pip install --global-option build_ext --global-option --compiler=mingw32 {opts} {packages}
+    python -m pip install {opts} {packages}
+
 commands =
     pytest
     make test
@@ -36,10 +48,6 @@ whitelist_externals =
 
 # needed for coverage to work
 usedevelop=True
-
-[testenv:py{35,36,37,38,39}-windows]
-install_command =
-    python -m pip install  --global-option build_ext --global-option --compiler=mingw32 {opts} {packages}
 
 # Note: this target is *not* used by Read The Docs, it runs sphinx-build
 # directly. Hence, all special build steps here are only relevant for

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+# when changing this list, adapt CONTRIBUTING.md accordingly:
 envlist = py{35,36,37,38,39}-{linux,macos,windows},docs
 
 # for the requires key


### PR DESCRIPTION
Expands sections on setting up a developer environment (closes #2058), how to run the regression tests locally with and without tox, how to build the documentation locally, and some small tox tweaks for "correctness". Supersedes some of #2090.