### PR TITLE
Increase coverage in xunit_reporter.py

### DIFF
--- a/cocotb/xunit_reporter.py
+++ b/cocotb/xunit_reporter.py
@@ -28,40 +28,6 @@
 from xml.etree.ElementTree import Element, SubElement
 import xml.etree.ElementTree as ET
 
-import mmap
-from io import StringIO
-
-TRUNCATE_LINES = 100
-
-
-# file from  http://stackoverflow.com/questions/136168/get-last-n-lines-of-a-file-with-python-similar-to-tail
-class File(StringIO):
-
-    def countlines(self):
-        buf = mmap.mmap(self.fileno(), 0)
-        lines = 0
-        while buf.readline():
-            lines += 1
-        return lines
-
-    def head(self, lines_2find=1):
-        self.seek(0)                            # Rewind file
-        return [self.next() for x in range(lines_2find)]
-
-    def tail(self, lines_2find=1):
-        self.seek(0, 2)                         # go to end of file
-        bytes_in_file = self.tell()
-        lines_found, total_bytes_scanned = 0, 0
-        while (lines_2find+1 > lines_found and
-               bytes_in_file > total_bytes_scanned):
-            byte_block = min(1024, bytes_in_file-total_bytes_scanned)
-            self.seek(-(byte_block+total_bytes_scanned), 2)
-            total_bytes_scanned += byte_block
-            lines_found += self.read(1024).count('\n')
-        self.seek(-total_bytes_scanned, 2)
-        line_list = list(self.readlines())
-        return line_list[-lines_2find:]
-
 
 class XUnitReporter:
 
@@ -84,30 +50,6 @@ class XUnitReporter:
             testsuite = self.last_testsuite
         self.last_property = SubElement(testsuite, "property", **kwargs)
         return self.last_property
-
-    def update_testsuite(self, testsuite=None, **kwargs):
-        if testsuite is None:
-            testsuite = self.last_testsuite
-        for k in kwargs:
-            testsuite.set(k, str(kwargs[k]))
-
-    def update_testsuites(self, **kwargs):
-        for k in kwargs:
-            self.results.set(k, str(kwargs[k]))
-
-    def add_log(self, logfile, testcase=None):
-        if testcase is None:
-            testcase = self.last_testcase
-        log = SubElement(testcase, "system-out")
-        f = File(logfile, 'r+')
-        lines = f.countlines()
-        if lines > (TRUNCATE_LINES * 2):
-            head = f.head(TRUNCATE_LINES)
-            tail = f.tail(TRUNCATE_LINES)
-            log.text = "".join(head + list("[...truncated %d lines...]\n" %
-                               ((lines - (TRUNCATE_LINES*2)))) + tail)
-        else:
-            log.text = "".join(f.readlines())
 
     def add_failure(self, testcase=None, **kwargs):
         if testcase is None:

--- a/documentation/source/newsfragments/2200.removal.rst
+++ b/documentation/source/newsfragments/2200.removal.rst
@@ -1,0 +1,1 @@
+The undocumented class ``cocotb.xunit_reporter.File`` has been removed.

--- a/tests/test_cases/test_failure/Makefile
+++ b/tests/test_cases/test_failure/Makefile
@@ -1,0 +1,14 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+MODULE := test_failure
+
+# ensure the test runs, squash any error code, and ensure a failing test was reported
+.PHONY: override_for_this_test
+override_for_this_test:
+	-$(MAKE) all
+	$(call check_for_results_file)
+	test $$(../../../bin/combine_results.py | grep "Failure in testsuite" | wc -l) -eq 1 && rm -f results.xml
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_failure/test_failure.py
+++ b/tests/test_cases/test_failure/test_failure.py
@@ -4,7 +4,7 @@
 """
 Tests the failure path for tests in the regression.py and xunit_reporter.py.
 
-The Makefile in the same repo is specially set up to squash any error code due
+The Makefile in this folder is specially set up to squash any error code due
 to a failing test and ensures the failing test is reported properly.
 """
 import cocotb

--- a/tests/test_cases/test_failure/test_failure.py
+++ b/tests/test_cases/test_failure/test_failure.py
@@ -1,0 +1,15 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Tests the failure path for tests in the regression.py and xunit_reporter.py.
+
+The Makefile in the same repo is specially set up to squash any error code due
+to a failing test and ensures the failing test is reported properly.
+"""
+import cocotb
+
+
+@cocotb.test()
+async def test_fail():
+    assert False


### PR DESCRIPTION
Adding more deprecations, removals, and tests to increase code coverage. While the deprecated code is still being counted towards the total coverage it will be removed after 1.5 releases and 2.0 development begins. If desired we can add `pragma: no cover` comments to deprecated code blocks to reflect post-removal coverage numbers.

~~Deprecate `cocotb.hook` Closes #920.~~ Remove internal dead code in xunit_reporter.py. ~~Deprecate `cocotb.utils.unpack` and `cocotb.utils.pack`.~~ Add test for a test failure that escapes the regression manager.