### PR TITLE
Use .value in asserts in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ async def test_dff_simple(dut):
         val = random.randint(0, 1)
         dut.d <= val  # Assign the random value val to the input port d
         await FallingEdge(dut.clk)
-        assert dut.q == val, "output q was incorrect on the {}th cycle".format(i)
+        assert dut.q.value == val, "output q was incorrect on the {}th cycle".format(i)
 ```
 
 A simple Makefile:

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -19,4 +19,4 @@ async def test_dff_simple(dut):
         val = random.randint(0, 1)
         dut.d <= val  # Assign the random value val to the input port d
         await FallingEdge(dut.clk)
-        assert dut.q == val, "output q was incorrect on the {}th cycle".format(i)
+        assert dut.q.value == val, "output q was incorrect on the {}th cycle".format(i)


### PR DESCRIPTION
This is not strictly necessary, but easier to understand for beginners.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
