### PR TITLE
Cleanup matrix_multiplier example

### DIFF
--- a/examples/matrix_multiplier/hdl/matrix_multiplier.sv
+++ b/examples/matrix_multiplier/hdl/matrix_multiplier.sv
@@ -4,11 +4,17 @@
 // Matrix Multiplier DUT
 `timescale 1ns/1ps
 
+`ifdef VERILATOR  // make parameter readable from VPI
+  `define VL_RD /*verilator public_flat_rd*/
+`else
+  `define VL_RD
+`endif
+
 module matrix_multiplier #(
-  parameter int DATA_WIDTH = 8,
-  parameter int A_ROWS = 8,
-  parameter int B_COLUMNS = 5,
-  parameter int A_COLUMNS_B_ROWS = 4,
+  parameter int DATA_WIDTH `VL_RD = 8,
+  parameter int A_ROWS `VL_RD = 8,
+  parameter int B_COLUMNS `VL_RD = 5,
+  parameter int A_COLUMNS_B_ROWS `VL_RD = 4,
   parameter int C_DATA_WIDTH = (2 * DATA_WIDTH) + $clog2(A_COLUMNS_B_ROWS)
 ) (
   input                           clk_i,
@@ -22,12 +28,12 @@ module matrix_multiplier #(
 
   logic [C_DATA_WIDTH-1:0] c_calc[A_ROWS * B_COLUMNS];
 
-  always @(*) begin
+  always @(*) begin : multiply
     logic [C_DATA_WIDTH-1:0] c_element;
-    for (int i = 0; i < A_ROWS; i = i + 1) begin
-      for (int j = 0; j < B_COLUMNS; j = j + 1) begin
+    for (int i = 0; i < A_ROWS; i = i + 1) begin : C_ROWS
+      for (int j = 0; j < B_COLUMNS; j = j + 1) begin : C_COLUMNS
         c_element = 0;
-        for (int k = 0; k < A_COLUMNS_B_ROWS; k = k + 1) begin
+        for (int k = 0; k < A_COLUMNS_B_ROWS; k = k + 1) begin : DOT_PRODUCT
           c_element = c_element + (a_i[(i * A_COLUMNS_B_ROWS) + k] * b_i[(k * B_COLUMNS) + j]);
         end
         c_calc[(i * B_COLUMNS) + j] = c_element;
@@ -35,7 +41,7 @@ module matrix_multiplier #(
     end
   end
 
-  always @(posedge clk_i) begin
+  always @(posedge clk_i) begin : proc_reg
     if (reset_i) begin
       valid_o <= 1'b0;
 

--- a/examples/matrix_multiplier/tests/Makefile
+++ b/examples/matrix_multiplier/tests/Makefile
@@ -55,13 +55,6 @@ endif
 # Fix the seed to ensure deterministic tests
 export RANDOM_SEED := 123456789
 
-# Export generics to test
-# Can't use plusargs since they aren't supported by ghdl
-export DATA_WIDTH
-export A_ROWS
-export B_COLUMNS
-export A_COLUMNS_B_ROWS
-
 TOPLEVEL    := matrix_multiplier
 MODULE      := test_matrix_multiplier
 


### PR DESCRIPTION
Closes #2233.

- Replace environment variables with parameters from cocotb.top
- Replace Scoreboard
- Make parameters readable for Verilator
- Add SystemVerilog block names to match VHDL
- Add log messages
