### PR TITLE
Fix scheduling issues with start_soon

### DIFF
--- a/documentation/source/newsfragments/2504.bugfix.rst
+++ b/documentation/source/newsfragments/2504.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed several scheduling issues related to the use of :meth:`cocotb.scheduler.start_soon <cocotb.scheduler.Scheduler.start_soon>`.

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -149,3 +149,19 @@ async def test_event_is_set(dut):
     assert e.is_set()
     e.clear()
     assert not e.is_set()
+
+
+@cocotb.test()
+async def test_combine_start_soon(_):
+    async def coro(delay):
+        start_time = cocotb.utils.get_sim_time(units="ns")
+        await Timer(delay, "ns")
+        assert cocotb.utils.get_sim_time(units="ns") == start_time + delay
+
+    max_delay = 10
+
+    coros = [cocotb.scheduler.start_soon(coro(d)) for d in range(1, max_delay + 1)]
+
+    test_start = cocotb.utils.get_sim_time(units="ns")
+    await Combine(*coros)
+    assert cocotb.utils.get_sim_time(units="ns") == test_start + max_delay


### PR DESCRIPTION
Closes #2489 and #2503.

This fixes ~two~ four scheduling issues related to `start_soon()`:
- `_schedule()` was recursively calling itself for each new queued coroutine, so if enough are queued up the stack will overflow.
- `await`ing a coroutine that's been queued by `start_soon()` but hasn't started would hit `_trigger_from_unstarted_coro()`, which would add it to the queue again, causing it to be incorrectly scheduled more than once.
- If a queued coroutine is killed before it starts scheduling, it is still run.
- If the test ends with any queued coroutines, they will be scheduled to run after the test ends.