### PR TITLE
Fix tox on Windows

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -246,24 +246,7 @@ jobs:
         make -j $(nproc)
         sudo make install
 
-      # Windows Testing
-    - name: Install cocotb build dependencies (Windows)
-      if: startsWith(matrix.os, 'windows')
-      run: conda install --yes -c msys2 m2-base m2-make m2w64-toolchain libpython
-    - name: Install cocotb (Windows)
-      if: startsWith(matrix.os, 'windows')
-      run: python -m pip install  --global-option build_ext --global-option --compiler=mingw32 -e .
-    - name: Install Python testing dependencies (Windows)
-      run: pip install coverage xunitparser pytest pytest-cov
-    - name: Test (Windows)
-      if: startsWith(matrix.os, 'windows')
-      continue-on-error: ${{matrix.may_fail || false}}
-      timeout-minutes: 15
-      run: |
-        pytest
-        make test
-
-      # Ubuntu / MacOS Testing
+      # Testing
     - name: Install cocotb build dependencies (Ubuntu - g++)
       if: startsWith(matrix.os, 'ubuntu') && (!matrix.cxx || matrix.cxx == 'g++')
       run: |
@@ -276,13 +259,11 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       run: |
         g++ --version
-    - name: Install Python testing dependencies (Ubuntu, MacOS)
-      if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+    - name: Install Python testing dependencies (All)
       run: |
-        pip install tox tox-gh-actions
-    - name: Test (Ubuntu, MacOS)
-      if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        pip install --upgrade tox tox-gh-actions tox-conda
+    - name: Test (All)
       continue-on-error: ${{matrix.may_fail || false}}
-      timeout-minutes: 15
+      timeout-minutes: 20
       run: |
         tox

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ conda_deps =
     windows: m2-make
     windows: m2w64-toolchain
     windows: libpython
+    
 install_command =
     windows: python -m pip install --global-option build_ext --global-option --compiler=mingw32 {opts} {packages}
     python -m pip install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ conda_deps =
     windows: m2-make
     windows: m2w64-toolchain
     windows: libpython
-    
 install_command =
     windows: python -m pip install --global-option build_ext --global-option --compiler=mingw32 {opts} {packages}
     python -m pip install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -39,10 +39,6 @@ conda_deps =
     windows: m2-make
     windows: m2w64-toolchain
     windows: libpython
-
-conda_channels =
-    windows: msys2
-
 install_command =
     windows: python -m pip install --global-option build_ext --global-option --compiler=mingw32 {opts} {packages}
     python -m pip install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,15 @@ deps =
     pytest
     pytest-cov
 
+conda_deps =
+    windows: m2-base
+    windows: m2-make
+    windows: m2w64-toolchain
+    windows: libpython
+
+conda_channels =
+    windows: msys2
+
 install_command =
     windows: python -m pip install --global-option build_ext --global-option --compiler=mingw32 {opts} {packages}
     python -m pip install {opts} {packages}


### PR DESCRIPTION
`tox-conda` recently fixed an issue (tox-dev/tox-conda#42) with environments on Windows and we should now be able to use it for regressions on Windows. I reverted GHA back to using tox-conda for regressions.