### PR TITLE
Remove deprecated top-level makefiles

### DIFF
--- a/makefiles/Makefile.inc
+++ b/makefiles/Makefile.inc
@@ -1,8 +1,0 @@
-# Copyright cocotb contributors
-# Licensed under the Revised BSD License, see LICENSE for details.
-# SPDX-License-Identifier: BSD-3-Clause
-
-$(error Outdated use of cocotb detected. \
-        Please install cocotb, and modify your makefile to \
-        "include $$(shell cocotb-config --makefile)/Makefile.sim" instead. \
-        Please refer to the documentation at https://docs.cocotb.org.)

--- a/makefiles/Makefile.sim
+++ b/makefiles/Makefile.sim
@@ -1,8 +1,0 @@
-# Copyright cocotb contributors
-# Licensed under the Revised BSD License, see LICENSE for details.
-# SPDX-License-Identifier: BSD-3-Clause
-
-$(error Outdated use of cocotb detected. \
-        Please install cocotb, and modify your makefile to \
-        "include $$(shell cocotb-config --makefile)/Makefile.sim" instead. \
-        Please refer to the documentation at https://docs.cocotb.org.)


### PR DESCRIPTION
These have been deprecated for a while. Since it's 2.0 time, we should remove them finally.