### PR TITLE
Remove RunningTest class

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -512,3 +512,10 @@ class test(coroutine, metaclass=_decorator_helper):
         self.stage = stage
         self.im_test = True    # For auto-regressions
         self.name = self._func.__name__
+
+    def __call__(self, *args, **kwargs):
+        inst = self._func(*args, **kwargs)
+        coro = RunningCoroutine(inst, self)
+        coro.__name__ = "Test {}".format(inst.__name__)
+        coro.__qualname__ = "Test {}".format(inst.__qualname__)
+        return coro

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -26,8 +26,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
-import time
-import logging
 import functools
 import inspect
 import os
@@ -36,7 +34,7 @@ import warnings
 import cocotb
 from cocotb.log import SimLog
 from cocotb.result import ReturnValue
-from cocotb.utils import get_sim_time, lazy_property, remove_traceback_frames, extract_coro_stack
+from cocotb.utils import lazy_property, remove_traceback_frames, extract_coro_stack
 from cocotb import outcomes
 
 # Sadly the Python standard logging module is very slow so it's better not to
@@ -268,80 +266,6 @@ class RunningCoroutine(RunningTask):
         self.__doc__ = parent._func.__doc__
         self.module = parent._func.__module__
         self.funcname = parent._func.__name__
-
-
-class RunningTest(RunningCoroutine):
-    """Add some useful Test functionality to a RunningCoroutine."""
-
-    class ErrorLogHandler(logging.Handler):
-        def __init__(self, fn):
-            self.fn = fn
-            logging.Handler.__init__(self, level=logging.DEBUG)
-
-        def handle(self, record):
-            # For historical reasons, only logs sent directly to the `cocotb`
-            # logger are recorded - logs to `cocotb.scheduler` for instance
-            # are not recorded. Changing this behavior may have significant
-            # memory usage implications, so should not be done without some
-            # thought.
-            if record.name == 'cocotb':
-                self.fn(self.format(record))
-
-    def __init__(self, inst, parent):
-        self.error_messages = []
-        RunningCoroutine.__init__(self, inst, parent)
-        self.log = SimLog("cocotb.test.%s" % inst.__qualname__, id(self))
-        self.started = False
-        self.start_time = 0
-        self.start_sim_time = 0
-        self.expect_fail = parent.expect_fail
-        self.expect_error = parent.expect_error
-        self.skip = parent.skip
-        self.stage = parent.stage
-        self.__name__ = "Test %s" % inst.__name__
-        self.__qualname__ = "Test %s" % inst.__qualname__
-
-        # make sure not to create a circular reference here
-        self.handler = RunningTest.ErrorLogHandler(self.error_messages.append)
-
-    def __str__(self):
-        return f"<{self.__name__}>"
-
-    def _advance(self, outcome):
-        if not self.started:
-            self.log.info("Starting test: \"%s\"\nDescription: %s" %
-                          (self.funcname, self.__doc__))
-            self.start_time = time.time()
-            self.start_sim_time = get_sim_time('ns')
-            self.started = True
-        return super()._advance(outcome)
-
-    # like RunningTask.kill(), but with a way to inject a failure
-    def abort(self, exc):
-        """Force this test to end early, without executing any cleanup.
-
-        This happens when a background task fails, and is consistent with
-        how the behavior has always been. In future, we may want to behave
-        more gracefully to allow the test body to clean up.
-
-        `exc` is the exception that the test should report as its reason for
-        aborting.
-        """
-        if self._outcome is not None:
-            # imported here to avoid circular imports
-            from cocotb.scheduler import InternalError
-            raise InternalError("Outcome already has a value, but is being set again.")
-        outcome = outcomes.Error(exc)
-        if _debug:
-            self.log.debug(f"outcome forced to {outcome}")
-        self._outcome = outcome
-        cocotb.scheduler._unschedule(self)
-
-    def sort_name(self):
-        if self.stage is None:
-            return f"{self.module}.{self.funcname}"
-        else:
-            return "%s.%d.%s" % (self.module, self.stage, self.funcname)
 
 
 class coroutine:
@@ -588,6 +512,3 @@ class test(coroutine, metaclass=_decorator_helper):
         self.stage = stage
         self.im_test = True    # For auto-regressions
         self.name = self._func.__name__
-
-    def __call__(self, *args, **kwargs):
-        return RunningTest(self._func(*args, **kwargs), self)

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -302,9 +302,6 @@ class RegressionManager:
         real_time = time.time() - self._test_start_time
         sim_time_ns = get_sim_time('ns') - self._test_start_sim_time
 
-        # stop capturing log output
-        cocotb.log.removeHandler(test.handler)
-
         self._record_result(
             test=self._test,
             outcome=self._test_task._outcome,
@@ -479,9 +476,6 @@ class RegressionManager:
                        self.count, self.ntests,
                        end,
                        self._test.__qualname__))
-
-        # start capturing log output
-        cocotb.log.addHandler(self._test_task.handler)
 
         self._test_start_time = time.time()
         self._test_start_sim_time = get_sim_time('ns')

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -518,11 +518,11 @@ class Scheduler:
             except (TestComplete, AssertionError) as e:
                 coro.log.info("Test stopped by this forked coroutine")
                 e = remove_traceback_frames(e, ['_unschedule', 'get'])
-                self._test.abort(e)
+                self._abort_test(e)
             except Exception as e:
                 coro.log.error("Exception raised by this forked coroutine")
                 e = remove_traceback_frames(e, ['_unschedule', 'get'])
-                self._test.abort(e)
+                self._abort_test(e)
 
     def _schedule_write(self, handle, write_func, *args):
         """ Queue `write_func` to be called on the next ReadWrite trigger. """
@@ -917,8 +917,26 @@ class Scheduler:
         return self._finish_test(exc)
 
     def _finish_test(self, exc):
-        self._test.abort(exc)
+        self._abort_test(exc)
         self._check_termination()
+
+    def _abort_test(self, exc):
+        """Force this test to end early, without executing any cleanup.
+
+        This happens when a background task fails, and is consistent with
+        how the behavior has always been. In future, we may want to behave
+        more gracefully to allow the test body to clean up.
+
+        `exc` is the exception that the test should report as its reason for
+        aborting.
+        """
+        if self._test._outcome is not None:
+            raise InternalError("Outcome already has a value, but is being set again.")
+        outcome = outcomes.Error(exc)
+        if _debug:
+            self._test.log.debug(f"outcome forced to {outcome}")
+        self._test._outcome = outcome
+        self._unschedule(self._test)
 
     def finish_scheduler(self, exc):
         """
@@ -937,7 +955,7 @@ class Scheduler:
 
         if self._test:
             self.log.debug("Issue sim closedown result to regression object")
-            self._test.abort(exc)
+            self._abort_test(exc)
             cocotb.regression_manager.handle_result(self._test)
 
     def cleanup(self):

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -930,7 +930,7 @@ class Scheduler:
         `exc` is the exception that the test should report as its reason for
         aborting.
         """
-        if self._test._outcome is not None:
+        if self._test._outcome is not None:  # pragma: no cover
             raise InternalError("Outcome already has a value, but is being set again.")
         outcome = outcomes.Error(exc)
         if _debug:

--- a/tests/test_cases/test_cocotb/test_logging.py
+++ b/tests/test_cases/test_cocotb/test_logging.py
@@ -32,12 +32,6 @@ async def test_logging_with_args(dut):
     dut._log.info("%s", counter)
     assert counter.str_counter == 1
 
-    # now try again on the root cocotb logger, which unlike nested loggers
-    # is captured
-    counter = StrCallCounter()
-    cocotb.log.info("%s", counter)
-    assert counter.str_counter == 2  # once for stdout, once for captured logs
-
     dut._log.info("No substitution")
 
     dut._log.warning("Testing multiple line\nmessage")


### PR DESCRIPTION
After the regression manager refactor, which made putting `test` decorator arguments on the `RunningTest` unnecessary, the only use of `RunningTest` was to hold error messages caught by the special handler. One could never access the `RunningTest` object without a private attribute access, and the error messages were never used internally, so the handler and error message are dead code. Considering that, the entire `RunningTest` class is pointless and can be removed.