### PR TITLE
Update some more tests for new syntax/conventions

### DIFF
--- a/tests/test_cases/issue_120/issue_120.py
+++ b/tests/test_cases/issue_120/issue_120.py
@@ -3,46 +3,42 @@
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, ReadOnly
-from cocotb.result import TestFailure
 
 
-@cocotb.coroutine
-def send_data(dut):
+async def send_data(dut):
     dut.stream_in_valid = 1
-    yield RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)
     dut.stream_in_valid = 0
 
 
-@cocotb.coroutine
-def monitor(dut):
+async def monitor(dut):
     for i in range(4):
-        yield RisingEdge(dut.clk)
-    yield ReadOnly()
-    if not dut.stream_in_valid.value.integer:
-        raise TestFailure("stream_in_valid should be high on the 5th cycle")
+        await RisingEdge(dut.clk)
+    await ReadOnly()
+    assert dut.stream_in_valid.value.integer, "stream_in_valid should be high on the 5th cycle"
 
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else False)
-def issue_120_scheduling(dut):
+async def issue_120_scheduling(dut):
 
-    cocotb.fork(Clock(dut.clk, 2500).start())
+    cocotb.fork(Clock(dut.clk, 10, 'ns').start())
     cocotb.fork(monitor(dut))
-    yield RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)
 
     # First attempt, not from coroutine - works as expected
     for i in range(2):
-        dut.stream_in_valid = 1
-        yield RisingEdge(dut.clk)
-        dut.stream_in_valid = 0
+        dut.stream_in_valid <= 1
+        await RisingEdge(dut.clk)
+        dut.stream_in_valid <= 0
 
-    yield RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)
 
     # Failure - we don't drive valid on the rising edge even though
     # behaviour should be identical to the above
-    yield send_data(dut)
-    dut.stream_in_valid = 1
-    yield RisingEdge(dut.clk)
-    dut.stream_in_valid = 0
+    await send_data(dut)
+    dut.stream_in_valid <= 1
+    await RisingEdge(dut.clk)
+    dut.stream_in_valid <= 0
 
-    yield RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)

--- a/tests/test_cases/issue_1279/issue_1279.py
+++ b/tests/test_cases/issue_1279/issue_1279.py
@@ -9,9 +9,9 @@ import cocotb
     expect_error=cocotb.result.SimFailure,
     stage=1,
 )
-def test_sim_failure_a(dut):
+async def test_sim_failure_a(dut):
     # invoke a deadlock, as nothing is driving this clock
-    yield cocotb.triggers.RisingEdge(dut.clk)
+    await cocotb.triggers.RisingEdge(dut.clk)
 
 
 @cocotb.test(
@@ -19,6 +19,5 @@ def test_sim_failure_a(dut):
     expect_error=cocotb.result.SimFailure,
     stage=2,
 )
-def test_sim_failure_b(dut):
-    yield cocotb.triggers.NullTrigger()
-    raise cocotb.result.TestFailure("This test should never run")
+async def test_sim_failure_b(dut):
+    assert False, "This test should never run"

--- a/tests/test_cases/issue_142/issue_142.py
+++ b/tests/test_cases/issue_142/issue_142.py
@@ -3,29 +3,27 @@
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge
-from cocotb.result import TestFailure
 from cocotb.binary import BinaryValue
 
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else False)
-def issue_142_overflow_error(dut):
+async def issue_142_overflow_error(dut):
     """Tranparently convert ints too long to pass
        through the GPI interface natively into BinaryValues"""
-    cocotb.fork(Clock(dut.clk, 2500).start())
+    cocotb.fork(Clock(dut.clk, 10, 'ns').start())
 
     def _compare(value):
-        if int(dut.stream_in_data_wide.value) != int(value):
-            raise TestFailure("Expecting 0x%x but got 0x%x on %s" % (
-                int(value), int(dut.stream_in_data_wide.value),
-                str(dut.stream_in_data_wide)))
+        assert int(dut.stream_in_data_wide.value) == int(value), "Expecting 0x%x but got 0x%x on %s" % (
+            int(value), int(dut.stream_in_data_wide.value),
+            str(dut.stream_in_data_wide))
 
     # Wider values are transparently converted to BinaryValues
     for value in [0, 0x7FFFFFFF, 0x7FFFFFFFFFFF, BinaryValue(0x7FFFFFFFFFFFFF,len(dut.stream_in_data_wide),bigEndian=False)]:
 
         dut.stream_in_data_wide <= value
