### PR TITLE
Update 1.5.0 release notes on master

### DIFF
--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -11,8 +11,9 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 
 .. towncrier release notes start
 
-Cocotb 1.5.0rc1 (2021-02-23)
-============================
+
+cocotb 1.5.0 (2021-03-11)
+=========================
 
 Features
 --------
@@ -84,6 +85,7 @@ Deprecations and Removals
   See the documentation for :class:`cocotb.hook` for suggestions on alternatives. (:pr:`2201`)
 - Deprecate :func:`~cocotb.utils.pack` and :func:`~cocotb.utils.unpack` and the use of :class:`python:ctypes.Structure` in signal assignments. (:pr:`2203`)
 - The outdated "ping" example has been removed from the documentation and repository. (:pr:`2232`)
+- Using the undocumented custom format :class:`dict` object in signal assignments has been deprecated. (:pr:`2240`)
 - The access modes of many interfaces in the cocotb core libraries were re-evaluated.
   Some interfaces that were previously public are now private and vice versa.
   Accessing the methods through their old name will create a :class:`DeprecationWarning`.
@@ -102,8 +104,7 @@ Deprecations and Removals
 Changes
 -------
 
-- Assigning out-of-range Python integers to signals would previously truncate the value silently for signal widths <= 32 bits and truncate the value with a warning for signal widths > 32 bits.
-  Assigning out-of-range Python integers to signals will now raise an :exc:`OverflowError`. (:pr:`913`)
+- Assigning negative Python integers to handles does an implicit two's compliment conversion. (:pr:`913`)
 - Updated :class:`~cocotb_bus.drivers.Driver`, :class:`~cocotb_bus.monitors.Monitor`, and all their subclasses to use the :keyword:`async`/:keyword:`await` syntax instead of the :keyword:`yield` syntax. (:pr:`2022`)
 - The package build process is now fully :pep:`517` compliant. (:pr:`2091`)
 - Improved support and performance for :ref:`sim-verilator` (version 4.106 or later now required). (:pr:`2105`)


### PR DESCRIPTION
Align the two branches to have the same release notes.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->