### PR TITLE
Convert test_cocotb to use assert

### DIFF
--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -9,7 +9,6 @@ import traceback
 from contextlib import contextmanager
 
 import cocotb
-from cocotb.result import TestFailure
 from cocotb.triggers import Timer
 
 
@@ -31,17 +30,14 @@ def _check_traceback(running_coro, exc_type, pattern):
     except exc_type:
         tb_text = traceback.format_exc()
     else:
-        raise TestFailure("Exception was not raised")
+        assert False, "Exception was not raised"
 
-    if not re.match(pattern, tb_text):
-        raise TestFailure(
-            (
-                "Traceback didn't match - got:\n\n"
-                "{}\n"
-                "which did not match the pattern:\n\n"
-                "{}"
-            ).format(tb_text, pattern)
-        )
+    assert re.match(pattern, tb_text), (
+        "Traceback didn't match - got:\n\n"
+        "{}\n"
+        "which did not match the pattern:\n\n"
+        "{}"
+    ).format(tb_text, pattern)
 
 
 @contextmanager
@@ -54,4 +50,4 @@ def assert_raises(exc_type, pattern=None):
                 "Correct exception type caught, but message did not match pattern"
         pass
     else:
-        raise AssertionError("{} was not raised".format(exc_type.__name__))
+        assert False, "{} was not raised".format(exc_type.__name__)

--- a/tests/test_cases/test_cocotb/test_clock.py
+++ b/tests/test_cases/test_cocotb/test_clock.py
@@ -71,9 +71,8 @@ def test_clock_with_units(dut):
 
 
 @cocotb.test(expect_fail=False)
-def test_anternal_clock(dut):
-    """Test ability to yield on an external non cocotb coroutine decorated
-    function"""
+def test_external_clock(dut):
+    """Test ability to yield on an external non-cocotb coroutine decorated function"""
     clk_gen = cocotb.fork(Clock(dut.clk, 100).start())
     count = 0
     while count != 100:

--- a/tests/test_cases/test_cocotb/test_generator_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_generator_coroutines.py
@@ -6,7 +6,6 @@ Tests that sepcifically test generator-based coroutines
 """
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.result import TestFailure
 from common import clock_gen, _check_traceback
 import textwrap
 
@@ -36,7 +35,7 @@ def test_function_not_a_coroutine(dut):
     except TypeError as exc:
         assert "isn't a valid coroutine" in str(exc)
     else:
-        raise TestFailure
+        assert False
 
 
 def normal_function(dut):
@@ -51,7 +50,7 @@ def test_function_not_decorated(dut):
         assert "yielded" in str(exc)
         assert "scheduler can't handle" in str(exc)
     else:
-        raise TestFailure
+        assert False
 
 
 @cocotb.test()
@@ -63,7 +62,7 @@ def test_function_not_decorated_fork(dut):
     except TypeError as exc:
         assert "isn't a coroutine" in str(exc)
     else:
-        raise TestFailure()
+        assert False
 
     yield Timer(500)
 
@@ -78,7 +77,7 @@ def test_adding_a_coroutine_without_starting(dut):
     except TypeError as exc:
         assert "a coroutine that hasn't started" in str(exc)
     else:
-        raise TestFailure
+        assert False
 
 
 @cocotb.test(expect_fail=False)
@@ -123,8 +122,7 @@ def test_coroutine_return(dut):
         yield
 
     ret = yield return_it(42)
-    if ret != 42:
-        raise TestFailure("Return statement did not work")
+    assert ret == 42, "Return statement did not work"
 
 
 @cocotb.test()
@@ -149,7 +147,7 @@ def test_immediate_coro(dut):
     except ValueError:
         pass
     else:
-        raise TestFailure("Exception was not raised")
+        assert False, "Exception was not raised"
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -8,7 +8,6 @@ import logging
 import random
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.result import TestFailure
 
 from common import assert_raises
 
@@ -24,9 +23,7 @@ def test_lessthan_raises_error(dut):
     except TypeError:
         pass
     else:
-        raise TestFailure(
-            "No exception was raised when confusing comparison with assignment"
-        )
+        assert False, "No exception was raised when confusing comparison with assignment"
 
     # to make this a generator
     if False:
@@ -87,8 +84,7 @@ def test_integer(dut):
     got_out = int(dut.stream_in_int)
     log.info("dut.stream_out_int = %d" % got_out)
     log.info("dut.stream_in_int = %d" % got_in)
-    if got_in != got_out:
-        raise TestFailure("stream_in_int and stream_out_int should not match")
+    assert got_in == got_out, "stream_in_int and stream_out_int should not match"
 
 
 @cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"])
@@ -106,8 +102,7 @@ def test_real_assign_double(dut):
     yield Timer(1)  # FIXME: Workaround for VHPI scheduling - needs investigation
     got = float(dut.stream_out_real)
     log.info("Read back value %g" % got)
-    if got != val:
-        raise TestFailure("Values didn't match!")
+    assert got == val, "Values didn't match!"
 
 
 @cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"])
@@ -124,8 +119,7 @@ def test_real_assign_int(dut):
     yield Timer(1)  # FIXME: Workaround for VHPI scheduling - needs investigation
     got = dut.stream_out_real
     log.info("Read back value %d" % got)
-    if got != float(val):
-        raise TestFailure("Values didn't match!")
+    assert got == float(val), "Values didn't match!"
 
 
 # identifiers starting with `_` are illegal in VHDL

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -13,7 +13,6 @@ import re
 
 import cocotb
 from cocotb.triggers import Join, Timer, RisingEdge, Trigger, NullTrigger, Combine, Event, ReadOnly, First
-from cocotb.result import TestFailure
 from cocotb.clock import Clock
 from common import clock_gen
 
@@ -37,11 +36,9 @@ def test_coroutine_kill(dut):
     clk_gen_two = cocotb.fork(clock_yield(clk_gen))
     yield Timer(100)
     clk_gen.kill()
-    if test_flag is not False:
-        raise TestFailure
+    assert not test_flag
     yield Timer(1000)
-    if test_flag is not True:
-        raise TestFailure
+    assert test_flag
 
 
 @cocotb.coroutine
@@ -163,7 +160,7 @@ def test_trigger_with_failing_prime(dut):
     except RuntimeError as exc:
         assert "oops" in str(exc)
     else:
-        raise TestFailure
+        assert False
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -35,7 +35,7 @@ def test_tests_are_tests(dut):
 @cocotb.test(expect_fail=True)
 async def test_async_test_can_fail(dut):
     await Timer(1)
-    raise TestFailure
+    raise TestFailure  # explicitly do not use assert here
 
 
 @cocotb.test()


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
