### PR TITLE
Allow tuning of matrix_multiplier test length in tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ passenv =
     ALDEC_LICENSE_FILE
     SYNOPSYS_LICENSE_FILE
     LM_LICENSE_FILE
+    # allow tuning of matrix_multiplier test length
+    NUM_SAMPLES
 
 deps =
     coverage


### PR DESCRIPTION
The `matrix_multiplier` test was intended to take 30s-1min, in order to provide some performance data. When using some simulators with lower performance, the test is longer than necessary for regression purposes. This allows shortening the test by setting the environment variable.
Riviera CI should be cut by ~half once this is in.
If any of the GHA regressions are taking too long we can tune them.