### PR TITLE
Remove last occurrences of legacy coroutine syntax from tests

### DIFF
--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -8,25 +8,22 @@ import re
 import traceback
 from contextlib import contextmanager
 
-import cocotb
 from cocotb.triggers import Timer
 
 
-@cocotb.coroutine
-def clock_gen(clock):
+async def clock_gen(clock):
     """Example clock gen for test use"""
     for i in range(5):
         clock <= 0
-        yield Timer(100, "ns")
+        await Timer(100, "ns")
         clock <= 1
-        yield Timer(100, "ns")
+        await Timer(100, "ns")
     clock._log.warning("Clock generator finished!")
 
 
-@cocotb.coroutine
-def _check_traceback(running_coro, exc_type, pattern):
+async def _check_traceback(running_coro, exc_type, pattern):
     try:
-        yield running_coro
+        await running_coro
     except exc_type:
         tb_text = traceback.format_exc()
     else:

--- a/tests/test_cases/test_cocotb/test_async_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_async_coroutines.py
@@ -14,13 +14,13 @@ from common import assert_raises
 class produce:
     """ Test helpers that produce a value / exception in different ways """
     @staticmethod
-    @cocotb.coroutine
+    @cocotb.coroutine   # testing legacy coroutine against async func
     def coro(outcome):
         yield Timer(1)
         return outcome.get()
 
     @staticmethod
-    @cocotb.coroutine
+    @cocotb.coroutine   # testing coroutine decorator on async func
     async def async_annotated(outcome):
         await Timer(1)
         return outcome.get()

--- a/tests/test_cases/test_cocotb/test_async_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_async_coroutines.py
@@ -36,7 +36,7 @@ class SomeException(Exception):
     pass
 
 
-@cocotb.test()
+@cocotb.test()  # test yielding decorated async coroutine in legacy coroutine
 def test_annotated_async_from_coro(dut):
     """
     Test that normal coroutines are able to call async functions annotated
@@ -112,7 +112,7 @@ async def test_await_causes_start(dut):
     assert coro.has_started()
 
 
-@cocotb.test()
+@cocotb.test()  # test forking undecorated async coroutine in legacy coroutine
 def test_undecorated_coroutine_fork(dut):
     ran = False
 
@@ -125,7 +125,7 @@ def test_undecorated_coroutine_fork(dut):
     assert ran
 
 
-@cocotb.test()
+@cocotb.test()  # test yielding undecorated async coroutine in legacy coroutine
 def test_undecorated_coroutine_yield(dut):
     ran = False
 

--- a/tests/test_cases/test_cocotb/test_async_generators.py
+++ b/tests/test_cases/test_cocotb/test_async_generators.py
@@ -31,7 +31,7 @@ async def test_forking_accidental_async_generator(dut):
         assert False, "should have thrown"
 
 
-@cocotb.coroutine
+@cocotb.coroutine   # testing cocotb.coroutine decorated async generator
 async def whoops_async_generator_decorated():
     yield cocotb.triggers.Timer(1)
 

--- a/tests/test_cases/test_cocotb/test_async_generators.py
+++ b/tests/test_cases/test_cocotb/test_async_generators.py
@@ -10,7 +10,7 @@ async def whoops_async_generator():
     yield cocotb.triggers.Timer(1)
 
 
-@cocotb.test()
+@cocotb.test()  # testing async generator in legacy coroutine syntax
 def test_yielding_accidental_async_generator(dut):
     # this test deliberately does not use `async def`, as we are testing the behavior of `yield`
     try:

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -75,8 +75,7 @@ async def test_first_does_not_kill(dut):
     """ Test that `First` does not kill coroutines that did not finish first """
     ran = False
 
-    # decorating `async def` is required to use `First`
-    @cocotb.coroutine
+    @cocotb.coroutine   # decorating `async def` is required to use `First`
     async def coro():
         nonlocal ran
         await Timer(2, units='ns')
@@ -97,7 +96,8 @@ async def test_first_does_not_kill(dut):
 @cocotb.test()
 async def test_exceptions_first(dut):
     """ Test exception propagation via cocotb.triggers.First """
-    @cocotb.coroutine
+
+    @cocotb.coroutine   # decorating `async def` is required to use `First`
     def raise_inner():
         yield Timer(10, "ns")
         raise ValueError('It is soon now')
@@ -111,7 +111,7 @@ async def test_exceptions_first(dut):
     expected = textwrap.dedent(r"""
     Traceback \(most recent call last\):
       File ".*common\.py", line \d+, in _check_traceback
-        yield running_coro
+        await running_coro
       File ".*test_concurrency_primitives\.py", line \d+, in raise_soon
         await cocotb\.triggers\.First\(raise_inner\(\)\)
       File ".*triggers\.py", line \d+, in _wait

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -27,7 +27,7 @@ def assert_deprecated(warning_category=DeprecationWarning):
 @cocotb.test()
 async def test_returnvalue_deprecated(dut):
 
