### PR TITLE
Alt: Slim down Quickstart by moving details to Writing Testbenches

### DIFF
--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -188,5 +188,5 @@ all you would need to change is the command line:
 
 
 This concludes our quick introduction to cocotb.
-You can now look through our :ref:`tutorials` or check out the
+You can now look through our Tutorials or check out the
 :ref:`writing_tbs` chapter for more details on the above.

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -4,93 +4,35 @@
 Quickstart Guide
 ****************
 
+In the following sections,
+we are walking you through creating and running a small but complete cocotb testbench
+for a fictional *Design Under Test* (:term:`DUT`) called ``my_design``.
 
-Running your first Example
-==========================
-
-Make sure you have the :ref:`prerequisites<install-prerequisites>`
-(Python with development packages, a C++11 compiler with development packages, GNU Make,
-a :ref:`supported simulator<simulator-support>`) and cocotb itself (``pip install cocotb``) available.
-
-Download and extract the cocotb source files according to the *release version* you are using from
-https://github.com/cocotb/cocotb/releases - you can check your cocotb version with ``cocotb-config --version``.
-
-The sources for cocotb's *development version* are available from https://github.com/cocotb/cocotb.
-See `Installing the Development Version <https://docs.cocotb.org/en/latest/install_devel.html>`_ for more details.
-
-The following lines are all you need to run a first simulation with cocotb:
-
-.. code-block:: bash
-
-    cd cocotb/examples/simple_dff
-    make
-
-This was running with the default simulator, Icarus Verilog,
-but selecting a different simulator is as easy as:
-
-.. code-block:: bash
-
-    make SIM=vcs
-
-
-Running the same example as VHDL
---------------------------------
-
-The ``simple_dff`` example includes both a VHDL and a Verilog :term:`RTL` implementation.
-The cocotb testbench can execute against either implementation using :term:`VPI` for
-Verilog and :term:`VHPI`/:term:`FLI` for VHDL.  To run the test suite against the VHDL
-implementation, use the following command (a :term:`VHPI` or :term:`FLI` capable simulator must
-be used):
-
-.. code-block:: bash
-
-    make SIM=ghdl TOPLEVEL_LANG=vhdl
-
-
-Using cocotb
-============
-
-A typical cocotb testbench requires no additional :term:`HDL` code (though nothing prevents you from adding testbench helper code).
-The Design Under Test (:term:`DUT`) is instantiated as the toplevel in the simulator
-without any wrapper code.
-Cocotb drives stimulus onto the inputs to the :term:`DUT` and monitors the outputs
-directly from Python.
-
-
-Creating a Makefile
--------------------
-
-To create a cocotb test we typically have to create a Makefile.  Cocotb provides
-rules which make it easy to get started.  We simply inform cocotb of the
-source files we need compiling, the toplevel entity to instantiate and the
-Python test script to load.
-
-.. code-block:: makefile
-
-    VERILOG_SOURCES = $(PWD)/submodule.sv $(PWD)/my_design.sv
-    # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file:
-    TOPLEVEL=my_design
-    # MODULE is the name of the Python test file:
-    MODULE=test_my_design
-
-    include $(shell cocotb-config --makefiles)/Makefile.sim
-
-We would then create a file called ``test_my_design.py`` containing our tests.
+Please install the :ref:`prerequisites<install-prerequisites>`
+and cocotb itself (``pip install cocotb``) now.
+Run ``cocotb-config --version`` in a terminal window to check that cocotb is correctly installed.
 
 
 .. _quickstart_creating_a_test:
 
-Creating a test
----------------
+Creating a Test
+===============
 
-The test is written in Python. Cocotb wraps your top level with the handle you
-pass it. In this documentation, and most of the examples in the project, that
-handle is ``dut``, but you can pass your own preferred name in instead. The
-handle is used in all Python files referencing your :term:`RTL` project. Assuming we
-have a toplevel port called ``clk`` we could create a test file containing the
-following:
+A typical cocotb testbench requires no additional :term:`HDL` code.
+The :term:`DUT` is instantiated as the toplevel in the simulator
+without any HDL wrapper code.
+
+The test is written in Python.
+
+In cocotb, you can access all internals of your design,
+e.g. signals, ports, parameters, etc. through an object that is passed to each test.
+In the following we'll call this object ``dut``.
+
+Let's create a test file ``test_my_design.py`` containing the following:
 
 .. code-block:: python3
