### PR TITLE
Add documentation on how to pass and fail tests

### DIFF
--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -224,7 +224,7 @@ Passing And Failing Tests
 
 A cocotb test is considered to have `failed` if the test coroutine,
 or any coroutine :func:`~cocotb.fork`\ ed by the test coroutine,
-fails an ``assert`` statement or raises an :exc:`cocotb.result.TestFailure`.
+fails an ``assert`` statement or raises a :exc:`cocotb.result.TestFailure`.
 Below are examples of `failing` tests.
 
 .. code-block:: python3
@@ -253,7 +253,7 @@ Below are examples of `failing` tests.
 
 When a test fails, a stacktrace is printed.
 If ``pytest`` is installed and ``assert`` statements are used,
-a more informative stacktrace, including the values that caused the ``assert`` to fail, is printed.
+a more informative stacktrace is printed which includes the values that caused the ``assert`` to fail.
 For example, see the output for the first test from above.
 
 .. code-block::

--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -219,7 +219,7 @@ A workaround is to use indirect access using
 ``dut._id("_some_signal", extended=False)``.
 
 
-Passing And Failing Tests
+Passing and Failing Tests
 =========================
 
 A cocotb test is considered to have `failed` if the test coroutine,
@@ -252,7 +252,7 @@ Below are examples of `failing` tests.
         await Timer(10, 'ns')
 
 When a test fails, a stacktrace is printed.
-If ``pytest`` is installed and ``assert`` statements are used,
+If :mod:`pytest` is installed and ``assert`` statements are used,
 a more informative stacktrace is printed which includes the values that caused the ``assert`` to fail.
 For example, see the output for the first test from above.
 

--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -218,6 +218,115 @@ A workaround is to use indirect access using
 :meth:`~cocotb.handle.HierarchyObject._id` like in the following example:
 ``dut._id("_some_signal", extended=False)``.
 
+
+Passing And Failing Tests
+=========================
+
+A cocotb test is considered to have `failed` if the test coroutine,
+or any coroutine :func:`~cocotb.fork`\ ed by the test coroutine,
+fails an ``assert`` statement or raises an :exc:`cocotb.result.TestFailure`.
+Below are examples of `failing` tests.
+
+.. code-block:: python3
+
+    @cocotb.test()
+    async def test(dut):
+        assert 1 > 2, "Testing the obvious"
+
+    @cocotb.test()
+    async def test(dut):
+        raise TestFailure("Reason")
+
+    @cocotb.test()
+    async def test(dut):
+        async def fails_test():
+            assert 1 > 2
+        cocotb.fork(fails_test())
+        await Timer(10, 'ns')
+
+    @cocotb.test()
+    async def test(dut):
+        async def fails_test():
+            raise TestFailure("Reason")
+        cocotb.fork(fails_test())
+        await Timer(10, 'ns')
+
+When a test fails, a stacktrace is printed.
+If ``pytest`` is installed and ``assert`` statements are used,
+a more informative stacktrace, including the values that caused the ``assert`` to fail, is printed.
+For example, see the output for the first test from above.
+
+.. code-block::
+
+    0.00ns ERROR    cocotb.regression                         regression.py:408  in _score_test                     Test Failed: test (result was AssertionError)
+                                                                                                                    Traceback (most recent call last):
+                                                                                                                      File "test.py", line3, in test
+                                                                                                                        assert 1 > 2, "Testing the obvious"
+                                                                                                                    AssertionError: Testing the obvious
+
+
+A cocotb test is considered to have `errored` if the test coroutine,
+or any coroutine :func:`~cocotb.fork`\ ed by the test coroutine,
+raises an exception that isn't considered a `failure`.
+Below are examples of `erroring` tests.
+
+.. code-block:: python3
+
+    @cocotb.test()
+    async def test(dut):
+        await coro_that_does_not_exist()  # NameError
+
+    @cocotb.test()
+    async def test(dut):
+        async def coro_with_an_error():
+            dut.signal_that_does_not_exist <= 1  # AttributeError
+        cocotb.fork(coro_with_an_error())
+        await Timer(10, 'ns')
+
+When a test ends with an error, a stacktrace is printed.
+For example, see the below output for the first test from above.
+
+.. code-block::
+
+    0.00ns ERROR    cocotb.regression                         regression.py:408  in _score_test                     Test Failed: test (result was NameError)
+                                                                                                                    Traceback (most recent call last):
+                                                                                                                      File "test.py", line 3, in test
+                                                                                                                        await coro_that_does_not_exist()  # NameError
+                                                                                                                    NameError: name 'coro_that_does_not_exist' is not defined
+
+
+If a test coroutine completes without `failing` or `erroring`,
+or if the test coroutine,
+or any coroutine :func:`~cocotb.fork`\ ed by the test coroutine,
+raises :exc:`cocotb.result.TestSuccess`,
+the test is considered to have `passed`.
+Below are examples of `passing` tests.
+
+.. code-block:: python3
+
+    @cocotb.test():
+    async def test(dut):
+        assert 2 > 1  # assertion is correct, then the coroutine ends
+
+    @cocotb.test()
+    async def test(dut):
+        raise TestSuccess("Reason")  # ends test with success early
+        assert 1 > 2  # this would fail, but it isn't run because the test was ended early
+
+    @cocotb.test()
+    async def test(dut):
+        async def ends_test_with_pass():
+            raise TestSuccess("Reason")
+        cocotb.fork(ends_test_with_pass())
+        await Timer(10, 'ns')
+
+A passing test will print the following output.
+
+.. code-block::
+
+    0.00ns INFO     cocotb.regression                         regression.py:373  in _score_test                     Test Passed: test
+
+
 Logging
 =======
 

