### PR TITLE
Fix error on dynamic libpython loading on mac

### DIFF
--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -281,6 +281,12 @@ def _get_python_lib():
 
     if os.name == "nt":
         python_lib = _get_python_lib_link() + "." + _get_lib_ext_name()
+    elif sys.platform == "darwin":
+        python_lib = os.path.join(sysconfig.get_config_var("LIBDIR"), "lib" + _get_python_lib_link() + ".")
+        if os.path.exists(python_lib + "dylib"):
+            python_lib += "dylib"
+        else:
+            python_lib += "so"
     else:
         python_lib = "lib" + _get_python_lib_link() + "." + _get_lib_ext_name()
 


### PR DESCRIPTION
Exiting "Error":
```
       -.--ns ERROR    cocotb.gpi                         ..s/cocotb_utils.cpp:69   in utils_dyn_open                  Unable to open lib libpython3.8.so: dlopen(libpython3.8.so, 9): image not found
       -.--ns ERROR    cocotb.gpi                         ..mbed/gpi_embed.cpp:127  in embed_init_python               Failed to find Python shared library
```
After: https://github.com/cocotb/cocotb/runs/1500502527?check_suite_focus=true#step:22:109

Closes #2246 
Related to #2247 