+
+    # test_my_design.py
 
     import cocotb
     from cocotb.triggers import Timer
@@ -99,196 +41,152 @@ following:
     async def my_first_test(dut):
         """Try accessing the design."""
 
-        dut._log.info("Running test!")
+        dut._log.info("Running test...")
         for cycle in range(10):
             dut.clk <= 0
-            await Timer(1, units='ns')
+            await Timer(1, units="ns")
             dut.clk <= 1
-            await Timer(1, units='ns')
-        dut._log.info("Running test!")
+            await Timer(1, units="ns")
 
-This will drive a square wave clock onto the ``clk`` port of the toplevel.
+        dut._log.info("my_signal_1 is", dut.my_signal_1.value)
+        assert dut.my_signal_2.value[0] == 0, "my_signal_2[0] is not 0!"
 
-
-Accessing the design
---------------------
-
-When cocotb initializes it finds the top-level instantiation in the simulator
-and creates a handle called ``dut``. Top-level signals can be accessed using the
-"dot" notation used for accessing object attributes in Python. The same mechanism
-can be used to access signals inside the design.
-
-.. code-block:: python3
-
-    # Get a reference to the "clk" signal on the top-level
-    clk = dut.clk
-
-    # Get a reference to a register "count"
-    # in a sub-block "inst_sub_block"
-    count = dut.inst_sub_block.count
+        dut._log.info("Running test...done")
 
 
-Assigning values to signals
----------------------------
+This will first drive 10 periods of a square wave clock onto a port ``clk`` of the toplevel.
+After this, the clock stops,
+the value of ``my_signal_1`` is printed,
+and the value of index ``0`` of ``my_signal_2`` is checked to be ``0``.
 
-Values can be assigned to signals using either the
-:attr:`~cocotb.handle.NonHierarchyObject.value` property of a handle object
-or using direct assignment while traversing the hierarchy.
+Things to note:
 
-.. code-block:: python3
+* Use the ``@cocotb.test()`` decorator to mark the test function to be run.
+* Use ``<=`` to assign a value to a signal (alternatively, use ``.value =``).
+* Use ``.value`` to get a signal's current value.
 
-    # Get a reference to the "clk" signal and assign a value
-    clk = dut.clk
-    clk.value = 1
+The test shown is running sequentially, from start to end.
+Each :keyword:`await` expression suspends execution of the test until
+whatever event the test is waiting for occurs and the simulator returns
+control back to cocotb (see :ref:`simulator-triggers`).
 
-    # Direct assignment through the hierarchy
-    dut.input_signal <= 12
-
-    # Assign a value to a memory deep in the hierarchy
-    dut.sub_block.memory.array[4] <= 2
-
-
-The syntax ``sig <= new_value`` is a short form of ``sig.value = new_value``.
-It not only resembles :term:`HDL` syntax, but also has the same semantics:
-writes are not applied immediately, but delayed until the next write cycle.
-Use ``sig.setimmediatevalue(new_val)`` to set a new value immediately
-(see :meth:`~cocotb.handle.NonHierarchyObject.setimmediatevalue`).
-
-Signed and unsigned values
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Both signed and unsigned values can be assigned to signals using a Python int.
-Cocotb makes no assumptions regarding the signedness of the signal. It only
-considers the width of the signal, so it will allow values in the range from
-the minimum negative value for a signed number up to the maximum positive
-value for an unsigned number: ``-2**(Nbits - 1) <= value <= 2**Nbits - 1``
-Note: assigning out-of-range values will raise an :exc:`OverflowError`.
-
-A :class:`BinaryValue` object can be used instead of a Python int to assign a
-value to signals with more fine-grained control (e.g. signed values only).
-
-.. code-block:: verilog
-
-    module my_module (
-        input   logic       clk,
-        input   logic       rst,
-        input   logic [2:0] data_in,
-        output  logic [2:0] data_out
-        );
+It's most likely that you will want to do several things "at the same time" however -
+think multiple ``always`` blocks in Verilog or ``process`` statements in VHDL.
+In cocotb, you might move the clock generation part of the example above into its own
+:keyword:`async` function and :func:`~cocotb.fork` it ("start it in the background")
+from the test:
 
 .. code-block:: python3
 
