### PR TITLE
Fix stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,6 +21,6 @@ jobs:
           If it has not been resolved, you may need to provide more information.
           If no more activity on this issue occurs in 7 days, it will be closed.
         stale-issue-label: "status:stale"
-        only-labels: "type:question,status:close?"
+        any-of-labels: "type:question,status:close?"
         exempt-issue-labels: "type:bug,type:feature"
-        operations-per-run: 5
+        operations-per-run: 30


### PR DESCRIPTION
Closes #2353. The tag `only-labels` implies only an intersection of the listed labels counts for marking as stale, so we switch to `any-of-labels`. Also bumped `operations-per-run` up to 30 to help mark more each day.