### PR TITLE
Revert BinaryValue change

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -157,12 +157,18 @@ class BinaryValue:
 
         self._n_bits = n_bits
 
-        self._convert_to = self._convert_to_map[self.binaryRepresentation].__get__(self, self.__class__)
-
-        self._convert_from = self._convert_from_map[self.binaryRepresentation].__get__(self, self.__class__)
-
         if value is not None:
             self.assign(value)
+
+    @property
+    def binaryRepresentation(self):
+        return self._binaryRepresentation
+
+    @binaryRepresentation.setter
+    def binaryRepresentation(self, binaryRepresentation):
+        self._binaryRepresentation = binaryRepresentation
+        self._convert_to = self._convert_to_map[binaryRepresentation].__get__(self, self.__class__)
+        self._convert_from = self._convert_from_map[binaryRepresentation].__get__(self, self.__class__)
 
     def assign(self, value):
         """Decides how best to assign the value to the vector.

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
+
 cocotb 1.5.1 (2021-XX-XX)
 =========================
 
@@ -15,6 +16,7 @@ Bugfixes
 
 - Prevent pytest assertion rewriting (:pr:`2028`) from capturing stdin, which causes problems with IPython support (:pr:`1649`). (:pr:`2462`)
 - Add dependency on `cocotb_bus <https://github.com/cocotb/cocotb-bus>`_ to prevent breaking users that were previously using the bus and testbenching objects. (:pr:`2477`)
+- Add back functionality to :class:`cocotb.binary.BinaryValue` that allows the user to change ``binaryRepresentation`` after object creation. (:pr:`2480`)
 
 
 cocotb 1.5.0 (2021-03-11)


### PR DESCRIPTION
Closes #2480. Reintroduces to the 1.5 release the ability of the user to change the `binaryRepresentation` of a `BinaryValue` object after its creation.