### PR TITLE
Remove sample_module calls to $display when using Verilator

### DIFF
--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -155,6 +155,7 @@ initial begin
     mybits = '1;
 end
 
+`ifndef VERILATOR
 always @(*) begin
     $display("%m: mybit has been updated, new value is %b", mybit);
 end
@@ -164,5 +165,6 @@ end
 always @(*) begin
     $display("%m: mybits_uninitialized has been updated, new value is %b", mybits_uninitialized);
 end
+`endif
 
 endmodule


### PR DESCRIPTION
Closes #2346.

When the always blocks that display value changes to the bit variables are included,
Verilator is unable to find a handle to the top-level module through VPI.

There is some underlying issue in Verilator that I haven't figured out, but this is a work-around for now.