-    # assignment of negative value
-    dut.data_in <= -4
+    # test_my_design.py (extended)
 
-    # assignment of positive value
-    dut.data_in <= 7
+    import cocotb
+    from cocotb.triggers import Timer
+    from cocotb.triggers import FallingEdge
 
-    # assignment of out-of-range values
-    dut.data_in <= 8   # raises OverflowError
-    dut.data_in <= -5  # raises OverflowError
+    async def generate_clock(dut):
+        """Generate clock pulses."""
 
-Forcing and freezing signals
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In addition to regular value assignments (deposits), signals can be forced
-to a predetermined value or frozen at their current value. To achieve this,
-the various actions described in :ref:`assignment-methods` can be used.
-
-.. code-block:: python3
-
-    # Deposit action
-    dut.my_signal <= 12
-    dut.my_signal <= Deposit(12)  # equivalent syntax
-
-    # Force action
-    dut.my_signal <= Force(12)    # my_signal stays 12 until released
-
-    # Release action
-    dut.my_signal <= Release()    # Reverts any force/freeze assignments
-
-    # Freeze action
-    dut.my_signal <= Freeze()     # my_signal stays at current value until released
-
-
-.. _quickstart_reading_values:
-
-Reading values from signals
----------------------------
-
-Values in the DUT can be accessed with the :attr:`~cocotb.handle.NonHierarchyObject.value`
-property of a handle object.
-A common mistake is forgetting the ``.value`` which just gives you a reference to a handle
-(useful for defining an alias name), not the value.
-
-The Python type of a value depends on the handle's HDL type:
-
-* Arrays of ``logic`` and subtypes of that (``sfixed``, ``unsigned``, etc.) are of type :class:`~cocotb.binary.BinaryValue`.
-* Integer nets and constants (``integer``, ``natural``, etc.) return :class:`int`.
-* Floating point nets and constants (``real``) return :class:`float`.
-* Boolean nets and constants (``boolean``) return :class:`bool`.
-* String nets and constants (``string``) return :class:`bytes`.
-
-For a :class:`~cocotb.binary.BinaryValue` object, any unresolved bits are preserved and
-can be accessed using the :attr:`~cocotb.binary.BinaryValue.binstr` attribute,
-or a resolved integer value can be accessed using the :attr:`~cocotb.binary.BinaryValue.integer` attribute.
-
-.. code-block:: pycon
-
-    >>> # Read a value back from the DUT
-    >>> count = dut.counter.value
-    >>> print(count.binstr)
-    1X1010
-    >>> # Resolve the value to an integer (X or Z treated as 0)
-    >>> print(count.integer)
-    42
-    >>> # Show number of bits in a value
-    >>> print(count.n_bits)
-    6
-
-We can also cast the signal handle directly to an integer:
-
-.. code-block:: pycon
-
-    >>> print(int(dut.counter))
-    42
-
-
-Parallel and sequential execution
----------------------------------
-
-An :keyword:`await` will run an :keyword:`async` coroutine and wait for it to complete.
-The called coroutine "blocks" the execution of the current coroutine.
-Wrapping the call in :func:`~cocotb.fork` runs the coroutine concurrently, allowing the current coroutine to continue executing.
-At any time you can :keyword:`await` the result of the forked coroutine, which will block until the forked coroutine finishes.
-
-The following example shows these in action:
-
-.. code-block:: python3
-
-    # A coroutine
-    async def reset_dut(reset_n, duration_ns):
-        reset_n <= 0
-        await Timer(duration_ns, units='ns')
-        reset_n <= 1
-        reset_n._log.debug("Reset complete")
+        for cycle in range(10):
+            dut.clk <= 0
+            await Timer(1, units="ns")
+            dut.clk <= 1
+            await Timer(1, units="ns")
 
     @cocotb.test()
