### PR TITLE
Extend cocotb-config to return path to libraries

### DIFF
--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -105,7 +105,7 @@ def help_vars_text():
 
 def lib_name(interface: str, simulator: str) -> str:
     """
-    Returns the name of interface library for given interface (VPI/VHPI/FLI) and simulator.
+    Return the name of interface library for given interface (VPI/VHPI/FLI) and simulator.
     """
 
     interface_name = interface.lower()
@@ -145,7 +145,7 @@ def lib_name(interface: str, simulator: str) -> str:
 
 def lib_name_path(interface, simulator):
     """
-    Returns the absolute path of interface library for given interface (VPI/VHPI/FLI) and simulator
+    Return the absolute path of interface library for given interface (VPI/VHPI/FLI) and simulator
     """
     library_name_path = os.path.join(libs_dir, lib_name(interface, simulator))
 
@@ -217,7 +217,7 @@ def get_parser():
     )
     parser.add_argument(
         "--libpython",
-        help="prints the absolute path to the libpython associated with the current Python installation",
+        help="Print the absolute path to the libpython associated with the current Python installation",
         action=PrintAction,
         text=find_libpython.find_libpython(),
     )

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -64,16 +64,6 @@ PYTHON_BIN ?= $(realpath $(shell cocotb-config --python-bin))
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.deprecations
 
 LIB_DIR=$(COCOTB_PY_DIR)/cocotb/libs
-LIB_PREFIX := lib
-
-ifeq ($(OS),Msys)
-    LIB_EXT := dll
-    ifneq (,$(wildcard $(LIB_DIR)/cocotb.dll))
-        LIB_PREFIX :=
-    endif
-else
-    LIB_EXT := so
-endif
 
 PYTHON_ARCH := $(shell $(PYTHON_BIN) -c 'from platform import architecture; print(architecture()[0])')
 ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -29,16 +29,16 @@ ACOM_ARGS += -dbg
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
     # backslashes needed because we embed in `echo` below
-    GPI_ARGS = -pli \"$(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_aldec)\"
+    GPI_ARGS = -pli \"$(shell cocotb-config --lib-name-path vpi activehdl)\"
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_aldec.$(LIB_EXT):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi activehdl):cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     # backslashes needed because we embed in `echo` below
-    GPI_ARGS = -loadvhpi \"$(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvhpi_aldec):vhpi_startup_routines_bootstrap\"
+    GPI_ARGS = -loadvhpi \"$(shell cocotb-config --lib-name-path vhpi activehdl):vhpi_startup_routines_bootstrap\"
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbvpi_aldec.$(LIB_EXT):cocotbvpi_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path vpi activehdl):cocotbvpi_entry_point
 endif
 else
    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -63,7 +63,7 @@ endif
 $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	MODULE=$(MODULE) \
 	TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_modelsim:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+        $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=$(shell cocotb-config --lib-name-path vpi cvc):vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 ifeq ($(CVC_ITERP),1)
