### PR TITLE
Reintroduce NextTimeStep() in Avalon bus driver

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -684,6 +684,7 @@ class AvalonSTPkts(ValidatedBusDriver):
             empty = BinaryValue(n_bits=len(self.bus.empty), bigEndian=False)
 
         # Drive some defaults since we don't know what state we're in
+        await NextTimeStep()
         if self.use_empty:
             self.bus.empty <= 0
         self.bus.startofpacket <= 0


### PR DESCRIPTION
The NextTimeStep() was introduced here 793fb695c7f5cf0372f7dee0c7d617b108a685a3
in order to fix the attempted writing during a
read-only phase and was removed here a61c371be6608f111c10a9550b8a274b02bb80a2
It looks like it is still needed as it's braking
the ping tup tap example.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
