### PR TITLE
Revert "Use setuptools_scm to automatically generate version number"

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -158,8 +158,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0  # ensure we clone all the tags so we can see setuptools_scm working
 
       # Install Python
     - name: Set up Python ${{matrix.python-version}}

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,3 @@ examples/*/tests/compile
 # Tachyon DA CVC
 tests/test_cases/*/verilog.log
 examples/*/tests/verilog.log
-
-# setuptools_scm artifact
-/cocotb/_version.py

--- a/cocotb/_version.py
+++ b/cocotb/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '1.5.0.dev0'
+__version__ = '1.6.0.dev0'

--- a/cocotb/_version.py
+++ b/cocotb/_version.py
@@ -1,0 +1,8 @@
+# Package versioning solution originally found here:
+# http://stackoverflow.com/q/458550
+
+# Store the version here so:
+# 1) we don't load dependencies by storing it in __init__.py
+# 2) we can import it in setup.py for the same reason
+# 3) we can import it into your module
+__version__ = '1.5.0.dev0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
@@ -36,4 +36,3 @@ build-backend = "setuptools.build_meta"
         directory = "change"
         name = "Changes"
         showcontent = true
-

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,9 @@ def package_files(directory):
     return paths
 
 
+# this sets the __version__ variable
+exec(read_file(path.join('cocotb', '_version.py')))
+
 # store log from build_libs and display at the end in verbose mode
 # see https://github.com/pypa/pip/issues/6634
 log_stream = StringIO()
@@ -84,11 +87,7 @@ log.addHandler(handler)
 setup(
     name='cocotb',
     cmdclass={'build_ext': build_ext},
-    use_scm_version=dict(
-        write_to='cocotb/_version.py',
-        write_to_template='__version__ = {version!r}',
-        version_scheme='release-branch-semver'
-    ),
+    version=__version__,  # noqa: F821
     description='cocotb is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.',
     url='https://docs.cocotb.org',
     license='BSD',
@@ -97,7 +96,6 @@ setup(
     author='Chris Higgs, Stuart Hodgson',
     maintainer='cocotb contributors',
     maintainer_email='cocotb@lists.librecores.org',
-    setup_requires=['setuptools_scm'],
     install_requires=[],
     python_requires='>=3.5',
     packages=find_packages(),


### PR DESCRIPTION
This reverts commit b7a756e76c95d36525759beee6e3022f4f6e6b43.

setuptools_scm doesn't work with releases done off a branch, see 
https://github.com/pypa/setuptools_scm/issues/523 for details.

Beyond that, setuptools_scm and the generation of release notes with
towncrier also poses interesting ordering challenge, which are solvable if
one takes care, however.

Not using setuptools_scm removes the exact git hash from installed 
development versions, which makes it harder for us and users of our 
development releases to figure out the version they're running. We have 
been OK with that for a fair while until we started using setuptools_scm,
so it's not the end of the world. (We can always look into including this
information back into the version without setuptools_scm.)


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->