### PR TITLE
Make docstring for BinaryValue.is_resolvable clearer

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -328,7 +328,8 @@ class BinaryValue:
 
     @property
     def is_resolvable(self) -> bool:
-        """Return whether the value contains only resolvable (i.e. no "unknown") bits.
+        """
+        Return whether the value contains only resolvable (i.e. no "unknown") bits.
 
         By default the values ``X``, ``Z``, ``U`` and ``W`` are considered unresolvable.
         This can be configured with :envvar:`COCOTB_RESOLVE_X`.

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -335,7 +335,7 @@ class BinaryValue:
         This can be configured with :envvar:`COCOTB_RESOLVE_X`.
 
         This is similar to the SystemVerilog Assertion ``$isunknown`` system function
-        (with an inverted meaning).
+        or the VHDL function ``is_x`` (with an inverted meaning).
         """
         return not any(char in self._str for char in BinaryValue._resolve_to_error)
 

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -327,8 +327,15 @@ class BinaryValue:
     get_value_signed = signed_integer.fget
 
     @property
-    def is_resolvable(self):
-        """Does the value contain any ``X``'s?  Inquiring minds want to know."""
+    def is_resolvable(self) -> bool:
+        """Return whether the value contains only resolvable (i.e. no "unknown") bits.
+
+        By default the values ``X``, ``Z``, ``U`` and ``W`` are considered unresolvable.
+        This can be configured with :envvar:`COCOTB_RESOLVE_X`.
+
+        This is similar to the SystemVerilog Assertion ``$isunknown`` system function
+        (with an inverted meaning).
+        """
         return not any(char in self._str for char in BinaryValue._resolve_to_error)
 
     @property


### PR DESCRIPTION
Refs #2215.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
