### PR TITLE
Mention Verilog's join/join_any in triggers.py

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -762,6 +762,8 @@ class Combine(_AggregateWaitable):
     Fires when all of *triggers* have fired.
 
     Like most triggers, this simply returns itself.
+
+    This is similar to Verilog's ``join``.
     """
     __slots__ = ()
 
@@ -790,6 +792,8 @@ class First(_AggregateWaitable):
     Fires when the first trigger in *triggers* fires.
 
     Returns the result of the trigger that fired.
+
+    This is similar to Verilog's ``join_any``.
 
     .. note::
         The event loop is single threaded, so while events may be simultaneous


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
