### PR TITLE
Fix deprecation warning for str(handle)

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -203,7 +203,7 @@ class RegionObject(SimHandleBase):
                     self._log.debug("Yielding index %d from %s (%s)", subindex, name, type(subhdl))
                     yield subhdl
             else:
-                self._log.debug("Yielding %s (%s)", name, handle)
+                self._log.debug("Yielding %s of type %s (%s)", name, type(handle), handle._path)
                 yield handle
 
     def _discover_all(self):

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -822,7 +822,7 @@ GpiIterator::Status VpiIterator::next_handle(std::string &name, GpiObjHdl **hdl,
     /* Simulators vary here. Some will allow the name to be accessed
        across boundary. We can simply return this up and allow
        the object to be created. Others do not. In this case
-       we see if the object is in out type range and if not
+       we see if the object is in our type range and if not
        return the raw_hdl up */
 
     const char *c_name = vpi_get_str(vpiName, obj);

--- a/tests/test_cases/issue_330/issue_330.py
+++ b/tests/test_cases/issue_330/issue_330.py
@@ -17,7 +17,7 @@ def issue_330_direct(dut):
 
     structure = dut.inout_if
 
-    tlog.info("Value of inout_if => a_in = %s ; b_out = %s" % (structure.a_in, structure.b_out))
+    tlog.info("Value of inout_if => a_in = %s ; b_out = %s" % (structure.a_in.value, structure.b_out.value))
 
 
 @cocotb.test(skip=cocotb.SIM_NAME in ["Icarus Verilog"])
@@ -33,7 +33,7 @@ def issue_330_iteration(dut):
 
     count = 0
     for member in structure:
-        tlog.info("Found %s" % member)
+        tlog.info("Found %s" % member._path)
         count += 1
 
     if count != 2:

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -260,13 +260,13 @@ async def access_const_string_verilog(dut):
     if not isinstance(string_const, StringObject):
         raise TestFailure("STRING_CONST was not StringObject")
     if string_const != b"TESTING_CONST":
-        raise TestFailure("Initial value of STRING_CONST was not == b\'TESTING_CONST\' but {} instead".format(string_const))
+        raise TestFailure("Initial value of STRING_CONST was not == b\'TESTING_CONST\' but {} instead".format(string_const.value))
 
     tlog.info("Modifying const string")
     string_const <= b"MODIFIED"
     await Timer(10, "ns")
     if string_const != b"TESTING_CONST":
-        raise TestFailure("STRING_CONST was not still b\'TESTING_CONST\' after modification but {} instead".format(string_const))
+        raise TestFailure("STRING_CONST was not still b\'TESTING_CONST\' after modification but {} instead".format(string_const.value))
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"],
@@ -281,13 +281,13 @@ async def access_var_string_verilog(dut):
     if not isinstance(string_var, StringObject):
         raise TestFailure("STRING_VAR was not StringObject")
     if string_var != b"TESTING_VAR":
-        raise TestFailure("Initial value of STRING_VAR was not == b\'TESTING_VAR\' but {} instead".format(string_var))
+        raise TestFailure("Initial value of STRING_VAR was not == b\'TESTING_VAR\' but {} instead".format(string_var.value))
 
     tlog.info("Modifying var string")
     string_var <= b"MODIFIED"
     await Timer(10, "ns")
     if string_var != b"MODIFIED":
-        raise TestFailure("STRING_VAR was not == b\'MODIFIED\' after modification but {} instead".format(string_var))
+        raise TestFailure("STRING_VAR was not == b\'MODIFIED\' after modification but {} instead".format(string_var.value))
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["verilog"])


### PR DESCRIPTION
The ``AttributeError`` will be thrown for ``RegionObject``s:

```
FutureWarning: `str(ConstantObject)` is deprecated, and in future will return `ConstantObject._path`. To get a string representation of the value, use `str(ConstantObject.value)`.
```

This can be seen with `test_discovery`.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