--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -258,11 +258,11 @@ For example, see the output for the first test from above.
 
 .. code-block::
 
-    0.00ns ERROR    cocotb.regression                         regression.py:408  in _score_test                     Test Failed: test (result was AssertionError)
-                                                                                                                    Traceback (most recent call last):
-                                                                                                                      File "test.py", line3, in test
-                                                                                                                        assert 1 > 2, "Testing the obvious"
-                                                                                                                    AssertionError: Testing the obvious
+    0.00ns ERROR    Test Failed: test (result was AssertionError)
+                    Traceback (most recent call last):
+                      File "test.py", line 3, in test
+                        assert 1 > 2, "Testing the obvious"
+                    AssertionError: Testing the obvious
 
 
 A cocotb test is considered to have `errored` if the test coroutine,
@@ -288,11 +288,11 @@ For example, see the below output for the first test from above.
 
 .. code-block::
 
-    0.00ns ERROR    cocotb.regression                         regression.py:408  in _score_test                     Test Failed: test (result was NameError)
-                                                                                                                    Traceback (most recent call last):
-                                                                                                                      File "test.py", line 3, in test
-                                                                                                                        await coro_that_does_not_exist()  # NameError
-                                                                                                                    NameError: name 'coro_that_does_not_exist' is not defined
+    0.00ns ERROR    Test Failed: test (result was NameError)
+                    Traceback (most recent call last):
+                      File "test.py", line 3, in test
+                        await coro_that_does_not_exist()  # NameError
+                    NameError: name 'coro_that_does_not_exist' is not defined
 
 
 If a test coroutine completes without `failing` or `erroring`,
@@ -324,7 +324,7 @@ A passing test will print the following output.
 
 .. code-block::
 
-    0.00ns INFO     cocotb.regression                         regression.py:373  in _score_test                     Test Passed: test
+    0.00ns INFO     Test Passed: test
 
 
 Logging


### PR DESCRIPTION
Closes #2491. Adds documentation to the "Writing Testbenches" page on what constitutes a passing, erroring, and failing test. How to use `assert` for checking, and what expected outputs are for each result.