### PR TITLE
Add dependency on cocotb-bus to 1.5

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -730,6 +730,11 @@ class ModifiableObject(NonConstantObject):
             :class:`ctypes.Structure` objects are no longer accepted as values for assignment.
             Convert the struct object to a :class:`~cocotb.binary.BinaryValue` before assignment using
             ``BinaryValue(value=bytes(struct_obj), n_bits=len(signal))`` instead.
+
+        .. deprecated:: 1.5
+            :class:`dict` objects are no longer accepted as values for assignment.
+            Convert the dictionary to an integer before assignment using
+            ``sum(v << (d['bits'] * i) for i, v in enumerate(d['values']))``.
         """
         value, set_action = self._check_for_set_action(value)
 
@@ -754,6 +759,11 @@ class ModifiableObject(NonConstantObject):
                 DeprecationWarning, stacklevel=3)
             value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
         elif isinstance(value, dict):
+            warnings.warn(
+                "dict values are no longer accepted for value assignment. "
+                "Use `sum(v << (d['bits'] * i) for i, v in enumerate(d['values']))` "
+                "to convert the dict to an int before assignment.",
+                DeprecationWarning, stacklevel=3)
             # We're given a dictionary with a list of values and a bit size...
             num = 0
             vallist = list(value["values"])

--- a/documentation/source/newsfragments/1051.doc.rst
+++ b/documentation/source/newsfragments/1051.doc.rst
@@ -1,3 +1,0 @@
-The  :ref:`mixed_signal` example has been added,
-showing how to use HDL helper modules in cocotb testbenches that exercise
-two mixed-signal (i.e. analog and digital) designs.

--- a/documentation/source/newsfragments/1502.doc.rst
+++ b/documentation/source/newsfragments/1502.doc.rst
@@ -1,1 +1,0 @@
-New example :ref:`matrix_multiplier`.

--- a/documentation/source/newsfragments/1798.feature.rst
+++ b/documentation/source/newsfragments/1798.feature.rst
@@ -1,2 +1,0 @@
-Support for building with Microsoft Visual C++ has been added.
-See :ref:`install` for more details.

--- a/documentation/source/newsfragments/1982.feature.rst
+++ b/documentation/source/newsfragments/1982.feature.rst
@@ -1,2 +1,0 @@
-Makefiles now automatically deduce :make:var:`TOPLEVEL_LANG` based on the value of :make:var:`VERILOG_SOURCES` and :make:var:`VHDL_SOURCES`.
-Makefiles also detect incorrect usage of :make:var:`TOPLEVEL_LANG` for simulators that only support one language.

--- a/documentation/source/newsfragments/2006.feature.rst
+++ b/documentation/source/newsfragments/2006.feature.rst
@@ -1,1 +1,0 @@
-:meth:`cocotb.fork` will now raise a descriptive :class:`TypeError` if a coroutine function is passed into them.

--- a/documentation/source/newsfragments/2022.change.rst
+++ b/documentation/source/newsfragments/2022.change.rst
@@ -1,1 +1,0 @@
-Updated :class:`~cocotb_bus.drivers.Driver`, :class:`~cocotb_bus.monitors.Monitor`, and all their subclasses to use the :keyword:`async`/:keyword:`await` syntax instead of the :keyword:`yield` syntax.

--- a/documentation/source/newsfragments/2023.feature.rst
+++ b/documentation/source/newsfragments/2023.feature.rst
@@ -1,2 +1,0 @@
-Added :meth:`cocotb.scheduler.start_soon <cocotb.scheduler.Scheduler.start_soon>` which schedules a coroutine to start *after* the current coroutine yields control.
-This behavior is distinct from :func:`cocotb.fork` which schedules the given coroutine immediately.

--- a/documentation/source/newsfragments/2028.feature.rst
+++ b/documentation/source/newsfragments/2028.feature.rst
@@ -1,2 +1,0 @@
-If ``pytest`` is installed, its assertion-rewriting framework will be used to
-produce more informative tracebacks from the :keyword:`assert` statement.

--- a/documentation/source/newsfragments/2038.bugfix.rst
+++ b/documentation/source/newsfragments/2038.bugfix.rst
@@ -1,1 +1,0 @@
-Fix GHDL's library search path, allowing libraries other than *work* to be used in simulation.

--- a/documentation/source/newsfragments/2045.bugfix.rst
+++ b/documentation/source/newsfragments/2045.bugfix.rst
@@ -1,1 +1,0 @@
-Tests skipped by default (created with `skip=True`) can again be run manually by setting the :envvar:`TESTCASE` variable.

--- a/documentation/source/newsfragments/2047.removal.rst
+++ b/documentation/source/newsfragments/2047.removal.rst
@@ -1,1 +1,0 @@
-The contents of :mod:`cocotb.generators` have been deprecated.

--- a/documentation/source/newsfragments/2049.removal.rst
+++ b/documentation/source/newsfragments/2049.removal.rst
@@ -1,1 +1,0 @@
-The outdated "Sorter" example has been removed from the documentation.

--- a/documentation/source/newsfragments/2079.bugfix.rst
+++ b/documentation/source/newsfragments/2079.bugfix.rst
@@ -1,8 +1,0 @@
-In :ref:`Icarus Verilog <sim-icarus>`, generate blocks are now accessible directly via lookup without having to iterate over parent handle. (:pr:`2079`, :pr:`2143`)
-
-  .. code-block:: python3
-
-      # Example pseudo-region
-      dut.genblk1       #<class 'cocotb.handle.HierarchyArrayObject'>
-
-  .. consume the towncrier issue number on this line.

--- a/documentation/source/newsfragments/2091.change.rst
+++ b/documentation/source/newsfragments/2091.change.rst
@@ -1,1 +1,0 @@
-The package build process is now fully :pep:`517` compliant.

--- a/documentation/source/newsfragments/2105.change.rst
+++ b/documentation/source/newsfragments/2105.change.rst
@@ -1,1 +1,0 @@
-Improved support and performance for :ref:`sim-verilator` (version 4.106 or later now required).

--- a/documentation/source/newsfragments/2117.removal.rst
+++ b/documentation/source/newsfragments/2117.removal.rst
@@ -1,2 +1,0 @@
-Passing :class:`bool` values to ``expect_error`` option of :class:`cocotb.test` is deprecated.
-Pass a specific :class:`Exception` or a tuple of Exceptions instead.

--- a/documentation/source/newsfragments/2129.bugfix.rst
+++ b/documentation/source/newsfragments/2129.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed an issue with VHPI on Mac OS and Linux where negative integers were returned as large positive values.

--- a/documentation/source/newsfragments/2133.removal.rst
+++ b/documentation/source/newsfragments/2133.removal.rst
@@ -1,1 +1,0 @@
-The system task overloads for ``$info``, ``$warn``, ``$error`` and ``$fatal`` in Verilog and mixed language testbenches have been removed.

--- a/documentation/source/newsfragments/2134.feature.rst
+++ b/documentation/source/newsfragments/2134.feature.rst
@@ -1,1 +1,0 @@
-The handle to :envvar:`TOPLEVEL`, typically seen as the first argument to a cocotb test function, is now available globally as :data:`cocotb.top`.

--- a/documentation/source/newsfragments/2171.feature.rst
+++ b/documentation/source/newsfragments/2171.feature.rst
@@ -1,6 +1,0 @@
-The ``units`` argument to :class:`cocotb.triggers.Timer`,
-:class:`cocotb.clock.Clock` and :func:`cocotb.utils.get_sim_steps`,
-and the ``timeout_unit`` argument to
-:func:`cocotb.triggers.with_timeout` and :class:`cocotb.test`
-now accepts ``'step'`` to mean the simulator time step.
-This used to be expressed using ``None``, which is now deprecated.

--- a/documentation/source/newsfragments/2175.feature.rst
+++ b/documentation/source/newsfragments/2175.feature.rst
@@ -1,1 +1,0 @@
-:func:`cocotb.regression.TestFactory.add_option` now supports groups of options when a full Cartesian product is not desired

--- a/documentation/source/newsfragments/2177.removal.rst
+++ b/documentation/source/newsfragments/2177.removal.rst
@@ -1,1 +1,0 @@
-:class:`~cocotb.result.TestError` has been deprecated, use :ref:`python:bltin-exceptions`.

--- a/documentation/source/newsfragments/2200.removal.rst
+++ b/documentation/source/newsfragments/2200.removal.rst
@@ -1,1 +1,0 @@
-The undocumented class ``cocotb.xunit_reporter.File`` has been removed.

--- a/documentation/source/newsfragments/2201.removal.rst
+++ b/documentation/source/newsfragments/2201.removal.rst
@@ -1,2 +1,0 @@
-Deprecated :class:`cocotb.hook` and :envvar:`COCOTB_HOOKS`.
-See the documentation for :class:`cocotb.hook` for suggestions on alternatives.

--- a/documentation/source/newsfragments/2203.removal.rst
+++ b/documentation/source/newsfragments/2203.removal.rst
@@ -1,1 +1,0 @@
-Deprecate :func:`~cocotb.utils.pack` and :func:`~cocotb.utils.unpack` and the use of :class:`python:ctypes.Structure` in signal assignments.

--- a/documentation/source/newsfragments/2232.removal.rst
+++ b/documentation/source/newsfragments/2232.removal.rst
@@ -1,1 +1,0 @@
-The outdated "ping" example has been removed from the documentation and repository.

--- a/documentation/source/newsfragments/2278.removal.rst
+++ b/documentation/source/newsfragments/2278.removal.rst
@@ -1,4 +1,0 @@
-The access modes of many interfaces in the cocotb core libraries were re-evaluated.
-Some interfaces that were previously public are now private and vice versa.
-Accessing the methods through their old name will create a :class:`DeprecationWarning`.
-In the future, the deprecated names will be removed.

--- a/documentation/source/newsfragments/2289.removal.rst
+++ b/documentation/source/newsfragments/2289.removal.rst
@@ -1,9 +1,0 @@
-The bus and testbenching components in cocotb have been officially moved to the `cocotb-bus <https://github.com/cocotb/cocotb-bus>`_ package.
-This includes
-:class:`~cocotb_bus.bus.Bus`,
-:class:`~cocotb_bus.scoreboard.Scoreboard`,
-everything in :mod:`cocotb_bus.drivers <cocotb.drivers>`,
-and everything in :mod:`cocotb_bus.monitors <cocotb.monitors>`.
-Documentation will remain in the main cocotb repository for now.
-Old names will continue to exist, but their use will cause a :class:`DeprecationWarning`,
-and will be removed in the future.

--- a/documentation/source/newsfragments/2297.feature.rst
+++ b/documentation/source/newsfragments/2297.feature.rst
@@ -1,1 +1,0 @@
-Added asyncio-style queues, :class:`cocotb.queue.Queue`, :class:`cocotb.queue.PriorityQueue`, and :class:`cocotb.queue.LifoQueue`.

--- a/documentation/source/newsfragments/2321.doc.rst
+++ b/documentation/source/newsfragments/2321.doc.rst
@@ -1,1 +1,0 @@
-A :ref:`refcard` showing the most used features of cocotb has been added.

--- a/documentation/source/newsfragments/2322.feature.rst
+++ b/documentation/source/newsfragments/2322.feature.rst
@@ -1,1 +1,0 @@
-Support for the SystemVerilog type ``bit`` has been added.

--- a/documentation/source/newsfragments/2340.doc.rst
+++ b/documentation/source/newsfragments/2340.doc.rst
@@ -1,1 +1,0 @@
-A chapter :ref:`custom-flows` has been added.

--- a/documentation/source/newsfragments/2341.change.rst
+++ b/documentation/source/newsfragments/2341.change.rst
@@ -1,1 +1,0 @@
-Changed how libraries are specified in :envvar:`GPI_EXTRA` to allow specifying libraries with paths, and names that don't start with "lib".

--- a/documentation/source/newsfragments/2387.feature.rst
+++ b/documentation/source/newsfragments/2387.feature.rst
@@ -1,1 +1,0 @@
-Added the ``--lib-dir``,  ``--lib-name`` and ``--lib-name-path`` options to the ``cocotb-config`` command to make cocotb integration into existing flows easier.

--- a/documentation/source/newsfragments/2408.feature.rst
+++ b/documentation/source/newsfragments/2408.feature.rst
@@ -1,3 +1,0 @@
-Support for using Questa's VHPI has been added.
-Use :make:var:`VHDL_GPI_INTERFACE` to select between using the FLI or VHPI when dealing with VHDL simulations.
-Note that VHPI support in Questa is still experimental at this time.

--- a/documentation/source/newsfragments/913.bugfix.rst
+++ b/documentation/source/newsfragments/913.bugfix.rst
@@ -1,1 +1,0 @@
-Assigning Python integers to signals greater than 32 bits wide will now work correctly for negative values.

--- a/documentation/source/newsfragments/913.change.rst
+++ b/documentation/source/newsfragments/913.change.rst
@@ -1,2 +1,0 @@
-Assigning out-of-range Python integers to signals would previously truncate the value silently for signal widths <= 32 bits and truncate the value with a warning for signal widths > 32 bits.
-Assigning out-of-range Python integers to signals will now raise an :exc:`OverflowError`.

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -84,6 +84,7 @@ Deprecations and Removals
   See the documentation for :class:`cocotb.hook` for suggestions on alternatives. (:pr:`2201`)
 - Deprecate :func:`~cocotb.utils.pack` and :func:`~cocotb.utils.unpack` and the use of :class:`python:ctypes.Structure` in signal assignments. (:pr:`2203`)
 - The outdated "ping" example has been removed from the documentation and repository. (:pr:`2232`)
+- Using the undocumented custom format :class:`dict` object in signal assignments has been deprecated. (:pr:`2240`)
 - The access modes of many interfaces in the cocotb core libraries were re-evaluated.
   Some interfaces that were previously public are now private and vice versa.
   Accessing the methods through their old name will create a :class:`DeprecationWarning`.

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -11,6 +11,105 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 
 .. towncrier release notes start
 
+Cocotb 1.5.0rc1 (2021-02-23)
+============================
+
+Features
+--------
+
+- Support for building with Microsoft Visual C++ has been added.
+  See :ref:`install` for more details. (:pr:`1798`)
+- Makefiles now automatically deduce :make:var:`TOPLEVEL_LANG` based on the value of :make:var:`VERILOG_SOURCES` and :make:var:`VHDL_SOURCES`.
+  Makefiles also detect incorrect usage of :make:var:`TOPLEVEL_LANG` for simulators that only support one language. (:pr:`1982`)
+- :meth:`cocotb.fork` will now raise a descriptive :class:`TypeError` if a coroutine function is passed into them. (:pr:`2006`)
+- Added :meth:`cocotb.scheduler.start_soon <cocotb.scheduler.Scheduler.start_soon>` which schedules a coroutine to start *after* the current coroutine yields control.
+  This behavior is distinct from :func:`cocotb.fork` which schedules the given coroutine immediately. (:pr:`2023`)
+- If ``pytest`` is installed, its assertion-rewriting framework will be used to
+  produce more informative tracebacks from the :keyword:`assert` statement. (:pr:`2028`)
+- The handle to :envvar:`TOPLEVEL`, typically seen as the first argument to a cocotb test function, is now available globally as :data:`cocotb.top`. (:pr:`2134`)
+- The ``units`` argument to :class:`cocotb.triggers.Timer`,
+  :class:`cocotb.clock.Clock` and :func:`cocotb.utils.get_sim_steps`,
+  and the ``timeout_unit`` argument to
+  :func:`cocotb.triggers.with_timeout` and :class:`cocotb.test`
+  now accepts ``'step'`` to mean the simulator time step.
+  This used to be expressed using ``None``, which is now deprecated. (:pr:`2171`)
+- :func:`cocotb.regression.TestFactory.add_option` now supports groups of options when a full Cartesian product is not desired (:pr:`2175`)
+- Added asyncio-style queues, :class:`cocotb.queue.Queue`, :class:`cocotb.queue.PriorityQueue`, and :class:`cocotb.queue.LifoQueue`. (:pr:`2297`)
+- Support for the SystemVerilog type ``bit`` has been added. (:pr:`2322`)
+- Added the ``--lib-dir``,  ``--lib-name`` and ``--lib-name-path`` options to the ``cocotb-config`` command to make cocotb integration into existing flows easier. (:pr:`2387`)
+- Support for using Questa's VHPI has been added.
+  Use :make:var:`VHDL_GPI_INTERFACE` to select between using the FLI or VHPI when dealing with VHDL simulations.
+  Note that VHPI support in Questa is still experimental at this time. (:pr:`2408`)
+
+
+Bugfixes
+--------
+
+- Assigning Python integers to signals greater than 32 bits wide will now work correctly for negative values. (:pr:`913`)
+- Fix GHDL's library search path, allowing libraries other than *work* to be used in simulation. (:pr:`2038`)
+- Tests skipped by default (created with `skip=True`) can again be run manually by setting the :envvar:`TESTCASE` variable. (:pr:`2045`)
+- In :ref:`Icarus Verilog <sim-icarus>`, generate blocks are now accessible directly via lookup without having to iterate over parent handle. (:pr:`2079`, :pr:`2143`)
+
+    .. code-block:: python3
+
+        # Example pseudo-region
+        dut.genblk1       #<class 'cocotb.handle.HierarchyArrayObject'>
+
+    .. consume the towncrier issue number on this line. (:pr:`2079`)
+- Fixed an issue with VHPI on Mac OS and Linux where negative integers were returned as large positive values. (:pr:`2129`)
+
+
+Improved Documentation
+----------------------
+
+- The  :ref:`mixed_signal` example has been added,
+  showing how to use HDL helper modules in cocotb testbenches that exercise
+  two mixed-signal (i.e. analog and digital) designs. (:pr:`1051`)
+- New example :ref:`matrix_multiplier`. (:pr:`1502`)
+- A :ref:`refcard` showing the most used features of cocotb has been added. (:pr:`2321`)
+- A chapter :ref:`custom-flows` has been added. (:pr:`2340`)
+
+
+Deprecations and Removals
+-------------------------
+
+- The contents of :mod:`cocotb.generators` have been deprecated. (:pr:`2047`)
+- The outdated "Sorter" example has been removed from the documentation. (:pr:`2049`)
+- Passing :class:`bool` values to ``expect_error`` option of :class:`cocotb.test` is deprecated.
+  Pass a specific :class:`Exception` or a tuple of Exceptions instead. (:pr:`2117`)
+- The system task overloads for ``$info``, ``$warn``, ``$error`` and ``$fatal`` in Verilog and mixed language testbenches have been removed. (:pr:`2133`)
+- :class:`~cocotb.result.TestError` has been deprecated, use :ref:`python:bltin-exceptions`. (:pr:`2177`)
+- The undocumented class ``cocotb.xunit_reporter.File`` has been removed. (:pr:`2200`)
+- Deprecated :class:`cocotb.hook` and :envvar:`COCOTB_HOOKS`.
+  See the documentation for :class:`cocotb.hook` for suggestions on alternatives. (:pr:`2201`)
+- Deprecate :func:`~cocotb.utils.pack` and :func:`~cocotb.utils.unpack` and the use of :class:`python:ctypes.Structure` in signal assignments. (:pr:`2203`)
+- The outdated "ping" example has been removed from the documentation and repository. (:pr:`2232`)
+- The access modes of many interfaces in the cocotb core libraries were re-evaluated.
+  Some interfaces that were previously public are now private and vice versa.
+  Accessing the methods through their old name will create a :class:`DeprecationWarning`.
+  In the future, the deprecated names will be removed. (:pr:`2278`)
+- The bus and testbenching components in cocotb have been officially moved to the `cocotb-bus <https://github.com/cocotb/cocotb-bus>`_ package.
+  This includes
+  :class:`~cocotb_bus.bus.Bus`,
+  :class:`~cocotb_bus.scoreboard.Scoreboard`,
+  everything in :mod:`cocotb_bus.drivers <cocotb.drivers>`,
+  and everything in :mod:`cocotb_bus.monitors <cocotb.monitors>`.
+  Documentation will remain in the main cocotb repository for now.
+  Old names will continue to exist, but their use will cause a :class:`DeprecationWarning`,
+  and will be removed in the future. (:pr:`2289`)
+
+
+Changes
+-------
+
+- Assigning out-of-range Python integers to signals would previously truncate the value silently for signal widths <= 32 bits and truncate the value with a warning for signal widths > 32 bits.
+  Assigning out-of-range Python integers to signals will now raise an :exc:`OverflowError`. (:pr:`913`)
+- Updated :class:`~cocotb_bus.drivers.Driver`, :class:`~cocotb_bus.monitors.Monitor`, and all their subclasses to use the :keyword:`async`/:keyword:`await` syntax instead of the :keyword:`yield` syntax. (:pr:`2022`)
+- The package build process is now fully :pep:`517` compliant. (:pr:`2091`)
+- Improved support and performance for :ref:`sim-verilator` (version 4.106 or later now required). (:pr:`2105`)
+- Changed how libraries are specified in :envvar:`GPI_EXTRA` to allow specifying libraries with paths, and names that don't start with "lib". (:pr:`2341`)
+
+
 Cocotb 1.4.0 (2020-07-08)
 =========================
 

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -11,7 +11,7 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 
 .. towncrier release notes start
 
-Cocotb 1.5.0rc1 (2021-02-23)
+cocotb 1.5.0rc2 (2021-03-04)
 ============================
 
 Features

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -11,7 +11,7 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 
 .. towncrier release notes start
 
-cocotb 1.5.0rc2 (2021-03-04)
+cocotb 1.5.0rc3 (2021-03-06)
 ============================
 
 Features

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -7,12 +7,8 @@ Release Notes
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
-.. include:: master-notes.rst
-
-.. towncrier release notes start
-
-cocotb 1.5.0rc3 (2021-03-06)
-============================
+cocotb 1.5.0 (2021-03-11)
+=========================
 
 Features
 --------

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -102,8 +102,7 @@ Deprecations and Removals
 Changes
 -------
 
-- Assigning out-of-range Python integers to signals would previously truncate the value silently for signal widths <= 32 bits and truncate the value with a warning for signal widths > 32 bits.
-  Assigning out-of-range Python integers to signals will now raise an :exc:`OverflowError`. (:pr:`913`)
+- Assigning negative Python integers to handles does an implicit two's compliment conversion. (:pr:`913`)
 - Updated :class:`~cocotb_bus.drivers.Driver`, :class:`~cocotb_bus.monitors.Monitor`, and all their subclasses to use the :keyword:`async`/:keyword:`await` syntax instead of the :keyword:`yield` syntax. (:pr:`2022`)
 - The package build process is now fully :pep:`517` compliant. (:pr:`2091`)
 - Improved support and performance for :ref:`sim-verilator` (version 4.106 or later now required). (:pr:`2105`)

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     maintainer='cocotb contributors',
     maintainer_email='cocotb@lists.librecores.org',
     setup_requires=['setuptools_scm'],
-    install_requires=[],
+    install_requires=['cocotb-bus<1.0'],
     python_requires='>=3.5',
     packages=find_packages(),
     package_data={

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -55,10 +55,7 @@ module sample_module #(
     input  string                               stream_in_string,
 `endif
     input  [7:0]                                stream_in_data,
-    input  [31:0]                               stream_in_data_dword,
-    input  [38:0]                               stream_in_data_39bit,
     input  [63:0]                               stream_in_data_wide,
-    input  [127:0]                              stream_in_data_dqword,
 
     input                                       stream_out_ready,
     output reg [7:0]                            stream_out_data_comb,

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -42,10 +42,7 @@ entity sample_module is
         clk                             : in    std_ulogic;
 
         stream_in_data                  : in    std_ulogic_vector(7 downto 0);
-        stream_in_data_dword            : in    std_ulogic_vector(31 downto 0);
-        stream_in_data_39bit            : in    std_ulogic_vector(38 downto 0);
         stream_in_data_wide             : in    std_ulogic_vector(63 downto 0);
-        stream_in_data_dqword           : in    std_ulogic_vector(127 downto 0);
         stream_in_valid                 : in    std_ulogic;
         stream_in_func_en               : in    std_ulogic;
         stream_in_ready                 : out   std_ulogic;

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -148,3 +148,10 @@ async def test_time_ps_deprecated(_):
         Timer(time=0, time_ps=7, units='ns')
     with assert_raises(TypeError):
         Timer(units='ps')
+
+
+@cocotb.test()
+async def test_value_assignment_truncation_deprecated(dut):
+    with assert_deprecated(FutureWarning):
+        # value too large to fit, will cause truncation
+        dut.stream_in_data <= 0x12345678

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -8,6 +8,7 @@ import warnings
 import ctypes
 from contextlib import contextmanager
 from common import assert_raises
+from typing import List
 
 
 @contextmanager
@@ -155,3 +156,26 @@ async def test_value_assignment_truncation_deprecated(dut):
     with assert_deprecated(FutureWarning):
         # value too large to fit, will cause truncation
         dut.stream_in_data <= 0x12345678
+
+
+def pack_bit_vector(values: List[int], bits: int):
+    """Pack the integers in `values` into a single integer, with each entry occupying `bits` bits.
+
+    >>> pack_bit_vector([0x012, 0x234, 0x456], bits=12) == 0x456234012
+    True
+    """
+    return sum(v << (bits * i) for i, v in enumerate(values))
+
+
+@cocotb.test()
+async def test_dict_signal_assignment_deprecated(dut):
+    """Assigning a dict to a ModifiableObject signal is deprecated"""
+
+    d = dict(values=[0xC, 0x5], bits=4)
+
+    with assert_deprecated():
+        dut.stream_in_data <= d
+
+    await Timer(1, 'step')
+
+    assert dut.stream_in_data.value == pack_bit_vector(**d)

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -10,7 +10,6 @@ import cocotb
 from cocotb.triggers import Timer
 
 from common import assert_raises
-from cocotb.handle import _Limits
 
 
 @cocotb.test()
@@ -93,198 +92,21 @@ async def test_delayed_assignment_still_errors(dut):
         dut.stream_in_int <= []
 
 
-async def int_values_test(signal, n_bits, limits=_Limits.VECTOR_NBIT):
-    """Test integer access to a signal."""
-    log = logging.getLogger("cocotb.test")
-    values = gen_int_test_values(n_bits, limits)
-    for val in values:
-        signal <= val
-        await Timer(1, 'ns')
-
-        if limits == _Limits.VECTOR_NBIT:
-            if val < 0:
-                got = signal.value.signed_integer
-            else:
-                got = signal.value.integer
-        else:
-            got = signal.value
-
-        assert got == val, "Expected value {}, got value {}!".format(val, got)
-
-
-def gen_int_test_values(n_bits, limits=_Limits.VECTOR_NBIT):
-    """Generates a list of int test values for a given number of bits."""
-    unsigned_min = 0
-    unsigned_max = 2**n_bits-1
-    signed_min = -2**(n_bits-1)
-    signed_max = 2**(n_bits-1)-1
-
-    if limits == _Limits.VECTOR_NBIT:
-        return [1, -1, 4, -4, unsigned_min, unsigned_max, signed_min, signed_max]
-    elif limits == _Limits.SIGNED_NBIT:
-        return [1, -1, 4, -4, signed_min, signed_max]
-    else:
-        return [1, -1, 4, -4, unsigned_min, unsigned_max]
-
-
-async def int_overflow_test(signal, n_bits, test_mode, limits=_Limits.VECTOR_NBIT):
-    """Test integer overflow."""
-    if test_mode == "ovfl":
-        value = gen_int_ovfl_value(n_bits, limits)
-    elif test_mode == "unfl":
-        value = gen_int_unfl_value(n_bits, limits)
-    else:
-        value = None
-
-    with assert_raises(OverflowError):
-        signal <= value
-
-
-def gen_int_ovfl_value(n_bits, limits=_Limits.VECTOR_NBIT):
-    unsigned_max = 2**n_bits-1
-    signed_max = 2**(n_bits-1)-1
-
-    if limits == _Limits.SIGNED_NBIT:
-        return signed_max + 1
-    elif limits == _Limits.UNSIGNED_NBIT:
-        return unsigned_max + 1
-    else:
-        return unsigned_max + 1
-
-
-def gen_int_unfl_value(n_bits, limits=_Limits.VECTOR_NBIT):
-    unsigned_min = 0
-    signed_min = -2**(n_bits-1)
-
-    if limits == _Limits.SIGNED_NBIT:
-        return signed_min - 1
-    elif limits == _Limits.UNSIGNED_NBIT:
-        return unsigned_min - 1
-    else:
-        return signed_min - 1
-
-
-@cocotb.test()
-async def test_int_8bit(dut):
-    """Test int access to 8-bit vector."""
-    await int_values_test(dut.stream_in_data, len(dut.stream_in_data))
-
-
-@cocotb.test()
-async def test_int_8bit_overflow(dut):
-    """Test 8-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data, len(dut.stream_in_data), "ovfl")
-
-
-@cocotb.test()
-async def test_int_8bit_underflow(dut):
-    """Test 8-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data, len(dut.stream_in_data), "unfl")
-
-
-@cocotb.test()
-async def test_int_32bit(dut):
-    """Test int access to 32-bit vector."""
-    await int_values_test(dut.stream_in_data_dword, len(dut.stream_in_data_dword))
-
-
-@cocotb.test()
-async def test_int_32bit_overflow(dut):
-    """Test 32-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data_dword, len(dut.stream_in_data_dword), "ovfl")
-
-
-@cocotb.test()
-async def test_int_32bit_underflow(dut):
-    """Test 32-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data_dword, len(dut.stream_in_data_dword), "unfl")
-
-
-@cocotb.test()
-async def test_int_39bit(dut):
-    """Test int access to 39-bit vector."""
-    await int_values_test(dut.stream_in_data_39bit, len(dut.stream_in_data_39bit))
-
-
-@cocotb.test()
-async def test_int_39bit_overflow(dut):
-    """Test 39-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data_39bit, len(dut.stream_in_data_39bit), "ovfl")
-
-
-@cocotb.test()
-async def test_int_39bit_underflow(dut):
-    """Test 39-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data_39bit, len(dut.stream_in_data_39bit), "unfl")
-
-
-@cocotb.test()
-async def test_int_64bit(dut):
-    """Test int access to 64-bit vector."""
-    await int_values_test(dut.stream_in_data_wide, len(dut.stream_in_data_wide))
-
-
-@cocotb.test()
-async def test_int_64bit_overflow(dut):
-    """Test 64-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data_wide, len(dut.stream_in_data_wide), "ovfl")
-
-
-@cocotb.test()
-async def test_int_64bit_underflow(dut):
-    """Test 64-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data_wide, len(dut.stream_in_data_wide), "unfl")
-
-
-@cocotb.test()
-async def test_int_128bit(dut):
-    """Test int access to 128-bit vector."""
-    await int_values_test(dut.stream_in_data_dqword, len(dut.stream_in_data_dqword))
-
-
-@cocotb.test()
-async def test_int_128bit_overflow(dut):
-    """Test 128-bit vector overflow."""
-    await int_overflow_test(dut.stream_in_data_dqword, len(dut.stream_in_data_dqword), "ovfl")
-
-
-@cocotb.test()
-async def test_int_128bit_underflow(dut):
-    """Test 128-bit vector underflow."""
-    await int_overflow_test(dut.stream_in_data_dqword, len(dut.stream_in_data_dqword), "unfl")
-
-
 @cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
 async def test_integer(dut):
-    """Test access to integers."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
-    else:
-        limits = _Limits.SIGNED_NBIT
-
-    await int_values_test(dut.stream_in_int, 32, limits)
-
-
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
-async def test_integer_overflow(dut):
-    """Test integer overflow."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
-    else:
-        limits = _Limits.SIGNED_NBIT
-
-    await int_overflow_test(dut.stream_in_int, 32, "ovfl", limits)
-
-
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
-async def test_integer_underflow(dut):
-    """Test integer underflow."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
-    else:
-        limits = _Limits.SIGNED_NBIT
-
-    await int_overflow_test(dut.stream_in_int, 32, "unfl", limits)
+    """
+    Test access to integers
+    """
+    log = logging.getLogger("cocotb.test")
+    await Timer(10, "ns")
+    dut.stream_in_int <= 4
+    await Timer(10, "ns")
+    await Timer(10, "ns")
+    got_in = int(dut.stream_out_int)
+    got_out = int(dut.stream_in_int)
+    log.info("dut.stream_out_int = %d" % got_out)
+    log.info("dut.stream_in_int = %d" % got_in)
+    assert got_in == got_out, "stream_in_int and stream_out_int should not match"
 
 
 @cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
