### PR TITLE
Add Github Actions annotations for test failures

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -52,6 +52,7 @@ jobs:
       CXX: ${{matrix.cxx || 'g++'}}
       CC: ${{matrix.cc || 'gcc'}}
       OS: ${{matrix.os}}
+      TOX_TESTENV_PASSENV: GITHUB_ACTIONS
 
     strategy:
       fail-fast: false

--- a/bin/combine_results.py
+++ b/bin/combine_results.py
@@ -81,6 +81,11 @@ def main():
                 if args.set_rc:
                     rc = 1
                 print("Failure in testsuite: '%s' classname: '%s' testcase: '%s' with parameters '%s'" % (testsuite.get('name'), testcase.get('classname'), testcase.get('name'), testsuite.get('package')))
+                if os.getenv('GITHUB_ACTIONS') is not None:
+                    # Get test file relative to root of repo
+                    repo_root = os.path.commonprefix([os.path.abspath(testcase.get('file')), os.path.abspath(__file__)])
+                    relative_file = testcase.get('file').replace(repo_root, "")
+                    print("::error file={2},line={3}::Test {0}:{1} failed".format(testcase.get('classname'), testcase.get('name'), relative_file, testcase.get('lineno')))
 
     print("Ran a total of %d TestSuites and %d TestCases" % (testsuite_count, testcase_count))
 

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -413,9 +413,15 @@ class RegressionManager:
     ) -> None:
 
         ratio_time = self._safe_divide(sim_time_ns, wall_time_s)
+        try:
+            lineno = inspect.getsourcelines(test._func)[1]
+        except OSError:
+            lineno = 1
 
         self.xunit.add_testcase(name=test.__qualname__,
                                 classname=test.__module__,
+                                file=inspect.getfile(test._func),
+                                lineno=repr(lineno),
                                 time=repr(wall_time_s),
                                 sim_time_ns=repr(sim_time_ns),
                                 ratio_time=repr(ratio_time))


### PR DESCRIPTION
Add annotations for failed tests so they can be seen from the summary page without diving into the failed job.

Edit: Now shows file path and line number of test function https://github.com/cocotb/cocotb/actions/runs/555861757