### PR TITLE
Add changes in BinaryValue to support zero vectors

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -193,6 +193,8 @@ class BinaryValue:
             )
 
     def _convert_to_unsigned(self, x):
+        if x == 0:
+            return self._adjust_unsigned("")
         x = bin(x)
         if x[0] == '-':
             raise ValueError('Attempt to assigned negative number to unsigned '
@@ -200,6 +202,8 @@ class BinaryValue:
         return self._adjust_unsigned(x[2:])
 
     def _convert_to_signed_mag(self, x):
+        if x == 0:
+            return self._adjust_unsigned("")
         x = bin(x)
         if x[0] == '-':
             binstr = self._adjust_signed_mag('1' + x[3:])
@@ -213,6 +217,8 @@ class BinaryValue:
         if x < 0:
             binstr = bin(2 ** (_clog2(abs(x)) + 1) + x)[2:]
             binstr = self._adjust_twos_comp(binstr)
+        elif x == 0:
+            binstr = self._adjust_twos_comp("")
         else:
             binstr = self._adjust_twos_comp('0' + bin(x)[2:])
         if self.big_endian:
@@ -220,15 +226,21 @@ class BinaryValue:
         return binstr
 
     def _convert_from_unsigned(self, x):
+        if not len(x):
+            return 0
         return int(x.translate(_resolve_table), 2)
 
     def _convert_from_signed_mag(self, x):
+        if not len(x):
+            return 0
         rv = int(self._str[1:].translate(_resolve_table), 2)
         if self._str[0] == '1':
             rv = rv * -1
         return rv
 
     def _convert_from_twos_comp(self, x):
+        if not len(x):
+            return 0
         if x[0] == '1':
             binstr = x[1:]
             binstr = self._invert(binstr)
@@ -278,7 +290,7 @@ class BinaryValue:
         if self._n_bits is None:
             return x
         l = len(x)
-        if l <= self._n_bits:
+        if l < self._n_bits:
             if self.big_endian:
                 rv = x[:-1] + '0' * (self._n_bits - 1 - l)
                 rv = rv + x[-1]
@@ -300,7 +312,9 @@ class BinaryValue:
         if self._n_bits is None:
             return x
         l = len(x)
-        if l <= self._n_bits:
+        if l == 0:
+            rv = x
+        elif l < self._n_bits:
             if self.big_endian:
                 rv = x + x[-1] * (self._n_bits - l)
             else:

--- a/documentation/source/newsfragments/2294.bugfix.rst
+++ b/documentation/source/newsfragments/2294.bugfix.rst
@@ -1,0 +1,1 @@
+VHDL signals that are zero bits in width now read as the integer ``0``, instead of raising an exception.

--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -8,6 +8,39 @@ from cocotb.binary import BinaryValue, BinaryRepresentation
 TRUNCATION_MATCH = r"\d+-bit value requested, truncating value"
 
 
+def test_init_zero_length():
+    bin1 = BinaryValue(value=0, n_bits=0, binaryRepresentation=BinaryRepresentation.UNSIGNED)
+    assert bin1._str == ""
+    assert bin1.binstr == ""
+    assert bin1.integer == 0
+
+    bin2 = BinaryValue(value=0, n_bits=0,
+                       binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
+    assert bin2._str == ""
+    assert bin2.binstr == ""
+    assert bin2.integer == 0
+
+    bin3 = BinaryValue(value=0, n_bits=0,
+                       binaryRepresentation=BinaryRepresentation.SIGNED_MAGNITUDE)
+    assert bin3._str == ""
+    assert bin3.binstr == ""
+    assert bin3.integer == 0
+
+    # Whatever value is set to a zero bit long BinaryValue, it should read 0
+    with pytest.warns(RuntimeWarning, match=TRUNCATION_MATCH):
+        bin4 = BinaryValue(value=10, n_bits=0,
+                           binaryRepresentation=BinaryRepresentation.SIGNED_MAGNITUDE)
+    assert bin4._str == ""
+    assert bin4.binstr == ""
+    assert bin4.integer == 0
+
+    with pytest.warns(RuntimeWarning, match=TRUNCATION_MATCH):
+        bin4 <= 5
+    assert bin4._str == ""
+    assert bin4.binstr == ""
+    assert bin4.integer == 0
+
+
 def test_init_big_endian_twos_comp():
     bin1 = BinaryValue(value=-1, n_bits=2, bigEndian=True, binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
     assert bin1._str == "11"

--- a/tests/test_cases/test_vhdl_zerovector/Makefile
+++ b/tests/test_cases/test_vhdl_zerovector/Makefile
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+ifeq ($(TOPLEVEL_LANG),vhdl)
+
+ifneq ($(filter $(SIM),ius xcelium),)
+    SIM_ARGS += -v93
+endif
+
+TOPLEVEL := vhdl_zerovector
+MODULE := test_vhdl_zerovector
+VHDL_SOURCES := vhdl_zerovector.vhdl
+
+# Cocotb inclusions
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+else
+all:
+	$(info Skipping simulation as only TOPLEVEL_LANG=vhdl is supported)
+
+clean::
+
+endif

--- a/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
+++ b/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
@@ -1,0 +1,39 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import cocotb
+from cocotb.triggers import Timer
+import pytest
+
+
+@cocotb.test()
+async def test_long_signal(dut):
+    """ Write and read a normal signal (longer than 0)."""
+    dut.data_in <= 0x5
+    await Timer(1, "ns")
+    assert dut.data_out == 0x5, "Failed to readback dut.data_out"
+
+
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith(
+    ("ghdl", "xmsim", "ncsim", "riviera", "aldec")) else ())
+async def test_read_zero_signal(dut):
+    """ Read a zero vector. It should always read 0."""
+    assert dut.Cntrl_out == 0, "Failed to readback dut.Cntrl_out"
+
+
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith(
+    ("ghdl", "xmsim", "ncsim", "riviera", "aldec")) else ())
+async def test_write_zero_signal_with_0(dut):
+    """ Write a zero vector with 0."""
+    dut.Cntrl_out <= 0x0
+    await Timer(1, "ns")
+    assert dut.Cntrl_out == 0, "Failed to readback dut.Cntrl_out"
+
+
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith(
+    ("ghdl", "xmsim", "ncsim", "riviera", "aldec")) else ())
+async def test_write_zero_signal_with_1(dut):
+    """ Write a zero vector with 1. Should catch a "out of range" exception."""
+    with pytest.raises(OverflowError):
+        dut.Cntrl_out <= 0x1

