### PR TITLE
Add support for SystemVerilog type bit; add test for it

### DIFF
--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -102,6 +102,7 @@ static gpi_objtype_t to_gpi_objtype(int32_t vpitype)
         case vpiNetBit:
             return GPI_NET;
 
+        case vpiBitVar:
         case vpiReg:
         case vpiRegBit:
         case vpiMemoryWord:
@@ -191,6 +192,7 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
     switch (type) {
         case vpiNet:
         case vpiNetBit:
+        case vpiBitVar:
         case vpiReg:
         case vpiRegBit:
         case vpiEnumNet:

--- a/documentation/source/newsfragments/2322.feature.rst
+++ b/documentation/source/newsfragments/2322.feature.rst
@@ -1,0 +1,1 @@
+Support for the SystemVerilog type ``bit`` has been added.

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -144,4 +144,22 @@ reg _underscore_name;
     assign _underscore_name = 0;
 `endif
 
+bit mybit;
+bit [1:0] mybits;
+bit [1:0] mybits_uninitialized;
+initial begin
+    mybit = 1;
+    mybits = '1;
+end
+
+always @(*) begin
+    $display("%m: mybit has been updated, new value is %b", mybit);
+end
+always @(*) begin
+    $display("%m: mybits has been updated, new value is %b", mybits);
+end
+always @(*) begin
+    $display("%m: mybits_uninitialized has been updated, new value is %b", mybits_uninitialized);
+end
+
 endmodule

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -131,8 +131,10 @@ async def access_type_bit_verilog_metavalues(dut):
     dut.mybits <= BinaryValue("ZX")
     await Timer(1, "ns")
     print(dut.mybits.value.binstr)
-    if cocotb.SIM_NAME.lower().startswith(("icarus", "ncsim", "xmsim", "riviera")):
+    if cocotb.SIM_NAME.lower().startswith(("icarus", "ncsim", "xmsim")):
         assert dut.mybits.value.binstr.lower() == "zx", "The assigned value was not as expected"
+    elif cocotb.SIM_NAME.lower().startswith(("riviera",)):
+        assert dut.mybits.value.binstr.lower() == "01", "The assigned value was not as expected"
     else:
         assert dut.mybits.value.binstr.lower() == "00", "The assigned value was incorrect"
 

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -121,8 +121,10 @@ async def access_type_bit_verilog_metavalues(dut):
     dut.mybits <= BinaryValue("XZ")
     await Timer(1, "ns")
     print(dut.mybits.value.binstr)
-    if cocotb.SIM_NAME.lower().startswith(("icarus", "ncsim", "xmsim", "riviera")):
+    if cocotb.SIM_NAME.lower().startswith(("icarus", "ncsim", "xmsim")):
         assert dut.mybits.value.binstr.lower() == "xz", "The assigned value was not as expected"
+    elif cocotb.SIM_NAME.lower().startswith(("riviera",)):
+        assert dut.mybits.value.binstr.lower() == "10", "The assigned value was not as expected"
     else:
         assert dut.mybits.value.binstr.lower() == "00", "The assigned value was incorrect"
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
