### PR TITLE
Add codecov dependencies to CI

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -290,6 +290,9 @@ jobs:
         tox
 
     # codecov
+    - name: Install codecov dependencies
+      # codecov-action apparently doesn't try to install any of its dependencies
+      run: pip install coverage
     - name: Upload to codecov
       # Notes:
       # - The "--relative/-r" argument is not available on macOS gcov, skip


### PR DESCRIPTION
Python code coverage was no longer being collected after switching to the codecov-action. This is seemingly because the codecov-action does not attempt to install its dependencies. The coveragepy module is necessary for collecting Python coverage. See it complain [here](https://github.com/cocotb/cocotb/runs/1871844530?check_suite_focus=true#step:26:171) about not having that dependency.