### PR TITLE
Adds $cocotb_pass_test() and $cocotb_fail_test() Verilog tasks

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -263,16 +263,14 @@ def _initialise_testbench(argv_):
 
 def _sim_event(level, message):
     """Function that can be called externally to signal an event."""
-    # SIM_INFO = 0
-    SIM_TEST_FAIL = 1
-    SIM_FAIL = 2
-    from cocotb.result import TestFailure, SimFailure
+    from cocotb.result import TestFailure, TestSuccess, SimFailure
+    from cocotb.simulator import TEST_FAIL_EVENT, TEST_PASS_EVENT, FAIL_EVENT
 
-    if level is SIM_TEST_FAIL:
-        scheduler.log.error("Failing test at simulator request")
-        scheduler.finish_test(TestFailure("Failure from external source: %s" %
-                              message))
-    elif level is SIM_FAIL:
+    if level == TEST_FAIL_EVENT:
+        scheduler.finish_test(TestFailure(message))
+    elif level == TEST_PASS_EVENT:
+        scheduler.finish_test(TestSuccess(message))
+    elif level == FAIL_EVENT:
         # We simply return here as the simulator will exit
         # so no cleanup is needed
         msg = ("Failing test at simulator request before test run completion: "

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -116,6 +116,7 @@ typedef enum gpi_event_e {
     SIM_INFO = 0,
     SIM_TEST_FAIL = 1,
     SIM_FAIL = 2,
+    SIM_TEST_PASS = 3
 } gpi_event_t;
 
 // Functions for controlling/querying the simulation state

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -932,7 +932,10 @@ static int add_module_constants(PyObject* simulator)
         PyModule_AddIntConstant(simulator, "OBJECTS",   GPI_OBJECTS   ) < 0 ||
         PyModule_AddIntConstant(simulator, "DRIVERS",   GPI_DRIVERS   ) < 0 ||
         PyModule_AddIntConstant(simulator, "LOADS",     GPI_LOADS     ) < 0 ||
-        false
+        PyModule_AddIntConstant(simulator, "INFO_EVENT", SIM_INFO) < 0 ||
+        PyModule_AddIntConstant(simulator, "TEST_FAIL_EVENT", SIM_TEST_FAIL) < 0 ||
+        PyModule_AddIntConstant(simulator, "FAIL_EVENT", SIM_FAIL) < 0 ||
+        PyModule_AddIntConstant(simulator, "TEST_PASS_EVENT", SIM_TEST_PASS) < 0
     ) {
         return -1;
     }

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -684,6 +684,7 @@ static void register_final_callback()
 COCOTBVPI_EXPORT void (*vlog_startup_routines[])() = {
     register_embed,
     gpi_load_extra_libs,
+    register_system_functions,
     register_initial_callback,
     register_final_callback,
     nullptr

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -276,4 +276,6 @@ private:
     VpiReadOnlyCbHdl m_read_only;
 };
 
+void register_system_functions();
+
 #endif /*COCOTB_VPI_IMPL_H_  */

--- a/cocotb/share/lib/vpi/VpiSystemTasks.cpp
+++ b/cocotb/share/lib/vpi/VpiSystemTasks.cpp
@@ -1,0 +1,42 @@
+#include "vpi_user.h"
+#include "gpi.h"
+#include "../gpi/gpi_priv.h"
+
+
+namespace {
+
+struct end_test_info {
+    gpi_event_t level;
+    char const * msg;
+};
+
+int end_test_calltf(char * userdata)
+{
+    end_test_info info = *((end_test_info *)userdata);
+    gpi_embed_event(info.level, info.msg);
+    return 0;
+}
+
+end_test_info test_pass = {SIM_TEST_PASS, "Simulator requesting passing test end"};
+end_test_info test_fail = {SIM_TEST_FAIL, "Simulator requesting failing test end"};
+
+}
+
+void register_system_functions()
+{
+    s_vpi_systf_data tfData;
+    tfData.type         = vpiSysTask;
+    tfData.sysfunctype  = vpiSysTask;
+    tfData.calltf       = end_test_calltf;
+    tfData.compiletf    = NULL;
+    tfData.sizetf       = NULL;
+
+    tfData.user_data    = (char *)&test_pass;
+    tfData.tfname       = "$cocotb_pass_test";
+    vpi_register_systf( &tfData );
+
+    tfData.user_data    = (char *)&test_fail;
+    tfData.tfname       = "$cocotb_fail_test";
+    vpi_register_systf( &tfData );
+
+}

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -405,6 +405,7 @@ def _get_vpi_lib_ext(
     lib_name = "libcocotbvpi_" + sim_define.lower()
     libcocotbvpi_sources = [
         os.path.join(share_lib_dir, "vpi", "VpiImpl.cpp"),
+        os.path.join(share_lib_dir, "vpi", "VpiSystemTasks.cpp"),
         os.path.join(share_lib_dir, "vpi", "VpiCbHdl.cpp"),
     ]
     if os.name == "nt":

--- a/documentation/source/newsfragments/2196.feature.rst
+++ b/documentation/source/newsfragments/2196.feature.rst
@@ -1,0 +1,1 @@
+Added ``$cocotb_test_pass()`` and ``$cocotb_test_fail()`` (System)Verilog system tasks for ending the current cocotb from Verilog with either a pass or fail.

--- a/tests/test_cases/test_end_system_tasks/Makefile
+++ b/tests/test_cases/test_end_system_tasks/Makefile
@@ -1,0 +1,23 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+TOPLEVEL_LANG ?= verilog
+TOPLEVEL := test_end_system_tasks
+MODULE := test_end_system_tasks
+PWD=$(shell pwd)
+VERILOG_SOURCES := $(PWD)/test_end_system_tasks.sv
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all::
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+
+clean::
+
+else
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+endif

--- a/tests/test_cases/test_end_system_tasks/test_end_system_tasks.py
+++ b/tests/test_cases/test_end_system_tasks/test_end_system_tasks.py
@@ -1,0 +1,15 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import cocotb
+
+
+@cocotb.test()
+async def test_system_task_passes(_):
+    await cocotb.triggers.Timer(100, 'ns')
+
+
+@cocotb.test(expect_fail=True)
+async def test_system_task_fails(_):
+    await cocotb.triggers.Timer(100, 'ns')

--- a/tests/test_cases/test_end_system_tasks/test_end_system_tasks.sv
+++ b/tests/test_cases/test_end_system_tasks/test_end_system_tasks.sv
@@ -1,0 +1,17 @@
+//-----------------------------------------------------------------------------
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//-----------------------------------------------------------------------------
+
+`timescale 1 ns / 1 ps
+
+module test_end_system_tasks;
+
+initial begin
+    #10ns $cocotb_pass_test();
+    #10ns $cocotb_fail_test();
+end
+
+endmodule


### PR DESCRIPTION
These two new system tasks end the currently running cocotb test with either a `TestSuccess` or a `TestFailure`, respectively. These system tasks are currently only implemented in VPI.

Closes #2094. Closes #2093.

I'm not very certain about this approach. It buries more assumption about the use of cocotb's testing framework into the GPI. That seems like a bleeding of responsibility to me. But #2195 is in the way if we wanted to move this into `gpi_embed`. In which case the registering code would be run in `gpi_embed_init` before elaboration has finished.

Suggestions welcome. Pinging @umarcor. Perhaps there should be a system task that returns the currently running test's name so the user doesn't have to make assumptions about which test is running in cocotb?