### PR TITLE
Add support for adding sets of parameters with TestFactory.add_option

### DIFF
--- a/documentation/source/newsfragments/2175.feature.rst
+++ b/documentation/source/newsfragments/2175.feature.rst
@@ -1,0 +1,1 @@
+:func:`cocotb.regression.TestFactory.add_option` now supports groups of options when a full Cartesian product is not desired

--- a/tests/test_cases/test_cocotb/Makefile
+++ b/tests/test_cases/test_cocotb/Makefile
@@ -10,6 +10,7 @@ MODULE := "\
 	test_synchronization_primitives,\
 	test_concurrency_primitives,\
 	test_tests,\
+	test_testfactory,\
 	test_generator_coroutines,\
 	test_timing_triggers,\
 	test_scheduler,\

--- a/tests/test_cases/test_cocotb/test_testfactory.py
+++ b/tests/test_cases/test_cocotb/test_testfactory.py
@@ -1,0 +1,30 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Tests of cocotb.regression.TestFactory functionality
+"""
+import cocotb
+from cocotb.regression import TestFactory
+
+
+testfactory_test_args = set()
+
+
+async def run_testfactory_test(dut, arg1, arg2, arg3):
+    testfactory_test_args.add((arg1, arg2, arg3))
+
+factory = TestFactory(run_testfactory_test)
+factory.add_option("arg1", ["a1v1", "a1v2"])
+factory.add_option(("arg2", "arg3"), [("a2v1", "a3v1"), ("a2v2", "a3v2")])
+factory.generate_tests()
+
+
+@cocotb.test()
+async def test_testfactory_verify_args(dut):
+    assert testfactory_test_args == set([
+        ("a1v1", "a2v1", "a3v1"),
+        ("a1v2", "a2v1", "a3v1"),
+        ("a1v1", "a2v2", "a3v2"),
+        ("a1v2", "a2v2", "a3v2"),
+    ])


### PR DESCRIPTION
Add support for adding sets of parameters with TestFactory.add_option using tuples, similar to pytest.mark.parametrize.  