-        yield RisingEdge(dut.clk)
+        await RisingEdge(dut.clk)
         _compare(value)
-        dut.stream_in_data_wide = value
-        yield RisingEdge(dut.clk)
+        dut.stream_in_data_wide <= value
+        await RisingEdge(dut.clk)
         _compare(value)

--- a/tests/test_cases/issue_253/issue_253.py
+++ b/tests/test_cases/issue_253/issue_253.py
@@ -2,31 +2,27 @@
 
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.result import TestFailure
 
 
-@cocotb.coroutine
-def toggle_clock(dut):
-    dut.clk = 0
-    yield Timer(10)
-    if dut.clk.value.integer != 0:
-        raise TestFailure("Clock not set to 0 as expected")
-    dut.clk = 1
-    yield Timer(10)
-    if dut.clk.value.integer != 1:
-        raise TestFailure("Clock not set to 1 as expected")
+async def toggle_clock(dut):
+    dut.clk <= 0
+    await Timer(10, 'ns')
+    assert dut.clk.value.integer == 0, "Clock not set to 0 as expected"
+    dut.clk <= 1
+    await Timer(10, 'ns')
+    assert dut.clk.value.integer == 1, "Clock not set to 1 as expected"
 
 
 @cocotb.test()
-def issue_253_empty(dut):
-    yield toggle_clock(dut)
+async def issue_253_empty(dut):
+    await toggle_clock(dut)
 
 
 @cocotb.test()
-def issue_253_none(dut):
-    yield toggle_clock(dut)
+async def issue_253_none(dut):
+    await toggle_clock(dut)
 
 
 @cocotb.test()
-def issue_253_notset(dut):
-    yield toggle_clock(dut)
+async def issue_253_notset(dut):
+    await toggle_clock(dut)

--- a/tests/test_cases/issue_330/issue_330.py
+++ b/tests/test_cases/issue_330/issue_330.py
@@ -2,32 +2,28 @@
 
 import cocotb
 import logging
-from cocotb.triggers import Timer
-from cocotb.result import TestFailure
 
 
-@cocotb.test(skip=cocotb.SIM_NAME in ["Icarus Verilog"])
-def issue_330_direct(dut):
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+async def issue_330_direct(dut):
     """
     Access a structure
     """
 
     tlog = logging.getLogger("cocotb.test")
-    yield Timer(10)
 
     structure = dut.inout_if
 
     tlog.info("Value of inout_if => a_in = %s ; b_out = %s" % (structure.a_in.value, structure.b_out.value))
 
 
-@cocotb.test(skip=cocotb.SIM_NAME in ["Icarus Verilog"])
-def issue_330_iteration(dut):
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+async def issue_330_iteration(dut):
     """
     Access a structure via issue_330_iteration
     """
 
     tlog = logging.getLogger("cocotb.test")
-    yield Timer(10)
 
     structure = dut.inout_if
 
@@ -36,5 +32,4 @@ def issue_330_iteration(dut):
         tlog.info("Found %s" % member._path)
         count += 1
 
-    if count != 2:
-        raise TestFailure("There should have been two members of the structure")
+    assert count == 2, "There should have been two members of the structure"

--- a/tests/test_cases/issue_348/issue_348.py
+++ b/tests/test_cases/issue_348/issue_348.py
@@ -1,27 +1,23 @@
 import cocotb
 from cocotb.log import SimLog
 from cocotb.triggers import Timer, Edge, RisingEdge, FallingEdge
-from cocotb.result import TestFailure
 
 
-@cocotb.coroutine
-def clock_gen(signal, num):
+async def clock_gen(signal, num):
     for x in range(num):
         signal <= 0
-        yield Timer(500)
+        await Timer(5, 'ns')
         signal <= 1
