### PR TITLE
Fix array bus driver with Verilator

### DIFF
--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -82,9 +82,7 @@ class Bus:
             else:
                 signame = sig_name
 
-            if array_idx is not None:
-                signame += "[{:d}]".format(array_idx)
-            self._add_signal(attr_name, signame)
+            self._add_signal(attr_name, signame, array_idx)
 
         # Also support a set of optional signals that don't have to be present
         for attr_name, sig_name in _build_sig_attr_dict(optional_signals).items():
@@ -93,19 +91,18 @@ class Bus:
             else:
                 signame = sig_name
 
-            if array_idx is not None:
-                signame += "[{:d}]".format(array_idx)
-
-            self._entity._log.debug("Signal name {}".format(signame))
             if hasattr(entity, signame):
-                self._add_signal(attr_name, signame)
+                self._add_signal(attr_name, signame, array_idx)
             else:
                 self._entity._log.debug("Ignoring optional missing signal "
                                         "%s on bus %s" % (sig_name, name))
 
-    def _add_signal(self, attr_name, signame):
-        self._entity._log.debug("Signal name {}".format(signame))
-        setattr(self, attr_name, getattr(self._entity, signame))
+    def _add_signal(self, attr_name, signame, array_idx=None):
+        self._entity._log.debug("Signal name {}, idx {}".format(signame, array_idx))
+        handle = getattr(self._entity, signame)
+        if array_idx is not None:
+            handle = handle[array_idx]
+        setattr(self, attr_name, handle)
         self._signals[attr_name] = getattr(self, attr_name)
 
     def drive(self, obj, strict=False):

--- a/tests/test_cases/test_array_buses/Makefile
+++ b/tests/test_cases/test_array_buses/Makefile
@@ -1,0 +1,17 @@
+TOPLEVEL_LANG ?= verilog
+PWD=$(shell pwd)
+TOPLEVEL := array_buses
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+    VERILOG_SOURCES = $(PWD)/array_buses.sv
+else
+ifeq ($(TOPLEVEL_LANG), vhdl)
+    VHDL_SOURCES = $(PWD)/array_buses.vhd
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
+endif
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+
+MODULE = test_array_buses

--- a/tests/test_cases/test_array_buses/array_buses.sv
+++ b/tests/test_cases/test_array_buses/array_buses.sv
@@ -1,0 +1,32 @@
+module array_buses
+   (
+      input            clk,
+      input      [7:0] in_data [0:1],
+      input            in_valid[0:1],
+      output     [7:0] out_data [0:1],
+      output           out_valid[0:1]
+      );
+
+   reg [7:0] tmp_data  [1:0];
+   reg       tmp_valid [1:0];
+
+   initial begin
+      tmp_data[0] = '0;
+      tmp_data[1] = '0;
+      tmp_valid[0] = 1'b0;
+      tmp_valid[1] = 1'b0;
+   end
+
+   always @(posedge clk) begin
+      tmp_data[0] <= in_data[0];
+      tmp_data[1] <= in_data[1];
+      tmp_valid[0] <= in_valid[0];
+      tmp_valid[1] <= in_valid[1];
+   end
+
+   assign out_data[0] = tmp_data[0];
+   assign out_data[1] = tmp_data[1];
+   assign out_valid[0] = tmp_valid[0];
+   assign out_valid[1] = tmp_valid[1];
+endmodule
+

--- a/tests/test_cases/test_array_buses/array_buses.vhd
+++ b/tests/test_cases/test_array_buses/array_buses.vhd
@@ -1,0 +1,43 @@
+library ieee;
+
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package array_types is
+    type io_array is array (0 to 1) of std_logic_vector(7 downto 0);
+end package array_types;
+
+library ieee;
+
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.array_types.all;
+
+entity array_buses is
+    port (
+        clk        : in  std_logic;
+        in_data    : in  io_array;
+        in_valid   : in  std_logic_vector(0 to 1);
+        out_data   : out io_array;
+        out_valid  : out std_logic_vector(0 to 1)
+    );
+end;
+
+architecture impl of array_buses is
+    signal tmp_data: io_array := (others => (others => '0'));
+    signal tmp_valid: std_logic_vector(0 to 1) := (others => '0');
+begin
+    process (clk)
+    begin
+        if (rising_edge(clk)) then
+            tmp_data <= in_data;
+            tmp_valid <= in_valid;
+        end if;
+    end process;
+
+   out_data(0) <= tmp_data(0);
+   out_data(1) <= tmp_data(1);
+   out_valid(0) <= tmp_valid(0);
+   out_valid(1) <= tmp_valid(1);
+
+end architecture;

--- a/tests/test_cases/test_array_buses/test_array_buses.py
+++ b/tests/test_cases/test_array_buses/test_array_buses.py
@@ -1,0 +1,79 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.drivers import BusDriver
+from cocotb.monitors import BusMonitor
+from cocotb.triggers import RisingEdge
+
+
+class TestDriver(BusDriver):
+    _signals = ["data", "valid"]
+
+    def __init__(self, entity, name, clock, **kwargs):
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
+        self.bus.valid <= 0
+
+    async def _driver_send(self, transaction, sync=True):
+        clkedge = RisingEdge(self.clock)
+        if sync:
+            await clkedge
+
+        self.log.info("Sending {}".format(transaction))
+        self.bus.valid <= 1
+        self.bus.data <= transaction
+
+        await clkedge
+        self.bus.valid <= 0
+
+
+class TestMonitor(BusMonitor):
+
+    _signals = ["data", "valid"]
+
+    def __init__(self, entity, name, clock, bank=0, **kwargs):
+        BusMonitor.__init__(self, entity, name, clock, **kwargs)
+        self.bank = bank
+        self.add_callback(self._get_result)
+        self.expected = []
+
+    async def _monitor_recv(self):
+        clkedge = RisingEdge(self.clock)
+        while True:
+            await clkedge
+            if self.bus.valid.value:
+                self._recv(int(self.bus.data))
+
+    def _get_result(self, transaction):
+        self.log.info("Received {} on bank {}".format(transaction, self.bank))
+        exp = self.expected.pop(0)
+        assert exp == int(transaction)
+
+    def add_expected(self, transaction):
+        self.expected.append(int(transaction))
+
+
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith('ghdl') else ())
+async def test_array_buses(dut):
+    clock = Clock(dut.clk, 10, units="ns")
+    cocotb.fork(clock.start())
+    clkedge = RisingEdge(dut.clk)
+    in_data_0 = TestDriver(dut, "in", dut.clk, array_idx=0)
+    in_data_1 = TestDriver(dut, "in", dut.clk, array_idx=1)
+    out_data_0 = TestMonitor(dut, "in", dut.clk, array_idx=0, bank=0)
+    out_data_1 = TestMonitor(dut, "in", dut.clk, array_idx=1, bank=1)
+    out_data_0.add_expected(10)
+    out_data_0.add_expected(30)
+    out_data_1.add_expected(20)
+    out_data_1.add_expected(40)
+
+    await in_data_0.send(10)
+    await clkedge
+    await in_data_1.send(20)
+    await clkedge
+    await in_data_0.send(30)
+    await clkedge
+    await in_data_1.send(40)
+    await clkedge
+    await clkedge
+
+    assert not out_data_0.expected
+    assert not out_data_1.expected


### PR DESCRIPTION
This is definitely a workaround for Verilator not providing "name[i]"
handles for array signals.

It is only a basis for discussion

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
