### PR TITLE
Runtime-load libpython and make binaries relocatable

### DIFF
--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -43,6 +43,7 @@ import os
 import sys
 import textwrap
 import cocotb
+import find_libpython
 
 __all__ = ["share_dir", "makefiles_dir"]
 
@@ -145,6 +146,12 @@ def get_parser():
         help="echo the version of cocotb",
         action=PrintAction,
         text=version,
+    )
+    parser.add_argument(
+        "--libpython",
+        help="prints the absolute path to the libpython associated with the current Python installation",
+        action=PrintAction,
+        text=find_libpython.find_libpython(),
     )
 
     return parser

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -43,7 +43,7 @@ import os
 import sys
 import textwrap
 import cocotb
-import find_libpython
+import cocotb.vendor.find_libpython as find_libpython
 
 __all__ = ["share_dir", "makefiles_dir"]
 

--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -37,39 +37,180 @@
 #define GPILOG_EXPORT COCOTB_IMPORT
 #endif
 
+#include <cstdarg>
+
 #ifdef __cplusplus
-# define EXTERN_C_START extern "C" {
-# define EXTERN_C_END }
-#else
-# define EXTERN_C_START
-# define EXTERN_C_END
+extern "C" {
 #endif
 
-EXTERN_C_START
-
+/** Named logging level
+ *
+ *  The native logger only logs level names at these log level values.
+ *  They were specifically chosen to align with the default level values in the Python logging module.
+ *  Implementers of custom loggers should emit human readable level names for these value, but may support other values
+ */
 enum gpi_log_levels {
-    GPIDebug = 10,
-    GPIInfo = 20,
-    GPIWarning = 30,
-    GPIError = 40,
-    GPICritical = 50
+    GPIDebug    = 10,   ///< Prints `DEBUG` by default. Verbose information, useful for debugging
+    GPIInfo     = 20,   ///< Prints `INFO` by default. Information about major events in the current program
+    GPIWarning  = 30,   ///< Prints `WARN` by default. Encountered a recoverable bug, or information about surprising behavior
+    GPIError    = 40,   ///< Prints `ERROR` by default. An unrecoverable error
+    GPICritical = 50    ///< Prints `CRITICAL` by default. An unrecoverable error, to be followed by immediate simulator shutdown
 };
 
+/** Logs a message at the given log level using the current log handler.
+    Automatically populates arguments using information in the called context.
+    @param level The level at which to log the message
+ */
+#define LOG_(level, ...) \
+    gpi_log("cocotb.gpi", level,      __FILE__, __func__, __LINE__, __VA_ARGS__);
 
-#define LOG_DEBUG(...)     gpi_log("cocotb.gpi", GPIDebug,         __FILE__, __func__, __LINE__, __VA_ARGS__);
-#define LOG_INFO(...)      gpi_log("cocotb.gpi", GPIInfo,          __FILE__, __func__, __LINE__, __VA_ARGS__);
-#define LOG_WARN(...)      gpi_log("cocotb.gpi", GPIWarning,       __FILE__, __func__, __LINE__, __VA_ARGS__);
-#define LOG_ERROR(...)     gpi_log("cocotb.gpi", GPIError,         __FILE__, __func__, __LINE__, __VA_ARGS__);
-#define LOG_CRITICAL(...)  gpi_log("cocotb.gpi", GPICritical,      __FILE__, __func__, __LINE__, __VA_ARGS__);
+/** Logs a message at DEBUG log level using the current log handler.
+    Automatically populates arguments using information in the called context.
+ */
+#define LOG_DEBUG(...) LOG_(GPIDebug, __VA_ARGS__)
 
-GPILOG_EXPORT void set_log_handler(void *handler);
-GPILOG_EXPORT void clear_log_handler(void);
-GPILOG_EXPORT void set_log_filter(void *filter);
-GPILOG_EXPORT void clear_log_filter(void);
-GPILOG_EXPORT void set_log_level(enum gpi_log_levels new_level);
+/** Logs a message at INFO log level using the current log handler.
+    Automatically populates arguments using information in the called context.
+ */
+#define LOG_INFO(...) LOG_(GPIInfo, __VA_ARGS__);
 
-GPILOG_EXPORT void gpi_log(const char *name, enum gpi_log_levels level, const char *pathname, const char *funcname, long lineno, const char *msg, ...);
+/** Logs a message at WARN log level using the current log handler.
+    Automatically populates arguments using information in the called context.
+ */
+#define LOG_WARN(...) LOG_(GPIWarning, __VA_ARGS__);
 
-EXTERN_C_END
+/** Logs a message at ERROR log level using the current log handler.
+    Automatically populates arguments using information in the called context.
+ */
+#define LOG_ERROR(...) LOG_(GPIError, __VA_ARGS__);
+
+/** Logs a message at CRITICAL log level using the current log handler.
+    Automatically populates arguments using information in the called context.
+ */
+#define LOG_CRITICAL(...) LOG_(GPICritical, __VA_ARGS__);
+
+/** Type of a log handler function.
+    @param userdata  private implementation data registered with this function
+    @param name      Name of the logger
+    @param level     Level at which to log the message
+    @param pathname  Name of the file where the call site is located
+    @param funcname  Name of the function where the call site is located
+    @param lineno    Line number of the call site
+    @param msg       The message to log, uses C-sprintf-style format specifier
+    @param args      Additional arguments; formatted and inserted in message according to format specifier in msg argument
+ */
+typedef void (gpi_log_handler_type)(
+    void *userdata,
+    const char *name,
+    int level,
+    const char *pathname,
+    const char *funcname,
+    long lineno,
+    const char *msg,
+    va_list args);
+
+/** Log a message using the currently registered log handler.
+    User is expected to populate all arguments to this function.
+    @param name      Name of the logger
+    @param level     Level at which to log the message
+    @param pathname  Name of the file where the call site is located
+    @param funcname  Name of the function where the call site is located
+    @param lineno    Line number of the call site
+    @param msg       The message to log, uses C-sprintf-style format specifier
+    @param ...       Additional arguments; formatted and inserted in message according to format specifier in msg argument
+ */
+GPILOG_EXPORT void gpi_log(
+    const char *name,
+    int level,
+    const char *pathname,
+    const char *funcname,
+    long lineno,
+    const char *msg,
+    ...);
+
+/** Log a message using the currently registered log handler.
+    User is expected to populate all arguments to this function.
+    @param name      Name of the logger
+    @param level     Level at which to log the message
+    @param pathname  Name of the file where the call site is located
+    @param funcname  Name of the function where the call site is located
+    @param lineno    Line number of the call site
+    @param msg       The message to log, uses C-sprintf-style format specifier
+    @param args      Additional arguments; formatted and inserted in message according to format specifier in msg argument
+ */
+GPILOG_EXPORT void gpi_vlog(
+    const char *name,
+    int level,
+    const char *pathname,
+    const char *funcname,
+    long lineno,
+    const char *msg,
+    va_list args);
+
+/** Retrieve the current log handler.
+    @param handler  Location to return current log handler. If no custom logger is registered this will be `NULL`.
+    @param userdata Location to return log handler userdata
+ */
+GPILOG_EXPORT void gpi_get_log_handler(gpi_log_handler_type **handler, void **userdata);
+
+/** Set custom log handler
+    @param handler   Handler function to call when the GPI logs a message
+    @param userdata  Data to pass to the handler function when logging a message
+ */
+GPILOG_EXPORT void gpi_set_log_handler(gpi_log_handler_type *handler, void *userdata);
+
+/** Clear the current custom log handler and use native logger
+ */
+GPILOG_EXPORT void gpi_clear_log_handler(void);
+
+/** Log a message using the native log handler.
+    User is expected to populate all arguments to this function.
+    @param name      Name of the logger
+    @param level     Level at which to log the message
+    @param pathname  Name of the file where the call site is located
+    @param funcname  Name of the function where the call site is located
+    @param lineno    Line number of the call site
+    @param msg       The message to log, uses C-sprintf-style format specifier
+    @param ...       Additional arguments; formatted and inserted in message according to format specifier in msg argument
+ */
+GPILOG_EXPORT void gpi_native_logger_log(
+    const char *name,
+    int level,
+    const char *pathname,
+    const char *funcname,
+    long lineno,
+    const char *msg,
+    ...);
+
+/** Log a message using the native log handler.
+    User is expected to populate all arguments to this function.
+    @param name      Name of the logger
+    @param level     Level at which to log the message
+    @param pathname  Name of the file where the call site is located
+    @param funcname  Name of the function where the call site is located
+    @param lineno    Line number of the call site
+    @param msg       The message to log, uses C-sprintf-style format specifier
+    @param args      Additional arguments; formatted and inserted in message according to format specifier in msg argument
+ */
+GPILOG_EXPORT void gpi_native_logger_vlog(
+    const char *name,
+    int level,
+    const char *pathname,
+    const char *funcname,
+    long lineno,
+    const char *msg,
+    va_list args);
+
+/** Set minimum logging level of the native logger.
+    If a logging request occurs where the logging level is lower than the level set by this function, it is not logged.
+    Only affects the native logger.
+    @param level     Logging level
+    @return          Previous logging level
+ */
+GPILOG_EXPORT int gpi_native_logger_set_level(int level);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COCOTB_GPI_LOGGING_H_ */

--- a/cocotb/share/include/py_gpi_logging.h
+++ b/cocotb/share/include/py_gpi_logging.h
@@ -1,0 +1,31 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef PY_GPI_LOGGING_H
+#define PY_GPI_LOGGING_H
+
+#include <exports.h>
+#ifdef PYGPILOG_EXPORTS
+#define PYGPILOG_EXPORT COCOTB_EXPORT
+#else
+#define PYGPILOG_EXPORT COCOTB_IMPORT
+#endif
+
+#define PY_GPI_LOG_SIZE 1024
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+PYGPILOG_EXPORT void py_gpi_logger_set_level(int level);
+
+PYGPILOG_EXPORT void py_gpi_logger_initialize(PyObject * handler, PyObject * filter);
+
+PYGPILOG_EXPORT void py_gpi_logger_finalize();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cocotb/share/lib/embed/embed.cpp
+++ b/cocotb/share/lib/embed/embed.cpp
@@ -1,0 +1,160 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <embed.h>
+#include <cocotb_utils.h>   // xstr, utils_dyn_open, utils_dyn_sym
+#include <gpi.h>            // gpi_event_t
+#include <cstdlib>          // getenv
+#if ! defined(__linux__) && ! defined(__APPLE__)
+#include <windows.h>        // Win32 API for loading the embed impl library
+#include <string>           // string
+#endif
+
+#ifndef PYTHON_LIB
+#error "Name of Python library required"
+#else
+#define PYTHON_LIB_STR xstr(PYTHON_LIB)
+#endif
+
+#ifndef EMBED_IMPL_LIB
+#error "Name of embed implementation library required"
+#else
+#define EMBED_IMPL_LIB_STR xstr(EMBED_IMPL_LIB)
+#endif
+
+
+static void (*_embed_init_python)();
+static void (*_embed_sim_cleanup)();
+static int (*_embed_sim_init)(int argc, char const * const * argv);
+static void (*_embed_sim_event)(gpi_event_t level, const char *msg);
+
+static bool init_failed = false;
+
+
+#if ! defined(__linux__) && ! defined(__APPLE__)
+HANDLE act_ctx = NULL;
+
+BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID)
+{
+
+    if (fdwReason == DLL_PROCESS_ATTACH) {
+        // Save current activation context.
+        GetCurrentActCtx(&act_ctx);
+    } else if (fdwReason == DLL_PROCESS_DETACH) {
+        if (act_ctx) {
+            ReleaseActCtx(act_ctx);
+        }
+    }
+
+    return TRUE;
+}
+#endif
+
+
+extern "C" void embed_init_python(void)
+{
+    // preload python library
+    char const * libpython_path = getenv("LIBPYTHON_LOC");
+    if (!libpython_path) {
+        // default to libpythonX.X.so
+        libpython_path = PYTHON_LIB_STR;
+    }
+    auto loaded = utils_dyn_open(libpython_path);
+    if (!loaded) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+
+#if ! defined(__linux__) && ! defined(__APPLE__)
+    if (!act_ctx) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+
+    ULONG_PTR Cookie;
+    if(!ActivateActCtx(act_ctx, &Cookie)) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+#endif
+
+    // load embed implementation library and functions
+    void * embed_impl_lib_handle;
+    if (!(embed_impl_lib_handle = utils_dyn_open(EMBED_IMPL_LIB_STR))) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+    if (!(_embed_init_python = reinterpret_cast<decltype(_embed_init_python)>(utils_dyn_sym(embed_impl_lib_handle, "_embed_init_python")))) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+    if (!(_embed_sim_cleanup = reinterpret_cast<decltype(_embed_sim_cleanup)>(utils_dyn_sym(embed_impl_lib_handle, "_embed_sim_cleanup")))) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+    if (!(_embed_sim_init = reinterpret_cast<decltype(_embed_sim_init)>(utils_dyn_sym(embed_impl_lib_handle, "_embed_sim_init")))) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+    if (!(_embed_sim_event = reinterpret_cast<decltype(_embed_sim_event)>(utils_dyn_sym(embed_impl_lib_handle, "_embed_sim_event")))) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+
+#if ! defined(__linux__) && ! defined(__APPLE__)
+    if(!DeactivateActCtx(0, Cookie)) {
+        // LCOV_EXCL_START
+        init_failed = true;
+        return;
+        // LCOV_EXCL_STOP
+    }
+#endif
+
+    // call to embed library impl
+    _embed_init_python();
+}
+
+
+extern "C" void embed_sim_cleanup(void)
+{
+    if (!init_failed) {
+        _embed_sim_cleanup();
+    }
+}
+
+
+extern "C" int embed_sim_init(int argc, char const * const * argv)
+{
+    if (init_failed) {
+        // LCOV_EXCL_START
+        return -1;
+        // LCOV_EXCL_STOP
+    } else {
+        return _embed_sim_init(argc, argv);
+    }
+}
+
+
+extern "C" void embed_sim_event(gpi_event_t level, const char *msg)
+{
+    if (!init_failed) {
+        _embed_sim_event(level, msg);
+    }
+}

