### PR TITLE
Deprecate cocotb.hook

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -451,7 +451,7 @@ class _decorator_helper(type):
 
 @public
 class hook(coroutine, metaclass=_decorator_helper):
-    """
+    r"""
     Decorator to mark a function as a hook for cocotb.
 
     Used as ``@cocotb.hook()``.

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -461,16 +461,16 @@ class hook(coroutine, metaclass=_decorator_helper):
 
     .. deprecated:: 1.5
         Hooks are deprecated.
-        Their functionality can be replaced with module-level Python code;
-        higher-priority tests using the ``stage`` option on `cocotb.test()`s;
-        or function decorators;
-        depending on what your original use case entailed.
+        Their functionality can be replaced with module-level Python code,
+        higher-priority tests using the ``stage`` argument to :func:`cocotb.test`\ s,
+        or custom decorators which perform work before and after the tests
+        they decorate.
     """
 
     def __init__(self, f):
         super(hook, self).__init__(f)
         warnings.warn(
-            "Hooks have been deprecated. Module-level code can be written to replace hooks.",
+            "Hooks have been deprecated. See the documentation for suggestions on alternatives.",
             DeprecationWarning, stacklevel=2)
         self.im_hook = True
         self.name = self._func.__name__

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -451,15 +451,25 @@ class _decorator_helper(type):
 
 @public
 class hook(coroutine, metaclass=_decorator_helper):
-    """Decorator to mark a function as a hook for cocotb.
+    """
+    Decorator to mark a function as a hook for cocotb.
 
     Used as ``@cocotb.hook()``.
 
     All hooks are run at the beginning of a cocotb test suite, prior to any
-    test code being run."""
+    test code being run.
+
+    .. deprecated:: 1.5
+        Hooks are deprecated. Their functionality can be replaced with module-level Python code;
+        higher-priority tests using the ``stage`` option; or function decorators; depending on
+        what your original use case entailed.
+    """
 
     def __init__(self, f):
         super(hook, self).__init__(f)
+        warnings.warn(
+            "Hooks have been deprecated. Module-level code can be written to replace hooks.",
+            DeprecationWarning, stacklevel=2)
         self.im_hook = True
         self.name = self._func.__name__
 

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -460,9 +460,11 @@ class hook(coroutine, metaclass=_decorator_helper):
     test code being run.
 
     .. deprecated:: 1.5
-        Hooks are deprecated. Their functionality can be replaced with module-level Python code;
-        higher-priority tests using the ``stage`` option; or function decorators; depending on
-        what your original use case entailed.
+        Hooks are deprecated.
+        Their functionality can be replaced with module-level Python code;
+        higher-priority tests using the ``stage`` option on `cocotb.test()`s;
+        or function decorators;
+        depending on what your original use case entailed.
     """
 
     def __init__(self, f):

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -168,6 +168,9 @@ Regression Manager
     A comma-separated list of modules that should be executed before the first test.
     You can also use the :class:`cocotb.hook` decorator to mark a function to be run before test code.
 
+    .. deprecated:: 1.5
+        :class:`cocotb.hook` has been deprecated and this variable is no longer used.
+
 
 Scheduler
 ~~~~~~~~~

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -169,7 +169,7 @@ Regression Manager
     You can also use the :class:`cocotb.hook` decorator to mark a function to be run before test code.
 
     .. deprecated:: 1.5
-        :class:`cocotb.hook` has been deprecated and this variable is no longer used.
+        :class:`cocotb.hook` is deprecated, and in the future this variable will be ignored.
 
 
 Scheduler

--- a/documentation/source/newsfragments/2201.removal.rst
+++ b/documentation/source/newsfragments/2201.removal.rst
@@ -1,0 +1,5 @@
+Deprecated :class:`cocotb.hook` and :envvar:`COCOTB_HOOKS`.
+Write module-level Python code;
+create higher-priority tests using the ``stage`` option of :class:`cocotb.test`;
+or define your own function decorators;
+depending on how you were using hooks.

--- a/documentation/source/newsfragments/2201.removal.rst
+++ b/documentation/source/newsfragments/2201.removal.rst
@@ -1,5 +1,2 @@
 Deprecated :class:`cocotb.hook` and :envvar:`COCOTB_HOOKS`.
-Write module-level Python code;
-create higher-priority tests using the ``stage`` option of :class:`cocotb.test`;
-or define your own function decorators;
-depending on how you were using hooks.
+See the documentation for :class:`cocotb.hook` for suggestions on alternatives.

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -78,3 +78,11 @@ async def test_raise_error_deprecated(dut):
     with assert_deprecated():
         with assert_raises(cocotb.result.TestError):
             cocotb.result.raise_error(cocotb.triggers.Timer(1), "A test exception")
+
+
+@cocotb.test()
+async def test_hook_deprecated(_):
+    async def example():
+        pass
+    with assert_deprecated():
+        cocotb.hook()(example)


### PR DESCRIPTION
Closes #920. Deprecates `cocotb.hook`.