### PR TITLE
Add release note for handle behavior change

### DIFF
--- a/documentation/source/newsfragments/2316.change.rst
+++ b/documentation/source/newsfragments/2316.change.rst
@@ -1,0 +1,2 @@
+Assigning out-of-range Python integers to signals would previously truncate the value silently for signal widths <= 32 bits and truncate the value with a warning for signal widths > 32 bits.
+Assigning out-of-range Python integers to signals will now raise an :exc:`OverflowError`.

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -11,8 +11,9 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 
 .. towncrier release notes start
 
-Cocotb 1.5.0rc1 (2021-02-23)
-============================
+
+cocotb 1.5.0 (2021-03-11)
+=========================
 
 Features
 --------
@@ -84,6 +85,7 @@ Deprecations and Removals
   See the documentation for :class:`cocotb.hook` for suggestions on alternatives. (:pr:`2201`)
 - Deprecate :func:`~cocotb.utils.pack` and :func:`~cocotb.utils.unpack` and the use of :class:`python:ctypes.Structure` in signal assignments. (:pr:`2203`)
 - The outdated "ping" example has been removed from the documentation and repository. (:pr:`2232`)
+- Using the undocumented custom format :class:`dict` object in signal assignments has been deprecated. (:pr:`2240`)
 - The access modes of many interfaces in the cocotb core libraries were re-evaluated.
   Some interfaces that were previously public are now private and vice versa.
   Accessing the methods through their old name will create a :class:`DeprecationWarning`.
@@ -102,8 +104,7 @@ Deprecations and Removals
 Changes
 -------
 
-- Assigning out-of-range Python integers to signals would previously truncate the value silently for signal widths <= 32 bits and truncate the value with a warning for signal widths > 32 bits.
-  Assigning out-of-range Python integers to signals will now raise an :exc:`OverflowError`. (:pr:`913`)
+- Assigning negative Python integers to handles does an implicit two's compliment conversion. (:pr:`913`)
 - Updated :class:`~cocotb_bus.drivers.Driver`, :class:`~cocotb_bus.monitors.Monitor`, and all their subclasses to use the :keyword:`async`/:keyword:`await` syntax instead of the :keyword:`yield` syntax. (:pr:`2022`)
 - The package build process is now fully :pep:`517` compliant. (:pr:`2091`)
 - Improved support and performance for :ref:`sim-verilator` (version 4.106 or later now required). (:pr:`2105`)


### PR DESCRIPTION
From https://github.com/cocotb/cocotb/pull/2463#discussion_r592869670. Depends on #2463.

The behavior change was added in 1.5.0.dev, but reverted for the release of 1.5.0. The behavior still exists on master, so we will add it to the next release changelog.