### PR TITLE
Fix some sphinx warnings

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -498,6 +498,7 @@ class test(coroutine, metaclass=_decorator_helper):
                 Test timeout is intended for protection against deadlock.
                 Users should use :class:`~cocotb.triggers.with_timeout` if they require a
                 more general-purpose timeout mechanism.
+
         timeout_unit (str, optional):
             Units of timeout_time, accepts any units that :class:`~cocotb.triggers.Timer` does.
 
@@ -505,8 +506,10 @@ class test(coroutine, metaclass=_decorator_helper):
 
             .. deprecated:: 1.5
                 Using None as the the *timeout_unit* argument is deprecated, use ``'step'`` instead.
-         expect_fail (bool, optional):
+
+        expect_fail (bool, optional):
             Don't mark the result as a failure if the test fails.
+
         expect_error (bool or exception type or tuple of exception types, optional):
             If ``True``, consider this test passing if it raises *any* :class:`Exception`, and failing if it does not.
             If given an exception type or tuple of exception types, catching *only* a listed exception type is considered passing.
@@ -525,9 +528,11 @@ class test(coroutine, metaclass=_decorator_helper):
 
             .. versionchanged:: 1.3
                 Specific exception types can be expected
+
         skip (bool, optional):
             Don't execute this test as part of the regression. Test can still be run
             manually by setting :make:var:`TESTCASE`.
+
         stage (int, optional)
             Order tests logically into stages, where multiple tests can share a stage.
     """

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -275,8 +275,8 @@ class AXI4Master(BusDriver):
 
         With unaligned writes (when ``address`` is not a multiple of ``size``),
         only the low ``size - address % size`` Bytes are written for:
-         * the last element of ``value`` for INCR or WRAP bursts, or
-         * every element of ``value`` for FIXED bursts.
+        * the last element of ``value`` for INCR or WRAP bursts, or
+        * every element of ``value`` for FIXED bursts.
 
         Args:
             address: The address to write to.

--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -53,23 +53,21 @@ class Monitor:
     """Base class for Monitor objects.
 
     Monitors are passive 'listening' objects that monitor pins going in or out of a DUT.
-    This class should not be used
-    directly, but should be sub-classed and the internal :any:`_monitor_recv` method
-    should be overridden and decorated as a :any:`coroutine`.  This :any:`_monitor_recv`
-    method should capture some behavior of the pins, form a transaction, and
-    pass this transaction to the internal :any:`_recv` method.  The :any:`_monitor_recv`
-    method is added to the cocotb scheduler during the ``__init__`` phase, so it
-    should not be awaited anywhere.
+    This class should not be used directly,
+    but should be sub-classed and the internal :meth:`_monitor_recv` method should be overridden.
+    This :meth:`_monitor_recv` method should capture some behavior of the pins, form a transaction,
+    and pass this transaction to the internal :meth:`_recv` method.
+    The :meth:`_monitor_recv` method is added to the cocotb scheduler during the ``__init__`` phase,
+    so it should not be awaited anywhere.
 
-    The primary use of a Monitor is as an interface for a
-    :class:`~cocotb.scoreboard.Scoreboard`.
+    The primary use of a Monitor is as an interface for a :class:`~cocotb.scoreboard.Scoreboard`.
 
     Args:
         callback (callable): Callback to be called with each recovered transaction
             as the argument. If the callback isn't used, received transactions will
             be placed on a queue and the event used to notify any consumers.
         event (cocotb.triggers.Event): Event that will be called when a transaction
-            is received through the internal :any:`_recv` method.
+            is received through the internal :meth:`_recv` method.
             `Event.data` is set to the received transaction.
     """
 
@@ -139,7 +137,7 @@ class Monitor:
         """Actual implementation of the receiver.
 
         Sub-classes should override this method to implement the actual receive
-        routine and call :any:`_recv` with the recovered transaction.
+        routine and call :meth:`_recv` with the recovered transaction.
         """
         raise NotImplementedError("Attempt to use base monitor class without "
                                   "providing a ``_monitor_recv`` method")

--- a/documentation/source/install_devel.rst
+++ b/documentation/source/install_devel.rst
@@ -30,7 +30,7 @@ The instructions for installing the development version of cocotb vary depending
 
     If your user does not have permissions to install cocotb using the instructions above,
     try adding the ``--user`` option to ``pip``
-    (see :ref:`the pip documentation<https://pip.pypa.io/en/stable/user_guide/#user-installs>`).
+    (see `the pip documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`_).
 
 .. warning::
 

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -30,6 +30,7 @@ Features
 
   ..
      towncrier will append the issue number taken from the file name here:
+
   Issue (:pr:`1255`)
 - The cocotb log configuration is now less intrusive, and only configures the root logger instance, ``logging.getLogger()``, as part of :func:`cocotb.log.default_config` (:pr:`1266`).
 
@@ -61,6 +62,7 @@ Features
 
   ..
      towncrier will append the issue number taken from the file name here:
+
   Issue (:pr:`1403`)
 - Custom logging handlers can now access the simulator time using
   :attr:`logging.LogRecord.created_sim_time`, provided the


### PR DESCRIPTION
The below warnings were generated by sphinx code in Python-land. This PR fixes these issues.

```
/home/kaleb/dev/cocotb/cocotb/decorators.py:docstring of cocotb.test:26: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/kaleb/dev/cocotb/cocotb/drivers/amba.py:docstring of cocotb.drivers.amba.AXI4Master.write:5: WARNING: Unexpected indentation.
/home/kaleb/dev/cocotb/documentation/source/release_notes.rst:33: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/kaleb/dev/cocotb/documentation/source/release_notes.rst:64: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/kaleb/dev/cocotb/documentation/source/install_devel.rst:31: WARNING: undefined label: https://pip.pypa.io/en/stable/user_guide/#user-installs (if the link has no caption the label must precede a section header)
/home/kaleb/dev/cocotb/cocotb/monitors/__init__.py:docstring of cocotb.monitors.Monitor:3: WARNING: more than one target found for 'any' cross-reference 'coroutine': could be :std:term:`coroutine` or :py:class:`cocotb.coroutine`
```