### PR TITLE
Add Logic and Bit datatypes

### DIFF
--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -60,3 +60,13 @@ if sys.version_info[:2] >= (3, 7):
 else:
     import collections
     insertion_ordered_dict = collections.OrderedDict
+
+
+# backport of Python 3.8's functools.cache decorator
+if sys.version_info < (3, 9):
+    from functools import lru_cache
+
+    def cache(f):
+        return lru_cache(maxsize=None)(f)
+else:
+    from functools import cache  # noqa: F401

--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -62,7 +62,7 @@ else:
     insertion_ordered_dict = collections.OrderedDict
 
 
-# backport of Python 3.8's functools.cache decorator
+# backport of Python 3.9's functools.cache decorator
 if sys.version_info < (3, 9):
     from functools import lru_cache
 

--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -29,7 +29,6 @@ These are for internal use - users should use a third party library like `six`
 if they want to use these shims in their own code
 """
 import sys
-from functools import lru_cache
 
 
 # backport of Python 3.7's contextlib.nullcontext
@@ -61,11 +60,3 @@ if sys.version_info[:2] >= (3, 7):
 else:
     import collections
     insertion_ordered_dict = collections.OrderedDict
-
-
-# backport of Python 3.9's functools.cache decorator
-if sys.version_info < (3, 9):
-    def cache(f):
-        return lru_cache(maxsize=None)(f)
-else:
-    from functools import cache  # noqa: F401

--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -29,6 +29,7 @@ These are for internal use - users should use a third party library like `six`
 if they want to use these shims in their own code
 """
 import sys
+from functools import lru_cache
 
 
 # backport of Python 3.7's contextlib.nullcontext
@@ -64,8 +65,6 @@ else:
 
 # backport of Python 3.9's functools.cache decorator
 if sys.version_info < (3, 9):
-    from functools import lru_cache
-
     def cache(f):
         return lru_cache(maxsize=None)(f)
 else:

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -1,1 +1,4 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 from .logic import Logic, Bit  # noqa: F401

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -1,0 +1,1 @@
+from .logic import Logic, Bit  # noqa: F401

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 from typing import Tuple  # noqa: F401
 from functools import lru_cache
 
@@ -71,6 +71,8 @@ class Logic:
     """
     __slots__ = ("_repr",)
 
+    __singleton_cache__: Dict[int, "Logic"] = {}
+
     _repr_map = {
         # 0 and weak 0
         False: 0,
@@ -107,8 +109,11 @@ class Logic:
             raise ValueError(
                 "{!r} is not convertible to a {}".format(value, cls.__qualname__)
             ) from None
-        obj = super().__new__(cls)
-        obj._repr = _repr
+        obj = cls.__singleton_cache__.get(_repr, None)
+        if obj is None:
+            obj = super().__new__(cls)
+            obj._repr = _repr
+            cls.__singleton_cache__[_repr] = obj
         return obj
 
     def __and__(self, other: "Logic") -> "Logic":
@@ -254,6 +259,8 @@ class Bit(Logic):
         ValueError: if the value cannot be constructed into a :class:`Bit`.
     """
     __slots__ = ()
