### PR TITLE
Deprecated cocotb.utils.pack and cocotb.utils.unpack

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -692,12 +692,17 @@ class ModifiableObject(NonConstantObject):
         because assigning integers less than 32 bits is faster.
 
         Args:
-            value (ctypes.Structure, cocotb.binary.BinaryValue, int, double):
+            value (cocotb.binary.BinaryValue, int):
                 The value to drive onto the simulator object.
 
         Raises:
             TypeError: If target is not wide enough or has an unsupported type
                  for value assignment.
+
+        .. deprecated:: 1.5
+            :class:`ctypes.Structure` objects are no longer accepted as values for assignment.
+            Convert the struct object to a :class:`~cocotb.binary.BinaryValue` before assignment using
+            ``BinaryValue(value=bytes(struct_obj), n_bits=len(signal))`` instead.
         """
         value, set_action = self._check_for_set_action(value)
 
@@ -705,6 +710,10 @@ class ModifiableObject(NonConstantObject):
             call_sim(self, self._handle.set_signal_val_long, set_action, value)
             return
         if isinstance(value, ctypes.Structure):
+            warnings.warn(
+                "`ctypes.Structure` values are no longer accepted for value assignment. "
+                "Use `BinaryValue(value=bytes(struct_obj), n_bits=len(signal))` instead",
+                DeprecationWarning, stacklevel=3)
             value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
         elif isinstance(value, int):
             value = BinaryValue(value=value, n_bits=len(self), bigEndian=False)

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -174,7 +174,13 @@ def pack(ctypes_obj):
 
     Returns:
         New Python string containing the bytes from memory holding *ctypes_obj*.
+
+    .. deprecated:: 1.5
+        This function is deprecated, use ``bytes(ctypes_obj)`` instead.
     """
+    warnings.warn(
+        "This function is deprecated and will be removed, use ``bytes(ctypes_obj)`` instead.",
+        DeprecationWarning, stacklevel=2)
     return ctypes.string_at(ctypes.addressof(ctypes_obj),
                             ctypes.sizeof(ctypes_obj))
 
@@ -196,7 +202,15 @@ def unpack(ctypes_obj, string, bytes=None):
         :exc:`ValueError`: If length of *string* and size of *ctypes_obj*
             are not equal.
         :exc:`MemoryError`: If *bytes* is longer than size of *ctypes_obj*.
+
+    .. deprecated:: 1.5
+        Converting bytes to a ctypes object should be done with :meth:`~ctypes._CData.from_buffer_copy`.
+        If you need to assign bytes into an *existing* ctypes object, use ``memoryview(ctypes_obj).cast('B')[:bytes] = string``,
+        see :class:`memoryview` for details.
     """
+    warnings.warn(
+        "This function is being removed, use ``memoryview(ctypes_obj).cast('B')[:bytes] = string`` instead.",
+        DeprecationWarning, stacklevel=2)
     if bytes is None:
         if len(string) != ctypes.sizeof(ctypes_obj):
             raise ValueError("Attempt to unpack a string of size %d into a \

--- a/documentation/source/newsfragments/2203.removal.rst
+++ b/documentation/source/newsfragments/2203.removal.rst
@@ -1,0 +1,1 @@
+Deprecate :func:`~cocotb.utils.pack` and :func:`~cocotb.utils.unpack` and the use of :class:`python:ctypes.Structure` in signal assignments.

--- a/tests/pytest/test_utils.py
+++ b/tests/pytest/test_utils.py
@@ -5,6 +5,8 @@ import pytest
 
 import cocotb.utils
 
+import ctypes
+
 
 class TestHexDump:
     def test_int_illegal(dut):
@@ -36,3 +38,40 @@ class TestHexDiffs:
 
         diff_bytes = cocotb.utils.hexdiffs(b'\x20\x65\x00\xff', b'\x20\x00\x65')
         assert diff_bytes == diff_str
+
+
+def test_pack_deprecated():
+
+    class Example(ctypes.Structure):
+        _fields_ = [
+            ("a", ctypes.c_byte),
+            ("b", ctypes.c_byte)]
+
+    e = Example(a=0xCC, b=0x55)
+
+    with pytest.warns(DeprecationWarning):
+        a = cocotb.utils.pack(e)
+
+    assert a == bytes(e)
+
+
+def test_unpack_deprecated():
+
+    class Example(ctypes.Structure):
+        _fields_ = [
+            ("a", ctypes.c_byte),
+            ("b", ctypes.c_byte)]
+
+    e = Example(a=0xCC, b=0x55)
+    f = Example(a=0xCC, b=0x55)
+
+    b = b'\x01\x02'
+
+    with pytest.warns(DeprecationWarning):
+        cocotb.utils.unpack(e, b)
+
+    assert e.a == 1 and e.b == 2
+
+    memoryview(f).cast('B')[:] = b
+
+    assert f.a == 1 and f.b == 2

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -129,6 +129,7 @@ async def test_assigning_structure_deprecated(dut):
 
     assert dut.stream_in_data_wide == BinaryValue(value=bytes(e), n_bits=len(dut.stream_in_data_wide))
 
+
 @cocotb.test()
 async def test_expect_error_bool_deprecated(_):
     async def t():

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -2,7 +2,10 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import cocotb
+from cocotb.triggers import Timer
+from cocotb.binary import BinaryValue
 import warnings
+import ctypes
 from contextlib import contextmanager
 from common import assert_raises
 
@@ -106,3 +109,22 @@ async def test_handle_compat_mapping(dut):
     with assert_deprecated():
         dut.fullname = "myfullname"
     assert dut.fullname == "myfullname"
+
+
+@cocotb.test()
+async def test_assigning_structure_deprecated(dut):
+    """signal <= ctypes.Structure assignment is deprecated"""
+
+    class Example(ctypes.Structure):
+        _fields_ = [
+            ("a", ctypes.c_byte),
+            ("b", ctypes.c_uint32)]
+
+    e = Example(a=0xCC, b=0x12345678)
+
+    with assert_deprecated():
+        dut.stream_in_data_wide <= e
+
+    await Timer(1, 'step')
+
+    assert dut.stream_in_data_wide == BinaryValue(value=bytes(e), n_bits=len(dut.stream_in_data_wide))

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -129,7 +129,6 @@ async def test_assigning_structure_deprecated(dut):
 
     assert dut.stream_in_data_wide == BinaryValue(value=bytes(e), n_bits=len(dut.stream_in_data_wide))
 
-    
 @cocotb.test()
 async def test_expect_error_bool_deprecated(_):
     async def t():


### PR DESCRIPTION
Split off from #2200.