### PR TITLE
Load custom entry point in Python from the GPI

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -227,7 +227,7 @@ def _initialise_testbench(argv_):  # pragma: no cover
                 include=["{}/*".format(os.path.dirname(__file__))])
             _library_coverage.start()
 
-        return _initialise_testbench_(argv_)
+        _initialise_testbench_(argv_)
 
 
 def _initialise_testbench_(argv_):
@@ -332,8 +332,6 @@ def _initialise_testbench_(argv_):
     regression_manager = RegressionManager.from_discovery(top)
     regression_manager.execute()
 
-    return True
-
 
 def _sim_event(level, message):
     """Function that can be called externally to signal an event."""
@@ -353,8 +351,6 @@ def _sim_event(level, message):
         scheduler._finish_scheduler(SimFailure(msg))
     else:
         scheduler.log.error("Unsupported sim event")
-
-    return True
 
 
 def process_plusargs():

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -41,13 +41,13 @@ from typing import Dict, List, Optional, Union
 from collections.abc import Coroutine
 
 import cocotb.handle
-import cocotb.log
 from cocotb.scheduler import Scheduler
 from cocotb.regression import RegressionManager
 from cocotb.decorators import RunningTask
 
 # Things we want in the cocotb namespace
 from cocotb.decorators import test, coroutine, function, external  # noqa: F401
+from cocotb.log import _log_from_c, _filter_from_c  # noqa: F401
 
 from ._version import __version__
 
@@ -73,7 +73,8 @@ def _setup_logging():
 
     # Don't set the logging up until we've attempted to fix the standard IO,
     # otherwise it will end up connected to the unfixed IO.
-    cocotb.log.default_config()
+    from cocotb.log import default_config
+    default_config()
     log = logging.getLogger(__name__)
 
     # we can't log these things until the logging is set up!

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -188,172 +188,138 @@ extern "C" COCOTB_EXPORT void _embed_sim_cleanup(void) {
     }
 }
 
