### PR TITLE
Add units='step'

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -485,11 +485,14 @@ class test(coroutine, metaclass=_decorator_helper):
                 Test timeout is intended for protection against deadlock.
                 Users should use :class:`~cocotb.triggers.with_timeout` if they require a
                 more general-purpose timeout mechanism.
-        timeout_unit (str or None, optional):
+        timeout_unit (str, optional):
             Units of timeout_time, accepts any units that :class:`~cocotb.triggers.Timer` does.
 
             .. versionadded:: 1.3
-        expect_fail (bool, optional):
+
+            .. deprecation:: 1.5
+                Using None as the the *timeout_unit* argument is deprecated, use ``'step'`` instead.
+         expect_fail (bool, optional):
             Don't mark the result as a failure if the test fails.
         expect_error (bool or exception type or tuple of exception types, optional):
             If ``True``, consider this test passing if it raises *any* :class:`Exception`, and failing if it does not.
@@ -518,10 +521,15 @@ class test(coroutine, metaclass=_decorator_helper):
 
     _id_count = 0  # used by the RegressionManager to sort tests in definition order
 
-    def __init__(self, f, timeout_time=None, timeout_unit=None,
+    def __init__(self, f, timeout_time=None, timeout_unit="step",
                  expect_fail=False, expect_error=False,
                  skip=False, stage=None):
 
+        if timeout_unit is None:
+            warnings.warn(
+                'Using timeout_unit=None is deprecated, use timeout_unit="step" instead.',
+                DeprecationWarning, stacklevel=2)
+            timeout_unit="step"  # don't propagate deprecated value
         self._id = self._id_count
         type(self)._id_count += 1
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -102,24 +102,32 @@ def get_time_from_sim_steps(steps, units):
     return _ldexp10(steps, _get_simulator_precision() - _get_log_time_scale(units))
 
 
-def get_sim_steps(time, units=None):
+def get_sim_steps(time, units="step"):
     """Calculates the number of simulation time steps for a given amount of *time*.
 
     Args:
         time (numbers.Real or decimal.Decimal):  The value to convert to simulation time steps.
-        units (str or None, optional):  String specifying the units of the result
-            (one of ``None``, ``'fs'``, ``'ps'``, ``'ns'``, ``'us'``, ``'ms'``, ``'sec'``).
-            ``None`` means time is already in simulation time steps.
+        units (str, optional):  String specifying the units of the result
+            (one of ``'step'``, ``'fs'``, ``'ps'``, ``'ns'``, ``'us'``, ``'ms'``, ``'sec'``).
+            ``'step'`` means time is already in simulation time steps.
 
     Returns:
         int: The number of simulation time steps.
 
     Raises:
         :exc:`ValueError`: If given *time* cannot be represented by simulator precision.
+
+    .. versionchanged:: 1.5
+        Support ``'step'`` as the the *units* argument to mean "simulator time step".
     """
     result = time
-    if units is not None:
+    if units not in (None, "step"):
         result = _ldexp10(result, _get_log_time_scale(units) - _get_simulator_precision())
+    if units is None:
+        warnings.warn(
+            'Using units=None is deprecated, use units="step" instead.',
+            DeprecationWarning, stacklevel=2)
+        units="step"  # don't propagate deprecated value
 
     result_rounded = math.floor(result)
 

--- a/documentation/source/newsfragments/2171.feature.rst
+++ b/documentation/source/newsfragments/2171.feature.rst
@@ -1,0 +1,6 @@
+The ``units`` argument to :class:`cocotb.triggers.Timer`,
+:class:`cocotb.clock.Clock` and :func:`cocotb.utils.get_sim_steps`,
+and the ``timeout_unit`` argument to
+:func:`cocotb.triggers.with_timeout` and :class:`cocotb.test`
+now accepts ``'step'`` to mean the simulator time step.
+This used to be expressed using ``None``, which is now deprecated.

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -91,11 +91,12 @@ async def test_real_assign_double(dut):
     """
     val = random.uniform(-1e307, 1e307)
     log = logging.getLogger("cocotb.test")
-    await Timer(1)
+    timer_shortest = Timer(1, "step")
+    await timer_shortest
     log.info("Setting the value %g" % val)
     dut.stream_in_real = val
-    await Timer(1)
-    await Timer(1)  # FIXME: Workaround for VHPI scheduling - needs investigation
+    await timer_shortest
+    await timer_shortest  # FIXME: Workaround for VHPI scheduling - needs investigation
     got = float(dut.stream_out_real)
     log.info("Read back value %g" % got)
     assert got == val, "Values didn't match!"
@@ -108,11 +109,12 @@ async def test_real_assign_int(dut):
     """
     val = random.randint(-2**31, 2**31 - 1)
     log = logging.getLogger("cocotb.test")
-    await Timer(1)
+    timer_shortest = Timer(1, "step")
+    await timer_shortest
     log.info("Setting the value %i" % val)
     dut.stream_in_real <= val
-    await Timer(1)
-    await Timer(1)  # FIXME: Workaround for VHPI scheduling - needs investigation
+    await timer_shortest
+    await timer_shortest  # FIXME: Workaround for VHPI scheduling - needs investigation
     got = dut.stream_out_real
     log.info("Read back value %d" % got)
     assert got == float(val), "Values didn't match!"

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -186,7 +186,7 @@ async def test_kill_coroutine_waiting_on_the_same_trigger(dut):
     victim_resumed = False
 
     async def victim():
-        await Timer(1)  # prevent scheduling of RisingEdge before killer
+        await Timer(1, "step")  # prevent scheduling of RisingEdge before killer
         await RisingEdge(dut.clk)
         nonlocal victim_resumed
         victim_resumed = True
@@ -197,9 +197,9 @@ async def test_kill_coroutine_waiting_on_the_same_trigger(dut):
         victim_task.kill()
     cocotb.fork(killer())
 
-    await Timer(2)  # allow Timer in victim to pass making it schedule RisingEdge after the killer
+    await Timer(2, "step")  # allow Timer in victim to pass making it schedule RisingEdge after the killer
     dut.clk <= 1
-    await Timer(1)
+    await Timer(1, "step")
     assert not victim_resumed
 
 


### PR DESCRIPTION
Use Timer.shortest() in cocotb_test.

Closes #2169, closes #2171

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
