### PR TITLE
Fix example code for rotating logger

### DIFF
--- a/documentation/source/rotating_logger.rst
+++ b/documentation/source/rotating_logger.rst
@@ -13,15 +13,16 @@ and the Python documentation for :class:`logging.handlers.RotatingFileHandler`.
 .. code-block:: python3
 
     from logging.handlers import RotatingFileHandler
+    from cocotb.log import SimLogFormatter
 
     root_logger = logging.getLogger()
 
     # undo the setup cocotb did
     for handler in root_logger.handlers:
-        root_logger.remove_handler(handler)
+        root_logger.removeHandler(handler)
         handler.close()
 
     # do whatever configuration you want instead
-    file_handler = RotatingFileHandler(logfile, maxBytes=(5 * 1024 * 1024), backupCount=2)
-    file_handler.setFormatter(cocotb.log.SimLogFormatter())
+    file_handler = RotatingFileHandler("rotating.log", maxBytes=(5 * 1024 * 1024), backupCount=2)
+    file_handler.setFormatter(SimLogFormatter())
     root_logger.addHandler(file_handler)


### PR DESCRIPTION
Correct method name removeHandler().
Prevent collision with our log alias for _log.
Give an explicity logfile name to make example more standalone.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