--- a/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
+++ b/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
@@ -1,0 +1,169 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <Python.h>         // all things Python
+#include <gpi_logging.h>    // all things GPI logging
+#include <py_gpi_logging.h> // PY_GPI_LOG_SIZE
+#include <cstdarg>          // va_list, va_copy, va_end
+#include <cstdio>           // fprintf, vsnprintf
+
+
+static PyObject *pLogHandler = nullptr;
+
+static PyObject *pLogFilter = nullptr;
+
+static int py_gpi_log_level = GPIInfo;
+
+
+static void py_gpi_log_handler(
+    void *,
+    const char *name,
+    int level,
+    const char *pathname,
+    const char *funcname,
+    long lineno,
+    const char *msg,
+    va_list argp)
+{
+    if (level < py_gpi_log_level) {
+        return;
+    }
+
+    va_list argp_copy;
+    va_copy(argp_copy, argp);
+
+    PyGILState_STATE gstate = PyGILState_Ensure();
+
+    // Declared here in order to be initialized before any goto statements and refcount cleanup
+    PyObject *logger_name_arg = NULL, *filename_arg = NULL, *lineno_arg = NULL, *msg_arg = NULL, *function_arg = NULL;
+
+    PyObject *level_arg = PyLong_FromLong(level);                  // New reference
+    if (level_arg == NULL) {
+        // LCOV_EXCL_START
+        goto error;
+        // LCOV_EXCL_STOP
+    }
+
+    logger_name_arg = PyUnicode_FromString(name);      // New reference
+    if (logger_name_arg == NULL) {
+        // LCOV_EXCL_START
+        goto error;
+        // LCOV_EXCL_STOP
+    }
+
+    {
+        // check if log level is enabled
+        PyObject *filter_ret = PyObject_CallFunctionObjArgs(pLogFilter, logger_name_arg, level_arg, NULL);
+        if (filter_ret == NULL) {
+            // LCOV_EXCL_START
+            goto error;
+            // LCOV_EXCL_STOP
+        }
+
+        int is_enabled = PyObject_IsTrue(filter_ret);
+        Py_DECREF(filter_ret);
+        if (is_enabled < 0) {
+            // LCOV_EXCL_START
+            /* A Python exception occured while converting `filter_ret` to bool */
+            goto error;
+            // LCOV_EXCL_STOP
+        }
+
+        if (!is_enabled) {
+            goto ok;
+        }
+    }
+
+    static char log_buff[PY_GPI_LOG_SIZE];
+
+    // Ignore truncation
+    {
+        int n = vsnprintf(log_buff, sizeof(log_buff), msg, argp);
+        if (n < 0 || n >= (int)sizeof(log_buff)) {
+            // LCOV_EXCL_START
+            fprintf(stderr, "Log message construction failed\n");
+            // LCOV_EXCL_STOP
+        }
+    }
+
+    filename_arg = PyUnicode_FromString(pathname);      // New reference
+    if (filename_arg == NULL) {
+        // LCOV_EXCL_START
+        goto error;
+        // LCOV_EXCL_STOP
+    }
+
+    lineno_arg = PyLong_FromLong(lineno);               // New reference
+    if (lineno_arg == NULL) {
+        // LCOV_EXCL_START
+        goto error;
+        // LCOV_EXCL_STOP
+    }
+
+    msg_arg = PyUnicode_FromString(log_buff);           // New reference
+    if (msg_arg == NULL) {
+        // LCOV_EXCL_START
+        goto error;
+        // LCOV_EXCL_STOP
+    }
+
+    function_arg = PyUnicode_FromString(funcname);      // New reference
+    if (function_arg == NULL) {
+        // LCOV_EXCL_START
+        goto error;
+        // LCOV_EXCL_STOP
+    }
+
+    {
+        // Log function args are logger_name, level, filename, lineno, msg, function
+        PyObject *handler_ret = PyObject_CallFunctionObjArgs(pLogHandler, logger_name_arg, level_arg, filename_arg, lineno_arg, msg_arg, function_arg, NULL);
+        if (handler_ret == NULL) {
+            // LCOV_EXCL_START
+            goto error;
+            // LCOV_EXCL_STOP
+        }
+        Py_DECREF(handler_ret);
+    }
+
+    goto ok;
+error:
+    // LCOV_EXCL_START
+    /* Note: don't call the LOG_ERROR macro because that might recurse */
+    gpi_native_logger_vlog(name, level, pathname, funcname, lineno, msg, argp_copy);
+    gpi_native_logger_log("cocotb.gpi", GPIError, __FILE__, __func__, __LINE__, "Error calling Python logging function from C++ while logging the above");
+    PyErr_Print();
+    // LCOV_EXCL_STOP
+ok:
+    va_end(argp_copy);
+    Py_XDECREF(logger_name_arg);
+    Py_XDECREF(level_arg);
+    Py_XDECREF(filename_arg);
+    Py_XDECREF(lineno_arg);
+    Py_XDECREF(msg_arg);
+    Py_XDECREF(function_arg);
+    PyGILState_Release(gstate);
+}
+
+
+extern "C" void py_gpi_logger_set_level(int level)
+{
+    py_gpi_log_level = level;
+    gpi_native_logger_set_level(level);
+}
+
+
+extern "C" void py_gpi_logger_initialize(PyObject * handler, PyObject * filter)
+{
+    pLogHandler = handler;
+    pLogFilter = filter;
+    gpi_set_log_handler(py_gpi_log_handler, nullptr);
+}
+
+
+extern "C" void py_gpi_logger_finalize()
+{
+    gpi_clear_log_handler();
+    Py_XDECREF(pLogHandler);
+    Py_XDECREF(pLogFilter);
+}

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -39,10 +39,11 @@ static int releases = 0;
 
 static int sim_ending = 0;
 
