### PR TITLE
Fix libcocotbutils on Linux and Mac OS

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -43,7 +43,7 @@ EXTRA_ARGS += --timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)
 
 SIM_BUILD_FLAGS += -std=c++11
 
-COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-Wl,-rpath,$(LIB_DIR) -L$(LIB_DIR) -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils"
+COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-Wl,-rpath,$(LIB_DIR) -L$(LIB_DIR) -lcocotbvpi_verilator"
 
 $(SIM_BUILD)/Vtop.mk: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp | $(SIM_BUILD)
 	$(CMD) -cc --exe -Mdir $(SIM_BUILD) -DCOCOTB_SIM=1 --top-module $(TOPLEVEL) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -343,11 +343,14 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
     ]
     if os.name == "nt":
         libcocotbutils_sources += ["libcocotbutils.rc"]
+    libcocotbutils_libraries = ["gpilog"]
+    if os.name != "nt":
+        libcocotbutils_libraries.append("dl")
     libcocotbutils = Extension(
         os.path.join("cocotb", "libs", "libcocotbutils"),
         define_macros=[("COCOTBUTILS_EXPORTS", "")] + _extra_defines,
         include_dirs=[include_dir],
-        libraries=["gpilog"],
+        libraries=libcocotbutils_libraries,
         sources=libcocotbutils_sources,
         extra_link_args=_extra_link_args(lib_name="libcocotbutils", rpaths=["$ORIGIN"]),
         extra_compile_args=_extra_cxx_compile_args,

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -345,7 +345,7 @@ def _get_common_lib_ext(include_dir, share_lib_dir):
         libcocotbutils_sources += ["libcocotbutils.rc"]
     libcocotbutils_libraries = ["gpilog"]
     if os.name != "nt":
-        libcocotbutils_libraries.append("dl")
+        libcocotbutils_libraries.append("dl")  # dlopen, dlerror, dlsym
     libcocotbutils = Extension(
         os.path.join("cocotb", "libs", "libcocotbutils"),
         define_macros=[("COCOTBUTILS_EXPORTS", "")] + _extra_defines,


### PR DESCRIPTION
libcocotbutils on Linux and Mac OS depends on the loader library "dl",
however this dependency was never added and cocotb works fine. This is
because libpython loaded libdl.so as a dependency, so it was resolved
transitively.

As of #2268, this dependency on libpython as a load-time dependency was
severed. This continued to not be a problem because simulators link
against libdl to load VPI library (like cocotb). However, verilator is
different, it is not a AoT compiled simulator that dynamically links in
cocotb, but compiles cocotb support into each simulation, so it doesn't
have the libdl dependency.

The libdl dependency by libcocotbutils is now explicitly added for Linux
and Mac OS. This is not a problem for Windows as all extension modules link
against kernel32.dll which provides that equivalent dependency on Windows.