-        yield Timer(500)
+        await Timer(5, 'ns')
 
 
-@cocotb.coroutine
-def signal_mon(signal, idx, edge):
-    log = SimLog("cocotb.signal_mon.%d.%s" % (idx, signal._name))
-    value = signal.value
-
+async def signal_mon(signal, idx, edge):
+    _ = SimLog("cocotb.signal_mon.%d.%s" % (idx, signal._name))
+    _ = signal.value
     edges = 0
 
     while True:
-        yield edge(signal)
+        await edge(signal)
         edges += 1
 
     return edges
@@ -34,43 +30,40 @@ class DualMonitor:
         self.monitor_edges = [0, 0]
         self.signal = signal
 
-    @cocotb.coroutine
-    def signal_mon(self, signal, idx, edge):
+    async def signal_mon(self, signal, idx, edge):
         while True:
-            yield edge(signal)
+            await edge(signal)
             self.monitor_edges[idx] += 1
 
-    @cocotb.coroutine
-    def start(self):
+    async def start(self):
         clock_edges = 10
 
         cocotb.fork(clock_gen(self.signal, clock_edges))
-        first = cocotb.fork(self.signal_mon(self.signal, 0, self.edge_type))
-        second = cocotb.fork(self.signal_mon(self.signal, 1, self.edge_type))
+        _ = cocotb.fork(self.signal_mon(self.signal, 0, self.edge_type))
+        _ = cocotb.fork(self.signal_mon(self.signal, 1, self.edge_type))
 
-        yield Timer(10000)
+        await Timer(100, 'ns')
 
         for mon in self.monitor_edges:
-            if not mon:
-                raise TestFailure("Monitor saw nothing")
+            assert mon, "Monitor saw nothing"
 
 
 # Cadence simulators: "Unable set up RisingEdge(ModifiableObject(sample_module.clk)) Trigger" with VHDL (see #1076)
-@cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else False)
-def issue_348_rising(dut):
+@cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else ())
+async def issue_348_rising(dut):
     """ Start two monitors on RisingEdge """
-    yield DualMonitor(RisingEdge, dut.clk).start()
+    await DualMonitor(RisingEdge, dut.clk).start()
 
 
 # Cadence simulators: "Unable set up FallingEdge(ModifiableObject(sample_module.clk)) Trigger" with VHDL (see #1076)
-@cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else False)
-def issue_348_falling(dut):
+@cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else ())
+async def issue_348_falling(dut):
     """ Start two monitors on FallingEdge """
-    yield DualMonitor(FallingEdge, dut.clk).start()
+    await DualMonitor(FallingEdge, dut.clk).start()
 
 
 # Cadence simulators: "Unable set up Edge(ModifiableObject(sample_module.clk)) Trigger" with VHDL (see #1076)
-@cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else False)
-def issue_348_either(dut):
+@cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else ())
+async def issue_348_either(dut):
     """ Start two monitors on Edge """
-    yield DualMonitor(Edge, dut.clk).start()
+    await DualMonitor(Edge, dut.clk).start()

--- a/tests/test_cases/issue_588/issue_588.py
+++ b/tests/test_cases/issue_588/issue_588.py
@@ -2,28 +2,28 @@
 # This is a very simple test; it just makes sure we can yield a list of both.
 
 import cocotb
-from cocotb import triggers, result, utils
+from cocotb import triggers, utils
 
 
-@cocotb.coroutine
-def sample_coroutine(dut):
+async def sample_coroutine(dut):
     """ Very simple coroutine that waits 5 ns."""
-    yield triggers.Timer(5, "ns")
+    await triggers.Timer(5, "ns")
     dut._log.info("Sample coroutine yielded.")
 
 
 @cocotb.test()
-def issue_588_coroutine_list(dut):
+async def issue_588_coroutine_list(dut):
     """ Yield a list of triggers and coroutines."""
 
     # Record simulation time.
     current_time = utils.get_sim_time("ns")
 
     # Yield a list, containing a RisingEdge trigger and a coroutine.
-    yield [sample_coroutine(dut), triggers.Timer(100, "ns")]
+    coro = cocotb.fork(sample_coroutine(dut))
+    await triggers.First(coro, triggers.Timer(100, "ns"))
+    coro.kill()
 
     # Make sure that only 5 ns passed, because the sample coroutine
     # terminated first.
     new_time = utils.get_sim_time("ns")