@@ -342,3 +164,23 @@ async def test_access_underscore_name(dut):
     dut._id("_underscore_name", extended=False) <= 0
     await Timer(1, 'ns')
     assert dut._id("_underscore_name", extended=False).value == 0
+
+
+@cocotb.test()
+async def test_reading_writing_logic_array_using_int(dut):
+    # in range, < 32 bits, positive
+    dut.stream_in_data.value = 1
+    await Timer(1, 'ns')
+    assert dut.stream_in_data.value.integer == 1
+    # in range, < 32 bit, negative
+    dut.stream_in_data.value = -1
+    await Timer(1, 'ns')
+    assert dut.stream_in_data.value.signed_integer == -1
+    # in range, >= 32 bit, positive
+    dut.stream_in_data_wide.value = 0x1234567890
+    await Timer(1, 'ns')
+    assert dut.stream_in_data_wide.value.integer == 0x1234567890
+    # in range, >= 32 bit, negative
+    dut.stream_in_data_wide.value = -0x1234567890
+    await Timer(1, 'ns')
+    assert dut.stream_in_data_wide.value.signed_integer == -0x1234567890

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -117,7 +117,7 @@ async def test_in_vect_packed_packed_packed(dut):
 async def test_in_vect_packed_packed_unpacked(dut):
     await Timer(1, "ns")
     print("Setting: dut.in_vect_packed_packed_unpacked type %s" % type(dut.in_vect_packed_packed_unpacked))
-    dut.in_vect_packed_packed_unpacked = [365, 365, 365]
+    dut.in_vect_packed_packed_unpacked = [95869805, 95869805, 95869805]
     await Timer(1, "ns")
     print("Getting: dut.out_vect_packed_packed_unpacked type %s" % type(dut.out_vect_packed_packed_unpacked))
     if dut.out_vect_packed_packed_unpacked != [365, 365, 365]:


### PR DESCRIPTION
What we did with cocotb-bus was perhaps a little overzealous. We added deprecation warnings, but we still broke users by requiring them to manually install cocotb-bus to resolve import errors when importing from `cocotb.bus`, etc. Adding cocotb-bus as a dependency will fix the break for 1.5. This does not need to be added to the master branch.