-    async def parallel_example(dut):
-        reset_n = dut.reset
+    async def my_second_test(dut):
+        """Try accessing the design."""
 
-        # Execution will block until reset_dut has completed
-        await reset_dut(reset_n, 500)
-        dut._log.debug("After reset")
+        dut._log.info("Running test...")
 
-        # Run reset_dut concurrently
-        reset_thread = cocotb.fork(reset_dut(reset_n, duration_ns=500))
+        cocotb.fork(generate_clock(dut))  # run the clock "in the background"
 
-        # This timer will complete before the timer in the concurrently executing "reset_thread"
-        await Timer(250, units='ns')
-        dut._log.debug("During reset (reset_n = %s)" % reset_n.value)
+        await Timer(5, units="ns")  # wait a bit
+        await FallingEdge(dut.clk)  # wait for falling edge/"negedge"
 
-        # Wait for the other thread to complete
-        await reset_thread
-        dut._log.debug("After reset")
+        dut._log.info("my_signal_1 is", dut.my_signal_1.value)
+        assert dut.my_signal_2.value[0] == 0, "my_signal_2[0] is not 0!"
 
-See :ref:`coroutines` for more examples of what can be done with coroutines.
+        dut._log.info("Running test...done")
+
+
+Note that the ``generate_clock()`` function is *not* marked with ``@cocotb.test()``
+since this is not a test on its own, just a helper function.
+
+See the sections :ref:`writing_tbs_concurrent_sequential` and :ref:`coroutines`
+for more information on such concurrent processes.
+
+.. note::
+   Since generating a clock is such a common task, cocotb provides a helper for it -
+   :class:`cocotb.clock.Clock`.
+   No need to write your own clock generator!
+
+   You would start :class:`~cocotb.clock.Clock` with
+   ``cocotb.fork(Clock(dut.clk, 1, units="ns").start())`` near the top of your test,
+   after importing it with ``from cocotb.clock import Clock``.
+
+
+.. _quickstart_creating_a_makefile:
+
+Creating a Makefile
+===================
+
+In order to run a test,
+you create a ``Makefile`` that contains information about your project
+(i.e. the specific DUT and test).
+
+In the ``Makefile`` shown below we specify:
+
+* the default simulator to use (:make:var:`SIM`),
+* the default language of the toplevel module or entity (:make:var:`TOPLEVEL_LANG`, ``verilog`` in our case),
+* the design source files (:make:var:`VERILOG_SOURCES` and :make:var:`VHDL_SOURCES`),
+* the toplevel module or entity to instantiate (:envvar:`TOPLEVEL`, ``my_design`` in our case),
+* and a Python module that contains our cocotb tests (:envvar:`MODULE`.
+  The file containing the test without the `.py` extension, ``test_my_design`` in our case).
+
+.. code-block:: makefile
+
+    # Makefile
+
+    # defaults
+    SIM ?= icarus
+    TOPLEVEL_LANG ?= verilog
+
+    VERILOG_SOURCES += $(PWD)/my_design.sv
+    # use VHDL_SOURCES for VHDL files
+
+    # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
+    TOPLEVEL = my_design
+
+    # MODULE is the basename of the Python test file
+    MODULE = test_my_design
+
+    # include cocotb's make rules to take care of the simulator setup
+    include $(shell cocotb-config --makefiles)/Makefile.sim
+
+
+.. _quickstart_running_a_test:
+
+Running a Test
+==============
+
+When you now type
+
+.. code-block:: bash
+
+   make
+
+Icarus Verilog will be used to simulate the Verilog implementation of the DUT because
+we defined these as the default values.
+
+If you want to simulate the DUT with Siemens Questa instead,
+all you would need to change is the command line:
+
+.. code-block:: bash
+
+    make SIM=questa
+
+
+This concludes our quick introduction to cocotb.
+You can now look through our :ref:`tutorials` or check out the
+:ref:`writing_tbs` chapter for more details on the above.

