### PR TITLE
Update test expectations for Riviera-PRO 2020.04/10

### DIFF
--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -346,7 +346,7 @@ async def test_discover_all(dut):
             pass_total = 813
         elif cocotb.SIM_VERSION.startswith(("2016.02")):
             pass_total = 947
-        elif cocotb.SIM_VERSION.startswith(("2019.10")):
+        elif cocotb.SIM_VERSION.startswith(("2019.10", "2020.")):
             # vpiVariables finds port_rec_out and sig_rec
             pass_total = 1006
         else:

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -46,7 +46,7 @@ def total_object_count():
 
     # Riviera-PRO
     if SIM_NAME.startswith("riviera"):
-        if SIM_VERSION.startswith("2019.10"):
+        if SIM_VERSION.startswith(("2019.10", "2020.")):
             return 27359
         if SIM_VERSION.startswith("2016.02"):
             return 32393
@@ -112,7 +112,7 @@ async def dual_iteration(dut):
     await Combine(loop_one, loop_two)
 
 
-@cocotb.test(expect_fail=(cocotb.SIM_NAME.lower().startswith("riviera") and cocotb.SIM_VERSION.startswith("2019.10")) or cocotb.SIM_NAME.lower().startswith("aldec"))
+@cocotb.test(expect_fail=(cocotb.SIM_NAME.lower().startswith("riviera") and cocotb.SIM_VERSION.startswith(("2019.10", "2020."))) or cocotb.SIM_NAME.lower().startswith("aldec"))
 async def test_n_dimension_array(dut):
     """Test iteration over multi-dimensional array."""
     tlog = logging.getLogger("cocotb.test")


### PR DESCRIPTION
Riviera-PRO 2020.04 and 2020.10 behave identical to 2019.10
in our discovery tests, update the expectations accordingly.