-    if int(new_time - current_time) != 5:
-        raise result.TestFailure("Did not yield coroutine in list.")
+    assert int(new_time - current_time) == 5, "Did not yield coroutine in list."

--- a/tests/test_cases/issue_768_a/issue_768.py
+++ b/tests/test_cases/issue_768_a/issue_768.py
@@ -14,8 +14,8 @@ value = 0
 
 
 @cocotb.test()
-def test(dut):
+async def test(dut):
     dut.stream_in_data.setimmediatevalue(value)
-    yield Timer(1)
+    await Timer(1, 'step')
     assert dut.stream_in_data.value == 0
-    yield ReadOnly()
+    await ReadOnly()

--- a/tests/test_cases/issue_768_b/issue_768.py
+++ b/tests/test_cases/issue_768_b/issue_768.py
@@ -14,8 +14,8 @@ value = BinaryValue(0, n_bits=8)
 
 
 @cocotb.test()
-def do_test(dut):
+async def do_test(dut):
     dut.stream_in_data.setimmediatevalue(value)
-    yield Timer(1)
+    await Timer(1, 'step')
     assert dut.stream_in_data.value == 0
-    yield ReadOnly()
+    await ReadOnly()

--- a/tests/test_cases/issue_857/issue_857.py
+++ b/tests/test_cases/issue_857/issue_857.py
@@ -3,9 +3,8 @@ import cocotb.regression
 import cocotb.triggers
 
 
-@cocotb.coroutine
-def dummy_coroutine(dut):
-    yield cocotb.triggers.Timer(10, "ns")
+async def dummy_coroutine(dut):
+    await cocotb.triggers.Timer(10, "ns")
 
 
 # Try to instantiate the TestFactory class using its full specifier name.

--- a/tests/test_cases/issue_892/issue_892.py
+++ b/tests/test_cases/issue_892/issue_892.py
@@ -3,13 +3,12 @@ from cocotb.triggers import Timer
 from cocotb.result import TestSuccess
 
 
-@cocotb.coroutine
-def raise_test_success():
-    yield Timer(1, units='ns')
+async def raise_test_success():
+    await Timer(1, units='ns')
     raise TestSuccess("TestSuccess")
 
 
 @cocotb.test()
-def error_test(dut):
+async def error_test(dut):
     cocotb.fork(raise_test_success())
-    yield Timer(10, units='ns')
+    await Timer(10, units='ns')

--- a/tests/test_cases/issue_893/issue_893.py
+++ b/tests/test_cases/issue_893/issue_893.py
@@ -2,13 +2,11 @@ import cocotb
 from cocotb.triggers import Timer
 
 
-@cocotb.coroutine
-def coroutine_with_undef():
+async def coroutine_with_undef():
     new_variable = undefined_variable  # noqa
-    yield Timer(1, units='ns')
 
 
 @cocotb.test(expect_error=True)
-def fork_erroring_coroutine(dut):
+async def fork_erroring_coroutine(dut):
     cocotb.fork(coroutine_with_undef())
-    yield Timer(10, units='ns')
+    await Timer(10, units='ns')

--- a/tests/test_cases/issue_957/issue_957.py
+++ b/tests/test_cases/issue_957/issue_957.py
@@ -2,19 +2,15 @@ import cocotb
 from cocotb.triggers import Timer, RisingEdge, First
 
 
-@cocotb.coroutine
-def wait_edge(dut):
+async def wait_edge(dut):
     # this trigger never fires
-    yield First(
-        RisingEdge(dut.stream_out_ready)
-    )
+    await First(RisingEdge(dut.stream_out_ready))
 
 
 @cocotb.test()
-def test1(dut):
+async def test1(dut):
     cocotb.fork(wait_edge(dut))
-
-    yield Timer(1000)
+    await Timer(10, 'ns')
 
 
 test2 = test1


### PR DESCRIPTION
Updated the issue-specific tests to use `async`/`await`, `assert`, and specify `units` in `Timer`. Passing specific exceptions to `expect_error` is #2223.