-    @cocotb.coroutine
+    @cocotb.coroutine   # testing ReturnValue deprecated
     def get_value():
         yield cocotb.triggers.Timer(1, units='ns')
         raise cocotb.result.ReturnValue(42)

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -14,7 +14,6 @@ from cocotb.triggers import RisingEdge, FallingEdge, Edge, Timer, ClockCycles, F
 from cocotb.clock import Clock
 
 
-@cocotb.coroutine
 async def count_edges_cycles(signal, edges):
     edge = RisingEdge(signal)
     for i in range(edges):
@@ -24,7 +23,6 @@ async def count_edges_cycles(signal, edges):
     return edges
 
 
-@cocotb.coroutine
 async def do_single_edge_check(dut, level):
     """Do test for rising edge"""
     old_value = dut.clk.value.integer
@@ -119,7 +117,6 @@ async def test_fork_and_monitor(dut, period=1000, clocks=6):
     assert result == clocks, "Expected task to return %d but got %s" % (clocks, repr(result))
 
 
-@cocotb.coroutine
 async def do_clock(dut, limit, period):
     """Simple clock with a limit"""
     wait_period = period / 2
@@ -131,7 +128,6 @@ async def do_clock(dut, limit, period):
         limit -= 1
 
 
-@cocotb.coroutine
 async def do_edge_count(dut, signal):
     """Count the edges"""
     global edges_seen
@@ -205,7 +201,6 @@ async def test_clock_cycles_forked(dut):
 
     clk_gen = cocotb.fork(Clock(dut.clk, 100, "ns").start())
 
-    @cocotb.coroutine
     async def wait_ten():
         await ClockCycles(dut.clk, 10)
 

--- a/tests/test_cases/test_cocotb/test_generator_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_generator_coroutines.py
@@ -175,7 +175,7 @@ def test_exceptions_direct(dut):
     Traceback \(most recent call last\):
       File ".*common\.py", line \d+, in _check_traceback
         await running_coro
-      File ".*\/cocotb\/decorators.py", line \d+, in __await__
+      File ".*cocotb[\\\/]decorators.py", line \d+, in __await__
         return \(yield self\)
       File ".*test_generator_coroutines\.py", line \d+, in raise_soon
         yield raise_inner\(\)
@@ -206,7 +206,7 @@ def test_exceptions_forked(dut):
     Traceback \(most recent call last\):
       File ".*common\.py", line \d+, in _check_traceback
         await running_coro
-      File ".*\/cocotb\/decorators.py", line \d+, in __await__
+      File ".*cocotb[\\\/]decorators.py", line \d+, in __await__
         return \(yield self\)
       File ".*test_generator_coroutines\.py", line \d+, in raise_soon
         yield coro\.join\(\)

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -165,7 +165,6 @@ async def test_stack_overflow(dut):
     before passing control to the simulator.
     """
     # gh-637
-    @cocotb.coroutine
     async def null_coroutine():
         await NullTrigger()
 
@@ -309,7 +308,7 @@ async def test_task_repr(dut):
         yield Timer(1, units='ns')
         raise ValueError("inner")
 
-    @cocotb.coroutine
+    @cocotb.coroutine   # testing debug with legacy coroutine syntax
     def generator_coro_outer():
         yield from generator_coro_inner()
 
@@ -339,7 +338,7 @@ async def test_task_repr(dut):
         log.info(repr(task))
         assert re.match(r"<Task \d+ adding coro=coroutine_outer\(\)>", repr(task))
 
-    @cocotb.coroutine
+    @cocotb.coroutine   # Combine requires use of cocotb.coroutine
     async def coroutine_wait():
         await Timer(1, units='ns')
 
@@ -419,7 +418,6 @@ async def test_start_soon_decorator(_):
     """ Tests start_soon works with RunningTasks """
     a = 0
 
-    @cocotb.coroutine
     async def example():
         nonlocal a
         a = 1

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -86,7 +86,6 @@ async def test_timer_with_rational_units(dut):
 exited = False
 
 
-@cocotb.coroutine
 async def do_test_readwrite_in_readonly(dut):
     global exited
     await RisingEdge(dut.clk)
@@ -95,7 +94,6 @@ async def do_test_readwrite_in_readonly(dut):
     exited = True
 
 
-@cocotb.coroutine
 async def do_test_cached_write_in_readonly(dut):
     global exited
     await RisingEdge(dut.clk)
@@ -104,7 +102,6 @@ async def do_test_cached_write_in_readonly(dut):
     exited = True
 
 
-@cocotb.coroutine
 async def do_test_afterdelay_in_readonly(dut, delay):
     global exited
     await RisingEdge(dut.clk)
@@ -175,7 +172,7 @@ async def test_writes_have_taken_effect_after_readwrite(dut):
     assert dut.stream_in_data.value == 2
 
 
-@cocotb.coroutine
+@cocotb.coroutine   # cocotb.coroutine necessary to use in with_timeout
 async def example():
     await Timer(10, 'ns')
     return 1


### PR DESCRIPTION
Closes #1731. Added justification comments to all uses of `cocotb.coroutine` and all uses of `cocotb.test` wrapping generators.