### PR TITLE
Export COCOTB_RESULTS_FILE make variable

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -91,6 +91,8 @@ COCOTB_RESULTS_FILE ?= results.xml
 COCOTB_HDL_TIMEUNIT ?= 1ns
 COCOTB_HDL_TIMEPRECISION ?= 1ps
 
+export COCOTB_RESULTS_FILE
+
 # Depend on all Python from the cocotb package. This triggers a
 # recompilation of the simulation if cocotb is updated.
 CUSTOM_SIM_DEPS += $(shell find $(COCOTB_PY_DIR)/cocotb/ -name "*.py")

--- a/documentation/source/newsfragments/2487.bugfix.rst
+++ b/documentation/source/newsfragments/2487.bugfix.rst
@@ -1,0 +1,1 @@
+:envvar:`COCOTB_RESULTS_FILE` now properly communicates with the :data:`Regression Manager <cocotb.regression_manager>` to allow overloading the result filename.


### PR DESCRIPTION
From [gitter chat](https://gitter.im/cocotb/Lobby?at=605781fc8478e061b94ebd6a). `COCOTB_RESULTS_FILE` as a Makefile variable is not being exported, is not being picked up by the regression manager, and appears to not work. Exporting the Makefile variable makes the variable work as expected.