### PR TITLE
Improve _compat_mapping deprecation warnings

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -162,7 +162,8 @@ class SimHandleBase:
     def __setattr__(self, name, value):
         if name in self._compat_mapping:
             if name not in _deprecation_warned:
-                warnings.warn("Use of attribute %r is deprecated, use %r instead" % (name, self._compat_mapping[name]))
+                warnings.warn("Use of attribute %r is deprecated, use %r instead" % (name, self._compat_mapping[name]),
+                              DeprecationWarning, stacklevel=3)
                 _deprecation_warned.add(name)
             return setattr(self, self._compat_mapping[name], value)
         else:
@@ -171,7 +172,8 @@ class SimHandleBase:
     def __getattr__(self, name):
         if name in self._compat_mapping:
             if name not in _deprecation_warned:
-                warnings.warn("Use of attribute %r is deprecated, use %r instead" % (name, self._compat_mapping[name]))
+                warnings.warn("Use of attribute %r is deprecated, use %r instead" % (name, self._compat_mapping[name]),
+                              DeprecationWarning, stacklevel=3)
                 _deprecation_warned.add(name)
             return getattr(self, self._compat_mapping[name])
         else:

--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -44,7 +44,7 @@ async def write_address_0(dut):
     value = dut.dut.r_temp_0
     assert value == DATA, ("Register at address 0x%08X should have been "
                            "0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
-    dut.log.info("Write 0x%08X to address 0x%08X" % (int(value), ADDRESS))
+    dut._log.info("Write 0x%08X to address 0x%08X" % (int(value), ADDRESS))
 
 
 # Read back a value at address 0x04

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -86,3 +86,23 @@ async def test_hook_deprecated(_):
         pass
     with assert_deprecated():
         cocotb.hook()(example)
+
+
+@cocotb.test()
+async def test_handle_compat_mapping(dut):
+    """
+    Test DeprecationWarnings for _compat_mapping.
+
+    Note that these only warn once per attribute.
+    """
+    # log
+    with assert_deprecated():
+        dut.log.info("'log' is deprecated")
+    # name
+    with assert_deprecated():
+        dut.name = "myname"
+    assert dut.name == "myname"
+    # fullname
+    with assert_deprecated():
+        dut.fullname = "myfullname"
+    assert dut.fullname == "myfullname"


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
