### PR TITLE
Remove old CI tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -115,13 +115,6 @@ jobs:
             # Test Verilator on Ubuntu
 
           - sim: verilator
-            sim-version: apt
-            lang: verilog
-            python-version: 3.8
-            os: ubuntu-20.04
-            may_fail: true
-
-          - sim: verilator
             sim-version: master
             lang: verilog
             python-version: 3.8

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -129,20 +129,8 @@ jobs:
             python-version: 3.8
             os: macos-latest
 
-          - sim: icarus             # Icarus homebrew stable
-            sim-version: homebrew
-            lang: verilog
-            python-version: 3.8
-            os: macos-latest
-
           - sim: icarus             # Icarus windows master from source
             sim-version: master
-            lang: verilog
-            python-version: 3.8
-            os: windows-latest
-
-          - sim: icarus             # Icarus windows 10.3 from source
-            sim-version: v10_3
             lang: verilog
             python-version: 3.8
             os: windows-latest


### PR DESCRIPTION
Since we have established that versions of Verilator < 4.106 are not supported anymore, there is no reason to test the version that exists on Ubuntu 20.04. And now that Icarus master works on Mac and Windows, there is no reason to test the older 10.3 branch on those OSes. 10.3 development is done and should continue to work without our continued testing.