--- a/tests/test_cases/test_vhdl_zerovector/vhdl_zerovector.vhdl
+++ b/tests/test_cases/test_vhdl_zerovector/vhdl_zerovector.vhdl
@@ -1,0 +1,21 @@
+-- Copyright cocotb contributors
+-- Licensed under the Revised BSD License, see LICENSE for details.
+-- SPDX-License-Identifier: BSD-3-Clause
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity vhdl_zerovector is
+  generic(DataWidth  : natural := 8;
+          CntrlWidth : natural := 0);
+  port(Data_in   : in  std_logic_vector(DataWidth - 1 downto 0);
+       Data_out  : out std_logic_vector(DataWidth - 1 downto 0);
+       Cntrl_in  : in  std_logic_vector(CntrlWidth - 1 downto 0);
+       Cntrl_out : out std_logic_vector(CntrlWidth - 1 downto 0));
+end entity vhdl_zerovector;
+
+architecture RTL of vhdl_zerovector is
+begin
+  Data_out  <= Data_in;
+  Cntrl_out <= Cntrl_in;
+end architecture RTL;


### PR DESCRIPTION
Add changes in BinaryValue class to handle VHDL zero vectors better.
With this changes, a zero vector reads as 0 instead of throwing an exception.

As a beginner in contributing to your project, I do not expect this pull request to be complete or ready to be merged. I hope you can guide me to a successful contribution. Thank you.

closes #2294 
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
