### PR TITLE
Add test for reading and writing ANSI-colored strings

### DIFF
--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -91,6 +91,11 @@ always @(stream_in_real)
 always @(stream_in_int)
     stream_out_int = stream_in_int;
 
+`ifndef VERILATOR
+always @(stream_in_string)
+    $display("%m: stream_in_string has been updated, new value is '%s'", stream_in_string);
+`endif
+
 test_if struct_var;
 `endif
 

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -91,13 +91,29 @@ always @(stream_in_real)
 always @(stream_in_int)
     stream_out_int = stream_in_int;
 
+var string stream_in_string_asciival_str;
+var int stream_in_string_asciival;
+var int stream_in_string_asciival_sum;
+`ifndef _VCP  // Aldec Riviera-PRO and Active-HDL
+  // workaround for
+  // # ELAB2: Fatal Error: ELAB2_0036 Unresolved hierarchical reference to "stream_in_string.len.len" from module "sample_module" (module not found).
 `ifndef VERILATOR
-always @(stream_in_string)
+always @(stream_in_string) begin
     $display("%m: stream_in_string has been updated, new value is '%s'", stream_in_string);
-`endif
+    stream_in_string_asciival_sum = 0;
+    for (int idx = 0; idx < stream_in_string.len(); idx=idx+1) begin
+        stream_in_string_asciival_str = $sformatf("%0d", stream_in_string[idx]);
+        stream_in_string_asciival = stream_in_string_asciival_str.atoi();
+        stream_in_string_asciival_sum += stream_in_string_asciival;
+        $display("%m: idx=%0d, stream_in_string_asciival=%0d -> stream_in_string_asciival_sum=%0d",
+                 idx, stream_in_string_asciival, stream_in_string_asciival_sum);
+    end
+end
+`endif //  `ifndef VERILATOR
+`endif //  `ifndef _VCP
 
 test_if struct_var;
-`endif
+`endif //  `ifndef __ICARUS__
 
 and test_and_gate(and_output, stream_in_ready, stream_in_valid);
 

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -51,7 +51,7 @@ entity sample_module is
         stream_in_ready                 : out   std_ulogic;
         stream_in_real                  : in    real;
         stream_in_int                   : in    integer;
-        stream_in_string                : in    string(1 to 8);
+        stream_in_string                : in    string(1 to 64);
         stream_in_bool                  : in    boolean;
 
         inout_if                        : in    test_if;
@@ -62,7 +62,7 @@ entity sample_module is
         stream_out_ready                : in    std_ulogic;
         stream_out_real                 : out   real;
         stream_out_int                  : out   integer;
-        stream_out_string               : out   string(1 to 8);
+        stream_out_string               : out   string(1 to 64);
         stream_out_bool                 : out   boolean
     );
 end;
@@ -128,6 +128,11 @@ begin
         if rising_edge(clk) then
             stream_out_data_registered <= stream_in_data;
         end if;
+    end process;
+
+    process (stream_in_string) is
+    begin
+      report "stream_in_string has been updated, new value is '" & stream_in_string & "'";
     end process;
 
     stream_out_data_comb <= afunc(stream_in_data) when stream_in_func_en = '0' else stream_in_data;

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -113,6 +113,8 @@ architecture impl of sample_module is
     constant NUM_OF_MODULES : natural := 4;
     signal temp             : std_logic_vector(NUM_OF_MODULES-1 downto 0);
 
+    signal stream_in_string_asciival_sum : natural;
+
 begin
 
     genblk1: for i in NUM_OF_MODULES - 1 downto 0 generate
@@ -131,8 +133,25 @@ begin
     end process;
 
     process (stream_in_string) is
+      variable v_idx : positive;
+      variable v_cur_char : character;
+      variable v_stream_in_string_asciival : natural;
+      variable v_stream_in_string_asciival_sum : natural;
     begin
       report "stream_in_string has been updated, new value is '" & stream_in_string & "'";
