### PR TITLE
Revert behavioral change for 1.5

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -723,7 +723,7 @@ class ModifiableObject(NonConstantObject):
             TypeError: If target has an unsupported type for value assignment.
 
         .. deprecated:: 1.5
-            Automatic truncation of values that exceed the size of the signal will result in a
+            Truncation of values that exceed the size of the signal will result in a
             :exc:`OverflowError` starting in 2.0.
 
         .. deprecated:: 1.5
@@ -735,9 +735,9 @@ class ModifiableObject(NonConstantObject):
 
         if isinstance(value, int):
             min_val, max_val = _value_limits(len(self), _Limits.VECTOR_NBIT)
-            if value < min_val or max_val < value:
+            if value < min_val or value > max_val:
                 warnings.warn(
-                    "Automatic truncation of values that exceed the size of the signal will raise an `OverflowError` starting in 2.0.",
+                    "Truncation of values that exceed the size of the signal will raise an `OverflowError` starting in 2.0.",
                     FutureWarning, stacklevel=3)
             if len(self) <= 32:
                 call_sim(self, self._handle.set_signal_val_int, set_action, value)

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -722,8 +722,9 @@ class ModifiableObject(NonConstantObject):
         Raises:
             TypeError: If target has an unsupported type for value assignment.
 
-            OverflowError: If int value is out of the range that can be represented
-                by the target. -2**(Nbits - 1) <= value <= 2**Nbits - 1
+        .. deprecated:: 1.5
+            Automatic truncation of values that exceed the size of the signal will result in a
+            :exc:`OverflowError` starting in 2.0.
 
         .. deprecated:: 1.5
             :class:`ctypes.Structure` objects are no longer accepted as values for assignment.
@@ -734,19 +735,17 @@ class ModifiableObject(NonConstantObject):
 
         if isinstance(value, int):
             min_val, max_val = _value_limits(len(self), _Limits.VECTOR_NBIT)
