### PR TITLE
Deprecate assigning dict object to signals

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -729,6 +729,11 @@ class ModifiableObject(NonConstantObject):
             :class:`ctypes.Structure` objects are no longer accepted as values for assignment.
             Convert the struct object to a :class:`~cocotb.binary.BinaryValue` before assignment using
             ``BinaryValue(value=bytes(struct_obj), n_bits=len(signal))`` instead.
+
+        .. deprecated:: 1.5
+            :class:`dict` objects are no longer accepted as values for assignment.
+            Convert the dictionary to an integer before assignment using
+            ``sum(v << (d['bits'] * i) for i, v in enumerate(d['values']))``.
         """
         value, set_action = self._check_for_set_action(value)
 
@@ -755,6 +760,11 @@ class ModifiableObject(NonConstantObject):
                 DeprecationWarning, stacklevel=3)
             value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
         elif isinstance(value, dict):
+            warnings.warn(
+                "dict values are no longer accepted for value assignment. "
+                "Use `sum(v << (d['bits'] * i) for i, v in enumerate(d['values']))` "
+                "to convert the dict to an int before assignment.",
+                DeprecationWarning, stacklevel=3)
             # We're given a dictionary with a list of values and a bit size...
             num = 0
             vallist = list(value["values"])

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -84,6 +84,7 @@ Deprecations and Removals
   See the documentation for :class:`cocotb.hook` for suggestions on alternatives. (:pr:`2201`)
 - Deprecate :func:`~cocotb.utils.pack` and :func:`~cocotb.utils.unpack` and the use of :class:`python:ctypes.Structure` in signal assignments. (:pr:`2203`)
 - The outdated "ping" example has been removed from the documentation and repository. (:pr:`2232`)
+- Using the undocumented custom format :class:`dict` object in signal assignments has been deprecated. (:pr:`2240`)
 - The access modes of many interfaces in the cocotb core libraries were re-evaluated.
   Some interfaces that were previously public are now private and vice versa.
   Accessing the methods through their old name will create a :class:`DeprecationWarning`.

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -8,6 +8,7 @@ import warnings
 import ctypes
 from contextlib import contextmanager
 from common import assert_raises
+from typing import List
 
 
 @contextmanager
@@ -148,3 +149,26 @@ async def test_time_ps_deprecated(_):
         Timer(time=0, time_ps=7, units='ns')
     with assert_raises(TypeError):
         Timer(units='ps')
+
+
+def pack_bit_vector(values: List[int], bits: int):
+    """Pack the integers in `values` into a single integer, with each entry occupying `bits` bits.
+
+    >>> pack_bit_vector([0x012, 0x234, 0x456], bits=12) == 0x456234012
+    True
+    """
+    return sum(v << (bits * i) for i, v in enumerate(values))
+
+
+@cocotb.test()
+async def test_dict_signal_assignment_deprecated(dut):
+    """Assigning a dict to a ModifiableObject signal is deprecated"""
+
+    d = dict(values=[0xC, 0x5], bits=4)
+
+    with assert_deprecated():
+        dut.stream_in_data <= d
+
+    await Timer(1, 'step')
+
+    assert dut.stream_in_data.value == pack_bit_vector(**d)


### PR DESCRIPTION
Companion to #2426. Applies change to master.