+
+    __singleton_cache__: Dict[int, "Bit"] = {}
 
     _repr_map = {
         # 0

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -137,10 +137,6 @@ class Logic:
     def __invert__(self):
         return type(self)(("1", "0", "X", "X")[self._repr])
 
-    __eq__ = object.__eq__
-
-    __hash__ = object.__hash__
-
     @cache
     def __repr__(self):
         return "{}({!r})".format(type(self).__name__, str(self))

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -33,7 +33,7 @@ class Logic:
     Model of a 4-value (``0``, ``1``, ``X``, ``Z``) datatype commonly seen in HDLs.
 
     Modeled after (System)Verilog's 4-value ``logic`` type.
-    VHDL's 8-value ``std_logic`` type maps to this type by treating weak values as full strength values
+    VHDL's 9-value ``std_ulogic`` type maps to this type by treating weak values as full strength values
     and "uninitialized" (``U``) and "don't care" (``-``) as "unknown" (``X``).
 
     Supports common logic operations ``&``, ``|``, ``^``, and ``~``.

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -17,13 +17,13 @@ operator `isinstance(other, type(self)`
 strict type equality
     To use `Logic` or `Bit` in hashable collections we need to define `__hash__` and `__eq__` such that
     "Hashable objects which compare equal must have the same hash value."
-    Retrieved from https://hynek.me/articles/hashes-and-equality/ on 2021-03-20.
+    (retrieved from https://hynek.me/articles/hashes-and-equality/ on 2021-03-20).
     The best way to achieve this is to make `Logic` and `Bit` never equal, like `tuple` and `list`.
     If we instead made them equal in hash and value, they would be substitutable; which we don't want.
 
 @cache
-    Shows extreme performance improvements.
-    Even faster than precomputing the results and storing them in the type.
+    Shows extreme performance improvements,
+    even faster than precomputing the results and storing them in the type.
     Everything can be cached since there are a (hopefully) limited number of valid values in all subclasses.
 """
 
@@ -32,21 +32,21 @@ class Logic:
     r"""
     Model of a 4-value (``0``, ``1``, ``X``, ``Z``) datatype commonly seen in HDLs.
 
-    Modeled after (System)Verilog's 4-value ``logic`` type.
+    This is modeled after (System)Verilog's 4-value ``logic`` type.
     VHDL's 9-value ``std_ulogic`` type maps to this type by treating weak values as full strength values
     and treating "uninitialized" (``U``) and "don't care" (``-``) as "unknown" (``X``).
 
-    Can be converted from :class:`int`, :class:`str`, :class:`bool`, and :class:`~cocotb.types.Bit` using the ``Logic(value)`` syntax.
+    :class:`Logic` can be converted from :class:`int`, :class:`str`, :class:`bool`, and :class:`~cocotb.types.Bit` using the ``Logic(value)`` syntax.
     The list of acceptable values includes ``0``, ``1``, ``True``, ``False``, ``'0'``, ``'1'``, ``'X'``, and ``'Z'``.
     For a comprehensive list of values that can be converted into :class:`Logic` see :file:`tests/pytest/test_logic.py`.
 
-    Can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
+    :class:`Logic` can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
     For example, ``int(Logic(0)) == 0``, ``bool(Logic(1)) is True``, and ``str(Logic('X')) == 'X'``.
     The :class:`int` and :class:`bool` conversions will raise :exc:`ValueError` if the value is not ``0`` or ``1``.
 
     :class:`Logic` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 
-    Supports common logic operations ``&``, ``|``, ``^``, and ``~``.
+    :class:`Logic` supports the common logic operations ``&``, ``|``, ``^``, and ``~``.
 
     .. code-block:: py3
 
@@ -182,19 +182,19 @@ class Bit(Logic):
     r"""
     Model of a 2-value (``0``, ``1``) datatype commonly seen in HDLs.
 
-    Modeled after (System)Verilog's 2-value ``bit`` type.
+    This is modeled after (System)Verilog's 2-value ``bit`` type.
     VHDL's ``bit`` type maps to this type perfectly.
 
-    Can be converted from :class:`int`, :class:`str`, :class:`bool`, and :class:`~cocotb.types.Logic` using the ``Bit(value)`` syntax.
+    :class:`Bit` can be converted from :class:`int`, :class:`str`, :class:`bool`, and :class:`~cocotb.types.Logic` using the ``Bit(value)`` syntax.
     The list of acceptable values includes ``0``, ``1``, ``True``, ``False``, ``'0'``, ``'1'``.
     For a comprehensive list of values that can be converted into :class:`Bit` see :file:`tests/pytest/test_logic.py`.
 
-    Can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
+    :class:`Bit` can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
     For example, ``int(Bit(0)) == 0``, ``bool(Bit(1)) is True``, and ``str(Bit('1')) == '1'``.
 
     :class:`Bit` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 
-    Supports common logic operations ``&``, ``|``, ``^``, and ``~``.
+    :class:`Bit` supports the common logic operations ``&``, ``|``, ``^``, and ``~``.
 
     .. code-block:: py3
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -7,26 +7,24 @@ from cocotb._py_compat import cache
 """ DESIGN NOTES
 
 __singleton_cache__
-    Used to ensure there is only ever one instance of a particular value. This is a
-    memory optimization: there will only ever be 4 objects allocated; and also a speed
-    optimization: value equality can be identity equality (as inherited from the `object`
-    base class).
+    Used to ensure there is only ever one instance of a particular value.
+    This is a memory optimization: there will only ever be 4 objects allocated;
+    and also a speed optimization: value equality can be identity equality (as inherited from the `object` base class).
 
 operator `isinstance(other, type(self)`
     Allows operation between a `Bit` and a `Logic` to return a `Logic`.
 
 strict type equality
-    To use `Logic` or `Bit` in hashable collections we need to define `__hash__` and
-    `__eq__` such that "Hashable objects which compare equal must have the same hash
-    value." (https://hynek.me/articles/hashes-and-equality/, 3/20/21). The best way to
-    achieve this is to make `Logic` and `Bit` never equal, like `tuple` and `list`. If we
-    instead made them equal in hash and value, they would be substitutable; which we
-    don't want.
+    To use `Logic` or `Bit` in hashable collections we need to define `__hash__` and `__eq__` such that
+    "Hashable objects which compare equal must have the same hash value."
+    Retreived from https://hynek.me/articles/hashes-and-equality/ on 20/3/21.
+    The best way to achieve this is to make `Logic` and `Bit` never equal, like `tuple` and `list`.
+    If we instead made them equal in hash and value, they would be substitutable; which we don't want.
 
 @cache
-    Shows extreme performance improvements. Even faster than precomputing the results and
-    storing them in the type. Everything can be cached since there are a (hopefully)
-    limited number of valid values in all subclasses.
+    Shows extreme performance improvements.
+    Even faster than precomputing the results and storing them in the type.
+    Everything can be cached since there are a (hopefully) limited number of valid values in all subclasses.
 """
 
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -1,0 +1,205 @@
+from cocotb._py_compat import cache
+
+
+""" DESIGN NOTES
+
+__singleton_cache__
+    Used to ensure there is only ever one instance of a particular value. This is a
+    memory optimization: there will only ever be 4 objects allocated; and also a speed
+    optimization: value equality can be identity equality (as inherited from the `object`
+    base class).
+
+operator `isinstance(other, type(self)`
+    Allows operation between a `Bit` and a `Logic` to return a `Logic`.
+
+strict type equality
+    To use `Logic` or `Bit` in hashable collections we need to define `__hash__` and
+    `__eq__` such that "Hashable objects which compare equal must have the same hash
+    value." (https://hynek.me/articles/hashes-and-equality/, 3/20/21). The best way to
+    achieve this is to make `Logic` and `Bit` never equal, like `tuple` and `list`. If we
+    instead made them equal in hash and value, they would be substitutable; which we
+    don't want.
+
+@cache
+    Shows extreme performance improvements. Even faster than precomputing the results and
+    storing them in the type. Everything can be cached since there are a (hopefully)
+    limited number of valid values in all subclasses.
+"""
+
+
+class Logic:
+    """
+    Models 4-value (0, 1, X, Z) datatype commonly seen in HDLs
+
+    Modeled after (System)Verilog's 4-value ``logic`` type.
+    VHDL's 8-value ``std_logic`` type maps to this type by treating weak values as full strength values
+    and "uninitialized" (``U``) and "don't care" (``-``) as "unknown" (``X``).
+
+    Supports common logic operations ``&``, ``|``, ``^``, and ``~``.
+    Can be converted to and from :class:`int`, :class:`str`, :class:`bool`, and :class:`cocotb.types.Bit`.
+    """
+
+    __singleton_cache__ = {}
+
+    _repr_map = {
+        # 0 and weak 0
+        False: 0,
+        0: 0,
+        "0": 0,
+        "L": 0,
+        "l": 0,
+        # 1 and weak 1
+        True: 1,
+        1: 1,
+        "1": 1,
+        "H": 1,
+        "h": 1,
+        # unknown, unassigned, and weak unknown
+        None: 2,
+        "X": 2,
+        "x": 2,
+        "U": 2,
+        "u": 2,
+        "W": 2,
+        "w": 2,
+        # high impedance
+        "Z": 3,
+        "z": 3,
+    }
+
+    @cache
+    def __new__(cls, value=None):
+        # convert to internal representation
+        try:
+            _repr = cls._repr_map[value]
+        except KeyError:
+            raise ValueError(
+                "{!r} is not convertable to a {}".format(value, cls.__qualname__)
+            ) from None
+        # ensure only one object is made per representation
+        if _repr not in cls.__singleton_cache__:
+            obj = super().__new__(cls)
+            obj._repr = _repr
+            cls.__singleton_cache__[_repr] = obj
+        return cls.__singleton_cache__[_repr]
+
+    @cache
+    def __and__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return type(self)(
+            (
+                ("0", "0", "0", "0"),
+                ("0", "1", "X", "X"),
+                ("0", "X", "X", "X"),
+                ("0", "X", "X", "X"),
+            )[self._repr][other._repr]
+        )
+
+    def __rand__(self, other):
+        return self & other
+
+    @cache
+    def __or__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return type(self)(
+            (
+                ("0", "1", "X", "X"),
+                ("1", "1", "1", "1"),
+                ("X", "1", "X", "X"),
+                ("X", "1", "X", "X"),
+            )[self._repr][other._repr]
+        )
+
+    def __ror__(self, other):
+        return self | other
+
+    @cache
+    def __xor__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return type(self)(
+            (
+                ("0", "1", "X", "X"),
+                ("1", "0", "X", "X"),
+                ("X", "X", "X", "X"),
+                ("X", "X", "X", "X"),
+            )[self._repr][other._repr]
+        )
+
+    def __rxor__(self, other):
+        return self ^ other
+
+    @cache
+    def __invert__(self):
+        return type(self)(("1", "0", "X", "X")[self._repr])
+
+    __eq__ = object.__eq__
+
+    __hash__ = object.__hash__
+
+    @cache
+    def __repr__(self):
+        return "{}({!r})".format(type(self).__name__, str(self))
+
+    @cache
+    def __str__(self):
+        return ("0", "1", "X", "Z")[self._repr]
+
+    @cache
+    def __bool__(self):
+        if self._repr < 2:
+            return bool(self._repr)
+        raise ValueError(
+            "Cannot convert non-0/1 {} to bool".format(type(self).__qualname__)
+        )
+
+    @cache
+    def __int__(self):
+        if self._repr < 2:
+            return self._repr
+        raise ValueError(
+            "Cannot convert non-0/1 {} to int".format(type(self).__qualname__)
+        )
+
+
+class Bit(Logic):
+    """
+    Models 2-value (0, 1) datatype commonly seen in HDLs
+
+    Modeled after (System)Verilog's 2-value ``bit`` type.
+    VHDL's ``bit`` type maps to this type perfectly.
+
+    Supports common logic operations ``&``, ``|``, ``^``, and ``~``.
+    Can be converted to and from :class:`int`, :class:`str`, :class:`bool`, and :class:`cocotb.types.Logic`..
+    """
+
+    # must create a separate cache for Bit
+    __singleton_cache__ = {}
+
+    _repr_map = {
+        # 0
+        None: 0,
+        False: 0,
+        0: 0,
+        "0": 0,
+        # 1
+        True: 1,
+        1: 1,
+        "1": 1,
+    }
+
+
+Logic._repr_map.update(
+    {
+        Logic("0"): 0,
+        Logic("1"): 1,
+        Logic("X"): 2,
+        Logic("Z"): 3,
+        Bit("0"): 0,
+        Bit("1"): 1,
+    }
+)
+
+Bit._repr_map.update({Logic("0"): 0, Logic("1"): 1, Bit("0"): 0, Bit("1"): 1})

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -30,7 +30,7 @@ strict type equality
 
 class Logic:
     """
-    Models 4-value (0, 1, X, Z) datatype commonly seen in HDLs
+    Model of 4-value (0, 1, X, Z) datatype commonly seen in HDLs.
 
     Modeled after (System)Verilog's 4-value ``logic`` type.
     VHDL's 8-value ``std_logic`` type maps to this type by treating weak values as full strength values
@@ -167,7 +167,7 @@ class Logic:
 
 class Bit(Logic):
     """
-    Models 2-value (0, 1) datatype commonly seen in HDLs
+    Model of 2-value (0, 1) datatype commonly seen in HDLs.
 
     Modeled after (System)Verilog's 2-value ``bit`` type.
     VHDL's ``bit`` type maps to this type perfectly.

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -133,7 +133,7 @@ class Logic:
         return self._repr
 
     def __repr__(self) -> str:
-        return "{}({!r})".format(self.__class__.__name__, str(self))
+        return "{}({!r})".format(self.__class__.__qualname__, str(self))
 
     def __str__(self) -> str:
         return ("0", "1", "X", "Z")[self._repr]

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -76,7 +76,7 @@ class Logic:
             _repr = cls._repr_map[value]
         except KeyError:
             raise ValueError(
-                "{!r} is not convertable to a {}".format(value, cls.__qualname__)
+                "{!r} is not convertible to a {}".format(value, cls.__qualname__)
             ) from None
         # ensure only one object is made per representation
         if _repr not in cls.__singleton_cache__:

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -150,7 +150,7 @@ class Logic:
         if self._repr < 2:
             return bool(self._repr)
         raise ValueError(
-            "Cannot convert {self!r} to bool".format(type(self).__qualname__)
+            f"Cannot convert {self!r} to bool"
         )
 
     @cache
@@ -158,7 +158,7 @@ class Logic:
         if self._repr < 2:
             return self._repr
         raise ValueError(
-            "Cannot convert {sefl!r} to int".format(type(self).__qualname__)
+            f"Cannot convert {sefl!r} to int"
         )
 
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -1,7 +1,8 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
+from typing import Tuple  # noqa: F401
 from functools import lru_cache
 
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -150,7 +150,7 @@ class Logic:
         if self._repr < 2:
             return bool(self._repr)
         raise ValueError(
-            "Cannot convert non-0/1 {} to bool".format(type(self).__qualname__)
+            "Cannot convert {self!r} to bool".format(type(self).__qualname__)
         )
 
     @cache
@@ -158,7 +158,7 @@ class Logic:
         if self._repr < 2:
             return self._repr
         raise ValueError(
-            "Cannot convert non-0/1 {} to int".format(type(self).__qualname__)
+            "Cannot convert {sefl!r} to int".format(type(self).__qualname__)
         )
 
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -111,9 +111,9 @@ class Logic:
         return obj
 
     def __and__(self, other: "Logic") -> "Logic":
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, type(self)):
             return NotImplemented
-        return self.__class__(
+        return type(self)(
             (
                 ("0", "0", "0", "0"),
                 ("0", "1", "X", "X"),
@@ -126,9 +126,9 @@ class Logic:
         return self & other
 
     def __or__(self, other: "Logic") -> "Logic":
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, type(self)):
             return NotImplemented
-        return self.__class__(
+        return type(self)(
             (
                 ("0", "1", "X", "X"),
                 ("1", "1", "1", "1"),
@@ -141,9 +141,9 @@ class Logic:
         return self | other
 
     def __xor__(self, other: "Logic") -> "Logic":
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, type(self)):
             return NotImplemented
-        return self.__class__(
+        return type(self)(
             (
                 ("0", "1", "X", "X"),
                 ("1", "0", "X", "X"),
@@ -156,10 +156,10 @@ class Logic:
         return self ^ other
 
     def __invert__(self) -> "Logic":
-        return self.__class__(("1", "0", "X", "X")[self._repr])
+        return type(self)(("1", "0", "X", "X")[self._repr])
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, type(self)):
             return NotImplemented
         return self._repr == other._repr
 
@@ -167,7 +167,7 @@ class Logic:
         return self._repr
 
     def __repr__(self) -> str:
-        return "{}({!r})".format(self.__class__.__qualname__, str(self))
+        return "{}({!r})".format(type(self).__qualname__, str(self))
 
     def __str__(self) -> str:
         return ("0", "1", "X", "Z")[self._repr]

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -1,6 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
+from typing import Any, Optional
 from cocotb._py_compat import cache
 
 
@@ -89,7 +90,7 @@ class Logic:
     }
 
     @cache
-    def __new__(cls, value=None):
+    def __new__(cls, value: Optional[Any] = None) -> 'Logic':
         # convert to internal representation
         try:
             _repr = cls._repr_map[value]
@@ -105,7 +106,7 @@ class Logic:
         return cls.__singleton_cache__[_repr]
 
     @cache
-    def __and__(self, other):
+    def __and__(self, other: Any) -> 'Logic':
         if not isinstance(other, type(self)):
             return NotImplemented
         return type(self)(
@@ -117,11 +118,11 @@ class Logic:
             )[self._repr][other._repr]
         )
 
-    def __rand__(self, other):
+    def __rand__(self, other: Any) -> 'Logic':
         return self & other
 
     @cache
-    def __or__(self, other):
+    def __or__(self, other: Any) -> 'Logic':
         if not isinstance(other, type(self)):
             return NotImplemented
         return type(self)(
@@ -133,11 +134,11 @@ class Logic:
             )[self._repr][other._repr]
         )
 
-    def __ror__(self, other):
+    def __ror__(self, other: Any) -> 'Logic':
         return self | other
 
     @cache
-    def __xor__(self, other):
+    def __xor__(self, other: Any) -> 'Logic':
         if not isinstance(other, type(self)):
             return NotImplemented
         return type(self)(
@@ -149,29 +150,29 @@ class Logic:
             )[self._repr][other._repr]
         )
 
-    def __rxor__(self, other):
+    def __rxor__(self, other: Any) -> 'Logic':
         return self ^ other
 
     @cache
-    def __invert__(self):
+    def __invert__(self) -> 'Logic':
         return type(self)(("1", "0", "X", "X")[self._repr])
 
     @cache
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{}({!r})".format(type(self).__name__, str(self))
 
     @cache
-    def __str__(self):
+    def __str__(self) -> str:
         return ("0", "1", "X", "Z")[self._repr]
 
     @cache
-    def __bool__(self):
+    def __bool__(self) -> bool:
         if self._repr < 2:
             return bool(self._repr)
         raise ValueError(f"Cannot convert {self!r} to bool")
 
     @cache
-    def __int__(self):
+    def __int__(self) -> int:
         if self._repr < 2:
             return self._repr
         raise ValueError(f"Cannot convert {self!r} to int")

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -48,13 +48,13 @@ class Logic:
 
         The :class:`int` and :class:`bool` conversions will raise :exc:`ValueError` if the value is not ``0`` or ``1``.
 
-    :class:`Logic` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
+    :class:`Logic` values are immutable and therefore hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 
     :class:`Logic` supports the common logic operations ``&``, ``|``, ``^``, and ``~``.
 
     .. code-block:: python3
 
-        >>> def full_adder(a: Logic, b: Logic, carry: Logic) -> (Logic, Logic):
+        >>> def full_adder(a: Logic, b: Logic, carry: Logic) -> Tuple[Logic, Logic]:
         ...     res = a ^ b ^ carry
         ...     carry_out = (a & b) | (b & carry) | (a & carry)
         ...     return res, carry_out

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 from functools import lru_cache
 
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -6,6 +6,20 @@ from typing import Tuple  # noqa: F401
 from functools import lru_cache
 
 
+class _StaticOnlyProp:
+
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __set_name__(self, cls, name):
+        self.__cls = cls
+
+    def __get__(self, instance, cls):
+        if cls is not self.__cls or instance is not None:
+            raise AttributeError
+        return self.fget()
+
+
 class Logic:
     r"""
     Model of a 4-value (``0``, ``1``, ``X``, ``Z``) datatype commonly seen in HDLs.
@@ -99,6 +113,22 @@ class Logic:
         "Z": 3,
         "z": 3,
     }
+
+    @_StaticOnlyProp
+    def _0():
+        return Logic("0")
+
+    @_StaticOnlyProp
+    def _1():
+        return Logic("1")
+
+    @_StaticOnlyProp
+    def X():
+        return Logic("X")
+
+    @_StaticOnlyProp
+    def Z():
+        return Logic("Z")
 
     @lru_cache(maxsize=None)
     def __new__(cls, value: Optional[Any] = None) -> "Logic":
@@ -273,6 +303,14 @@ class Bit(Logic):
         1: 1,
         "1": 1,
     }