--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -1,19 +1,210 @@
+.. _writing_tbs:
+
 *******************
 Writing Testbenches
 *******************
 
-Handling Errors
-===============
 
-It may not be clear when to raise an exception and when to use ``log.error()``.
+.. _writing_tbs_accessing_design:
 
-* Use ``raise`` if the caller called your function in an invalid way, and it doesn't make sense to continue.
-* Use ``log.error()`` if the hardware itself is misbehaving, and throwing an error immediately would leave it an invalid state.
+Accessing the design
+====================
 
-Even if you do eventually throw an exception (if you weren't able to do it immediately), you should also ``log.error()`` so that the simulation time of when things went wrong is recorded.
+When cocotb initializes it finds the toplevel instantiation in the simulator
+and creates a handle called ``dut``. Toplevel signals can be accessed using the
+"dot" notation used for accessing object attributes in Python. The same mechanism
+can be used to access signals inside the design.
 
-TL;DR: ``log.error()`` is for humans only, ``raise`` is for both humans and code.
+.. code-block:: python3
 
+    # Get a reference to the "clk" signal on the toplevel
+    clk = dut.clk
+
+    # Get a reference to a register "count"
+    # in a sub-block "inst_sub_block"
+    count = dut.inst_sub_block.count
+
+
+.. _writing_tbs_assigning_values:
+
+Assigning values to signals
+===========================
+
+Values can be assigned to signals using either the
+:attr:`~cocotb.handle.NonHierarchyObject.value` property of a handle object
+or using direct assignment while traversing the hierarchy.
+
+.. code-block:: python3
+
+    # Get a reference to the "clk" signal and assign a value
+    clk = dut.clk
+    clk.value = 1
+
+    # Direct assignment through the hierarchy
+    dut.input_signal <= 12
+
+    # Assign a value to a memory deep in the hierarchy
+    dut.sub_block.memory.array[4] <= 2
+
+
+The syntax ``sig <= new_value`` is a short form of ``sig.value = new_value``.
+It not only resembles :term:`HDL` syntax, but also has the same semantics:
+writes are not applied immediately, but delayed until the next write cycle.
+Use ``sig.setimmediatevalue(new_val)`` to set a new value immediately
+(see :meth:`~cocotb.handle.NonHierarchyObject.setimmediatevalue`).
+
+.. _writing_tbs_assigning_values_signed_unsigned:
+
+Signed and unsigned values
+--------------------------
+
+Both signed and unsigned values can be assigned to signals using a Python int.
+Cocotb makes no assumptions regarding the signedness of the signal. It only
+considers the width of the signal, so it will allow values in the range from
+the minimum negative value for a signed number up to the maximum positive
+value for an unsigned number: ``-2**(Nbits - 1) <= value <= 2**Nbits - 1``
+Note: assigning out-of-range values will raise an :exc:`OverflowError`.
+
+A :class:`BinaryValue` object can be used instead of a Python int to assign a
+value to signals with more fine-grained control (e.g. signed values only).
+
+.. code-block:: verilog
+
+    module my_module (
+        input   logic       clk,
+        input   logic       rst,
+        input   logic [2:0] data_in,
+        output  logic [2:0] data_out
+        );
+
+.. code-block:: python3
+
+    # assignment of negative value
+    dut.data_in <= -4
+
+    # assignment of positive value
+    dut.data_in <= 7
+
+    # assignment of out-of-range values
+    dut.data_in <= 8   # raises OverflowError
+    dut.data_in <= -5  # raises OverflowError
+
+
+.. _writing_tbs_reading_values:
+
+Reading values from signals
+===========================
+
+Values in the DUT can be accessed with the :attr:`~cocotb.handle.NonHierarchyObject.value`
+property of a handle object.
+A common mistake is forgetting the ``.value`` which just gives you a reference to a handle
+(useful for defining an alias name), not the value.
+
+The Python type of a value depends on the handle's HDL type:
+
+* Arrays of ``logic`` and subtypes of that (``sfixed``, ``unsigned``, etc.)
+  are of type :class:`~cocotb.binary.BinaryValue`.
+* Integer nets and constants (``integer``, ``natural``, etc.) return :class:`int`.
+* Floating point nets and constants (``real``) return :class:`float`.
+* Boolean nets and constants (``boolean``) return :class:`bool`.
+* String nets and constants (``string``) return :class:`bytes`.
+
+For a :class:`~cocotb.binary.BinaryValue` object, any unresolved bits are preserved and
+can be accessed using the :attr:`~cocotb.binary.BinaryValue.binstr` attribute,
+or a resolved integer value can be accessed using the :attr:`~cocotb.binary.BinaryValue.integer` attribute.
+
+.. code-block:: pycon
+
+    >>> # Read a value back from the DUT
+    >>> count = dut.counter.value
+    >>> print(count.binstr)
+    1X1010
+    >>> # Resolve the value to an integer (X or Z treated as 0)
+    >>> print(count.integer)
+    42
+    >>> # Show number of bits in a value
+    >>> print(count.n_bits)
+    6
+
+We can also cast the signal handle directly to an integer:
+
+.. code-block:: pycon
+
+    >>> print(int(dut.counter))
+    42
+
+
+.. _writing_tbs_concurrent_sequential:
+
+Concurrent and sequential execution
+===================================
+
+An :keyword:`await` will run an :keyword:`async` coroutine and wait for it to complete.
+The called coroutine "blocks" the execution of the current coroutine.
+Wrapping the call in :func:`~cocotb.fork` runs the coroutine concurrently,
+allowing the current coroutine to continue executing.
+At any time you can :keyword:`await` the result of the forked coroutine,
+which will block until the forked coroutine finishes.
+
+The following example shows these in action:
+
+.. code-block:: python3
+
+    # A coroutine
+    async def reset_dut(reset_n, duration_ns):
+        reset_n <= 0
+        await Timer(duration_ns, units="ns")
+        reset_n <= 1
+        reset_n._log.debug("Reset complete")
+
+    @cocotb.test()
+    async def parallel_example(dut):
+        reset_n = dut.reset
+
+        # Execution will block until reset_dut has completed
+        await reset_dut(reset_n, 500)
+        dut._log.debug("After reset")
+
+        # Run reset_dut concurrently
+        reset_thread = cocotb.fork(reset_dut(reset_n, duration_ns=500))
+
+        # This timer will complete before the timer in the concurrently executing "reset_thread"
+        await Timer(250, units="ns")
+        dut._log.debug("During reset (reset_n = %s)" % reset_n.value)
+
+        # Wait for the other thread to complete
+        await reset_thread
+        dut._log.debug("After reset")
+
+See :ref:`coroutines` for more examples of what can be done with coroutines.
+
+
+.. _writing_tbs_assigning_values_forcing_freezing:
+
+Forcing and freezing signals
+============================
+
+In addition to regular value assignments (deposits), signals can be forced
+to a predetermined value or frozen at their current value. To achieve this,
+the various actions described in :ref:`assignment-methods` can be used.
+
+.. code-block:: python3
+
+    # Deposit action
+    dut.my_signal <= 12
+    dut.my_signal <= Deposit(12)  # equivalent syntax
+
+    # Force action
+    dut.my_signal <= Force(12)    # my_signal stays 12 until released
+
+    # Release action
+    dut.my_signal <= Release()    # Reverts any force/freeze assignments
+
+    # Freeze action
+    dut.my_signal <= Freeze()     # my_signal stays at current value until released
+
+
+.. _writing_tbs_accessing_underscore_identifiers:
 
 Accessing Identifiers Starting with an Underscore
 =================================================


### PR DESCRIPTION
(Alternative to #2377 that removes the part where we run the existing `simple_dff` example.)

The Quickstart chapter had too many details.
Only the most important information is now there still.
Most of the original sections moved to the Writing Testbenches chapter,
almost unchanged.

Co-authored-by: Marlon James <marlon.james@gmail.com>
Co-authored-by: Kaleb Barrett <dev.ktbarrett@gmail.com>
Co-authored-by: Philipp Wagner <mail@philipp-wagner.com>

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
