### PR TITLE
Configure pytest to not capture output

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -297,7 +297,7 @@ def _initialise_testbench_(argv_):
             # import the test modules.
             from _pytest.config import Config
             from _pytest.assertion import install_importhook
-            pytest_conf = Config.fromdictargs([], {})
+            pytest_conf = Config.fromdictargs({}, ['--capture=no'])
             install_importhook(pytest_conf)
         except Exception:
             log.exception(

--- a/tests/test_cases/test_cocotb/test_pytest.py
+++ b/tests/test_cases/test_cocotb/test_pytest.py
@@ -4,6 +4,7 @@
 """ Tests relating to pytest integration """
 
 import cocotb
+from cocotb.result import TestFailure
 
 # pytest is an optional dependency
 try:
@@ -16,7 +17,9 @@ except ImportError:
 async def test_assertion_rewriting(dut):
     """ Test that assertion rewriting hooks take effect in cocotb tests """
     try:
-        assert 1 != 42
+        assert 1 == 42
     except AssertionError as e:
         assert "42" in str(e), (
             f"Assertion rewriting seems not to work, message was {e}")
+    else:
+        raise TestFailure('AssertionError was not thrown')


### PR DESCRIPTION
Closes #2462.

When using pytest for assertion rewriting, configure to not capture output and consequently not affect `stdin`.

By default, pytest captures `stdin` and `stdout`, and changes `stdin`: https://docs.pytest.org/en/stable/capture.html#default-stdout-stderr-stdin-capturing-behaviour

Also fix the test.