### PR TITLE
Log full object name when releasing VHPI handle

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -40,8 +40,8 @@ using bufSize_type = decltype(vhpiValueT::bufSize);
 extern "C" void handle_vhpi_callback(const vhpiCbDataT *cb_data);
 
 VhpiArrayObjHdl::~VhpiArrayObjHdl() {
-    LOG_DEBUG("VHPI: Releasing VhpiArrayObjHdl handle at %p",
-              (void *)get_handle<vhpiHandleT>());
+    LOG_DEBUG("VHPI: Releasing VhpiArrayObjHdl handle for %s at %p",
+              get_fullname_str(), (void *)get_handle<vhpiHandleT>());
     if (vhpi_release_handle(get_handle<vhpiHandleT>())) check_vhpi_error();
 }
 
@@ -49,8 +49,8 @@ VhpiObjHdl::~VhpiObjHdl() {
     /* Don't release handles for pseudo-regions, as they borrow the handle of
      * the containing region */
     if (m_type != GPI_GENARRAY) {
-        LOG_DEBUG("VHPI: Releasing VhpiObjHdl handle at %p",
-                  (void *)get_handle<vhpiHandleT>());
+        LOG_DEBUG("VHPI: Releasing VhpiObjHdl handle for %s at %p",
+                  get_fullname_str(), (void *)get_handle<vhpiHandleT>());
         if (vhpi_release_handle(get_handle<vhpiHandleT>())) check_vhpi_error();
     }
 }
@@ -67,8 +67,8 @@ VhpiSignalObjHdl::~VhpiSignalObjHdl() {
 
     if (m_binvalue.value.str) delete[] m_binvalue.value.str;
 
-    LOG_DEBUG("VHPI: Releasing VhpiSignalObjHdl handle at %p",
-              (void *)get_handle<vhpiHandleT>());
+    LOG_DEBUG("VHPI: Releasing VhpiSignalObjHdl handle for %s at %p",
+              get_fullname_str(), (void *)get_handle<vhpiHandleT>());
     if (vhpi_release_handle(get_handle<vhpiHandleT>())) check_vhpi_error();
 }
 


### PR DESCRIPTION
Add the object name when releasing the handle for better diagnostics.

`VHPI: Releasing VhpiSignalObjHdl handle for test.clock at 0979C810`
vs
`VHPI: Releasing VhpiSignalObjHdl handle at 0979C810`