-#include <cocotb_utils.h>     // COCOTB_UNUSED
+#include <cocotb_utils.h>       // COCOTB_UNUSED
 #include <type_traits>
 #include <Python.h>
-#include "gpi_logging.h"
+#include <gpi_logging.h>        // LOG_* macros
+#include <py_gpi_logging.h>     // py_gpi_logger_set_level
 #include "gpi.h"
 
 // This file defines the routines available to Python
@@ -897,17 +898,18 @@ static PyObject *deregister(gpi_hdl_Object<gpi_cb_hdl> *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+
 static PyObject *log_level(PyObject *self, PyObject *args)
 {
     COCOTB_UNUSED(self);
 
-    long l_level;
+    int l_level;
 
-    if (!PyArg_ParseTuple(args, "l:log_level", &l_level)) {
+    if (!PyArg_ParseTuple(args, "i:log_level", &l_level)) {
         return NULL;
     }
 
-    set_log_level((enum gpi_log_levels)l_level);
+    py_gpi_logger_set_level(l_level);
 
     Py_RETURN_NONE;
 }

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -122,6 +122,29 @@ endif
 
 endif
 
+define find_libpython_errmsg =
+
+
+find_libpython was not able to find a libpython in the current Python environment. Ensure
+the Python development packages are installed. If they are installed and find_libpython
+is not finding the path to libpython, file an upstream bug in find_libpython; then
+manually override the LIBPYTHON_LOC make variable with the aboslute path to libpython.so
+(or libpython.dll on Windows).
+
+endef
+
+# get the path to libpython and the return code from the script
+# adapted from https://stackoverflow.com/a/24658961/6614127
+FIND_LIBPYTHON_RES := $(shell find_libpython; echo; echo $$?)
+FIND_LIBPYTHON_RC := $(lastword $(FIND_LIBPYTHON_RES))
+LIBPYTHON_LOC := $(strip $(subst $(FIND_LIBPYTHON_RC)QQQQ,,$(FIND_LIBPYTHON_RES)QQQQ))
+
+# complain if libpython isn't found, and export otherwise
+ifneq ($(FIND_LIBPYTHON_RC),0)
+    $(error $(find_libpython_errmsg))
+endif
+export LIBPYTHON_LOC
+
 else
     $(warning Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.)
 endif # COCOTB_MAKEFILE_INC_INCLUDED

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -135,7 +135,7 @@ endef
 
 # get the path to libpython and the return code from the script
 # adapted from https://stackoverflow.com/a/24658961/6614127
-FIND_LIBPYTHON_RES := $(shell find_libpython; echo; echo $$?)
+FIND_LIBPYTHON_RES := $(shell cocotb-config --libpython; echo $$?)
 FIND_LIBPYTHON_RC := $(lastword $(FIND_LIBPYTHON_RES))
 LIBPYTHON_LOC := $(strip $(subst $(FIND_LIBPYTHON_RC)QQQQ,,$(FIND_LIBPYTHON_RES)QQQQ))
 

--- a/cocotb/vendor/find_libpython/__init__.py
+++ b/cocotb/vendor/find_libpython/__init__.py
@@ -1,0 +1,383 @@
+"""
+Locate libpython associated with this Python executable.
+"""
+
+# License
+#
+# Copyright 2018, Takafumi Arakaki
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from logging import getLogger
+import ctypes.util
+import functools
+import os
+import sys
+import sysconfig
+
+logger = getLogger("find_libpython")
+
+is_windows = os.name == "nt"
+is_apple = sys.platform == "darwin"
+
+SHLIB_SUFFIX = sysconfig.get_config_var("SHLIB_SUFFIX")
+if SHLIB_SUFFIX is None:
+    if is_windows:
+        SHLIB_SUFFIX = ".dll"
+    else:
+        SHLIB_SUFFIX = ".so"
+if is_apple:
+    # sysconfig.get_config_var("SHLIB_SUFFIX") can be ".so" in macOS.
+    # Let's not use the value from sysconfig.
+    SHLIB_SUFFIX = ".dylib"
+
+
+def linked_libpython():
+    """
+    Find the linked libpython using dladdr (in *nix).
+
+    Calling this in Windows always return `None` at the moment.
+
+    Returns
+    -------
+    path : str or None
+        A path to linked libpython.  Return `None` if statically linked.
+    """
+    if is_windows:
+        return None
+    return _linked_libpython_unix()
+
+
+class Dl_info(ctypes.Structure):
+    _fields_ = [
+        ("dli_fname", ctypes.c_char_p),
+        ("dli_fbase", ctypes.c_void_p),
+        ("dli_sname", ctypes.c_char_p),
+        ("dli_saddr", ctypes.c_void_p),
+    ]
+
+
+def _linked_libpython_unix():
+    libdl = ctypes.CDLL(ctypes.util.find_library("dl"))
+    libdl.dladdr.argtypes = [ctypes.c_void_p, ctypes.POINTER(Dl_info)]
+    libdl.dladdr.restype = ctypes.c_int
+
+    dlinfo = Dl_info()
+    retcode = libdl.dladdr(
+        ctypes.cast(ctypes.pythonapi.Py_GetVersion, ctypes.c_void_p),
+        ctypes.pointer(dlinfo),
+    )
+    if retcode == 0:  # means error
+        return None
+    path = os.path.realpath(dlinfo.dli_fname.decode())
+    if path == os.path.realpath(sys.executable):
+        return None
+    return path
+
+
+def library_name(name, suffix=SHLIB_SUFFIX, is_windows=is_windows):
+    """
+    Convert a file basename `name` to a library name (no "lib" and ".so" etc.)
+
+    >>> library_name("libpython3.7m.so")                   # doctest: +SKIP
+    'python3.7m'
+    >>> library_name("libpython3.7m.so", suffix=".so", is_windows=False)
+    'python3.7m'
+    >>> library_name("libpython3.7m.dylib", suffix=".dylib", is_windows=False)
+    'python3.7m'
+    >>> library_name("python37.dll", suffix=".dll", is_windows=True)
+    'python37'
+    """
+    if not is_windows and name.startswith("lib"):
+        name = name[len("lib") :]
+    if suffix and name.endswith(suffix):
+        name = name[: -len(suffix)]
+    return name
+
+
+def append_truthy(list, item):
+    if item:
+        list.append(item)
+
+
+def uniquifying(items):
+    """
+    Yield items while excluding the duplicates and preserving the order.
+
+    >>> list(uniquifying([1, 2, 1, 2, 3]))
+    [1, 2, 3]
+    """
+    seen = set()
+    for x in items:
+        if x not in seen:
+            yield x
+        seen.add(x)
+
+
+def uniquified(func):
+    """ Wrap iterator returned from `func` by `uniquifying`. """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwds):
+        return uniquifying(func(*args, **kwds))
+
+    return wrapper
+
+
+@uniquified
+def candidate_names(suffix=SHLIB_SUFFIX):
+    """
+    Iterate over candidate file names of libpython.
+
+    Yields
+    ------
+    name : str
+        Candidate name libpython.
+    """
+    LDLIBRARY = sysconfig.get_config_var("LDLIBRARY")
+    if LDLIBRARY:
+        yield LDLIBRARY
+
+    LIBRARY = sysconfig.get_config_var("LIBRARY")
+    if LIBRARY:
+        yield os.path.splitext(LIBRARY)[0] + suffix
+
+    dlprefix = "" if is_windows else "lib"
+    sysdata = dict(
+        v=sys.version_info,
+        # VERSION is X.Y in Linux/macOS and XY in Windows:
+        VERSION=(
+            sysconfig.get_config_var("VERSION")
+            or "{v.major}.{v.minor}".format(v=sys.version_info)
+        ),
+        ABIFLAGS=(
+            sysconfig.get_config_var("ABIFLAGS")
+            or sysconfig.get_config_var("abiflags")
+            or ""
+        ),
+    )
+
+    for stem in [
+        "python{VERSION}{ABIFLAGS}".format(**sysdata),
+        "python{VERSION}".format(**sysdata),
+        "python{v.major}".format(**sysdata),
+        "python",
+    ]:
+        yield dlprefix + stem + suffix
+
+
+@uniquified
+def candidate_paths(suffix=SHLIB_SUFFIX):
+    """
+    Iterate over candidate paths of libpython.
+
+    Yields
+    ------
+    path : str or None
+        Candidate path to libpython.  The path may not be a fullpath
+        and may not exist.
+    """
+
+    yield linked_libpython()
+
+    # List candidates for directories in which libpython may exist
+    lib_dirs = []
+    append_truthy(lib_dirs, sysconfig.get_config_var("LIBPL"))
+    append_truthy(lib_dirs, sysconfig.get_config_var("srcdir"))
+    append_truthy(lib_dirs, sysconfig.get_config_var("LIBDIR"))
+
+    # LIBPL seems to be the right config_var to use.  It is the one
+    # used in python-config when shared library is not enabled:
+    # https://github.com/python/cpython/blob/v3.7.0/Misc/python-config.in#L55-L57
+    #
+    # But we try other places just in case.
+
+    if is_windows:
+        lib_dirs.append(os.path.join(os.path.dirname(sys.executable)))
+    else:
+        lib_dirs.append(
+            os.path.join(os.path.dirname(os.path.dirname(sys.executable)), "lib")
+        )
+
+    # For macOS:
+    append_truthy(lib_dirs, sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX"))
+
+    lib_dirs.append(sys.exec_prefix)
+    lib_dirs.append(os.path.join(sys.exec_prefix, "lib"))
+
+    lib_basenames = list(candidate_names(suffix=suffix))
+
+    for directory in lib_dirs:
+        for basename in lib_basenames:
+            yield os.path.join(directory, basename)
+
+    # In macOS and Windows, ctypes.util.find_library returns a full path:
+    for basename in lib_basenames:
+        yield ctypes.util.find_library(library_name(basename))
+
+
+# Possibly useful links:
+# * https://packages.ubuntu.com/bionic/amd64/libpython3.6/filelist
+# * https://github.com/Valloric/ycmd/issues/518
+# * https://github.com/Valloric/ycmd/pull/519
+
+
+def normalize_path(path, suffix=SHLIB_SUFFIX, is_apple=is_apple):
+    """
+    Normalize shared library `path` to a real path.
+
+    If `path` is not a full path, `None` is returned.  If `path` does
+    not exists, append `SHLIB_SUFFIX` and check if it exists.
+    Finally, the path is canonicalized by following the symlinks.
+
+    Parameters
+    ----------
+    path : str ot None
+        A candidate path to a shared library.
+    """
+    if not path:
+        return None
+    if not os.path.isabs(path):
+        return None
+    if os.path.exists(path):
+        return os.path.realpath(path)
+    if os.path.exists(path + suffix):
+        return os.path.realpath(path + suffix)
+    if is_apple:
+        return normalize_path(_remove_suffix_apple(path), suffix=".so", is_apple=False)
+    return None
+
+
+def _remove_suffix_apple(path):
+    """
+    Strip off .so or .dylib.
+
+    >>> _remove_suffix_apple("libpython.so")
+    'libpython'
+    >>> _remove_suffix_apple("libpython.dylib")
+    'libpython'
+    >>> _remove_suffix_apple("libpython3.7")
+    'libpython3.7'
+    """
+    if path.endswith(".dylib"):
+        return path[: -len(".dylib")]
+    if path.endswith(".so"):
+        return path[: -len(".so")]
+    return path
+
+
+@uniquified
+def finding_libpython():
+    """
+    Iterate over existing libpython paths.
+
+    The first item is likely to be the best one.
+
+    Yields
+    ------
+    path : str
+        Existing path to a libpython.
+    """
+    logger.debug("is_windows = %s", is_windows)
+    logger.debug("is_apple = %s", is_apple)
+    for path in candidate_paths():
+        logger.debug("Candidate: %s", path)
+        normalized = normalize_path(path)
+        if normalized:
+            logger.debug("Found: %s", normalized)
+            yield normalized
+        else:
+            logger.debug("Not found.")
+
+
+def find_libpython():
+    """
+    Return a path (`str`) to libpython or `None` if not found.
+
+    Parameters
+    ----------
+    path : str or None
+        Existing path to the (supposedly) correct libpython.
+    """
+    for path in finding_libpython():
+        return os.path.realpath(path)
+
+
+def print_all(items):
+    for x in items:
+        print(x)
+
+
+def cli_find_libpython(cli_op, verbose):
+    import logging
+
+    # Importing `logging` module here so that using `logging.debug`
+    # instead of `logger.debug` outside of this function becomes an
+    # error.
+
+    if verbose:
+        logging.basicConfig(format="%(levelname)s %(message)s", level=logging.DEBUG)
+
+    if cli_op == "list-all":
+        print_all(finding_libpython())
+    elif cli_op == "candidate-names":
+        print_all(candidate_names())
+    elif cli_op == "candidate-paths":
+        print_all(p for p in candidate_paths() if p and os.path.isabs(p))
+    else:
+        path = find_libpython()
+        if path is None:
+            return 1
+        print(path, end="")
+
+
+def main(args=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print debugging information."
+    )
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--list-all",
+        action="store_const",
+        dest="cli_op",
+        const="list-all",
+        help="Print list of all paths found.",
+    )
+    group.add_argument(
+        "--candidate-names",
+        action="store_const",
+        dest="cli_op",
+        const="candidate-names",
+        help="Print list of candidate names of libpython.",
+    )
+    group.add_argument(
+        "--candidate-paths",
+        action="store_const",
+        dest="cli_op",
+        const="candidate-paths",
+        help="Print list of candidate paths of libpython.",
+    )
+
+    ns = parser.parse_args(args)
+    parser.exit(cli_find_libpython(**vars(ns)))

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -344,11 +344,28 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         libgpilog_sources += ["libgpilog.rc"]
     libgpilog = Extension(
         os.path.join("cocotb", "libs", "libgpilog"),
-        define_macros=[("GPILOG_EXPORTS", "")]  + _extra_defines,
+        define_macros=[("GPILOG_EXPORTS", "")] + _extra_defines,
         include_dirs=[include_dir],
-        library_dirs=python_lib_dirs,
         sources=libgpilog_sources,
         extra_link_args=_extra_link_args(lib_name="libgpilog", rpaths=["$ORIGIN"]),
+        extra_compile_args=_extra_cxx_compile_args,
+    )
+
+    #
+    #  libpygpilog
+    #
+    libpygpilog_sources = [
+        os.path.join(share_lib_dir, "py_gpi_log", "py_gpi_logging.cpp")
+    ]
+    if os.name == "nt":
+        libpygpilog_sources += ["libpygpilog.rc"]
+    libpygpilog = Extension(
+        os.path.join("cocotb", "libs", "libpygpilog"),
+        define_macros=[("PYGPILOG_EXPORTS", "")] + _extra_defines,
+        include_dirs=[include_dir],
+        libraries=["gpilog"],
+        sources=libpygpilog_sources,
+        extra_link_args=_extra_link_args(lib_name="libpygpilog", rpaths=["$ORIGIN"]),
         extra_compile_args=_extra_cxx_compile_args,
     )
 
@@ -364,7 +381,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         os.path.join("cocotb", "libs", "libcocotb"),
         define_macros=[("COCOTB_EMBED_EXPORTS", ""), ("PYTHON_SO_LIB", _get_python_lib())] + _extra_defines,
         include_dirs=[include_dir],
-        libraries=[_get_python_lib_link(), "gpilog", "cocotbutils"],
+        libraries=[_get_python_lib_link(), "gpilog", "cocotbutils", "pygpilog"],
         library_dirs=python_lib_dirs,
         sources=libcocotb_sources,
         extra_link_args=_extra_link_args(lib_name="libcocotb", rpaths=["$ORIGIN"] + python_lib_dirs),
@@ -402,7 +419,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         os.path.join("cocotb", "simulator"),
         define_macros=_extra_defines,
         include_dirs=[include_dir],
-        libraries=["cocotbutils", "gpilog", "gpi"],
+        libraries=["cocotbutils", "gpilog", "gpi", "pygpilog"],
         library_dirs=python_lib_dirs,
         sources=simulator_sources,
         extra_compile_args=_extra_cxx_compile_args,
@@ -412,7 +429,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     # The libraries in this list are compiled in order of their appearance.
     # If there is a linking dependency on one library to another,
     # the linked library must be built first.
-    return [libgpilog, libcocotbutils, libcocotb, libgpi, libsim]
+    return [libgpilog, libpygpilog, libcocotbutils, libcocotb, libgpi, libsim]
 
 
 def _get_vpi_lib_ext(

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ exclude =
     venv
     .tox
     examples/endian_swapper/cosim
+    vendor
 
 ignore =
     E202  # whitespace before ')'

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     author='Chris Higgs, Stuart Hodgson',
     maintainer='cocotb contributors',
     maintainer_email='cocotb@lists.librecores.org',
-    install_requires=['find_libpython'],
+    install_requires=[],
     python_requires='>=3.5',
     packages=find_packages(),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -96,14 +96,14 @@ setup(
     author='Chris Higgs, Stuart Hodgson',
     maintainer='cocotb contributors',
     maintainer_email='cocotb@lists.librecores.org',
-    install_requires=[],
+    install_requires=['find_libpython'],
     python_requires='>=3.5',
     packages=find_packages(),
     package_data={
         'cocotb': (
             package_files('cocotb/share/makefiles') +   # noqa: W504
             package_files('cocotb/share/include') +     # noqa: W504
-            package_files('cocotb/share/def') +
+            package_files('cocotb/share/def') +         # noqa: W504
             package_files('cocotb/share/lib/verilator')
         )
     },


### PR DESCRIPTION
Builds on #2000. 

## Break load-time dependency on libcocotb and load libpython at runtime

libcocotb A.K.A gpi_embed calls Python functions. To support Windows and some security-hardened Linuxes, these functions must be resolved by the time libcocotb is finished loading. However, libpython is attempted to be loaded *in* libcocotb. This works on most Linuxes, but not all, and definitely not Windows. To prevent this issue, we link libpython as a dependency.

This is less than ideal since some simulators monkey with LD_LIBRARY_PATH and the wrong libpython could be loaded by the simulator on first load. Setting the RPATH is an effective work-around, but makes the binaries not relocatable. The best solution is to load libpython at runtime using the absolute path to the libpython associated with the cocotb install.

To prevent libpython being loaded as a dependency when the simulator first loads the PLI object, we must break the link dependency between the GPI and libcocotb. To accomplish that we create a small stub library to fill in for the "embed" library. This stub library runtime-loads libpython using an absolute path to the library. The stub library then runtime-loads the "implementation" embed library and proxies calls to it. This forces the correct libpython to be loaded, and all dependent libraries to load strictly after that.

## Find libpython in makefiles and load in embed.cpp

When we feed the libpython path to the embed stub library at build time, we bind the binaries to the environment permanently. This means the binaries are not relocatable, which is not good for wheel reuse or for binary distribution in general.

So instead we obtain the path to libpython when the makefiles run, and set the path in an environment variable that is used by the embed library stub. We use the find_libpython library to locate the libpython associated with the cocotb installation.

## TODO
- [x] Add `cocotb-config --libpython`
- [x] Fail more gracefully in embed if `LIBPYTHON_LOC` is not set.
- [x] Fix all uses of ANSI-encoding functions in Win API code. Use the Unicode version and translate to UTF-8 before passing to Python (for instance `LOG_*`).
- [x] Work code reviews from #2000.

## Future Work

- ~~The final step is to prevent Python distutils < 3.8 from linking all `Extensions` against libpython. This can probably be accomplished using #1739.~~ May not be necessary.
- With this merged, we can producing and distributing relocatable wheels using the `manylinux2014` spec. Ideally this can be done automatically in CI.