### PR TITLE
Remove extra tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.9]
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{matrix.python-version}}
@@ -100,13 +100,6 @@ jobs:
             os: ubuntu-20.04
 
             # Test GHDL on Ubuntu
-
-          - sim: ghdl
-            sim-version: apt
-            lang: vhdl
-            python-version: 3.8
-            os: ubuntu-20.04
-            may_fail: true
 
           - sim: ghdl
             sim-version: nightly


### PR DESCRIPTION
The GHDL apt test is unnecessary if even HEAD is still not passing. And we don't need to test with flake on more than one python version.