### PR TITLE
Only try to upload to codecov if that will work

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -295,7 +295,18 @@ jobs:
 
     # codecov
     - name: Upload to codecov
-      if: steps.windowstesting.outcome == 'success' || steps.unixtesting.outcome == 'success'
+      # Notes:
+      # - The "--relative/-r" argument is not available on macOS gcov, skip
+      #   coverage upload there.
+      # - Clang builds must use llvm-cov instead of gcov, which isn't picked
+      #   currently by the codecov uploader. Hence we do not upload coverage
+      #   from clang builds currently, which don't add much anyways.
+      if: >
+        (steps.windowstesting.outcome == 'success'
+         || steps.unixtesting.outcome == 'success')
+        && !startsWith(matrix.os, 'macos')
+        && matrix.cxx != 'clang++'
+
       run: |
         pip install codecov
         codecov --gcov-args='-rl'


### PR DESCRIPTION
Currently we have some jobs which try to upload coverage data to
codecov, but fail in doing so. Remove those jobs from the CI
configuration.

* On macOS, the `-r` gcov argument isn't available.
* On clang builds, we need to use llvm-cov instead of gcov. gcov is
  called under the hood by the codecov bash uploader. We could add more
  custom code to pre-process the coverage data, but I don't see the
  value in doing so: the clang builds will give us pretty much the same
  coverage as the GCC builds. Let's keep things simple.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->