### PR TITLE
Add missing import of the warnings module

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -31,6 +31,7 @@ import logging
 import functools
 import inspect
 import os
+import warnings
 
 import cocotb
 from cocotb.log import SimLog


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