@@ -80,7 +80,7 @@ ifeq ($(CVC_ITERP),1)
     debug:  $(CUSTOM_SIM_DEPS)
 	MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        gdb --args $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=$(LIB_DIR)/modelsim/$(LIB_PREFIX)cocotbvpi:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+        gdb --args $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=$(shell cocotb-config --lib-name-path vpi cvc):vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 else
     debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	MODULE=$(MODULE) \

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -76,7 +76,7 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) --vpi=$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_ghdl.$(LIB_EXT) $(SIM_ARGS) $(PLUSARGS)
+	$(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) --vpi=$(shell cocotb-config --lib-name-path vpi ghdl) $(SIM_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -69,7 +69,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m $(LIB_PREFIX)cocotbvpi_icarus $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
+        $(ICARUS_BIN_DIR)/vvp -M $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
 
 	$(call check_for_results_file)
 
@@ -77,7 +77,7 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        gdb --args $(ICARUS_BIN_DIR)/vvp -M $(LIB_DIR) -m $(LIB_PREFIX)cocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+        gdb --args $(ICARUS_BIN_DIR)/vvp $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -70,10 +70,10 @@ ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
-# GPI_EXTRA=$(LIB_PREFIX)cocotbvhpi.$(LIB_EXT) if needed.
+# GPI_EXTRA=$(shell cocotb-config --lib-name-path vhpi ius) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if vpi library name is libvpi.so
-GPI_ARGS = -loadvpi $(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_ius:vlog_startup_routines_bootstrap
+GPI_ARGS = -loadvpi $(shell cocotb-config --lib-name-path vpi ius):vlog_startup_routines_bootstrap
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     EXTRA_ARGS += -v93
@@ -81,10 +81,10 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     ROOT_LEVEL = $(TOPLEVEL)
 ifneq ($(VHDL_SOURCES),)
     HDL_SOURCES += $(VHDL_SOURCES)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_ius.$(LIB_EXT):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi ius):cocotbvhpi_entry_point
 endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_ius.$(LIB_EXT):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi ius):cocotbvhpi_entry_point
     EXTRA_ARGS += -v93
     EXTRA_ARGS += -top $(TOPLEVEL)
     RTL_LIBRARY ?= $(TOPLEVEL)

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -69,7 +69,7 @@ else
     VSIM_ARGS += -onfinish exit
 endif
 
-FLI_LIB := $(LIB_DIR)/$(LIB_PREFIX)cocotbfli_modelsim.$(LIB_EXT)
+FLI_LIB := $(shell cocotb-config --lib-name-path fli questa)
 # if this target is run, then cocotb did not build the library
 $(FLI_LIB):
 	@echo -e "ERROR: cocotb was not installed with an FLI library, as the mti.h header could not be located.\n\
@@ -79,15 +79,15 @@ $(FLI_LIB):
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),vhdl)
     CUSTOM_COMPILE_DEPS += $(FLI_LIB)