-            if min_val <= value <= max_val:
-                if len(self) <= 32:
-                    call_sim(self, self._handle.set_signal_val_int, set_action, value)
-                    return
-
-                if value < 0:
-                    value = BinaryValue(value=value, n_bits=len(self), bigEndian=False, binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
-                else:
-                    value = BinaryValue(value=value, n_bits=len(self), bigEndian=False, binaryRepresentation=BinaryRepresentation.UNSIGNED)
+            if value < min_val or max_val < value:
+                warnings.warn(
+                    "Automatic truncation of values that exceed the size of the signal will raise an `OverflowError` starting in 2.0.",
+                    FutureWarning, stacklevel=3)
+            if len(self) <= 32:
+                call_sim(self, self._handle.set_signal_val_int, set_action, value)
+                return
+            if value < 0:
+                value = BinaryValue(value=value, n_bits=len(self), bigEndian=False, binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT)
             else:
-                raise OverflowError(
-                    "Int value ({!r}) out of range for assignment of {!r}-bit signal ({!r})"
-                    .format(value, len(self), self._name))
+                value = BinaryValue(value=value, n_bits=len(self), bigEndian=False, binaryRepresentation=BinaryRepresentation.UNSIGNED)
 
         if isinstance(value, ctypes.Structure):
             warnings.warn(

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -102,8 +102,7 @@ Deprecations and Removals
 Changes
 -------
 
-- Assigning out-of-range Python integers to signals would previously truncate the value silently for signal widths <= 32 bits and truncate the value with a warning for signal widths > 32 bits.
-  Assigning out-of-range Python integers to signals will now raise an :exc:`OverflowError`. (:pr:`913`)
+- Assigning negative Python integers to handles does an implicit two's compliment conversion. (:pr:`913`)
 - Updated :class:`~cocotb_bus.drivers.Driver`, :class:`~cocotb_bus.monitors.Monitor`, and all their subclasses to use the :keyword:`async`/:keyword:`await` syntax instead of the :keyword:`yield` syntax. (:pr:`2022`)
 - The package build process is now fully :pep:`517` compliant. (:pr:`2091`)
 - Improved support and performance for :ref:`sim-verilator` (version 4.106 or later now required). (:pr:`2105`)

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -55,10 +55,7 @@ module sample_module #(
     input  string                               stream_in_string,
 `endif
     input  [7:0]                                stream_in_data,
-    input  [31:0]                               stream_in_data_dword,
-    input  [38:0]                               stream_in_data_39bit,
     input  [63:0]                               stream_in_data_wide,
-    input  [127:0]                              stream_in_data_dqword,
 
     input                                       stream_out_ready,
     output reg [7:0]                            stream_out_data_comb,

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -42,10 +42,7 @@ entity sample_module is
         clk                             : in    std_ulogic;
 
         stream_in_data                  : in    std_ulogic_vector(7 downto 0);
-        stream_in_data_dword            : in    std_ulogic_vector(31 downto 0);
-        stream_in_data_39bit            : in    std_ulogic_vector(38 downto 0);
         stream_in_data_wide             : in    std_ulogic_vector(63 downto 0);
-        stream_in_data_dqword           : in    std_ulogic_vector(127 downto 0);
         stream_in_valid                 : in    std_ulogic;
         stream_in_func_en               : in    std_ulogic;
         stream_in_ready                 : out   std_ulogic;

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -148,3 +148,10 @@ async def test_time_ps_deprecated(_):
         Timer(time=0, time_ps=7, units='ns')
     with assert_raises(TypeError):
         Timer(units='ps')
+
+
+@cocotb.test()
+async def test_value_assignment_truncation_deprecated(dut):
+    with assert_deprecated(FutureWarning):
+        # value too large to fit, will cause truncation
+        dut.stream_in_data <= 0x12345678

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -10,7 +10,6 @@ import cocotb
 from cocotb.triggers import Timer
 
 from common import assert_raises
-from cocotb.handle import _Limits
 
 
 @cocotb.test()
@@ -93,198 +92,21 @@ async def test_delayed_assignment_still_errors(dut):
         dut.stream_in_int <= []
 
 
-async def int_values_test(signal, n_bits, limits=_Limits.VECTOR_NBIT):
-    """Test integer access to a signal."""
-    log = logging.getLogger("cocotb.test")
-    values = gen_int_test_values(n_bits, limits)
-    for val in values:
-        signal <= val
-        await Timer(1, 'ns')
-
-        if limits == _Limits.VECTOR_NBIT:
-            if val < 0:
-                got = signal.value.signed_integer
-            else:
-                got = signal.value.integer
-        else:
-            got = signal.value
-
-        assert got == val, "Expected value {}, got value {}!".format(val, got)
-
-
-def gen_int_test_values(n_bits, limits=_Limits.VECTOR_NBIT):
-    """Generates a list of int test values for a given number of bits."""
-    unsigned_min = 0
-    unsigned_max = 2**n_bits-1
-    signed_min = -2**(n_bits-1)
-    signed_max = 2**(n_bits-1)-1
-
-    if limits == _Limits.VECTOR_NBIT:
-        return [1, -1, 4, -4, unsigned_min, unsigned_max, signed_min, signed_max]
-    elif limits == _Limits.SIGNED_NBIT:
-        return [1, -1, 4, -4, signed_min, signed_max]
-    else:
-        return [1, -1, 4, -4, unsigned_min, unsigned_max]
-
-
-async def int_overflow_test(signal, n_bits, test_mode, limits=_Limits.VECTOR_NBIT):
-    """Test integer overflow."""
-    if test_mode == "ovfl":
-        value = gen_int_ovfl_value(n_bits, limits)
-    elif test_mode == "unfl":
-        value = gen_int_unfl_value(n_bits, limits)
-    else:
-        value = None
-
-    with assert_raises(OverflowError):
-        signal <= value
-
-
-def gen_int_ovfl_value(n_bits, limits=_Limits.VECTOR_NBIT):
-    unsigned_max = 2**n_bits-1
-    signed_max = 2**(n_bits-1)-1
-
-    if limits == _Limits.SIGNED_NBIT:
-        return signed_max + 1
-    elif limits == _Limits.UNSIGNED_NBIT:
-        return unsigned_max + 1
-    else:
-        return unsigned_max + 1
-
-
-def gen_int_unfl_value(n_bits, limits=_Limits.VECTOR_NBIT):
-    unsigned_min = 0
-    signed_min = -2**(n_bits-1)
-
-    if limits == _Limits.SIGNED_NBIT:
-        return signed_min - 1
-    elif limits == _Limits.UNSIGNED_NBIT:
-        return unsigned_min - 1
-    else:
-        return signed_min - 1
-
-
-@cocotb.test()
-async def test_int_8bit(dut):
-    """Test int access to 8-bit vector."""
-    await int_values_test(dut.stream_in_data, len(dut.stream_in_data))
-
-
-@cocotb.test()
-async def test_int_8bit_overflow(dut):
-    """Test 8-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data, len(dut.stream_in_data), "ovfl")
-
-
-@cocotb.test()
-async def test_int_8bit_underflow(dut):
-    """Test 8-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data, len(dut.stream_in_data), "unfl")
-
-
-@cocotb.test()
-async def test_int_32bit(dut):
-    """Test int access to 32-bit vector."""
-    await int_values_test(dut.stream_in_data_dword, len(dut.stream_in_data_dword))
-
-
-@cocotb.test()
-async def test_int_32bit_overflow(dut):
-    """Test 32-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data_dword, len(dut.stream_in_data_dword), "ovfl")
-
-
-@cocotb.test()
-async def test_int_32bit_underflow(dut):
-    """Test 32-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data_dword, len(dut.stream_in_data_dword), "unfl")
-
-
-@cocotb.test()
-async def test_int_39bit(dut):
-    """Test int access to 39-bit vector."""
-    await int_values_test(dut.stream_in_data_39bit, len(dut.stream_in_data_39bit))
-
-
-@cocotb.test()
-async def test_int_39bit_overflow(dut):
-    """Test 39-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data_39bit, len(dut.stream_in_data_39bit), "ovfl")
-
-
-@cocotb.test()
-async def test_int_39bit_underflow(dut):
-    """Test 39-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data_39bit, len(dut.stream_in_data_39bit), "unfl")
-
-
-@cocotb.test()
-async def test_int_64bit(dut):
-    """Test int access to 64-bit vector."""
-    await int_values_test(dut.stream_in_data_wide, len(dut.stream_in_data_wide))
-
-
-@cocotb.test()
-async def test_int_64bit_overflow(dut):
-    """Test 64-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data_wide, len(dut.stream_in_data_wide), "ovfl")
-
-
-@cocotb.test()
-async def test_int_64bit_underflow(dut):
-    """Test 64-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data_wide, len(dut.stream_in_data_wide), "unfl")
-
-
-@cocotb.test()
-async def test_int_128bit(dut):
-    """Test int access to 128-bit vector."""
-    await int_values_test(dut.stream_in_data_dqword, len(dut.stream_in_data_dqword))
-
-
-@cocotb.test()
-async def test_int_128bit_overflow(dut):
-    """Test 128-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data_dqword, len(dut.stream_in_data_dqword), "ovfl")
-
-
-@cocotb.test()
-async def test_int_128bit_underflow(dut):
-    """Test 128-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data_dqword, len(dut.stream_in_data_dqword), "unfl")
-
-
 @cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
 async def test_integer(dut):
-    """Test access to integers."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
-    else:
-        limits = _Limits.SIGNED_NBIT
-
-    await int_values_test(dut.stream_in_int, 32, limits)
-
-
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
-async def test_integer_overflow(dut):
-    """Test integer overflow."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
-    else:
-        limits = _Limits.SIGNED_NBIT
-
-    await int_overflow_test(dut.stream_in_int, 32, "ovfl", limits)
-
-
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
-async def test_integer_underflow(dut):
-    """Test integer underflow."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
-    else:
-        limits = _Limits.SIGNED_NBIT
-
-    await int_overflow_test(dut.stream_in_int, 32, "unfl", limits)
+    """
+    Test access to integers
+    """
+    log = logging.getLogger("cocotb.test")
+    await Timer(10, "ns")
+    dut.stream_in_int <= 4
+    await Timer(10, "ns")
+    await Timer(10, "ns")
+    got_in = int(dut.stream_out_int)
+    got_out = int(dut.stream_in_int)
+    log.info("dut.stream_out_int = %d" % got_out)
+    log.info("dut.stream_in_int = %d" % got_in)
+    assert got_in == got_out, "stream_in_int and stream_out_int should not match"
 
 
 @cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
@@ -342,3 +164,23 @@ async def test_access_underscore_name(dut):
     dut._id("_underscore_name", extended=False) <= 0
     await Timer(1, 'ns')
     assert dut._id("_underscore_name", extended=False).value == 0
+
+
+@cocotb.test()
+async def test_reading_writing_logic_array_using_int(dut):
+    # in range, < 32 bits, positive
+    dut.stream_in_data.value = 1
+    await Timer(1, 'ns')
+    assert dut.stream_in_data.value.integer == 1
+    # in range, < 32 bit, negative
+    dut.stream_in_data.value = -1
+    await Timer(1, 'ns')
+    assert dut.stream_in_data.value.signed_integer == -1
+    # in range, >= 32 bit, positive
+    dut.stream_in_data_wide.value = 0x1234567890
+    await Timer(1, 'ns')
+    assert dut.stream_in_data_wide.value.integer == 0x1234567890
+    # in range, >= 32 bit, negative
+    dut.stream_in_data_wide.value = -0x1234567890
+    await Timer(1, 'ns')
+    assert dut.stream_in_data_wide.value.signed_integer == -0x1234567890

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -117,7 +117,7 @@ async def test_in_vect_packed_packed_packed(dut):
 async def test_in_vect_packed_packed_unpacked(dut):
     await Timer(1, "ns")
     print("Setting: dut.in_vect_packed_packed_unpacked type %s" % type(dut.in_vect_packed_packed_unpacked))
-    dut.in_vect_packed_packed_unpacked = [365, 365, 365]
+    dut.in_vect_packed_packed_unpacked = [95869805, 95869805, 95869805]
     await Timer(1, "ns")
     print("Getting: dut.out_vect_packed_packed_unpacked type %s" % type(dut.out_vect_packed_packed_unpacked))
     if dut.out_vect_packed_packed_unpacked != [365, 365, 365]:


### PR DESCRIPTION
Partial revert of #2316, keeps C++ level changes. Still solves #913 by doing the right thing when negative values are assigned to handles. No longer throws an `OverflowError` when a value larger than the signal is assigned to handle. Continues the tried and true silent truncation of values, but throws a `FutureWarning` stating that it won't be allowed in 2.0.