### PR TITLE
Convert type annotations for variables to Py3.6 style

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -37,7 +37,7 @@ import threading
 import random
 import time
 import warnings
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 from collections.abc import Coroutine
 
 import cocotb.handle
@@ -96,40 +96,66 @@ def _setup_logging():
 # so that cocotb.scheduler gives you the singleton instance and not the
 # scheduler package
 
-scheduler = None  # type: cocotb.scheduler.Scheduler
-"""The global scheduler instance."""
+scheduler: Optional[Scheduler] = None
+"""The global scheduler instance.
 
-regression_manager = None  # type: cocotb.regression.RegressionManager
-"""The global regression manager instance."""
+This is guaranteed to hold a value at test time.
+"""
 
-argv = None  # type: List[str]
-"""The argument list as seen by the simulator"""
+regression_manager: Optional[RegressionManager] = None
+"""The global regression manager instance.
 
-argc = None  # type: int
-"""The length of :data:`cocotb.argv`"""
+This is guaranteed to hold a value at test time.
+"""
 
-plusargs = None  # type: Dict[str, Union[bool, str]]
-"""A dictionary of "plusargs" handed to the simulation. See :make:var:`PLUSARGS` for details."""
+argv: Optional[List[str]] = None
+"""The argument list as seen by the simulator.
 
-LANGUAGE = os.getenv("TOPLEVEL_LANG")  # type: str
-"""The value of :make:var:`TOPLEVEL_LANG`"""
+This is guaranteed to hold a value at test time.
+"""
 
-SIM_NAME = None  # type: str
-"""The running simulator product information. ``None`` if :mod:`cocotb` was not loaded from a simulator"""
+argc: Optional[int] = None
+"""The length of :data:`cocotb.argv`.
 
-SIM_VERSION = None  # type: str
-"""The version of the running simulator. ``None`` if :mod:`cocotb` was not loaded from a simulator"""
+This is guaranteed to hold a value at test time.
+"""
 
-RANDOM_SEED = None  # type: int
+plusargs: Optional[Dict[str, Union[bool, str]]] = None
+"""A dictionary of "plusargs" handed to the simulation.
+
+See :make:var:`PLUSARGS` for details.
+This is guaranteed to hold a value at test time.
+"""
+
+LANGUAGE: Optional[str] = os.getenv("TOPLEVEL_LANG")
+"""The value of :make:var:`TOPLEVEL_LANG`.
+
+This is guaranteed to hold a value at test time.
+"""
+
+SIM_NAME: Optional[str] = None
+"""The running simulator product information.
+
+``None`` if :mod:`cocotb` was not loaded from a simulator.
+"""
+
+SIM_VERSION: Optional[str] = None
+"""The version of the running simulator.
+
+``None`` if :mod:`cocotb` was not loaded from a simulator."""
+
+RANDOM_SEED: Optional[int] = None
 """
 The value passed to the Python default random number generator.
+
 See :envvar:`RANDOM_SEED` for details on how the value is computed.
+This is guaranteed to hold a value at test time.
 """
 
 _library_coverage = None
 """ used for cocotb library coverage """
 
-top = None  # type: cocotb.handle.SimHandleBase
+top: Optional[cocotb.handle.SimHandleBase] = None
 r"""
 A handle to the :envvar:`TOPLEVEL` entity/module.
 

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -33,6 +33,7 @@ import ctypes
 import warnings
 import enum
 from functools import lru_cache
+from typing import Optional
 
 import cocotb
 from cocotb import simulator
@@ -90,25 +91,25 @@ class SimHandleBase:
             path (str): Path to this handle, ``None`` if root.
         """
         self._handle = handle
-        self._len = None  # type: int
+        self._len: Optional[int] = None
         """The "length" (the number of elements) of the underlying object. For vectors this is the number of bits."""
-        self._sub_handles = {}  # type: dict
+        self._sub_handles: dict = {}
         """Dictionary of this handle's children."""
-        self._invalid_sub_handles = set()  # type: set
+        self._invalid_sub_handles: set = set()
         """Python :class:`set` of invalid queries, for caching purposes."""
-        self._name = self._handle.get_name_string()  # type: str
+        self._name: str = self._handle.get_name_string()
         """The name of an object.
 
         :meta public:
         """
-        self._type = self._handle.get_type_string()  # type: str
+        self._type: str = self._handle.get_type_string()
         """The type of an object as a string.
 
         :meta public:
         """
-        self._fullname = self._name + "(%s)" % self._type  # type: str
+        self._fullname: str = self._name + "(%s)" % self._type
         """The name of an object with its type appended in parentheses."""
-        self._path = self._name if path is None else path  # type: str
+        self._path: str = self._name if path is None else path
         """The path to this handle, or its name if this is the root handle.
 
         :meta public:
@@ -116,7 +117,7 @@ class SimHandleBase:
         self._log = SimLog("cocotb.%s" % self._name)
         """The logging object."""
         self._log.debug("Created")
-        self._def_name = self._handle.get_definition_name()  # type: str
+        self._def_name: str = self._handle.get_definition_name()
         """The name of a GPI object's definition.
 
         This is the value of ``vpiDefName`` for VPI, ``vhpiNameP`` for VHPI,
@@ -125,7 +126,7 @@ class SimHandleBase:
 
         :meta public:
         """
-        self._def_file = self._handle.get_definition_file()  # type: str
+        self._def_file: str = self._handle.get_definition_file()
         """The name of the file that sources the object's definition.
 
         This is the value of ``vpiDefFile`` for VPI, ``vhpiFileNameP`` for VHPI,
@@ -480,7 +481,7 @@ class NonHierarchyObject(SimHandleBase):
     def __eq__(self, other):
         """Equality comparator for non-hierarchy objects
 
-        If ``other`` is not a :class:`SimHandleBase` instance the comparision
+        If ``other`` is not a :class:`SimHandleBase` instance the comparison
         uses the comparison method of the ``other`` object against our
         ``.value``.
         """


### PR DESCRIPTION
See also #2069.
Depends on #2422.

Doc rendering: https://cocotb--2424.org.readthedocs.build/en/2424/library_reference.html#other-runtime-information

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
