### PR TITLE
Hooks for failing tests on errors

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -136,6 +136,9 @@ class RunningTask:
     def _finished(self):
         return self._outcome is not None
 
+    def fail(self, exc):
+        self._outcome = outcomes.Error(exc)
+
     def __iter__(self):
         return self
 

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -72,6 +72,9 @@ def _my_import(name: str) -> Any:
 
 _logger = SimLog(__name__)
 
+_test_cbs = []
+def register_test_cb(cb):
+    _test_cbs.append(cb)
 
 class RegressionManager:
     """Encapsulates all regression capability into a single place"""
@@ -227,6 +230,10 @@ class RegressionManager:
                 if hasattr(thing, "im_hook"):
                     yield thing
 
+    @property
+    def test(self) -> Test:
+        return self._test
+
     def _init_hook(self, hook: Hook) -> Optional[RunningTask]:
         try:
             test = hook(self._dut)
@@ -295,6 +302,9 @@ class RegressionManager:
 
         # stop capturing log output
         cocotb.log.removeHandler(test.handler)
+
+        for cb in _test_cbs:
+            cb(self._test, self._test_task)
 
         self._record_result(
             test=self._test,


### PR DESCRIPTION
Related to:
https://github.com/cocotb/cocotb/issues/2296

These are the changes I needed to add my own `logging.Handler` to count error / critical log messages and fail a test if it takes any.  If this is acceptable, I'm happy to work on testing for this as well.  Also, if desirable I can add my module which has the customer Handler which I'm invoking via `COCOTB_HOOKS`.

Some notes:
`_tests_cbs` cannot be a member of `RegressionManager` because the `COCOTB_HOOKS` are invoked during the construction of the `RegressionManager`.

I'm exposing `_test` in `RegressionManager` so that I can tell which test is logging an error and/or finishing.