### PR TITLE
Remove erroneous assignment to input port

### DIFF
--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -136,10 +136,6 @@ assign logic_a = stream_in_valid;
 always@* logic_b = stream_in_valid;
 always@(posedge clk) logic_c <= stream_in_valid;
 
-`ifndef __ICARUS__
-assign inout_if.b_out = inout_if.a_in;
-`endif
-
 reg _underscore_name;
 `ifdef __ICARUS__
     // By default, a variable must be used in some way in order

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -183,11 +183,9 @@ async def test_struct(dut):
     dut.inout_if.a_in <= 1
     await Timer(1000, 'ns')
     _check_value(tlog, dut.inout_if.a_in, 1)
-    _check_value(tlog, dut.inout_if.b_out, 1)
     dut.inout_if.a_in <= 0
     await Timer(1000, 'ns')
     _check_value(tlog, dut.inout_if.a_in, 0)
-    _check_value(tlog, dut.inout_if.b_out, 0)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Interestingly, both Xcelium and Questa allow that
while Verilator and Riviera show an error.

Closes #2262.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
