### PR TITLE
Fix reference to start_soon() in newsfragment

### DIFF
--- a/documentation/source/newsfragments/2023.feature.rst
+++ b/documentation/source/newsfragments/2023.feature.rst
@@ -1,2 +1,2 @@
-Added :func:`cocotb.scheduler.start_soon` which schedules a coroutine to start *after* the current coroutine yields control.
+Added :meth:`cocotb.scheduler.start_soon <cocotb.scheduler.Scheduler.start_soon>` which schedules a coroutine to start *after* the current coroutine yields control.
 This behavior is distinct from :func:`cocotb.fork` which schedules the given coroutine immediately.


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
