### PR TITLE
Allow plusargs to have values containing `=`

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -343,7 +343,7 @@ def process_plusargs():
     for option in cocotb.argv:
         if option.startswith('+'):
             if option.find('=') != -1:
-                (name, value) = option[1:].split('=')
+                (name, value) = option[1:].split('=', 1)
                 plusargs[name] = value
             else:
                 plusargs[option[1:]] = True

--- a/documentation/source/newsfragments/2483.bugfix.rst
+++ b/documentation/source/newsfragments/2483.bugfix.rst
@@ -1,0 +1,1 @@
+Correctly parse plusargs with ``=``\ s in the value.

--- a/tests/designs/plusargs_module/tb_top.v
+++ b/tests/designs/plusargs_module/tb_top.v
@@ -36,6 +36,8 @@ initial begin
     $display("SIM: Plusargs test");
     result = $value$plusargs("foo=%s", foo_string);
     $display("SIM: Plusarg foo has value %0s", foo_string);
+    result = $value$plusargs("lol=%s", foo_string);
+    $display("SIM: Plusarg lol has value %0s", foo_string);
     #1 $display("SIM: Test running");
 end
 

--- a/tests/test_cases/test_plusargs/Makefile
+++ b/tests/test_cases/test_plusargs/Makefile
@@ -29,6 +29,6 @@
 
 include ../../designs/plusargs_module/Makefile
 
-PLUSARGS=+foo=bar +test1 +test2 +options=fubar
+PLUSARGS=+foo=bar +test1 +test2 +options=fubar +lol=wow=4
 
 MODULE = plusargs

--- a/tests/test_cases/test_plusargs/plusargs.py
+++ b/tests/test_cases/test_plusargs/plusargs.py
@@ -30,7 +30,6 @@
 """
 
 import cocotb
-from cocotb.result import TestFailure
 
 
 @cocotb.test()
@@ -40,5 +39,6 @@ async def plusargs_test(dut):
     for name in cocotb.plusargs:
         print("COCOTB:", name, cocotb.plusargs[name])
 
-    if cocotb.plusargs['foo'] != 'bar':
-        raise TestFailure("plusargs 'foo' value '{}' does not match expected 'bar'".format(cocotb.plusargs['foo']))
+    assert 'test1' in cocotb.plusargs
+    assert cocotb.plusargs['foo'] == 'bar'
+    assert cocotb.plusargs['lol'] == 'wow=4'


### PR DESCRIPTION
Fixes https://github.com/cocotb/cocotb/issues/2482

Ensuring plusargs are always split into at most two parts
This would enable passing plusargs with more than one "=" sign to a testbench