### PR TITLE
VPI: Fix callback handle leak and optimize callback registration

### DIFF
--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -44,11 +44,11 @@
 #include <cocotb_utils.h>  // COCOTB_UNUSED
 
 typedef enum gpi_cb_state {
-    GPI_FREE = 0,
-    GPI_PRIMED = 1,
-    GPI_CALL = 2,
-    GPI_REPRIME = 3,
-    GPI_DELETE = 4,
+    GPI_FREE = 0,           ///< No sim callback is registered or sim callback is disabled
+    GPI_PRIMED = 1,         ///< Sim callback is registered and enabled
+    GPI_CALL = 2,           ///< User callback function is executing
+    GPI_REPRIME = 3,        ///< Callback is armed again while in user callback function
+    GPI_DELETE = 4,         ///< Callback is marked for cleanup and user callback will not be called
 } gpi_cb_state_e;
 
 class GpiCbHdl;

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -104,7 +104,7 @@ class VpiSignalObjHdl;
 class VpiValueCbHdl : public VpiCbHdl, public GpiValueCbHdl {
 public:
     VpiValueCbHdl(GpiImplInterface *impl, VpiSignalObjHdl *sig, int edge);
-    int cleanup_callback() override;
+
 private:
     s_vpi_value m_vpi_value;
 };


### PR DESCRIPTION
Closes #2300.

All callbacks except `cbValueChange` and `cbAfterDelay` were leaking callback handles
and weren't properly removing the callbacks from the simulator.

After some recent changes on Verilator master it gets stuck in an infinite loop because the `ReadWrite` callback wasn't removed, cocotb just released the handle.

VPI callback cleanup will now properly remove simulator callbacks when
appropriate. During the execution of a callback, calling cleanup_callback()
will mark the callback for removal, but won't call `vpi_remove_cb()` until after
the user callback is executed, because the callback may be re-primed during
callback execution. This saves the work of removing and then re-adding a new
simulator callback.

`cleanup_callback()` was also changed to return 0 instead of -1 when an error
occurs, as a non-zero return will delete the callback object. Some of the
callback objects are singletons, so returning a -1 would likely cause major issues or
a crash.

---

This needs testing with Modelsim, as `vpi_free_object()` is now being called on the `cbAfterDelay` callback handle for `vpiTimedCbHdl` objects.