-    VSIM_ARGS += -foreign \"cocotb_init $(call to_tcl_path,$(FLI_LIB))\"
+    VSIM_ARGS += -foreign \"cocotb_init $(FLI_LIB)\"
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbvpi_modelsim.$(LIB_EXT):cocotbvpi_entry_point
+    GPI_EXTRA =  $(shell cocotb-config --lib-name-path vpi questa):cocotbvpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),verilog)
-    VSIM_ARGS += -pli $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_modelsim.$(LIB_EXT))
+    VSIM_ARGS += -pli $(shell cocotb-config --lib-name-path vpi questa)
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbfli_modelsim.$(LIB_EXT):cocotbfli_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path fli questa):cocotbfli_entry_point
 endif
 
 else

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -86,15 +86,15 @@ endif
 
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
-    GPI_ARGS = -pli $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_aldec)
+    GPI_ARGS = -pli $(shell cocotb-config --lib-name-path vpi riviera)
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_aldec.$(LIB_EXT):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi riviera):cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_ARGS = -loadvhpi $(call to_tcl_path,$(LIB_DIR)/$(LIB_PREFIX)cocotbvhpi_aldec):vhpi_startup_routines_bootstrap
+    GPI_ARGS = -loadvhpi $(shell cocotb-config --lib-name-path vhpi riviera):vhpi_startup_routines_bootstrap
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbvpi_aldec.$(LIB_EXT):cocotbvpi_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path vpi riviera)):cocotbvpi_entry_point
 endif
 
 else

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -75,7 +75,7 @@ $(SIM_BUILD)/simv: $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(CUSTOM_COMPILE_DEPS
 	TOPLEVEL=$(TOPLEVEL) \
 	$(CMD) -top $(TOPLEVEL) $(PLUSARGS) +acc+1 +vpi -P pli.tab +define+COCOTB_SIM=1 -sverilog \
 	-timescale=$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) -debug -load $(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_vcs.so $(COMPILE_ARGS) $(VERILOG_SOURCES)
+	$(EXTRA_ARGS) -debug -load $(shell cocotb-config --lib-name-path vpi vcs) $(COMPILE_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -44,7 +44,7 @@ EXTRA_ARGS += --timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)
 
 SIM_BUILD_FLAGS += -std=c++11
 
-COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-Wl,-rpath,$(LIB_DIR) -L$(LIB_DIR) -lcocotbvpi_verilator"
+COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o $(TOPLEVEL) -LDFLAGS "-Wl,-rpath,$(shell cocotb-config --lib-dir) -L$(shell cocotb-config --lib-dir) -lcocotbvpi_verilator"
 
 $(SIM_BUILD)/Vtop.mk: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp | $(SIM_BUILD)
 	$(CMD) -cc --exe -Mdir $(SIM_BUILD) -DCOCOTB_SIM=1 --top-module $(TOPLEVEL) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES) $(COCOTB_SHARE_DIR)/lib/verilator/verilator.cpp

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -78,20 +78,20 @@ ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
-# GPI_EXTRA=$(LIB_PREFIX)cocotbvhpi.$(LIB_EXT) if needed.
+# GPI_EXTRA=$(shell cocotb-config --lib-name-path vhpi xcelium) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if VPI library name is libvpi.so
-GPI_ARGS = -loadvpi $(LIB_DIR)/$(LIB_PREFIX)cocotbvpi_ius:vlog_startup_routines_bootstrap
+GPI_ARGS = -loadvpi $(shell cocotb-config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap
 ifeq ($(TOPLEVEL_LANG),verilog)
     HDL_SOURCES = $(VERILOG_SOURCES)
     ROOT_LEVEL = $(TOPLEVEL)
     EXTRA_ARGS += -top $(TOPLEVEL)
     ifneq ($(VHDL_SOURCES),)
         HDL_SOURCES += $(VHDL_SOURCES)
-        GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_ius.$(LIB_EXT):cocotbvhpi_entry_point
+        GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point
     endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_EXTRA = $(LIB_PREFIX)cocotbvhpi_ius.$(LIB_EXT):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point
     EXTRA_ARGS += -top $(TOPLEVEL)
     RTL_LIBRARY ?= $(TOPLEVEL)
     MAKE_LIB = -makelib $(RTL_LIBRARY)

--- a/documentation/source/newsfragments/2387.feature.rst
+++ b/documentation/source/newsfragments/2387.feature.rst
@@ -1,1 +1,1 @@
-Added ``--lib-dir``,  ``--lib-name`` and ``--lib-name-path`` to ``cocotb-config`` command.
+Added the ``--lib-dir``,  ``--lib-name`` and ``--lib-name-path`` options to the ``cocotb-config`` command to make cocotb integration into existing flows easier.

--- a/documentation/source/newsfragments/2387.feature.rst
+++ b/documentation/source/newsfragments/2387.feature.rst
@@ -1,0 +1,1 @@
+Added ``--lib-dir``,  ``--lib-name`` and ``--lib-name-path`` to ``cocotb-config`` command.

--- a/tests/test_cases/issue_253/Makefile
+++ b/tests/test_cases/issue_253/Makefile
@@ -46,19 +46,19 @@ $(COCOTB_RESULTS_FILE):
 notset_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	MODULE=$(MODULE) \
 	TESTCASE=issue_253_notset TOPLEVEL= \
-	vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+	vvp -M $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 	mkdir -p $@_result && mv results.xml $@_result/
 
 empty_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	MODULE=$(MODULE) \
 	TESTCASE=issue_253_empty TOPLEVEL="" \
-	vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+	vvp -M $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 	mkdir -p $@_result && mv results.xml $@_result/
 
 no_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	MODULE=$(MODULE) \
 	TESTCASE=issue_253_none \
-	vvp -M $(LIB_DIR) -m libcocotbvpi_icarus $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+	vvp -M $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 	mkdir -p $@_result && mv results.xml $@_result/
 
 endif


### PR DESCRIPTION
Related #2351

An interesting complication is that Icarus accepts library name without extension only. All others seem to be ok with extension name.

- [x] news fragment
- [x] Should I change all makefiles to use it?

