### PR TITLE
Use '<=' in places where 'dut.sig = val' was used

### DIFF
--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -101,9 +101,9 @@ following:
 
         dut._log.info("Running test!")
         for cycle in range(10):
-            dut.clk = 0
+            dut.clk <= 0
             await Timer(1, units='ns')
-            dut.clk = 1
+            dut.clk <= 1
             await Timer(1, units='ns')
         dut._log.info("Running test!")
 

--- a/examples/endian_swapper/hal_tests/test_endian_swapper_hal.py
+++ b/examples/endian_swapper/hal_tests/test_endian_swapper_hal.py
@@ -38,11 +38,11 @@ import io_module
 
 async def reset(dut, duration=10):
     dut._log.debug("Resetting DUT")
-    dut.reset_n = 0
-    dut.stream_in_valid = 0
+    dut.reset_n <= 0
+    dut.stream_in_valid <= 0
     await Timer(duration, units='ns')
     await RisingEdge(dut.clk)
-    dut.reset_n = 1
+    dut.reset_n <= 1
     dut._log.debug("Out of reset")
 
 

--- a/examples/mean/tests/test_mean.py
+++ b/examples/mean/tests/test_mean.py
@@ -105,7 +105,7 @@ async def mean_randomised_test(dut):
 
     dut.rst <= 1
     for i in range(BUS_WIDTH):
-        dut.i_data[i] = 0
+        dut.i_data[i] <= 0
     dut.i_valid <= 0
     await RisingEdge(dut.clk)
     await RisingEdge(dut.clk)
@@ -115,7 +115,7 @@ async def mean_randomised_test(dut):
         nums = []
         for i in range(BUS_WIDTH):
             x = random.randint(0, 2**DATA_WIDTH - 1)
-            dut.i_data[i] = x
+            dut.i_data[i] <= x
             nums.append(x)
         dut.i_valid <= 1
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
