### PR TITLE
Make logging more customization friendly

### DIFF
--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -123,6 +123,47 @@ The directory :file:`cocotb/examples/axi_lite_slave/` contains ...
     Write documentation, see :file:`README.md`
 
 
+.. _example_custom_logger:
+
+Custom Logger
+=============
+
+The directory :file:`cocotb/examples/custom_logger/` contains an example of
+a custom logger class. It inherits from :class:`~cocotb.log.SimColourLogFormatter`
+and re-implements :meth:`~cocotb.log.SimLogFormatter.format_sim_time`.
+A test shows the class' usage.
+
+Changes compared to the default logger are:
+
+* Prints timestamps in microseconds.
+* Prints a vertical "bracket" highlighting timestamp changes:
+
+  * a "├" in the leftmost column if the current timestamp is different from the previous one, and
+  * a "│" in the leftmost column if the current timestamp is the same as the previous one.
+
+The output then looks as follows:
+
+.. code-block::
+
+   ├    0.0010us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 0, msg 0
+   │    0.0010us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 0, msg 1
+   │    0.0010us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 0, msg 2
+   │    0.0010us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 0, msg 3
+   │    0.0010us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 0, msg 4
+   ├    0.0020us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 1, msg 0
+   ├    0.0030us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 2, msg 0
+   │    0.0030us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 2, msg 1
+   │    0.0030us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 2, msg 2
+   ├    0.0050us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 4, msg 0
+   │    0.0050us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 4, msg 1
+   │    0.0050us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 4, msg 2
+   │    0.0050us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 4, msg 3
+   │    0.0050us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 4, msg 4
+   ├    0.0060us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 5, msg 0
+   │    0.0060us INFO    cocotb.dummy                       ..t_custom_logger.py:48   in do_log                         timestep 5, msg 1
+   ...
+
+
 .. _mixed_signal:
 
 Mixed-signal (analog/digital)

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -208,12 +208,14 @@ Logging
 .. autofunction:: default_config
 
 .. autoclass:: SimLogFormatter
+    :members:
+    :member-order: bysource
     :show-inheritance:
-    :no-members:
 
 .. autoclass:: SimColourLogFormatter
+    :members:
+    :member-order: bysource
     :show-inheritance:
-    :no-members:
 
 .. autoclass:: SimTimeContextFilter
     :show-inheritance:
@@ -223,7 +225,7 @@ Logging
 
 .. attribute:: logging.LogRecord.created_sim_time
 
-    The result of :func:`get_sim_time` at the point the log was created
+    The result of :func:`~cocotb.simulator.get_sim_time` at the point the log was created
     (in simulator units). The formatter is responsible for converting this
     to something like nanoseconds via :func:`~cocotb.utils.get_time_from_sim_steps`.
 

--- a/documentation/source/newsfragments/2320.feature.rst
+++ b/documentation/source/newsfragments/2320.feature.rst
@@ -1,0 +1,10 @@
+The :class:`cocotb.log.SimLogFormatter` class now defines
+:meth:`~cocotb.log.SimLogFormatter._format_sim_time`,
+:meth:`~cocotb.log.SimLogFormatter._format_recordname`,
+:meth:`~cocotb.log.SimLogFormatter._format_filename`,
+:meth:`~cocotb.log.SimLogFormatter._format_funcname`,
+:meth:`~cocotb.log.SimLogFormatter._format_exc_msg` and
+:meth:`~cocotb.log.SimLogFormatter._format_build_line`
+to help in customizing the log output.
+
+A new example ``custom_logger`` shows how this can be used in practice.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -30,6 +30,7 @@
 EXAMPLES := adder/tests \
             simple_dff \
             matrix_multiplier/tests \
+            custom_logger \
             mixed_language/tests
 
 .PHONY: $(EXAMPLES)