+      v_stream_in_string_asciival_sum := 0;
+      for v_idx in stream_in_string'range loop
+        v_cur_char := stream_in_string(v_idx);
+        if v_cur_char /= ' ' then  -- only work on non-space characters
+          v_stream_in_string_asciival := character'pos(v_cur_char);
+          v_stream_in_string_asciival_sum := v_stream_in_string_asciival_sum + v_stream_in_string_asciival;
+          -- report "v_idx=" & integer'image(v_idx) &
+          --   ", v_stream_in_string_asciival=" & integer'image(v_stream_in_string_asciival) &
+          --   -- ", v_cur_char='" & v_cur_char & "'" &  -- this often ends the report output here
+          --   " -> v_stream_in_string_asciival_sum=" & integer'image(v_stream_in_string_asciival_sum);
+        end if;
+      end loop;  -- v_idx
+      stream_in_string_asciival_sum <= v_stream_in_string_asciival_sum;
     end process;
 
     stream_out_data_comb <= afunc(stream_in_data) when stream_in_func_en = '0' else stream_in_data;

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -56,9 +56,7 @@ async def test_string_handle_takes_bytes(dut):
 async def test_string_ansi_color(dut):
     """Check how different simulators treat ANSI-colored strings, see gh-2328"""
     teststr = "\x1b[33myellow\x1b[49m\x1b[39m"
-    asciival_sum = 0
-    for char in teststr:
-        asciival_sum += ord(char)
+    asciival_sum = sum(ord(char) for char in teststr)
     await cocotb.triggers.Timer(10, 'ns')
     dut.stream_in_string.value = bytes(teststr.encode("ascii"))
     await cocotb.triggers.Timer(10, 'ns')

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -66,10 +66,10 @@ async def test_string_ansi_color(dut):
         # Riviera-PRO doesn't return anything with VHDL:
         assert val == b""
         # ...and the value shows up differently in the HDL:
-        assert dut.stream_in_string_asciival_sum.value == 1587
+        assert dut.stream_in_string_asciival_sum.value == sum(ord(char) for char in teststr.replace('\x1b', '\0'))
     elif cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
         # Xcelium with VPI strips the escape char when reading:
-        assert val == b"[33myellow[49m[39m"
+        assert val == bytes(teststr.replace('\x1b', '').encode("ascii"))
         # the HDL gets the correct value though:
         assert dut.stream_in_string_asciival_sum.value == asciival_sum
     else:

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -51,21 +51,32 @@ async def test_string_handle_takes_bytes(dut):
     assert val == b"bytes"
 
 
-@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")) or
+             cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(("riviera")))
 async def test_string_ansi_color(dut):
+    """Check how different simulators treat ANSI-colored strings, see gh-2328"""
+    teststr = "\x1b[33myellow\x1b[49m\x1b[39m"
+    asciival_sum = 0
+    for char in teststr:
+        asciival_sum += ord(char)
     await cocotb.triggers.Timer(10, 'ns')
-    dut.stream_in_string.value = b"\x1b[33myellow\x1b[49m\x1b[39m"
+    dut.stream_in_string.value = bytes(teststr.encode("ascii"))
     await cocotb.triggers.Timer(10, 'ns')
     val = dut.stream_in_string.value
     assert isinstance(val, bytes)
     if cocotb.LANGUAGE in ["vhdl"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        # Riviera-PRO doesn't return anything with VHDL; gh-2328
+        # Riviera-PRO doesn't return anything with VHDL:
         assert val == b""
+        # ...and the value shows up differently in the HDL:
+        assert dut.stream_in_string_asciival_sum.value == 1587
     elif cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
-        # Xcelium with VPI breaks ANSI coloring when reading; gh-2328
+        # Xcelium with VPI strips the escape char when reading:
         assert val == b"[33myellow[49m[39m"
+        # the HDL gets the correct value though:
+        assert dut.stream_in_string_asciival_sum.value == asciival_sum
     else:
-        assert val == b"\x1b[33myellow\x1b[49m\x1b[39m"
+        assert val == bytes(teststr.encode("ascii"))
+        assert dut.stream_in_string_asciival_sum.value == asciival_sum
 
 
 async def test_delayed_assignment_still_errors(dut):


### PR DESCRIPTION
Special-cases Xcelium with SystemVerilog; see #2328.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
