### PR TITLE
Change with_timeout behavior

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -890,7 +890,7 @@ class ClockCycles(Waitable):
 
 
 async def with_timeout(trigger, timeout_time, timeout_unit="step"):
-    """
+    r"""
     Waits on triggers and coroutines, throws an exception if it waits longer than the given time.
 
     When used with a coroutine, the coroutine will be forked and awaited, and the return value forwarded when the coroutine finishes.  If the timeout expires, the coroutine will be killed.

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -919,7 +919,7 @@ async def with_timeout(trigger, timeout_time, timeout_unit="step"):
     .. versionadded:: 1.3
 
     .. versionchanged:: 1.6
-        Support passing :term:`python:coroutine`\\ s.
+        Support passing :term:`python:coroutine`\ s.
 
     .. deprecated:: 1.5
         Using None as the the *timeout_unit* argument is deprecated, use ``'step'`` instead.

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -945,7 +945,7 @@ async def with_timeout(trigger, timeout_time, timeout_unit="step"):
         :class:`~cocotb.coroutine`\ s that are passed unstarted are now killed if there is a timeout.
     """
 
-    if inspect.iscoroutine(trigger) or isinstance(trigger, cocotb.decorators.coroutine) and not trigger._started:
+    if inspect.iscoroutine(trigger) or isinstance(trigger, cocotb.decorators.RunningCoroutine) and not trigger._started:
         task = cocotb.fork(trigger)
         try:
             res = await with_timeout(task, timeout_time, timeout_unit)

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -901,7 +901,7 @@ async def with_timeout(trigger, timeout_time, timeout_unit="step"):
     and :exc:`SimTimeoutError` is raised.
 
     When a :func:`~cocotb.fork`\ ed coroutine is passed,
-    the caller blocks until the collee completes
+    the caller blocks until the callee completes
     and the callee's result is returned to the caller.
     If timeout occurs, the callee coroutine `continues to run`
     and :exc:`SimTimeoutError` is raised.

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -918,7 +918,7 @@ async def with_timeout(trigger, timeout_time, timeout_unit="step"):
 
     .. versionadded:: 1.3
 
-    .. versionchanged:: 1.5
+    .. versionchanged:: 1.6
         Support passing :term:`python:coroutine`\\ s.
 
     .. deprecated:: 1.5
@@ -932,7 +932,7 @@ async def with_timeout(trigger, timeout_time, timeout_unit="step"):
         except cocotb.result.SimTimeoutError:
             task.kill()
             raise
-        return await task
+        return res
 
     if timeout_unit is None:
         warnings.warn(

--- a/documentation/source/newsfragments/2494.change.rst
+++ b/documentation/source/newsfragments/2494.change.rst
@@ -1,0 +1,1 @@
+Passing :term:`python:coroutine`\ s to :func:`~cocotb.triggers.with_timeout` is now supported.

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -219,7 +219,7 @@ async def test_decorated_coroutine_killed_after_timeout(_):
         await cocotb.triggers.with_timeout(coro, timeout_time=1, timeout_unit='ns')
     except cocotb.result.SimTimeoutError:
         pass
-    assert not coro._finished
+    assert coro._finished
     assert await coro == 1
 
 

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -209,6 +209,21 @@ async def test_timeout_func_pass(dut):
 
 
 @cocotb.test()
+async def test_decorated_coroutine_killed_after_timeout(_):
+    @cocotb.coroutine
+    async def example():
+        await Timer(10, 'ns')
+        return 1
+    coro = example()
+    try:
+        await cocotb.triggers.with_timeout(coro, timeout_time=1, timeout_unit='ns')
+    except cocotb.result.SimTimeoutError:
+        pass
+    assert not coro._finished
+    assert await coro == 1
+
+
+@cocotb.test()
 async def test_readwrite(dut):
     """ Test that ReadWrite can be waited on """
     # gh-759

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -220,7 +220,7 @@ async def test_decorated_coroutine_killed_after_timeout(_):
     except cocotb.result.SimTimeoutError:
         pass
     assert coro._finished
-    assert await coro == 1
+    assert await coro is None
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -11,6 +11,7 @@ Tests related to timing triggers
 * with_timeout
 """
 import cocotb
+import pytest
 import warnings
 from cocotb.triggers import Timer, RisingEdge, ReadOnly, ReadWrite, Join, NextTimeStep, First, TriggerException
 from cocotb.utils import get_sim_time, get_sim_steps
@@ -172,7 +173,24 @@ async def test_writes_have_taken_effect_after_readwrite(dut):
     assert dut.stream_in_data.value == 2
 
 
-@cocotb.coroutine   # cocotb.coroutine necessary to use in with_timeout
+@cocotb.coroutine
+async def example_coro():
+    await Timer(10, 'ns')
+    return 1
+
+
+@cocotb.test()
+async def test_timeout_func_coro_fail(dut):
+    with pytest.raises(cocotb.result.SimTimeoutError):
+        await cocotb.triggers.with_timeout(example_coro(), timeout_time=1, timeout_unit='ns')
+
+
+@cocotb.test()
+async def test_timeout_func_coro_pass(dut):
+    res = await cocotb.triggers.with_timeout(example_coro(), timeout_time=100, timeout_unit='ns')
+    assert res == 1
+
+
 async def example():
     await Timer(10, 'ns')
     return 1
@@ -180,12 +198,8 @@ async def example():
 
 @cocotb.test()
 async def test_timeout_func_fail(dut):
-    try:
+    with pytest.raises(cocotb.result.SimTimeoutError):
         await cocotb.triggers.with_timeout(example(), timeout_time=1, timeout_unit='ns')
-    except cocotb.result.SimTimeoutError:
-        pass
-    else:
-        assert False, "Expected a Timeout"
 
 
 @cocotb.test()


### PR DESCRIPTION
Potential follow-on to #2494. Changes the behavior of `with_timeout` so that coroutines that are passed in unstarted are both started and killed (if timeout occurs) by `with_timeout`, only coroutines that have been previous `fork`ed will remain alive if timeout occurs. Also adds more descriptive documentation to `with_timeout`. Pinging @alexforencich.