-/**
- * @name    Initialization
- * @brief   Called by the simulator on initialization. Load cocotb Python module
- * @ingroup python_c_api
- *
- * GILState before calling: Not held
- *
- * GILState after calling: Not held
- *
- * Makes one call to PyGILState_Ensure and one call to PyGILState_Release
- *
- * Loads the Python module called cocotb and calls the _initialise_testbench
- * function
- */
+namespace {
 
-static int get_module_ref(const char *modname, PyObject **mod) {
-    PyObject *pModule = PyImport_ImportModule(modname);
+template <typename F>
+class Deferable {
+  public:
+    constexpr Deferable(F f) : f_(f){};
+    ~Deferable() { f_(); }
 
-    if (pModule == NULL) {
-        // LCOV_EXCL_START
-        PyErr_Print();
-        LOG_ERROR("Failed to load Python module \"%s\"", modname);
-        return -1;
-        // LCOV_EXCL_STOP
-    }
+  private:
+    F f_;
+};
 
-    *mod = pModule;
-    return 0;
+template <typename F>
+constexpr Deferable<F> make_deferable(F f) {
+    return Deferable<F>(f);
 }
+
+}  // namespace
+
+#define DEFER1(a, b) a##b
+#define DEFER0(a, b) DEFER1(a, b)
+#define DEFER(statement) \
+    auto DEFER0(_defer, __COUNTER__) = make_deferable([&]() { statement; });
 
 extern "C" COCOTB_EXPORT int _embed_sim_init(int argc,
                                              char const *const *argv) {
-    int i;
-    int ret = 0;
-
-    /* Check that we are not already initialized */
-    if (pEventFn) return ret;
-
-    PyObject *cocotb_module, *cocotb_init, *cocotb_retval;
-    PyObject *cocotb_log_module = NULL;
-    PyObject *log_func;
-    PyObject *filter_func;
-    PyObject *argv_list;
-
-    cocotb_module = NULL;
+    // Check that we are not already initialized
+    if (pEventFn) {
+        return 0;
+    }
 
     // Ensure that the current thread is ready to call the Python C API
-    PyGILState_STATE gstate = PyGILState_Ensure();
+    auto gstate = PyGILState_Ensure();
+    DEFER(PyGILState_Release(gstate));
+
     to_python();
+    DEFER(to_simulator());
 
-    if (get_module_ref("cocotb", &cocotb_module)) {
-        // LCOV_EXCL_START
-        goto cleanup;
-        // LCOV_EXCL_STOP
-    }
-
-    LOG_INFO("Python interpreter initialized and cocotb loaded!");
-
-    if (get_module_ref("cocotb.log", &cocotb_log_module)) {
-        // LCOV_EXCL_START
-        goto cleanup;
-        // LCOV_EXCL_STOP
-    }
-
-    // Obtain the function to use when logging from C code
-    log_func = PyObject_GetAttrString(cocotb_log_module,
-                                      "_log_from_c");  // New reference
-    if (log_func == NULL) {
+    auto entry_utility_module = PyImport_ImportModule("pygpi.entry");
+    if (!entry_utility_module) {
         // LCOV_EXCL_START
         PyErr_Print();
-        LOG_ERROR("Failed to get the _log_from_c function");
-        goto cleanup;
+        return -1;
         // LCOV_EXCL_STOP
     }
+    DEFER(Py_DECREF(entry_utility_module));
 
-    // Obtain the function to check whether to call log function
-    filter_func = PyObject_GetAttrString(cocotb_log_module,
-                                         "_filter_from_c");  // New reference
-    if (filter_func == NULL) {
-        // LCOV_EXCL_START
-        Py_DECREF(log_func);
-        PyErr_Print();
-        LOG_ERROR("Failed to get the _filter_from_c method");
-        goto cleanup;
-        // LCOV_EXCL_STOP
-    }
-
-    py_gpi_logger_initialize(
-        log_func, filter_func);  // Note: This function steals references to
-                                 // log_func and filter_func.
-
-    pEventFn =
-        PyObject_GetAttrString(cocotb_module, "_sim_event");  // New reference
-    if (pEventFn == NULL) {
+    auto entry_info_tuple =
+        PyObject_CallMethod(entry_utility_module, "load_entry", NULL);
+    if (!entry_info_tuple) {
         // LCOV_EXCL_START
         PyErr_Print();
-        LOG_ERROR("Failed to get the _sim_event method");
-        goto cleanup;
+        return -1;
         // LCOV_EXCL_STOP
     }
+    DEFER(Py_DECREF(entry_info_tuple));
 
-    cocotb_init = PyObject_GetAttrString(
-        cocotb_module, "_initialise_testbench");  // New reference
-    if (cocotb_init == NULL) {
+    PyObject *entry_module;
+    PyObject *entry_point;
+    if (!PyArg_ParseTuple(entry_info_tuple, "OO", &entry_module,
+                          &entry_point)) {
         // LCOV_EXCL_START
         PyErr_Print();
-        LOG_ERROR("Failed to get the _initialise_testbench method");
-        goto cleanup;
+        return -1;
         // LCOV_EXCL_STOP
     }
+    // Objects returned from ParseTuple are borrowed from tuple
+
+    auto log_func = PyObject_GetAttrString(entry_module, "_log_from_c");
+    if (!log_func) {
+        // LCOV_EXCL_START
+        PyErr_Print();
+        return -1;
+        // LCOV_EXCL_STOP
+    }
+    DEFER(Py_DECREF(log_func));
+
+    auto filter_func = PyObject_GetAttrString(entry_module, "_filter_from_c");
+    if (!filter_func) {
+        // LCOV_EXCL_START
+        PyErr_Print();
+        return -1;
+        // LCOV_EXCL_STOP
+    }
+    DEFER(Py_DECREF(filter_func));
+
+    py_gpi_logger_initialize(log_func, filter_func);
+
+    pEventFn = PyObject_GetAttrString(entry_module, "_sim_event");
+    if (!pEventFn) {
+        // LCOV_EXCL_START
+        PyErr_Print();
+        return -1;
+        // LCOV_EXCL_STOP
+    }
+    // cocotb must hold _sim_event until _embed_sim_end runs
 
     // Build argv for cocotb module
-    argv_list = PyList_New(argc);  // New reference
+    auto argv_list = PyList_New(argc);
     if (argv_list == NULL) {
         // LCOV_EXCL_START
         PyErr_Print();
-        LOG_ERROR("Unable to create argv list");
-        goto cleanup;
+        return -1;
         // LCOV_EXCL_STOP
     }
-    for (i = 0; i < argc; i++) {
+    for (int i = 0; i < argc; i++) {
         // Decode, embedding non-decodable bytes using PEP-383. This can only
         // fail with MemoryError or similar.
-        PyObject *argv_item = PyUnicode_DecodeLocale(
-            argv[i], "surrogateescape");  // New reference
-        if (argv_item == NULL) {
+        auto argv_item = PyUnicode_DecodeLocale(argv[i], "surrogateescape");
+        if (!argv_item) {
             // LCOV_EXCL_START
             PyErr_Print();
-            LOG_ERROR(
-                "Unable to convert command line argument %d to Unicode string.",
-                i);
-            Py_DECREF(argv_list);
-            goto cleanup;
+            return -1;
             // LCOV_EXCL_STOP
         }
-        PyList_SET_ITEM(argv_list, i, argv_item);  // Note: This function steals
-                                                   // the reference to argv_item
+        PyList_SetItem(argv_list, i, argv_item);
     }
+    DEFER(Py_DECREF(argv_list))
 
-    cocotb_retval = PyObject_CallFunctionObjArgs(cocotb_init, argv_list, NULL);
-    Py_DECREF(argv_list);
-    Py_DECREF(cocotb_init);
-
-    if (cocotb_retval != NULL) {
-        LOG_DEBUG("_initialise_testbench successful");
-        Py_DECREF(cocotb_retval);
-    } else {
+    auto cocotb_retval =
+        PyObject_CallFunctionObjArgs(entry_point, argv_list, NULL);
+    if (!cocotb_retval) {
         // LCOV_EXCL_START
         PyErr_Print();
-        LOG_ERROR("cocotb initialization failed - exiting");
-        goto cleanup;
+        return -1;
         // LCOV_EXCL_STOP
     }
+    Py_DECREF(cocotb_retval);
 
-    goto ok;
+    LOG_INFO("cocotb initialization successful");
 
-cleanup:
-    ret = -1;
-ok:
-    Py_XDECREF(cocotb_module);
-    Py_XDECREF(cocotb_log_module);
-
-    PyGILState_Release(gstate);
-    to_simulator();
-
-    return ret;
+    return 0;
 }
 
 extern "C" COCOTB_EXPORT void _embed_sim_event(gpi_event_t level,

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -317,7 +317,6 @@ extern "C" COCOTB_EXPORT int _embed_sim_init(int argc,
     }
     Py_DECREF(cocotb_retval);
 
-
     return 0;
 }
 

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -283,7 +283,7 @@ extern "C" COCOTB_EXPORT int _embed_sim_init(int argc,
         return -1;
         // LCOV_EXCL_STOP
     }
-    // cocotb must hold _sim_event until _embed_sim_end runs
+    // cocotb must hold _sim_event until _embed_sim_cleanup runs
 
     // Build argv for cocotb module
     auto argv_list = PyList_New(argc);

--- a/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/cocotb/share/lib/embed/gpi_embed.cpp
@@ -317,7 +317,6 @@ extern "C" COCOTB_EXPORT int _embed_sim_init(int argc,
     }
     Py_DECREF(cocotb_retval);
 
-    LOG_INFO("cocotb initialization successful");
 
     return 0;
 }

--- a/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
+++ b/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
@@ -153,6 +153,8 @@ extern "C" void py_gpi_logger_set_level(int level) {
 }
 
 extern "C" void py_gpi_logger_initialize(PyObject *handler, PyObject *filter) {
+    Py_INCREF(handler);
+    Py_INCREF(filter);
     pLogHandler = handler;
     pLogFilter = filter;
     gpi_set_log_handler(py_gpi_log_handler, nullptr);

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -230,13 +230,17 @@ PyGPI
     The string before the colon is the Python module to import
     and the string following the colon is the object to call as the entry function.
 
-    The entry function must be a callable that takes a single positional argument, the command ``argv`` list.
+    The entry function must be a callable matching this form:
+
+    * ``entry_function(argv: List[str]) -> bool``
+
     The entry module must have the following additional functions defined:
 
-    * ``_sim_event(level: int)``
-    * ``_log_from_c(logger_name: str, level: int, filename: str, lineno: int, msg: str, function_name: str))``
-    * ``_filter_from_c(logger_name: str, level: int)``
+    * ``_sim_event(level: int) -> bool``
+    * ``_log_from_c(logger_name: str, level: int, filename: str, lineno: int, msg: str, function_name: str)) -> bool``
+    * ``_filter_from_c(logger_name: str, level: int) -> bool``
 
+    The entry module functions return ``True`` on success. On failure, they should return ``False`` or raise an :class:`Exception`.
     These additional requirements on the entry module may be relaxed over time.
 
 

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -218,6 +218,27 @@ GPI
         and loading from libraries that `aren't` prefixed with "lib".
         Paths `should not` contain commas.
 
+PyGPI
+-----
+
+.. envvar:: COCOTB_ENTRY_POINT
+
+    The Python module and callable that starts up the Python cosimulation environment.
+    This defaults to :value:`cocotb:_initialise_testbench`, which is the cocotb standard entry point.
+    User overloads can be used to enter alternative Python frameworks or to hook existing cocotb functionality.
+    The variable is formatted as ``path.to.entry.module:entry_point.function``.
+    The string before the colon is the Python module to import
+    and the string following the colon is the object to call as the entry function.
+
+    The entry function must be a callable that takes a single positional argument, the command ``argv`` list.
+    The entry module must have the following additional functions defined:
+
+    * ``_sim_event(level: int)``
+    * ``_log_from_c(logger_name: str, level: int, filename: str, lineno: int, msg: str, function_name: str))``
+    * ``_filter_from_c(logger_name: str, level: int)``
+
+    These additional requirements on the entry module may be relaxed over time.
+
 
 Makefile-based Test Scripts
 ---------------------------

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -221,7 +221,7 @@ GPI
 PyGPI
 -----
 
-.. envvar:: COCOTB_ENTRY_POINT
+.. envvar:: PYGPI_ENTRY_POINT
 
     The Python module and callable that starts up the Python cosimulation environment.
     This defaults to :data:`cocotb:_initialise_testbench`, which is the cocotb standard entry point.

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -224,7 +224,7 @@ PyGPI
 .. envvar:: COCOTB_ENTRY_POINT
 
     The Python module and callable that starts up the Python cosimulation environment.
-    This defaults to :value:`cocotb:_initialise_testbench`, which is the cocotb standard entry point.
+    This defaults to :data:`cocotb:_initialise_testbench`, which is the cocotb standard entry point.
     User overloads can be used to enter alternative Python frameworks or to hook existing cocotb functionality.
     The variable is formatted as ``path.to.entry.module:entry_point.function``.
     The string before the colon is the Python module to import

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -232,16 +232,14 @@ PyGPI
 
     The entry function must be a callable matching this form:
 
-    * ``entry_function(argv: List[str]) -> bool``
+    * ``entry_function(argv: List[str]) -> None``
 
-    The entry module must have the following additional functions defined:
-
-    * ``_sim_event(level: int) -> bool``
-    * ``_log_from_c(logger_name: str, level: int, filename: str, lineno: int, msg: str, function_name: str)) -> bool``
-    * ``_filter_from_c(logger_name: str, level: int) -> bool``
-
-    The entry module functions return ``True`` on success. On failure, they should return ``False`` or raise an :class:`Exception`.
+    The entry module must have the following additional functions defined.
     These additional requirements on the entry module may be relaxed over time.
+
+    * ``_sim_event(level: int) -> None``
+    * ``_log_from_c(logger_name: str, level: int, filename: str, lineno: int, msg: str, function_name: str)) -> None``
+    * ``_filter_from_c(logger_name: str, level: int) -> bool``
 
 
 Makefile-based Test Scripts

--- a/documentation/source/newsfragments/1225.feature.rst
+++ b/documentation/source/newsfragments/1225.feature.rst
@@ -1,0 +1,1 @@
+Support a custom entry point from C to Python with :envvar:`PYGPI_ENTRY_POINT`.

--- a/pygpi/entry.py
+++ b/pygpi/entry.py
@@ -4,7 +4,7 @@ from functools import reduce
 
 
 def load_entry():
-    """Gather entry point information by parsing :envar:`COCOTB_ENTRY_POINT`."""
+    """Gather entry point information by parsing :envvar:`COCOTB_ENTRY_POINT`."""
     entry_point_str = os.environ.get("COCOTB_ENTRY_POINT", "cocotb:_initialise_testbench")
     try:
         if ":" not in entry_point_str:

--- a/pygpi/entry.py
+++ b/pygpi/entry.py
@@ -6,15 +6,15 @@ from typing import Tuple, Callable
 
 
 def load_entry() -> Tuple[ModuleType, Callable]:
-    """Gather entry point information by parsing :envvar:`COCOTB_ENTRY_POINT`."""
-    entry_point_str = os.environ.get("COCOTB_ENTRY_POINT", "cocotb:_initialise_testbench")
+    """Gather entry point information by parsing :envvar:`PYGPI_ENTRY_POINT`."""
+    entry_point_str = os.environ.get("PYGPI_ENTRY_POINT", "cocotb:_initialise_testbench")
     try:
         if ":" not in entry_point_str:
-            raise ValueError("Invalid COCOTB_ENTRY_POINT, missing entry function (no colon).")
+            raise ValueError("Invalid PYGPI_ENTRY_POINT, missing entry function (no colon).")
         entry_module_str, entry_func_str = entry_point_str.split(":", 1)
         entry_module = importlib.import_module(entry_module_str)
         entry_func = reduce(getattr, entry_func_str.split('.'), entry_module)
     except Exception as e:
-        raise RuntimeError("Failure to parse COCOTB_ENTRY_POINT ('{}')".format(entry_point_str)) from e
+        raise RuntimeError("Failure to parse PYGPI_ENTRY_POINT ('{}')".format(entry_point_str)) from e
     else:
         return entry_module, entry_func

--- a/pygpi/entry.py
+++ b/pygpi/entry.py
@@ -1,0 +1,18 @@
+import os
+import importlib
+from functools import reduce
+
+
+def load_entry():
+    """Gather entry point information by parsing :envar:`COCOTB_ENTRY_POINT`."""
+    entry_point_str = os.environ.get("COCOTB_ENTRY_POINT", "cocotb:_initialise_testbench")
+    try:
+        if ":" not in entry_point_str:
+            raise ValueError("Invalid COCOTB_ENTRY_POINT, missing entry function (no colon).")
+        entry_module_str, entry_func_str = entry_point_str.split(":", 1)
+        entry_module = importlib.import_module(entry_module_str)
+        entry_func = reduce(getattr, entry_func_str.split('.'), entry_module)
+    except Exception as e:
+        raise RuntimeError("Failure to parse COCOTB_ENTRY_POINT ('{}')".format(entry_point_str)) from e
+    else:
+        return entry_module, entry_func

--- a/pygpi/entry.py
+++ b/pygpi/entry.py
@@ -1,9 +1,11 @@
 import os
 import importlib
 from functools import reduce
+from types import ModuleType
+from typing import Tuple, Callable
 
 
-def load_entry():
+def load_entry() -> Tuple[ModuleType, Callable]:
     """Gather entry point information by parsing :envvar:`COCOTB_ENTRY_POINT`."""
     entry_point_str = os.environ.get("COCOTB_ENTRY_POINT", "cocotb:_initialise_testbench")
     try:

--- a/tests/test_cases/test_custom_entry/.gitignore
+++ b/tests/test_cases/test_custom_entry/.gitignore
@@ -1,0 +1,1 @@
+results.log

--- a/tests/test_cases/test_custom_entry/Makefile
+++ b/tests/test_cases/test_custom_entry/Makefile
@@ -4,6 +4,6 @@ export PYGPI_ENTRY_POINT := custom_entry:entry_func
 .PHONY: override_for_this_test
 override_for_this_test:
 	-$(MAKE) all
-	diff --strip-trailing-cr results.log expected_results.log &>/dev/null
+	python -c 'assert open("results.log").readlines() == open("expected_results.log").readlines()'
 
 include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_custom_entry/Makefile
+++ b/tests/test_cases/test_custom_entry/Makefile
@@ -4,6 +4,6 @@ export PYGPI_ENTRY_POINT := custom_entry:entry_func
 .PHONY: override_for_this_test
 override_for_this_test:
 	-$(MAKE) all
-	diff results.log expected_results.log &>/dev/null
+	diff --strip-trailing-cr results.log expected_results.log &>/dev/null
 
 include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_custom_entry/Makefile
+++ b/tests/test_cases/test_custom_entry/Makefile
@@ -1,0 +1,9 @@
+export PYTHONPATH := .
+export PYGPI_ENTRY_POINT := custom_entry:entry_func
+
+.PHONY: override_for_this_test
+override_for_this_test:
+	-$(MAKE) all
+	diff results.log expected_results.log &>/dev/null
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_custom_entry/custom_entry.py
+++ b/tests/test_cases/test_custom_entry/custom_entry.py
@@ -1,0 +1,13 @@
+from typing import List
+
+from cocotb.log import _filter_from_c, _log_from_c  # noqa: F401
+
+file = open("results.log", "w")
+
+
+def entry_func(argv: List[str]) -> None:
+    print("got entry", file=file)
+
+
+def _sim_event(level: int, message: str) -> None:
+    print(f"got event level={level} message={message}", file=file)

--- a/tests/test_cases/test_custom_entry/custom_entry.py
+++ b/tests/test_cases/test_custom_entry/custom_entry.py
@@ -2,12 +2,12 @@ from typing import List
 
 from cocotb.log import _filter_from_c, _log_from_c  # noqa: F401
 
-file = open("results.log", "w")
-
 
 def entry_func(argv: List[str]) -> None:
-    print("got entry", file=file)
+    with open("results.log", "w") as file:
+        print("got entry", file=file)
 
 
 def _sim_event(level: int, message: str) -> None:
-    print(f"got event level={level} message={message}", file=file)
+    with open("results.log", "a") as file:
+        print(f"got event level={level} message={message}", file=file)

--- a/tests/test_cases/test_custom_entry/expected_results.log
+++ b/tests/test_cases/test_custom_entry/expected_results.log
@@ -1,0 +1,2 @@
+got entry
+got event level=2 message=Simulator shutdown prematurely


### PR DESCRIPTION
Closes #1225. From https://github.com/cocotb/cocotb/issues/1225#issuecomment-738573856, solution 2. Sorry the diff is mostly unreadable. I found it was more work than it was worth to split the changes between DEFER and the rest.

The value of this PR is that we can easily experiment with alternative regression managers and schedulers while keeping existing code working by loading into another entry point. It can also be used by users to setup hooks on cocotb functionality before a test runs.

gpi_embed is no longer hardcoded to enter
"cocotb:_initialize_testbench", but uses an entry module and function
specified by the COCOTB_ENTRY_POINT environment variable. The variable
is of the format: "path.to.entry.module:entry_point.function". The GPI
embed also assumes the "_log_from_c", "_filter_from_c", and "_sim_event"
function are located in the entry module. This may be cleaned up in the
future.

Additionally, the body of the "_embed_sim_init" function has been
improved to remove some of the complexity regarding object lifetimes in
the function by using a "DEFER" statement, which is seen in a few other
languages.

Finally, "py_gpi_log_initialize" was changed to increment the ref on the
passed functions to simplify object lifetime concerns in
"_embed_sim_init".

## TODO

- [x] document COCOTB_ENTRY_POINT
- [x] test
