### PR TITLE
Add dependency on cocotb-bus to 1.5

### DIFF
--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -14,6 +14,7 @@ Bugfixes
 --------
 
 - Prevent pytest assertion rewriting (:pr:`2028`) from capturing stdin, which causes problems with IPython support (:pr:`1649`). (:pr:`2462`)
+- Add dependency on `cocotb_bus <https://github.com/cocotb/cocotb-bus>`_ to prevent breaking users that were previously using the bus and testbenching objects. (:pr:`2477`)
 
 
 cocotb 1.5.0 (2021-03-11)

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     maintainer='cocotb contributors',
     maintainer_email='cocotb@lists.librecores.org',
     setup_requires=['setuptools_scm'],
-    install_requires=[],
+    install_requires=['cocotb-bus<1.0'],
     python_requires='>=3.5',
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
What we did with cocotb-bus was perhaps a little overzealous. We added deprecation warnings, but we still broke users by requiring them to manually install cocotb-bus to resolve import errors when importing from `cocotb.bus`, etc. Adding cocotb-bus as a dependency will fix the break for 1.5. This does not need to be added to the master branch.