### PR TITLE
Pick pytest ipython fix

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -270,7 +270,7 @@ def _initialise_testbench_(argv_):
             # import the test modules.
             from _pytest.config import Config
             from _pytest.assertion import install_importhook
-            pytest_conf = Config.fromdictargs([], {})
+            pytest_conf = Config.fromdictargs({}, ['--capture=no'])
             install_importhook(pytest_conf)
         except Exception:
             log.exception(

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -7,6 +7,15 @@ Release Notes
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
+cocotb 1.5.1 (2021-XX-XX)
+=========================
+
+Bugfixes
+--------
+
+- Prevent pytest assertion rewriting (:pr:`2028`) from capturing stdin, which causes problems with IPython support (:pr:`1649`). (:pr:`2462`)
+
+
 cocotb 1.5.0 (2021-03-11)
 =========================
 

--- a/tests/test_cases/test_cocotb/test_pytest.py
+++ b/tests/test_cases/test_cocotb/test_pytest.py
@@ -4,6 +4,7 @@
 """ Tests relating to pytest integration """
 
 import cocotb
+from cocotb.result import TestFailure
 
 # pytest is an optional dependency
 try:
@@ -16,7 +17,9 @@ except ImportError:
 async def test_assertion_rewriting(dut):
     """ Test that assertion rewriting hooks take effect in cocotb tests """
     try:
-        assert 1 != 42
+        assert 1 == 42
     except AssertionError as e:
         assert "42" in str(e), (
-            "Assertion rewriting seems not to work, message was {}".format(e))
+            "Assertion rewriting seems not to work, message was '{}'".format(e))
+    else:
+        raise TestFailure('AssertionError was not thrown')


### PR DESCRIPTION
Cherry-pick of #2469. Adds a newsfragment.

This also fixes an issue where capturing stdin prevent Ctrl-C from killing simulations.