### PR TITLE
Add GCC problem matcher for GitHub Actions

### DIFF
--- a/.github/problem-matchers/gcc.json
+++ b/.github/problem-matchers/gcc.json
@@ -1,0 +1,18 @@
+{
+    "__comment": "Taken from vscode-cpptools's Extension/package.json gcc rule",
+    "problemMatcher": [
+        {
+            "owner": "gcc-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -241,6 +241,11 @@ jobs:
         make -j $(nproc)
         sudo make install
 
+    - name: Register GCC problem matcher
+      if: (!matrix.cxx || matrix.cxx == 'g++')
+      run: |
+        echo "::add-matcher::.github/problem-matchers/gcc.json"
+
       # Windows Testing
     - name: Install Python testing dependencies (Windows)
       if: startsWith(matrix.os, 'windows')

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -34,6 +34,7 @@
  * Uses GPI calls to interface to the simulator.
  */
 
+int unused;
 static int takes = 0;
 static int releases = 0;
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
