### PR TITLE
gitpod: Compile Verilator stable; small UX tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ __pycache__
 
 # Waveforms
 *.vcd
+*.fst
+*.fst.hier
 
 # Results
 results.xml

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -10,36 +10,46 @@ RUN pyenv global ${PYTHON_VERSION}
 
 RUN pip3 install --upgrade pip
 
-# Install linters
-RUN pip3 install -U flake8 pylint
+# Install extra packages
+RUN pip3 install -U flake8 pylint pytype mypy gcovr cherrypy dowser
 
-# Re-synchronize the package index
+# Re-synchronize the OS package index
 RUN sudo apt-get update
 
-# Install needed packages
-RUN sudo apt-get install -y flex gnat gtkwave swig
+# Install all needed packages for all simulators
+RUN sudo apt-get install -y perl make flex gnat gtkwave swig autoconf g++ bison libfl2 libfl-dev ccache libgoogle-perftools-dev numactl perl-doc
 RUN sudo rm -rf /var/lib/apt/lists/*
 
 ## Install Icarus Verilog
 RUN brew install icarus-verilog
 
 ## Install Verilator
-RUN brew install verilator
+ENV VERILATOR_BRANCH=stable
+
+RUN git clone https://github.com/verilator/verilator.git --branch ${VERILATOR_BRANCH} verilator \
+    && unset VERILATOR_ROOT \
+    && cd verilator \
+    && autoconf \
+    && ./configure \
+    && make --silent \
+    && sudo make --silent install \
+    && cd .. \
+    && rm -rf verilator
 
 ## Install GHDL
 ENV GHDL_BRANCH=v0.37
 RUN git clone https://github.com/ghdl/ghdl.git --depth=1 --branch ${GHDL_BRANCH} ghdl \
     && cd ghdl \
     && ./configure \
-    && make -s \
-    && sudo make -s install \
+    && make --silent \
+    && sudo make --silent install \
     && cd .. \
     && rm -rf ghdl
 
 # Install cvc
 RUN git clone https://github.com/cambridgehackers/open-src-cvc.git --depth=1 cvc \
     && cd cvc/src \
-    && make -f makefile.cvc64 -s \
+    && make -f makefile.cvc64 --silent \
     && sudo cp cvc64 /usr/local/bin \
     && cd ../.. \
     && rm -rf cvc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,16 +13,18 @@ tasks:
       gp open Makefile &&
       gp open dff_cocotb.py &&
       make SIM=icarus &&
-      EXTRA_ARGS="-CFLAGS -DVM_TRACE_FST=1 --trace-fst --trace-structs" make SIM=verilator &&
-      gtkwave dump.fst &
+      EXTRA_ARGS="--trace-fst --trace-structs" make SIM=verilator &&
+      gtkwave dump.fst --rcvar 'initial_window_x 1920' --rcvar 'initial_window_y 1061' --rcvar 'do_initial_zoom_fit yes' &
     command: >
       cd /workspace/cocotb/examples/dff/tests ;
       history -s make SIM=cvc ;
       history -s make SIM=ghdl TOPLEVEL_LANG=vhdl ;
       history -s make SIM=icarus ;
-      history -s EXTRA_ARGS="-CFLAGS -DVM_TRACE_FST=1 --trace-fst --trace-structs" make SIM=verilator ;
-      history -s gtkwave dump.fst ;
+      history -s EXTRA_ARGS=\"--trace-fst --trace-structs\" make SIM=verilator ;
+      history -s gtkwave dump.fst --rcvar \'initial_window_x 1920\' --rcvar \'initial_window_y 1061\' --rcvar \'do_initial_zoom_fit yes\' ;
       history -d 3
+
+# NOTE: the geometry for gtkwave's fullscreen size can be found with xwininfo -root
 
 # https://www.gitpod.io/docs/config-ports/
 ports:


### PR DESCRIPTION
Homebrew doesn't keep up with Verilator releases.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
