### PR TITLE
Update instructions for installing development version

### DIFF
--- a/documentation/source/install_devel.rst
+++ b/documentation/source/install_devel.rst
@@ -31,7 +31,7 @@ The instructions for installing the development version of cocotb itself vary de
 
       .. code-block:: bash
 
-          pip install --global-option build_ext --global-option --compiler=mingw32 https://github.com/cocotb/cocotb/archive/master.zip
+          pip install --global-option build_ext --global-option --compiler=mingw32 git+https://github.com/cocotb/cocotb@master
 
    .. group-tab:: Linux and macOS
 
@@ -39,7 +39,7 @@ The instructions for installing the development version of cocotb itself vary de
 
       .. code-block:: bash
 
-          pip install https://github.com/cocotb/cocotb/archive/master.zip
+          pip install git+https://github.com/cocotb/cocotb@master
 
 .. note::
 

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -15,8 +15,8 @@ a :ref:`supported simulator<simulator-support>`) and cocotb itself (``pip instal
 Download and extract the cocotb source files according to the *release version* you are using from
 https://github.com/cocotb/cocotb/releases - you can check your cocotb version with ``cocotb-config --version``.
 
-The sources for cocotb's *development version* are available from
-https://github.com/cocotb/cocotb/archive/master.zip
+The sources for cocotb's *development version* are available from https://github.com/cocotb/cocotb.
+See :ref:`install-devel` for more details.
 
 The following lines are all you need to run a first simulation with cocotb:
 


### PR DESCRIPTION
Following the move to setuptools_scm installing from master.zip no
longer works. setuptools_scm needs a copy of the sources with all of the
git information, and master.zip does not contain that information.

Closes #2356.