### PR TITLE
 Fix coverage collection in CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Codecov configuration
+codecov:
+    notify:
+        # Codecov claims [1] to wait until all CI runs have completed, but that
+        # doesn't work for our CI setup, causing early reports to come in which
+        # indicate a drop in coverage. These reports are later updated as more
+        # reports come in. But by that time the first issue comment has already
+        # been made and an email has been sent. Prevent that by explicitly
+        # specifying the number of builds that need to be uploaded to codecov
+        # [2].
+        #
+        # Keep this number in sync with the CI configuration!
+        #
+        # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
+        # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
+        after_n_builds: 10

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -304,6 +304,8 @@ jobs:
       # - Clang builds must use llvm-cov instead of gcov, which isn't picked
       #   currently by the codecov uploader. Hence we do not upload coverage
       #   from clang builds currently, which don't add much anyways.
+      # - When changing how many builds are uploaded to codecov also update
+      #   `codecov.notify.after_n_builds` in `.codecov.yml`.
       if: >
         (steps.windowstesting.outcome == 'success'
          || steps.unixtesting.outcome == 'success')

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -52,6 +52,7 @@ jobs:
       CXX: ${{matrix.cxx || 'g++'}}
       CC: ${{matrix.cc || 'gcc'}}
       OS: ${{matrix.os}}
+      PYTHON_VERSION: ${{matrix.python-version}}
       TOX_TESTENV_PASSENV: GITHUB_ACTIONS
 
     strategy:
@@ -244,7 +245,8 @@ jobs:
       run: conda install --yes -c msys2 m2-base m2-make m2w64-toolchain libpython
     - name: Install cocotb (Windows, mingw)
       if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'mingw'
-      run: python -m pip install  --global-option build_ext --global-option --compiler=mingw32 -v -e .[bus]
+      run: |
+        python -m pip install --global-option build_ext --global-option --compiler=mingw32 -v -e .[bus]
       continue-on-error: ${{matrix.may_fail || false}}
     - name: Install cocotb (Windows, msvc)
       if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'msvc'
@@ -261,9 +263,13 @@ jobs:
       id: windowstesting
       continue-on-error: ${{matrix.may_fail || false}}
       timeout-minutes: 15
+      # Keep the commands and environment variables below in sync with tox.ini.
       run: |
         pytest
         make test
+        bash -c 'find . -type f -name ".coverage.cocotb" -print -exec coverage combine --append {} \;'
+      env:
+        COCOTB_LIBRARY_COVERAGE: "1"
 
       # Ubuntu / MacOS Testing
     - name: Install cocotb build dependencies (Ubuntu - g++)
@@ -303,9 +309,12 @@ jobs:
          || steps.unixtesting.outcome == 'success')
         && !startsWith(matrix.os, 'macos')
         && matrix.cxx != 'clang++'
-      uses: codecov/codecov-action@v1
-      with:
-        # There seems to be no way (as of Feb 2021) to get the job name in a
-        # variable; we hence have to re-assemble it here.
-        name: "${{matrix.extra_name}}${{matrix.sim}} (${{matrix.sim-version}}) | ${{matrix.os}} | Python ${{matrix.python-version}}"
-        gcov_args: "-rl"
+      # There seems to be no way (as of Feb 2021) to get the job name in a
+      # variable; we hence have to re-assemble it here.
+      shell: bash
+      run: |
+        pip install coverage
+        bash <(curl -s https://codecov.io/bash) \
+          -n "${{matrix.extra_name}}${{matrix.sim}} (${{matrix.sim-version}}) | ${{matrix.os}} | Python ${{matrix.python-version}}" \
+          -e SIM,TOPLEVEL_LANG,CXX,OS,PYTHON_VERSION \
+          -a "-rl"

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ install_command =
 commands =
     pytest
     make test
-    bash -c 'find . -type f -name "\.coverage\.cocotb" | xargs coverage combine --append'
+    bash -c 'find . -type f -name ".coverage.cocotb" -exec coverage combine --append \{\} \;'
 
 whitelist_externals =
     make


### PR DESCRIPTION
* Properly collect and combine Python coverage on Windows.
  *On Windows, C coverage isn't collected yet as I haven't found out how
  to actually do that. Taking the same CFLAGS & Co. approach we do on
  Linux doesn't seem to do the trick.*
* Switch from the codecov-action GitHub Action to calling the codecov
  bash uploader directly. The codecov-action doesn't install the Python
  coverage package, which is required to collect our coverage data.
  Installing it before calling the action doesn't work, unfortunately,
  for not entirely clear reasons (`command -v coverage` does not return
  the path where the binary is installed; `command` is both a bash
  builtin and a PowerShell alias, and it also makes use of $PATH, so
  somewhere along those lines something is going wrong -- it's not clear
  what exactly is going on, however).
* Improve the `find` command line to avoid an additional `xargs`.

I'll open a follow-up issue to get C coverage looked into for Windows, but I'm running out of desire to do anything about that for now.

Now also includes a second commit to prevent codecov notifications from appearing before all CI jobs have reported back. That's more a workaround than a solution, but the best we can do for now.