### PR TITLE
Add section 'Extending existing Simulation Setups' for each simulator

### DIFF
--- a/documentation/source/custom_flows.rst
+++ b/documentation/source/custom_flows.rst
@@ -1,0 +1,170 @@
+.. _custom-flows:
+
+******************************
+Extending existing build flows
+******************************
+
+In order to extend an existing build flow for use with cocotb,
+this chapter shows the minimum settings to be done.
+
+.. note::
+   These instructions are an unsupported alternative to using the Makefiles provided by cocotb.
+
+
+For all simulators, the following environment variables need to be set:
+
+* Define :envvar:`LIBPYTHON_LOC` using ``$(cocotb-config --libpython)``.
+* Define :envvar:`MODULE` with the name of the Python module containing your testcases.
+
+See the sections below for additional settings to be done, depending on the simulator.
+
+.. _custom-flows-icarus:
+
+Icarus Verilog
+==============
+
+* Call the ``vvp`` executable with the options
+  ``-M $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus)``.
+
+Verilator
+=========
+
+* Extend the call to ``verilator`` with these options:
+
+   .. code-block::
+
+      --vpi --public-flat-rw --prefix Vtop \
+      -LDFLAGS "-Wl,-rpath,$(shell cocotb-config --lib-dir) \
+          -L$(shell cocotb-config --lib-dir) \
+          -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils" \
+      $(cocotb-config --share)/lib/verilator/verilator.cpp
+
+* Run Verilator's makefile as follows: ``CPPFLAGS="-std=c++11" make -f Vtop.mk``
+
+.. _custom-flows-vcs:
+
+Synopsys VCS
+============
+
+* Create a file :file:`pli.tab` with the content ``acc+=rw,wn:*`` (or equivalent)
+  to allow cocotb to access values in the design.
+* Extend the ``vcs`` call with the options
+  ``+vpi -P pli.tab -load $(shell cocotb-config --lib-name-path vpi vcs)``.
+
+.. _custom-flows-aldec:
+.. _custom-flows-riviera:
+
+Aldec Riviera-PRO
+=================
+
+* The ``alog`` call needs the ``-pli libgpi`` option set.
+* The ``asim`` call needs the ``+access +w`` option set to allow cocotb to access values in the design.
+
+.. tabs::
+
+   .. group-tab:: Design with a VHDL Toplevel
+
+      For a design with a VHDL toplevel, call the ``asim`` executable with the option
+      ``-pli $(shell cocotb-config --lib-name-path vpi riviera)``.
+
+      Set the :envvar:`GPI_EXTRA` variable to ``$(shell cocotb-config --lib-name-path vhpi riviera):cocotbvhpi_entry_point``
+      if there are also (System)Verilog modules in the design.
+
+   .. group-tab:: Design with a (System)Verilog Toplevel
+
+      For a design with a (System)Verilog toplevel, call the ``asim`` executable with the option
+      ``-loadvhpi $(shell cocotb-config --lib-name-path vhpi riviera):vhpi_startup_routines_bootstrap``.
+
+      Set the :envvar:`GPI_EXTRA` variable to ``$(shell cocotb-config --lib-name-path vpi riviera)):cocotbvpi_entry_point``
+      if there are also VHDL modules in the design.
+
+.. _custom-flows-activehdl:
+
+Aldec Active-HDL
+================
+
+* The ``asim`` call needs the ``+access +w`` option set to allow cocotb to access values in the design.
+
+.. tabs::
+
+   .. group-tab:: Design with a VHDL Toplevel
+
+      For a design with a VHDL toplevel, call the ``asim`` executable with the option
+      ``-pli $(shell cocotb-config --lib-name-path vpi activehdl)``.
+
+      Set the :envvar:`GPI_EXTRA` variable to ``$(shell cocotb-config --lib-name-path vhpi activehdl):cocotbvhpi_entry_point``
+      if there are also (System)Verilog modules in the design.
+
+   .. group-tab:: Design with a (System)Verilog Toplevel
+
+      For a design with a (System)Verilog toplevel, call the ``asim`` executable with the option
+      ``-loadvhpi $(shell cocotb-config --lib-name-path vhpi activehdl):vhpi_startup_routines_bootstrap``.
+
+      Set the :envvar:`GPI_EXTRA` variable to ``$(shell cocotb-config --lib-name-path vpi activehdl)):cocotbvpi_entry_point``
+      if there are also VHDL modules in the design.
+
+.. _custom-flows-siemens:
+
+Mentor/Siemens EDA Questa and Modelsim
+======================================
+
+.. tabs::
+
+   .. group-tab:: Design with a VHDL Toplevel
+
+      For a design with a VHDL toplevel, call the ``vsim`` executable with the option
+      ``-foreign "cocotb_init $(shell cocotb-config --lib-name-path fli questa)"``.
+
+      Set the :envvar:`GPI_EXTRA` variable to ``$(shell cocotb-config --lib-name-path vpi questa):cocotbvpi_entry_point``
+      if there are also (System)Verilog modules in the design.
+
+   .. group-tab:: Design with a (System)Verilog Toplevel
+
+      For a design with a (System)Verilog toplevel, call the ``vsim`` executable with the option
+      ``-pli $(shell cocotb-config --lib-name-path vpi questa)``.
+
+      Set the :envvar:`GPI_EXTRA` variable to ``$(shell cocotb-config --lib-name-path fli questa):cocotbfli_entry_point``
+      if there are also VHDL modules in the design.
+
+.. _custom-flows-cadence:
+
+Cadence Incisive and Xcelium
+============================
+
+* The ``xrun`` call (or ``xmelab`` in multi-step mode) needs the ``-access +rwc``
+  (or equivalent, e.g. :samp:`-afile {afile}`) option set to allow cocotb to access values in the design.
+
+.. tabs::
+
+   .. group-tab:: Design with a VHDL Toplevel
+
+      For a design with a VHDL toplevel, call the ``xrun`` or ``xmelab`` executable with the option
+      ``-loadvpi $(shell cocotb-config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap``.
+
+      Set the :envvar:`GPI_EXTRA` variable to ``$(shell cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point``.
+      This is because directly loading the VHPI library causes an error in Xcelium,
+      so always load the VPI library and supply VHPI via ``GPI_EXTRA``.
+
+   .. group-tab:: Design with a (System)Verilog Toplevel
+
+      For a design with a (System)Verilog toplevel, call the ``xrun`` or ``xmelab`` executable with the option
+      ``-loadvpi $(shell cocotb-config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap``.
+
+      Set the :envvar:`GPI_EXTRA` variable to ``$(shell cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point``
+      if there are also VHDL modules in the design.
+
+.. _custom-flows-ghdl:
+
+GHDL
+====
+
+* Extend the ``ghdl -r`` call with the option
+  ``--vpi=$(shell cocotb-config --lib-name-path vpi ghdl)``.
+
+.. _custom-flows-cvc:
+
+Tachyon DA CVC
+==============
+
+* Extend the ``cvc64`` call with the option
+  ``+interp +acc+2 +loadvpi=$(shell cocotb-config --lib-name-path vpi cvc):vlog_startup_routines_bootstrap``.

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -122,6 +122,7 @@ A test can spawn multiple coroutines, allowing for independent flows of executio
    coroutines
    triggers
    testbench_tools
+   custom_flows
    rotating_logger
 
 .. todo::

--- a/documentation/source/newsfragments/2340.doc.rst
+++ b/documentation/source/newsfragments/2340.doc.rst
@@ -1,0 +1,1 @@
+A chapter :ref:`custom-flows` has been added.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -187,6 +187,7 @@ In order to use this simulator, set :make:var:`SIM` to ``riviera``:
 The :envvar:`LICENSE_QUEUE` environment variable can be used for this simulator –
 this setting will be mirrored in the TCL ``license_queue`` variable to control runtime license checkouts.
 
+
 .. _sim-aldec-issues:
 
 Issues for this simulator
@@ -258,7 +259,7 @@ In order to use this simulator, set :make:var:`SIM` to ``modelsim``:
 .. note::
 
    In order to use :term:`FLI` (for VHDL), a ``vdbg`` executable from the simulator installation directory needs to be available on the ``PATH`` during cocotb installation.
-   This is needed to access the proprietary ``mti.h`` header file.
+   This is needed to access the proprietary :file:`mti.h` header file.
 
 Any ModelSim PE or ModelSim PE derivatives (like the ModelSim Microsemi, Intel, Lattice Editions) do not support the VHDL :term:`FLI` feature.
 If you try to use them with :term:`FLI`, you will see a ``vsim-FLI-3155`` error:
@@ -365,7 +366,7 @@ The option can be set on the command line, as shown in the following example.
 
     SIM_ARGS=--vcd=anyname.vhd make SIM=ghdl
 
-A VCD file named ``anyname.vcd`` will be generated in the current directory.
+A VCD file named :file:`anyname.vcd` will be generated in the current directory.
 
 :make:var:`SIM_ARGS` can also be used to pass command line arguments related to :ref:`other waveform formats supported by GHDL <ghdl:export_waves>`.
 


### PR DESCRIPTION
Start with Modelsim/Questa. Rendered docs: https://cocotb--2340.org.readthedocs.build/en/2340/simulator_support.html#extending-existing-simulation-setups

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