--- a/examples/custom_logger/Makefile
+++ b/examples/custom_logger/Makefile
@@ -1,0 +1,15 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+TOPLEVEL_LANG ?= verilog
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+  VERILOG_SOURCES = $(shell pwd)/dummy.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+  VHDL_SOURCES = $(shell pwd)/dummy.vhdl
+endif
+
+MODULE = test_custom_logger
+TOPLEVEL = dummy
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/examples/custom_logger/dummy.sv
+++ b/examples/custom_logger/dummy.sv
@@ -1,0 +1,8 @@
+// This file is public domain, it can be freely copied without restrictions.
+// SPDX-License-Identifier: CC0-1.0
+
+`timescale 1ns/1ns
+
+module dummy ();
+
+endmodule

--- a/examples/custom_logger/dummy.vhdl
+++ b/examples/custom_logger/dummy.vhdl
@@ -1,0 +1,9 @@
+-- This file is public domain, it can be freely copied without restrictions.
+-- SPDX-License-Identifier: CC0-1.0
+
+entity dummy is
+end dummy;
+
+architecture empty of dummy is
+begin
+end empty;

--- a/examples/custom_logger/test_custom_logger.py
+++ b/examples/custom_logger/test_custom_logger.py
@@ -1,0 +1,74 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+"""Example of a custom logger class and a test showing its usage."""
+
+import cocotb
+from cocotb.log import SimColourLogFormatter, get_time_from_sim_steps
+from cocotb.triggers import Timer
+
+import logging
+import random
+
+
+class CustomLogFormatter(SimColourLogFormatter):
+    """Example of a custom log formatter class.
+
+    Changes compared to the default logger are:
+    * Prints timestamps in microseconds.
+    * Prints a vertical "bracket" highlighting timestamp changes:
+      * a "├" in the leftmost column if the current timestamp is different from the previous one, and
+      * a "│" in the leftmost column if the current timestamp is the same as the previous one.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.sim_time_str_old = None
+
+    def _format_sim_time(self, record, time_chars=12, time_base="us"):
+        sim_time = getattr(record, "created_sim_time", None)
+        if sim_time is None:
+            sim_time_str = "  -.--{}".format(time_base)
+        else:
+            time_with_base = get_time_from_sim_steps(sim_time, time_base)
+            sim_time_str = "{:4.4f}{}".format(time_with_base, time_base)
+        if sim_time_str != self.sim_time_str_old:
+            self.sim_time_str_old = sim_time_str
+            return "".join(["├", sim_time_str.rjust(time_chars)])
+        else:
+            return "".join(["│", sim_time_str.rjust(time_chars)])
+
+
+async def do_log(dut):
+    for timestep in range(10):
+        rand_wait = random.randrange(7)
+        await Timer(1, "ns")
+        for idx_msg in range(rand_wait):
+            dut._log.info("timestep %s, msg %s", timestep, idx_msg)
+
+
+@cocotb.test()
+async def test_custom_logger(dut):
+    """Test the custom logger."""
+
+    fmt = CustomLogFormatter()
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        handler.setFormatter(fmt)
+
+    await do_log(dut)
+
+    # some sanity checks for the example, you don't need this in user code
+
+    # print("_format_recordname:", fmt._format_recordname.cache_info())
+    # print("_format_filename:", fmt._format_filename.cache_info())
+    # print("_format_funcname:", fmt._format_funcname.cache_info())
+    assert (
+        fmt._format_recordname.cache_info().hits > 0
+    ), "Nothing was taken from the _format_recordname LRU cache"
+    assert (
+        fmt._format_filename.cache_info().hits > 0
+    ), "Nothing was taken from the _format_filename LRU cache"
+    assert (
+        fmt._format_funcname.cache_info().hits > 0
+    ), "Nothing was taken from the _format_funcname LRU cache"


### PR DESCRIPTION
The added overhead for using function calls to format the single
log line elements is compensated by introducing LRU caching.

Add a custom logger test that adds visual brackets to sim timestamps.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