+
+    @_StaticOnlyProp
+    def _0():
+        return Bit("0")
+
+    @_StaticOnlyProp
+    def _1():
+        return Bit("1")
 
 
 Logic._repr_map.update(

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -30,7 +30,7 @@ strict type equality
 
 class Logic:
     """
-    Model of 4-value (0, 1, X, Z) datatype commonly seen in HDLs.
+    Model of a 4-value (``0``, ``1``, ``X``, ``Z``) datatype commonly seen in HDLs.
 
     Modeled after (System)Verilog's 4-value ``logic`` type.
     VHDL's 8-value ``std_logic`` type maps to this type by treating weak values as full strength values
@@ -63,6 +63,7 @@ class Logic:
         "u": 2,
         "W": 2,
         "w": 2,
+        "-": 2,
         # high impedance
         "Z": 3,
         "z": 3,
@@ -167,13 +168,13 @@ class Logic:
 
 class Bit(Logic):
     """
-    Model of 2-value (0, 1) datatype commonly seen in HDLs.
+    Model of a 2-value (``0``, ``1``) datatype commonly seen in HDLs.
 
     Modeled after (System)Verilog's 2-value ``bit`` type.
     VHDL's ``bit`` type maps to this type perfectly.
 
     Supports common logic operations ``&``, ``|``, ``^``, and ``~``.
-    Can be converted to and from :class:`int`, :class:`str`, :class:`bool`, and :class:`cocotb.types.Logic`..
+    Can be converted to and from :class:`int`, :class:`str`, :class:`bool`, and :class:`cocotb.types.Logic`.
     """
 
     # must create a separate cache for Bit

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -17,7 +17,7 @@ operator `isinstance(other, type(self)`
 strict type equality
     To use `Logic` or `Bit` in hashable collections we need to define `__hash__` and `__eq__` such that
     "Hashable objects which compare equal must have the same hash value."
-    Retreived from https://hynek.me/articles/hashes-and-equality/ on 20/3/21.
+    Retrieved from https://hynek.me/articles/hashes-and-equality/ on 2021-03-20.
     The best way to achieve this is to make `Logic` and `Bit` never equal, like `tuple` and `list`.
     If we instead made them equal in hash and value, they would be substitutable; which we don't want.
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -158,7 +158,7 @@ class Logic:
         if self._repr < 2:
             return self._repr
         raise ValueError(
-            f"Cannot convert {sefl!r} to int"
+            f"Cannot convert {self!r} to int"
         )
 
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -37,14 +37,14 @@ class Logic:
     and treating "uninitialized" (``U``) and "don't care" (``-``) as "unknown" (``X``).
 
     :class:`Logic` can be converted from :class:`int`, :class:`str`, :class:`bool`, and :class:`~cocotb.types.Bit` using the ``Logic(value)`` syntax.
-    The list of acceptable values includes ``0``, ``1``, ``True``, ``False``, ``'0'``, ``'1'``, ``'X'``, and ``'Z'``.
+    The list of acceptable values includes ``0``, ``1``, ``True``, ``False``, ``"0"``, ``"1"``, ``"X"``, and ``"Z"``.
     For a comprehensive list of values that can be converted into :class:`Logic` see :file:`tests/pytest/test_logic.py`.
 
     :class:`Logic` can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
-    For example, ``int(Logic(0)) == 0``, ``bool(Logic(1)) is True``, and ``str(Logic('X')) == 'X'``.
+    For example, ``int(Logic(0)) == 0``, ``bool(Logic(1)) is True``, and ``str(Logic("X")) == "X"``.
     The :class:`int` and :class:`bool` conversions will raise :exc:`ValueError` if the value is not ``0`` or ``1``.
 
-    The default value of ``Logic()`` is ``Logic('X')``.
+    The default value of ``Logic()`` is ``Logic("X")``.
 
     :class:`Logic` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 
@@ -167,17 +167,13 @@ class Logic:
     def __bool__(self):
         if self._repr < 2:
             return bool(self._repr)
-        raise ValueError(
-            f"Cannot convert {self!r} to bool"
-        )
+        raise ValueError(f"Cannot convert {self!r} to bool")
 
     @cache
     def __int__(self):
         if self._repr < 2:
             return self._repr
-        raise ValueError(
-            f"Cannot convert {self!r} to int"
-        )
+        raise ValueError(f"Cannot convert {self!r} to int")
 
 
 class Bit(Logic):
@@ -188,13 +184,13 @@ class Bit(Logic):
     VHDL's ``bit`` type maps to this type perfectly.
 
     :class:`Bit` can be converted from :class:`int`, :class:`str`, :class:`bool`, and :class:`~cocotb.types.Logic` using the ``Bit(value)`` syntax.
-    The list of acceptable values includes ``0``, ``1``, ``True``, ``False``, ``'0'``, ``'1'``.
+    The list of acceptable values includes ``0``, ``1``, ``True``, ``False``, ``"0"``, ``"1"``.
     For a comprehensive list of values that can be converted into :class:`Bit` see :file:`tests/pytest/test_logic.py`.
 
     :class:`Bit` can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
-    For example, ``int(Bit(0)) == 0``, ``bool(Bit(1)) is True``, and ``str(Bit('1')) == '1'``.
+    For example, ``int(Bit(0)) == 0``, ``bool(Bit(1)) is True``, and ``str(Bit("1")) == "1"``.
 
-    The default value of ``Bit()`` is ``Bit('0')``.
+    The default value of ``Bit()`` is ``Bit("0")``.
 
     :class:`Bit` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -1,3 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 from cocotb._py_compat import cache
 
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -44,6 +44,8 @@ class Logic:
     For example, ``int(Logic(0)) == 0``, ``bool(Logic(1)) is True``, and ``str(Logic('X')) == 'X'``.
     The :class:`int` and :class:`bool` conversions will raise :exc:`ValueError` if the value is not ``0`` or ``1``.
 
+    The default value of ``Logic()`` is ``Logic('X')``.
+
     :class:`Logic` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 
     :class:`Logic` supports the common logic operations ``&``, ``|``, ``^``, and ``~``.
@@ -191,6 +193,8 @@ class Bit(Logic):
 
     :class:`Bit` can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
     For example, ``int(Bit(0)) == 0``, ``bool(Bit(1)) is True``, and ``str(Bit('1')) == '1'``.
+
+    The default value of ``Bit()`` is ``Bit('0')``.
 
     :class:`Bit` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -110,7 +110,7 @@ class Logic:
         obj._repr = _repr
         return obj
 
-    def __and__(self, other: Any) -> "Logic":
+    def __and__(self, other: "Logic") -> "Logic":
         if not isinstance(other, self.__class__):
             return NotImplemented
         return self.__class__(
@@ -122,10 +122,10 @@ class Logic:
             )[self._repr][other._repr]
         )
 
-    def __rand__(self, other: Any) -> "Logic":
+    def __rand__(self, other: "Logic") -> "Logic":
         return self & other
 
-    def __or__(self, other: Any) -> "Logic":
+    def __or__(self, other: "Logic") -> "Logic":
         if not isinstance(other, self.__class__):
             return NotImplemented
         return self.__class__(
@@ -137,10 +137,10 @@ class Logic:
             )[self._repr][other._repr]
         )
 
-    def __ror__(self, other: Any) -> "Logic":
+    def __ror__(self, other: "Logic") -> "Logic":
         return self | other
 
-    def __xor__(self, other: Any) -> "Logic":
+    def __xor__(self, other: "Logic") -> "Logic":
         if not isinstance(other, self.__class__):
             return NotImplemented
         return self.__class__(
@@ -152,13 +152,13 @@ class Logic:
             )[self._repr][other._repr]
         )
 
-    def __rxor__(self, other: Any) -> "Logic":
+    def __rxor__(self, other: "Logic") -> "Logic":
         return self ^ other
 
     def __invert__(self) -> "Logic":
         return self.__class__(("1", "0", "X", "X")[self._repr])
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, self.__class__):
             return NotImplemented
         return self._repr == other._repr

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -29,15 +29,31 @@ strict type equality
 
 
 class Logic:
-    """
+    r"""
     Model of a 4-value (``0``, ``1``, ``X``, ``Z``) datatype commonly seen in HDLs.
 
     Modeled after (System)Verilog's 4-value ``logic`` type.
     VHDL's 9-value ``std_ulogic`` type maps to this type by treating weak values as full strength values
-    and "uninitialized" (``U``) and "don't care" (``-``) as "unknown" (``X``).
+    and treating "uninitialized" (``U``) and "don't care" (``-``) as "unknown" (``X``).
+
+    Can be converted from :class:`int`, :class:`str`, :class:`bool`, and :class:`~cocotb.types.Bit` using the ``Logic(value)`` syntax.
+    The list of acceptable values includes ``0``, ``1``, ``True``, ``False``, ``'0'``, ``'1'``, ``'X'``, and ``'Z'``.
+    For a comprehensive list of values that can be converted into :class:`Logic` see :file:`tests/pytest/test_logic.py`.
+
+    Can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
+    For example, ``int(Logic(0)) == 0``, ``bool(Logic(1)) is True``, and ``str(Logic('X')) == 'X'``.
+    The :class:`int` and :class:`bool` conversions will raise :exc:`ValueError` if the value is not ``0`` or ``1``.
+
+    :class:`Logic` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 
     Supports common logic operations ``&``, ``|``, ``^``, and ``~``.
-    Can be converted to and from :class:`int`, :class:`str`, :class:`bool`, and :class:`cocotb.types.Bit`.
+
+    .. code-block:: py3
+
+        def full_adder(a: Logic, b: Logic, c_in: Logic) -> (Logic, Logic):
+            res = a ^ b ^ c_in
+            c_out = (a & b) | (b & c_in) | (a & c_in)
+            return res, c_out
     """
 
     __singleton_cache__ = {}
@@ -163,14 +179,27 @@ class Logic:
 
 
 class Bit(Logic):
-    """
+    r"""
     Model of a 2-value (``0``, ``1``) datatype commonly seen in HDLs.
 
     Modeled after (System)Verilog's 2-value ``bit`` type.
     VHDL's ``bit`` type maps to this type perfectly.
 
+    Can be converted from :class:`int`, :class:`str`, :class:`bool`, and :class:`~cocotb.types.Logic` using the ``Bit(value)`` syntax.
+    The list of acceptable values includes ``0``, ``1``, ``True``, ``False``, ``'0'``, ``'1'``.
+    For a comprehensive list of values that can be converted into :class:`Bit` see :file:`tests/pytest/test_logic.py`.
+
+    Can be converted to :class:`int`, :class:`str`, :class:`bool` using the appropriate constructor syntax.
+    For example, ``int(Bit(0)) == 0``, ``bool(Bit(1)) is True``, and ``str(Bit('1')) == '1'``.
+
+    :class:`Bit` values are hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
+
     Supports common logic operations ``&``, ``|``, ``^``, and ``~``.
-    Can be converted to and from :class:`int`, :class:`str`, :class:`bool`, and :class:`cocotb.types.Logic`.
+
+    .. code-block:: py3
+
+        def mux(a: Bit, b: Bit, s: Bit) -> Bit
+            return (a & ~s) | (b & s)
     """
 
     # must create a separate cache for Bit

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -77,9 +77,9 @@ class Logic:
         return obj
 
     def __and__(self, other: Any) -> "Logic":
-        if not isinstance(other, type(self)):
+        if not isinstance(other, self.__class__):
             return NotImplemented
-        return type(self)(
+        return self.__class__(
             (
                 ("0", "0", "0", "0"),
                 ("0", "1", "X", "X"),
@@ -92,9 +92,9 @@ class Logic:
         return self & other
 
     def __or__(self, other: Any) -> "Logic":
-        if not isinstance(other, type(self)):
+        if not isinstance(other, self.__class__):
             return NotImplemented
-        return type(self)(
+        return self.__class__(
             (
                 ("0", "1", "X", "X"),
                 ("1", "1", "1", "1"),
@@ -107,9 +107,9 @@ class Logic:
         return self | other
 
     def __xor__(self, other: Any) -> "Logic":
-        if not isinstance(other, type(self)):
+        if not isinstance(other, self.__class__):
             return NotImplemented
-        return type(self)(
+        return self.__class__(
             (
                 ("0", "1", "X", "X"),
                 ("1", "0", "X", "X"),
@@ -122,10 +122,10 @@ class Logic:
         return self ^ other
 
     def __invert__(self) -> "Logic":
-        return type(self)(("1", "0", "X", "X")[self._repr])
+        return self.__class__(("1", "0", "X", "X")[self._repr])
 
     def __eq__(self, other) -> bool:
-        if not isinstance(other, type(self)):
+        if not isinstance(other, self.__class__):
             return NotImplemented
         return self._repr == other._repr
 
@@ -133,7 +133,7 @@ class Logic:
         return self._repr
 
     def __repr__(self) -> str:
-        return "{}({!r})".format(type(self).__name__, str(self))
+        return "{}({!r})".format(self.__class__.__name__, str(self))
 
     def __str__(self) -> str:
         return ("0", "1", "X", "Z")[self._repr]

--- a/cocotb/types/logic.py
+++ b/cocotb/types/logic.py
@@ -57,6 +57,7 @@ class Logic:
             c_out = (a & b) | (b & c_in) | (a & c_in)
             return res, c_out
     """
+    __slots__ = ("_repr",)
 
     __singleton_cache__ = {}
 
@@ -201,6 +202,7 @@ class Bit(Logic):
         def mux(a: Bit, b: Bit, s: Bit) -> Bit
             return (a & ~s) | (b & s)
     """
+    __slots__ = ()
 
     # must create a separate cache for Bit
     __singleton_cache__ = {}

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -75,6 +75,8 @@ as the types used by cocotb's `simulator handles <#simulation-object-handles>`_.
 
 .. autoclass:: cocotb.types.Bit
 
+.. versionadded:: 2.0
+
 Triggers
 --------
 See :ref:`simulator-triggers` for a list of sub-classes. Below are the internal

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -64,6 +64,17 @@ Interacting with the Simulator
 
 .. autofunction:: cocotb.decorators.RunningTask.kill
 
+HDL Datatypes
+-------------
+
+These are a set of datatypes that model the behavior of common HDL datatypes.
+They can be used independently of cocotb for modeling and will replace :class:`BinaryValue`
+as the types used by cocotb's `simulator handles <#simulation-object-handles>`_.
+
+.. autoclass:: cocotb.types.Logic
+
+.. autoclass:: cocotb.types.Bit
+
 Triggers
 --------
 See :ref:`simulator-triggers` for a list of sub-classes. Below are the internal

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -71,11 +71,12 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
 They can be used independently of cocotb for modeling and will replace :class:`BinaryValue`
 as the types used by cocotb's `simulator handles <#simulation-object-handles>`_.
 
+.. versionadded:: 2.0
+
 .. autoclass:: cocotb.types.Logic
 
 .. autoclass:: cocotb.types.Bit
 
-.. versionadded:: 2.0
 
 Triggers
 --------

--- a/documentation/source/newsfragments/2059.feature.rst
+++ b/documentation/source/newsfragments/2059.feature.rst
@@ -1,0 +1,1 @@
+Added :class:`~cocotb.types.Logic` and :class:`~cocotb.types.Bit` modeling datatypes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ testpaths =
     tests/pytest
     cocotb/utils.py
     cocotb/binary.py
+    cocotb/types/
     cocotb/_sim_versions.py
 # log_cli = true
 # log_cli_level = DEBUG

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -72,6 +72,16 @@ def test_logic_bit_equality():
     assert Logic(0) != Bit(0)
 
 
+def test_logic_hashability():
+    s = {Logic('0'), Logic('1'), Logic('X'), Logic('Z')}
+    assert len(s) == 4
+
+
+def test_bit_hashability():
+    s = {Bit(0), Bit(1)}
+    assert len(s) == 2
+
+
 def test_logic_default_value():
     assert Logic() == Logic('X')
 

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -24,6 +24,10 @@ def test_logic_conversions():
     Logic('U')
     Logic('z')
     Logic('Z')
+    Logic(Logic('0'))
+    Logic(Logic('1'))
+    Logic(Logic('X'))
+    Logic(Logic('Z'))
     with pytest.raises(ValueError):
         Logic('j')
 
@@ -35,6 +39,8 @@ def test_bit_conversions():
     Bit(True)
     Bit('0')
     Bit('1')
+    Bit(Bit('0'))
+    Bit(Bit('1'))
     with pytest.raises(ValueError):
         _ = Bit(object())
 

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -127,6 +127,17 @@ def test_bit_hashability():
     assert len(s) == 2
 
 
+def test_logic_bit_hashability():
+    s = {
+        Logic('0'),
+        Logic('1'),
+        Logic('X'),
+        Logic('Z'),
+        Bit('0'),
+        Bit('1')}
+    assert len(s) == 6
+
+
 def test_logic_default_value():
     assert Logic() == Logic('X')
 

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -78,8 +78,8 @@ def test_bit_equality():
 
 
 def test_logic_bit_equality():
-    assert Logic(0) != Bit(0)
-    assert Logic(1) != Bit(1)
+    assert Logic(0) == Bit(0)
+    assert Logic(1) == Bit(1)
 
 
 def test_logic_hashability():
@@ -94,7 +94,7 @@ def test_bit_hashability():
 
 def test_logic_bit_hashability():
     s = {Logic("0"), Logic("1"), Logic("X"), Logic("Z"), Bit("0"), Bit("1")}
-    assert len(s) == 6
+    assert len(s) == 4
 
 
 def test_logic_default_value():

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -1,0 +1,222 @@
+from cocotb.types import Logic, Bit
+import pytest
+
+
+def test_logic_conversions():
+    Logic(0)
+    Logic(1)
+    Logic(True)
+    Logic(False)
+    Logic('0')
+    Logic('l')
+    Logic('L')
+    Logic('1')
+    Logic('h')
+    Logic('H')
+    Logic('x')
+    Logic('X')
+    Logic('w')
+    Logic('W')
+    Logic('u')
+    Logic('U')
+    Logic('z')
+    Logic('Z')
+    with pytest.raises(ValueError):
+        Logic('j')
+
+
+def test_bit_conversions():
+    Bit(0)
+    Bit(1)
+    Bit(False)
+    Bit(True)
+    Bit('0')
+    Bit('1')
+    with pytest.raises(ValueError):
+        _ = Bit(object())
+
+
+def test_bit_logic_conversions():
+    Logic(Bit(0))
+    Logic(Bit(1))
+    Bit(Logic(0))
+    Bit(Logic(1))
+    with pytest.raises(ValueError):
+        Bit(Logic('X'))
+    with pytest.raises(ValueError):
+        Bit(Logic('Z'))
+
+
+def test_logic_equality():
+    assert Logic(0) == Logic('0')
+    assert Logic(0) != Logic('X')
+    assert Logic(0) != object()
+
+
+def test_bit_equality():
+    assert Bit(0) == Bit(False)
+    assert Bit(1) != Bit('0')
+    assert Bit(1) != object()
+
+
+def test_logic_bit_equality():
+    assert Logic(0) != Bit(0)
+
+
+def test_logic_default_value():
+    assert Logic() == Logic('X')
+
+
+def test_bit_default_value():
+    assert Bit() == Bit('0')
+
+
+def test_logic_bool_conversions():
+    assert bool(Logic('1')) is True
+    assert bool(Logic('0')) is False
+    with pytest.raises(ValueError):
+        bool(Logic('X'))
+    with pytest.raises(ValueError):
+        bool(Logic('Z'))
+
+
+def test_bit_bool_conversions():
+    assert bool(Bit(1)) is True
+    assert bool(Bit(0)) is False
+
+
+def test_logic_str_conversions():
+    assert str(Logic('0')) == '0'
+    assert str(Logic('1')) == '1'
+    assert str(Logic('X')) == 'X'
+    assert str(Logic('Z')) == 'Z'
+
+
+def test_bit_str_conversions():
+    assert str(Bit(0)) == '0'
+    assert str(Bit(1)) == '1'
+
+
+def test_logic_int_conversions():
+    assert int(Logic('0')) == 0
+    assert int(Logic('1')) == 1
+    with pytest.raises(ValueError):
+        int(Logic('X'))
+    with pytest.raises(ValueError):
+        int(Logic('Z'))
+
+
+def test_bit_int_conversions():
+    assert int(Bit('0')) == 0
+    assert int(Bit('1')) == 1
+
+
+def test_logic_repr():
+    assert eval(repr(Logic('0'))) == Logic('0')
+    assert eval(repr(Logic('1'))) == Logic('1')
+    assert eval(repr(Logic('X'))) == Logic('X')
+    assert eval(repr(Logic('Z'))) == Logic('Z')
+
+
+def test_bit_repr():
+    assert eval(repr(Bit('0'))) == Bit('0')
+    assert eval(repr(Bit('1'))) == Bit('1')
+
+
+def test_logic_and():
+    # will not be exhaustive
+    assert Logic('0') & Logic('Z') == Logic(0)
+    assert Logic(1) & Logic('1') == Logic(1)
+    assert Logic('X') & Logic('Z') == Logic('X')
+    with pytest.raises(TypeError):
+        Logic('1') & 8
+    with pytest.raises(TypeError):
+        8 & Logic('1')
+
+
+def test_bit_and():
+    assert Bit('0') & Bit('1') == Bit(0)
+    assert Bit(1) & Bit('1') == Bit(1)
+    with pytest.raises(TypeError):
+        Bit('1') & 8
+    with pytest.raises(TypeError):
+        8 & Bit('1')
+
+
+def test_logic_bit_and():
+    r = Logic(0) & Bit(1)
+    assert type(r) == Logic
+    assert r == Logic(0)
+    r = Bit(1) & Logic(0)
+    assert type(r) == Logic
+    assert r == Logic(0)
+
+
+def test_logic_or():
+    # will not be exhaustive
+    assert Logic('1') | Logic('Z') == Logic('1')
+    assert Logic(0) | Logic('0') == Logic(0)
+    assert Logic('X') | Logic('Z') == Logic('X')
+    with pytest.raises(TypeError):
+        8 | Logic(0)
+    with pytest.raises(TypeError):
+        Logic(0) | 8
+
+
+def test_bit_or():
+    assert Bit('0') | Bit('1') == Bit(1)
+    assert Bit(0) | Bit(False) == Bit(0)
+    with pytest.raises(TypeError):
+        8 | Bit(0)
+    with pytest.raises(TypeError):
+        Bit(0) | 8
+
+
+def test_logic_bit_or():
+    r = Logic(0) | Bit(1)
+    assert type(r) == Logic
+    assert r == Logic(1)
+    r = Bit(1) | Logic(0)
+    assert type(r) == Logic
+    assert r == Logic(1)
+
+
+def test_logic_xor():
+    # will not be exhaustive
+    assert (Logic('1') ^ Logic(True)) == Logic(0)
+    assert (Logic(1) ^ Logic('X')) == Logic('X')
+    assert (Logic(1) ^ Logic(False)) == Logic(1)
+    with pytest.raises(TypeError):
+        Logic(1) ^ ()
+    with pytest.raises(TypeError):
+        () ^ Logic(1)
+
+
+def test_bit_xor():
+    assert Bit(0) ^ Bit('1') == Bit(1)
+    assert Bit(False) ^ Bit(0) == Bit('0')
+    with pytest.raises(TypeError):
+        Bit(1) ^ ()
+    with pytest.raises(TypeError):
+        () ^ Bit(1)
+
+
+def test_logic_bit_xor():
+    r = Logic(0) ^ Bit(1)
+    assert type(r) == Logic
+    assert r == Logic(1)
+    r = Bit(0) ^ Logic(0)
+    assert type(r) == Logic
+    assert r == Logic(0)
+
+
+def test_logic_invert():
+    assert ~Logic(0) == Logic(1)
+    assert ~Logic(1) == Logic(0)
+    assert ~Logic('X') == Logic('X')
+    assert ~Logic('Z') == Logic('X')
+
+
+def test_bit_invert():
+    assert ~Bit(0) == Bit(1)
+    assert ~Bit(1) == Bit(0)

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -1,3 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 from cocotb.types import Logic, Bit
 import pytest
 

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -28,8 +28,10 @@ def test_logic_conversions():
     Logic(Logic('1'))
     Logic(Logic('X'))
     Logic(Logic('Z'))
-    with pytest.raises(ValueError):
-        Logic('j')
+
+    for value in ('j', 2, object()):
+        with pytest.raises(ValueError):
+            Logic(value)
 
 
 def test_bit_conversions():
@@ -41,8 +43,10 @@ def test_bit_conversions():
     Bit('1')
     Bit(Bit('0'))
     Bit(Bit('1'))
-    with pytest.raises(ValueError):
-        _ = Bit(object())
+
+    for value in ('X', 2, object()):
+        with pytest.raises(ValueError):
+            Bit(value)
 
 
 def test_bit_logic_conversions():

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -6,29 +6,32 @@ import pytest
 
 
 def test_logic_conversions():
-    Logic(0)
-    Logic(1)
-    Logic(True)
-    Logic(False)
-    Logic('0')
-    Logic('l')
-    Logic('L')
-    Logic('1')
-    Logic('h')
-    Logic('H')
-    Logic('x')
-    Logic('X')
-    Logic('w')
-    Logic('W')
-    Logic('u')
-    Logic('U')
-    Logic('-')
-    Logic('z')
-    Logic('Z')
-    Logic(Logic('0'))
-    Logic(Logic('1'))
-    Logic(Logic('X'))
-    Logic(Logic('Z'))
+    l = Logic('0')
+    assert Logic('l') == l
+    assert Logic('L') == l
+    assert Logic(0) == l
+    assert Logic(False) == l
+    assert Logic(Logic('0')) == l
+
+    l = Logic('1')
+    assert Logic(1) == l
+    assert Logic(True) == l
+    assert Logic('h') == l
+    assert Logic('H') == l
+    assert Logic(Logic('1')) == l
+
+    l = Logic('X')
+    assert Logic('x') == l
+    assert Logic('w') == l
+    assert Logic('W') == l
+    assert Logic('u') == l
+    assert Logic('U') == l
+    assert Logic('-') == l
+    assert Logic(Logic('X')) == l
+
+    l = Logic('Z')
+    assert Logic('z') == l
+    assert Logic(Logic('Z')) == l
 
     for value in ('j', 2, object()):
         with pytest.raises(ValueError):
@@ -36,14 +39,15 @@ def test_logic_conversions():
 
 
 def test_bit_conversions():
-    Bit(0)
-    Bit(1)
-    Bit(False)
-    Bit(True)
-    Bit('0')
-    Bit('1')
-    Bit(Bit('0'))
-    Bit(Bit('1'))
+    b = Bit(0)
+    assert Bit(False) == b
+    assert Bit('0') == b
+    assert Bit(Bit(0)) == b
+
+    b = Bit(1)
+    assert Bit(True) == b
+    assert Bit('1') == b
+    assert Bit(Bit(1)) == b
 
     for value in ('X', 2, object()):
         with pytest.raises(ValueError):
@@ -76,45 +80,6 @@ def test_bit_equality():
 def test_logic_bit_equality():
     assert Logic(0) != Bit(0)
     assert Logic(1) != Bit(1)
-
-
-def test_logic_self_identity():
-    l = Logic('0')
-    assert Logic('l') == l
-    assert Logic('L') == l
-    assert Logic(0) == l
-    assert Logic(False) == l
-    assert Logic(Logic('0')) == l
-
-    l = Logic('1')
-    assert Logic(1) == l
-    assert Logic(True) == l
-    assert Logic('h') == l
-    assert Logic('H') == l
-    assert Logic(Logic('1')) == l
-
-    l = Logic('X')
-    assert Logic('x') == l
-    assert Logic('w') == l
-    assert Logic('W') == l
-    assert Logic('u') == l
-    assert Logic('U') == l
-    assert Logic('-') == l
-    assert Logic(Logic('X')) == l
-
-    l = Logic('Z')
-    assert Logic('z') == l
-    assert Logic(Logic('Z')) == l
-
-
-def test_bit_self_identity():
-    b = Bit(0)
-    assert Bit(False) == b
-    assert Bit('0') == b
-
-    b = Bit(1)
-    assert Bit(True) == b
-    assert Bit('1') == b
 
 
 def test_logic_hashability():

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -22,6 +22,7 @@ def test_logic_conversions():
     Logic('W')
     Logic('u')
     Logic('U')
+    Logic('-')
     Logic('z')
     Logic('Z')
     Logic(Logic('0'))
@@ -98,6 +99,7 @@ def test_logic_self_identity():
     assert Logic('W') == l
     assert Logic('u') == l
     assert Logic('U') == l
+    assert Logic('-') == l
     assert Logic(Logic('X')) == l
 
     l = Logic('Z')

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -257,10 +257,14 @@ def test_bit_invert():
 
 
 def test_logic_identity():
-    assert Logic(0) is Logic(False)
-    assert Logic("X") is Logic("X")
+    assert Logic._0 is Logic(False)
+    assert Logic._1 is Logic(1)
+    assert Logic("X") is Logic.X
+    assert Logic.Z is Logic("Z")
 
 
 def test_bit_identity():
-    assert Bit(0) is Bit(False)
-    assert Bit(Logic(1)) is Bit("1")
+    assert Bit._0 is Bit(False)
+    assert Bit(Logic(1)) is Bit._1
+    with pytest.raises(AttributeError):
+        Bit.X

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -74,6 +74,45 @@ def test_bit_equality():
 
 def test_logic_bit_equality():
     assert Logic(0) != Bit(0)
+    assert Logic(1) != Bit(1)
+
+
+def test_logic_self_identity():
+    l = Logic('0')
+    assert Logic('l') == l
+    assert Logic('L') == l
+    assert Logic(0) == l
+    assert Logic(False) == l
+    assert Logic(Logic('0')) == l
+
+    l = Logic('1')
+    assert Logic(1) == l
+    assert Logic(True) == l
+    assert Logic('h') == l
+    assert Logic('H') == l
+    assert Logic(Logic('1')) == l
+
+    l = Logic('X')
+    assert Logic('x') == l
+    assert Logic('w') == l
+    assert Logic('W') == l
+    assert Logic('u') == l
+    assert Logic('U') == l
+    assert Logic(Logic('X')) == l
+
+    l = Logic('Z')
+    assert Logic('z') == l
+    assert Logic(Logic('Z')) == l
+
+
+def test_bit_self_identity():
+    b = Bit(0)
+    assert Bit(False) == b
+    assert Bit('0') == b
+
+    b = Bit(1)
+    assert Bit(True) == b
+    assert Bit('1') == b
 
 
 def test_logic_hashability():

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -6,34 +6,34 @@ import pytest
 
 
 def test_logic_conversions():
-    l = Logic('0')
-    assert Logic('l') == l
-    assert Logic('L') == l
+    l = Logic("0")
+    assert Logic("l") == l
+    assert Logic("L") == l
     assert Logic(0) == l
     assert Logic(False) == l
-    assert Logic(Logic('0')) == l
+    assert Logic(Logic("0")) == l
 
-    l = Logic('1')
+    l = Logic("1")
     assert Logic(1) == l
     assert Logic(True) == l
-    assert Logic('h') == l
-    assert Logic('H') == l
-    assert Logic(Logic('1')) == l
+    assert Logic("h") == l
+    assert Logic("H") == l
+    assert Logic(Logic("1")) == l
 
-    l = Logic('X')
-    assert Logic('x') == l
-    assert Logic('w') == l
-    assert Logic('W') == l
-    assert Logic('u') == l
-    assert Logic('U') == l
-    assert Logic('-') == l
-    assert Logic(Logic('X')) == l
+    l = Logic("X")
+    assert Logic("x") == l
+    assert Logic("w") == l
+    assert Logic("W") == l
+    assert Logic("u") == l
+    assert Logic("U") == l
+    assert Logic("-") == l
+    assert Logic(Logic("X")) == l
 
-    l = Logic('Z')
-    assert Logic('z') == l
-    assert Logic(Logic('Z')) == l
+    l = Logic("Z")
+    assert Logic("z") == l
+    assert Logic(Logic("Z")) == l
 
-    for value in ('j', 2, object()):
+    for value in ("j", 2, object()):
         with pytest.raises(ValueError):
             Logic(value)
 
@@ -41,15 +41,15 @@ def test_logic_conversions():
 def test_bit_conversions():
     b = Bit(0)
     assert Bit(False) == b
-    assert Bit('0') == b
+    assert Bit("0") == b
     assert Bit(Bit(0)) == b
 
     b = Bit(1)
     assert Bit(True) == b
-    assert Bit('1') == b
+    assert Bit("1") == b
     assert Bit(Bit(1)) == b
 
-    for value in ('X', 2, object()):
+    for value in ("X", 2, object()):
         with pytest.raises(ValueError):
             Bit(value)
 
@@ -60,20 +60,20 @@ def test_bit_logic_conversions():
     Bit(Logic(0))
     Bit(Logic(1))
     with pytest.raises(ValueError):
-        Bit(Logic('X'))
+        Bit(Logic("X"))
     with pytest.raises(ValueError):
-        Bit(Logic('Z'))
+        Bit(Logic("Z"))
 
 
 def test_logic_equality():
-    assert Logic(0) == Logic('0')
-    assert Logic(0) != Logic('X')
+    assert Logic(0) == Logic("0")
+    assert Logic(0) != Logic("X")
     assert Logic(0) != object()
 
 
 def test_bit_equality():
     assert Bit(0) == Bit(False)
-    assert Bit(1) != Bit('0')
+    assert Bit(1) != Bit("0")
     assert Bit(1) != object()
 
 
@@ -83,7 +83,7 @@ def test_logic_bit_equality():
 
 
 def test_logic_hashability():
-    s = {Logic('0'), Logic('1'), Logic('X'), Logic('Z')}
+    s = {Logic("0"), Logic("1"), Logic("X"), Logic("Z")}
     assert len(s) == 4
 
 
@@ -93,31 +93,25 @@ def test_bit_hashability():
 
 
 def test_logic_bit_hashability():
-    s = {
-        Logic('0'),
-        Logic('1'),
-        Logic('X'),
-        Logic('Z'),
-        Bit('0'),
-        Bit('1')}
+    s = {Logic("0"), Logic("1"), Logic("X"), Logic("Z"), Bit("0"), Bit("1")}
     assert len(s) == 6
 
 
 def test_logic_default_value():
-    assert Logic() == Logic('X')
+    assert Logic() == Logic("X")
 
 
 def test_bit_default_value():
-    assert Bit() == Bit('0')
+    assert Bit() == Bit("0")
 
 
 def test_logic_bool_conversions():
-    assert bool(Logic('1')) is True
-    assert bool(Logic('0')) is False
+    assert bool(Logic("1")) is True
+    assert bool(Logic("0")) is False
     with pytest.raises(ValueError):
-        bool(Logic('X'))
+        bool(Logic("X"))
     with pytest.raises(ValueError):
-        bool(Logic('Z'))
+        bool(Logic("Z"))
 
 
 def test_bit_bool_conversions():
@@ -126,61 +120,61 @@ def test_bit_bool_conversions():
 
 
 def test_logic_str_conversions():
-    assert str(Logic('0')) == '0'
-    assert str(Logic('1')) == '1'
-    assert str(Logic('X')) == 'X'
-    assert str(Logic('Z')) == 'Z'
+    assert str(Logic("0")) == "0"
+    assert str(Logic("1")) == "1"
+    assert str(Logic("X")) == "X"
+    assert str(Logic("Z")) == "Z"
 
 
 def test_bit_str_conversions():
-    assert str(Bit(0)) == '0'
-    assert str(Bit(1)) == '1'
+    assert str(Bit(0)) == "0"
+    assert str(Bit(1)) == "1"
 
 
 def test_logic_int_conversions():
-    assert int(Logic('0')) == 0
-    assert int(Logic('1')) == 1
+    assert int(Logic("0")) == 0
+    assert int(Logic("1")) == 1
     with pytest.raises(ValueError):
-        int(Logic('X'))
+        int(Logic("X"))
     with pytest.raises(ValueError):
-        int(Logic('Z'))
+        int(Logic("Z"))
 
 
 def test_bit_int_conversions():
-    assert int(Bit('0')) == 0
-    assert int(Bit('1')) == 1
+    assert int(Bit("0")) == 0
+    assert int(Bit("1")) == 1
 
 
 def test_logic_repr():
-    assert eval(repr(Logic('0'))) == Logic('0')
-    assert eval(repr(Logic('1'))) == Logic('1')
-    assert eval(repr(Logic('X'))) == Logic('X')
-    assert eval(repr(Logic('Z'))) == Logic('Z')
+    assert eval(repr(Logic("0"))) == Logic("0")
+    assert eval(repr(Logic("1"))) == Logic("1")
+    assert eval(repr(Logic("X"))) == Logic("X")
+    assert eval(repr(Logic("Z"))) == Logic("Z")
 
 
 def test_bit_repr():
-    assert eval(repr(Bit('0'))) == Bit('0')
-    assert eval(repr(Bit('1'))) == Bit('1')
+    assert eval(repr(Bit("0"))) == Bit("0")
+    assert eval(repr(Bit("1"))) == Bit("1")
 
 
 def test_logic_and():
     # will not be exhaustive
-    assert Logic('0') & Logic('Z') == Logic(0)
-    assert Logic(1) & Logic('1') == Logic(1)
-    assert Logic('X') & Logic('Z') == Logic('X')
+    assert Logic("0") & Logic("Z") == Logic(0)
+    assert Logic(1) & Logic("1") == Logic(1)
+    assert Logic("X") & Logic("Z") == Logic("X")
     with pytest.raises(TypeError):
-        Logic('1') & 8
+        Logic("1") & 8
     with pytest.raises(TypeError):
-        8 & Logic('1')
+        8 & Logic("1")
 
 
 def test_bit_and():
-    assert Bit('0') & Bit('1') == Bit(0)
-    assert Bit(1) & Bit('1') == Bit(1)
+    assert Bit("0") & Bit("1") == Bit(0)
+    assert Bit(1) & Bit("1") == Bit(1)
     with pytest.raises(TypeError):
-        Bit('1') & 8
+        Bit("1") & 8
     with pytest.raises(TypeError):
-        8 & Bit('1')
+        8 & Bit("1")
 
 
 def test_logic_bit_and():
@@ -194,9 +188,9 @@ def test_logic_bit_and():
 
 def test_logic_or():
     # will not be exhaustive
-    assert Logic('1') | Logic('Z') == Logic('1')
-    assert Logic(0) | Logic('0') == Logic(0)
-    assert Logic('X') | Logic('Z') == Logic('X')
+    assert Logic("1") | Logic("Z") == Logic("1")
+    assert Logic(0) | Logic("0") == Logic(0)
+    assert Logic("X") | Logic("Z") == Logic("X")
     with pytest.raises(TypeError):
         8 | Logic(0)
     with pytest.raises(TypeError):
@@ -204,7 +198,7 @@ def test_logic_or():
 
 
 def test_bit_or():
-    assert Bit('0') | Bit('1') == Bit(1)
+    assert Bit("0") | Bit("1") == Bit(1)
     assert Bit(0) | Bit(False) == Bit(0)
     with pytest.raises(TypeError):
         8 | Bit(0)
@@ -223,8 +217,8 @@ def test_logic_bit_or():
 
 def test_logic_xor():
     # will not be exhaustive
-    assert (Logic('1') ^ Logic(True)) == Logic(0)
-    assert (Logic(1) ^ Logic('X')) == Logic('X')
+    assert (Logic("1") ^ Logic(True)) == Logic(0)
+    assert (Logic(1) ^ Logic("X")) == Logic("X")
     assert (Logic(1) ^ Logic(False)) == Logic(1)
     with pytest.raises(TypeError):
         Logic(1) ^ ()
@@ -233,8 +227,8 @@ def test_logic_xor():
 
 
 def test_bit_xor():
-    assert Bit(0) ^ Bit('1') == Bit(1)
-    assert Bit(False) ^ Bit(0) == Bit('0')
+    assert Bit(0) ^ Bit("1") == Bit(1)
+    assert Bit(False) ^ Bit(0) == Bit("0")
     with pytest.raises(TypeError):
         Bit(1) ^ ()
     with pytest.raises(TypeError):
@@ -253,8 +247,8 @@ def test_logic_bit_xor():
 def test_logic_invert():
     assert ~Logic(0) == Logic(1)
     assert ~Logic(1) == Logic(0)
-    assert ~Logic('X') == Logic('X')
-    assert ~Logic('Z') == Logic('X')
+    assert ~Logic("X") == Logic("X")
+    assert ~Logic("Z") == Logic("X")
 
 
 def test_bit_invert():

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -254,3 +254,13 @@ def test_logic_invert():
 def test_bit_invert():
     assert ~Bit(0) == Bit(1)
     assert ~Bit(1) == Bit(0)
+
+
+def test_logic_identity():
+    assert Logic(0) is Logic(False)
+    assert Logic("X") is Logic("X")
+
+
+def test_bit_identity():
+    assert Bit(0) is Bit(False)
+    assert Bit(Logic(1)) is Bit("1")


### PR DESCRIPTION
Logic (4-value) and Bit (2-value) datatypes models are added for use in system modelling and eventual use in the handle class. xref #2059.

I think doing this piecemeal is better than all at once, we can put a lot of attention into each piece.
A heterogenous `Array` type is basically done, and ` LogicArray` specialization is implemented and needs some testing.
I am thinking we will think through how we want to intregrate these types with `cocotb.handle` after we get the types in.
Since `cocotb.handle` just emits and consumes `BinaryValue`s (it doesn't do anything weird like update references in place or anything like that), any types with value semantics should be easily substitutable (and by "easily", I mean it will break a lot of crap).

The one thing I'm iffy about is the use of `cache` (unbounded cache) on functions that can return `NotImplemented` in response to *any* value put in. I feel better knowing that 99.999999 times out of 100 it will result in an exception. The only way to cause an issue with this would be through malice.