### PR TITLE
Update miniconda-action to v2

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -179,7 +179,7 @@ jobs:
         python-version: ${{matrix.python-version}}
     - name: Set up Anaconda ${{matrix.python-version}} (Windows)
       if: startsWith(matrix.os, 'windows')
-      uses: conda-incubator/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         python-version: ${{matrix.python-version}}


### PR DESCRIPTION
This should stop the Windows tests from failing. Closes #2207.