### PR TITLE
[Verilator] For debug, build the Verilator interfaces with debug info

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -33,6 +33,7 @@ ifeq ($(VERILATOR_SIM_DEBUG), 1)
   COMPILE_ARGS += --debug
   PLUSARGS += +verilator+debug
   SIM_BUILD_FLAGS += -DVL_DEBUG
+  USER_CPPFLAGS += -g
 endif
 
 ifeq ($(VERILATOR_TRACE),1)


### PR DESCRIPTION
Add `-g` to build the Verilator interfaces with debug info for debugging. This allows stepping through the Verilator VPI code in a debugger.