### PR TITLE
Fix newsfragment for #2091

### DIFF
--- a/documentation/source/newsfragments/2091.change.rst
+++ b/documentation/source/newsfragments/2091.change.rst
@@ -1,0 +1,1 @@
+The package build process is now fully :pep:`517` compliant.

--- a/documentation/source/newsfragments/2091.changes.rst
+++ b/documentation/source/newsfragments/2091.changes.rst
@@ -1,1 +1,0 @@
-The package build process is now fully PEP517 compliant.


### PR DESCRIPTION
Fix file name so it's included in release notes. Also changed to use `:pep:` reference.