### PR TITLE
Mention job name in codecov upload

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -309,7 +309,9 @@ jobs:
          || steps.unixtesting.outcome == 'success')
         && !startsWith(matrix.os, 'macos')
         && matrix.cxx != 'clang++'
-
-      run: |
-        pip install codecov
-        codecov --gcov-args='-rl'
+      uses: codecov/codecov-action@v1
+      with:
+        # There seems to be no way (as of Feb 2021) to get the job name in a
+        # variable; we hence have to re-assemble it here.
+        name: "${{matrix.extra_name}}${{matrix.sim}} (${{matrix.sim-version}}) | ${{matrix.os}} | Python ${{matrix.python-version}}"
+        gcov_args: "-rl"


### PR DESCRIPTION
We upload multiple results to codecov, which get merged into each other.
However, codecov keeps the original uploads and provides a way to show
only data from a single upload, which is quite helpful for debugging.
Give our uploads a sensible name to distinguish them.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->