### PR TITLE
Cleanup TestError

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -217,9 +217,10 @@ class RegionObject(SimHandleBase):
         self._log.debug("Discovering all on %s", self._name)
         for thing in self._handle.iterate(simulator.OBJECTS):
             name = thing.get_name_string()
+            path = self._child_path(name)
             try:
-                hdl = SimHandle(thing, self._child_path(name))
-            except TypeError as e:
+                hdl = SimHandle(thing, path)
+            except NotImplementedError as e:
                 self._log.debug("%s", e)
                 continue
 
@@ -918,7 +919,7 @@ def SimHandle(handle, path=None):
         The `SimHandle` object.
 
     Raises:
-        TypeError: If no matching object for GPI type could be found.
+        NotImplementedError: If no matching object for GPI type could be found.
     """
     _type2cls = {
         simulator.MODULE:      HierarchyObject,

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -36,7 +36,6 @@ import cocotb
 from cocotb import simulator
 from cocotb.binary import BinaryValue
 from cocotb.log import SimLog
-from cocotb.result import TestError
 
 # Only issue a warning for each deprecated attribute access
 _deprecation_warned = set()
@@ -220,7 +219,7 @@ class RegionObject(SimHandleBase):
             name = thing.get_name_string()
             try:
                 hdl = SimHandle(thing, self._child_path(name))
-            except TestError as e:
+            except TypeError as e:
                 self._log.debug("%s", e)
                 continue
 
@@ -919,7 +918,7 @@ def SimHandle(handle, path=None):
         The `SimHandle` object.
 
     Raises:
-        TestError: If no matching object for GPI type could be found.
+        TypeError: If no matching object for GPI type could be found.
     """
     _type2cls = {
         simulator.MODULE:      HierarchyObject,
@@ -956,7 +955,7 @@ def SimHandle(handle, path=None):
         return obj
 
     if t not in _type2cls:
-        raise TestError("Couldn't find a matching object for GPI type %d (path=%s)" % (t, path))
+        raise TypeError("Couldn't find a matching object for GPI type %d (path=%s)" % (t, path))
     obj = _type2cls[t](handle, path)
     _handle2obj[handle] = obj
     return obj

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -955,7 +955,7 @@ def SimHandle(handle, path=None):
         return obj
 
     if t not in _type2cls:
-        raise TypeError("Couldn't find a matching object for GPI type %d (path=%s)" % (t, path))
+        raise NotImplementedError("Couldn't find a matching object for GPI type %d (path=%s)" % (t, path))
     obj = _type2cls[t](handle, path)
     _handle2obj[handle] = obj
     return obj

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -956,7 +956,7 @@ def SimHandle(handle, path=None):
         return obj
 
     if t not in _type2cls:
-        raise NotImplementedError("Couldn't find a matching object for GPI type %d (path=%s)" % (t, path))
+        raise NotImplementedError("Couldn't find a matching object for GPI type %s(%d) (path=%s)" % (handle.get_type_string(), t, path))
     obj = _type2cls[t](handle, path)
     _handle2obj[handle] = obj
     return obj

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -118,6 +118,7 @@ class ExternalException(Exception):
 class TestError(TestComplete):
     """
     Exception showing that the test was completed with severity Error.
+
     .. deprecated:: 1.5
         Raise a standard Python exception instead of calling this function.
         A stacktrace will be printed by cocotb automatically if the exception is unhandled.

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -118,17 +118,16 @@ class ExternalException(Exception):
 class TestError(TestComplete):
     """
     Exception showing that the test was completed with severity Error.
-    
     .. deprecated:: 1.5
         Raise a standard Python exception instead of calling this function.
         A stacktrace will be printed by cocotb automatically if the exception is unhandled.
     """
 
     def __init__(self, *args, **kwargs):
-            warnings.warn(
-                "TestError is deprecated - raise a standard Exception instead",
-                DeprecationWarning, stacklevel=2)
-            super().__init__(*args, **kwargs)
+        warnings.warn(
+            "TestError is deprecated - raise a standard Exception instead",
+            DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
 
 
 class TestFailure(TestComplete, AssertionError):

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -120,7 +120,7 @@ class TestError(TestComplete):
     Exception showing that the test was completed with severity Error.
 
     .. deprecated:: 1.5
-        Raise a standard Python exception instead of calling this function.
+        Raise a standard Python exception instead.
         A stacktrace will be printed by cocotb automatically if the exception is unhandled.
     """
 

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -38,16 +38,15 @@ def raise_error(obj, msg):
     """Create a :exc:`TestError` exception and raise it after printing a traceback.
 
     .. deprecated:: 1.3
-        Use ``raise TestError(msg)`` instead of this function. A stacktrace will
-        be printed by cocotb automatically if the exception is unhandled.
+        Raise a standard Python exception instead of calling this function.
+        A stacktrace will be printed by cocotb automatically if the exception is unhandled.
 
     Args:
         obj: Object with a log method.
         msg (str): The log message.
     """
     warnings.warn(
-        "``raise_error`` is deprecated - use ``raise TestError(msg)`` (or any "
-        "other exception type) instead",
+        "``raise_error`` is deprecated - raise a standard Exception instead",
         DeprecationWarning, stacklevel=2)
     _raise_error(obj, msg)
 
@@ -67,15 +66,14 @@ def create_error(obj, msg):
     simply to avoid too many levels of nested `try/except` blocks.
 
     .. deprecated:: 1.3
-        Use ``TestError(msg)`` directly instead of this function.
+        Raise a standard Python exception instead of calling this function.
 
     Args:
         obj: Object with a log method.
         msg (str): The log message.
     """
     warnings.warn(
-        "``create_error`` is deprecated - use ``TestError(msg)`` directly "
-        "(or any other exception type) instead",
+        "``create_error`` is deprecated - raise a standard Exception instead",
         DeprecationWarning, stacklevel=2)
     try:
         # use the private version to avoid multiple warnings
@@ -118,8 +116,19 @@ class ExternalException(Exception):
 
 
 class TestError(TestComplete):
-    """Exception showing that the test was completed with severity Error."""
-    pass
+    """
+    Exception showing that the test was completed with severity Error.
+    
+    .. deprecated:: 1.5
+        Raise a standard Python exception instead of calling this function.
+        A stacktrace will be printed by cocotb automatically if the exception is unhandled.
+    """
+
+    def __init__(self, *args, **kwargs):
+            warnings.warn(
+                "TestError is deprecated - raise a standard Exception instead",
+                DeprecationWarning, stacklevel=2)
+            super().__init__(*args, **kwargs)
 
 
 class TestFailure(TestComplete, AssertionError):

--- a/documentation/source/newsfragments/2177.removal.rst
+++ b/documentation/source/newsfragments/2177.removal.rst
@@ -1,0 +1,1 @@
+:class:`~cocotb.result.TestError` has been deprecated, use a standard :ref:`Python Exception <python:library/exception>`.

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -16,7 +16,7 @@ def assert_deprecated(warning_category=DeprecationWarning):
             warnings.simplefilter("always")
             yield warns  # note: not a cocotb yield, but a contextlib one!
     finally:
-        assert len(warns) == 1
+        assert len(warns) >= 1
         msg = "Expected {}".format(warning_category.__qualname__)
         assert issubclass(warns[0].category, warning_category), msg
 


### PR DESCRIPTION
`TestError` was unnecessary here. It was used to fail the test if a signal could not be mapped to a Python SimHandle type. This could be easily done with a standard exception. This cleans up the last usage of `TestError` in core code and will allow for it's deprecation.

Closes #2174.