### PR TITLE
Add custom TRACE logging level below DEBUG.

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -52,6 +52,10 @@ _FILENAME_CHARS = 20  # noqa
 _LINENO_CHARS   = 4  # noqa
 _FUNCNAME_CHARS = 31  # noqa
 
+# Custom log level
+logging.TRACE = 5
+logging.addLevelName(5, "TRACE")
+
 # Default log level if not overwritten by the user.
 _COCOTB_LOG_LEVEL_DEFAULT = "INFO"
 
@@ -99,7 +103,7 @@ def default_config():
     try:
         log.setLevel(level)
     except ValueError:
-        valid_levels = ('CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG')
+        valid_levels = ('CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE')
         raise ValueError("Invalid log level %r passed through the "
                          "COCOTB_LOG_LEVEL environment variable. Valid log "
                          "levels: %s" % (level, ', '.join(valid_levels)))
@@ -235,6 +239,7 @@ class SimColourLogFormatter(SimLogFormatter):
     """Log formatter to provide consistent log message handling."""
 
     loglevel2colour = {
+        logging.TRACE   :       "%s",
         logging.DEBUG   :       "%s",
         logging.INFO    :       "%s",
         logging.WARNING :       ANSI.COLOR_WARNING + "%s" + ANSI.COLOR_DEFAULT,

--- a/cocotb/share/include/cocotb_utils.h
+++ b/cocotb/share/include/cocotb_utils.h
@@ -62,7 +62,7 @@ extern COCOTBUTILS_EXPORT int is_python_context;
             exit(1);                                     \
         }                                                \
         ++is_python_context;                             \
-        LOG_DEBUG("Returning to Python");                \
+        LOG_TRACE("Returning to Python");                \
     } while (0)
 
 #define to_simulator()                                              \
@@ -72,7 +72,7 @@ extern COCOTBUTILS_EXPORT int is_python_context;
             exit(1);                                                \
         }                                                           \
         --is_python_context;                                        \
-        LOG_DEBUG("Returning to simulator");                        \
+        LOG_TRACE("Returning to simulator");                        \
     } while (0)
 
 #define COCOTB_UNUSED(x) ((void)x)

--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -51,6 +51,8 @@ extern "C" {
  *  readable level names for these value, but may support other values.
  */
 enum gpi_log_levels {
+    GPITrace = 5,   ///< Prints `TRACE` by default. Information about execution
+                    ///< of simulator callbacks and Python / simulator contexts
     GPIDebug = 10,  ///< Prints `DEBUG` by default. Verbose information, useful
                     ///< for debugging
     GPIInfo = 20,  ///< Prints `INFO` by default. Information about major events
@@ -68,6 +70,11 @@ enum gpi_log_levels {
  */
 #define LOG_(level, ...) \
     gpi_log("cocotb.gpi", level, __FILE__, __func__, __LINE__, __VA_ARGS__);
+
+/** Logs a message at TRACE log level using the current log handler.
+    Automatically populates arguments using information in the called context.
+ */
+#define LOG_TRACE(...) LOG_(GPITrace, __VA_ARGS__)
 
 /** Logs a message at DEBUG log level using the current log handler.
     Automatically populates arguments using information in the called context.

--- a/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -77,9 +77,9 @@ int GpiObjHdl::initialise(std::string &name, std::string &fq_name) {
 }
 
 int GpiCbHdl::run_callback() {
-    LOG_DEBUG("Generic run_callback");
+    LOG_TRACE("Generic run_callback");
     this->gpi_function(m_cb_data);
-    LOG_DEBUG("Generic run_callback done");
+    LOG_TRACE("Generic run_callback done");
     return 0;
 }
 

--- a/cocotb/share/lib/gpi_log/gpi_logging.cpp
+++ b/cocotb/share/lib/gpi_log/gpi_logging.cpp
@@ -93,7 +93,7 @@ struct _log_level_table {
 };
 
 static struct _log_level_table log_level_table[] = {
-    {10, "DEBUG"}, {20, "INFO"},     {30, "WARNING"},
+    {5, "TRACE"},  {10, "DEBUG"},    {20, "INFO"}, {30, "WARNING"},
     {40, "ERROR"}, {50, "CRITICAL"}, {0, NULL},
 };
 

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -111,7 +111,9 @@ Cocotb
 .. envvar:: COCOTB_LOG_LEVEL
 
     The default logging level to use. This is set to ``INFO`` unless overridden.
-    Valid values are ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``.
+    Valid values are ``TRACE``, ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``.
+
+    ``TRACE`` is used for internal low-level logging and produces very verbose logs.
 
 .. envvar:: COCOTB_RESOLVE_X
 

--- a/documentation/source/newsfragments/2502.change.rst
+++ b/documentation/source/newsfragments/2502.change.rst
@@ -1,0 +1,2 @@
+The environment variable :envvar:`COCOTB_LOG_LEVEL` now supports ``TRACE`` value,
+which is used for verbose low-level logging that was previously in ``DEBUG`` logs.

--- a/tests/test_cases/test_cocotb/test_logging.py
+++ b/tests/test_cases/test_cocotb/test_logging.py
@@ -65,6 +65,11 @@ async def test_logging_default_config(dut):
         log_default_config()
         assert cocotb_log.level == logging.ERROR, cocotb_log.level
 
+        # Set custom TRACE log level
+        os.environ['COCOTB_LOG_LEVEL'] = 'TRACE'
+        log_default_config()
+        assert cocotb_log.level == logging.TRACE, cocotb_log.level
+
     finally:
         # Restore pre-test configuration
         os.environ = os_environ_prev


### PR DESCRIPTION
Closes #2141.

cocotb produces enormous amounts of `DEBUG` log messages relating to
the execution flow between Python and GPI. These messages bloat the
resulting logs and are not useful in most cases.

Move these messages to a new lower log level `TRACE`, which can be
enabled using `COCOTB_LOG_LEVEL=TRACE`.

TODO:
- [x] newsfragment
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
