### PR TITLE
Remove hook

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -47,7 +47,7 @@ from cocotb.regression import RegressionManager
 from cocotb.decorators import RunningTask
 
 # Things we want in the cocotb namespace
-from cocotb.decorators import test, coroutine, hook, function, external  # noqa: F401
+from cocotb.decorators import test, coroutine, function, external  # noqa: F401
 
 from ._version import __version__
 
@@ -188,9 +188,6 @@ def _initialise_testbench(argv_):  # pragma: no cover
 
     The test must be defined by the environment variables
     :envvar:`MODULE` and :envvar:`TESTCASE`.
-
-    The environment variable :envvar:`COCOTB_HOOKS`, if present, contains a
-    comma-separated list of modules to be executed before the first test.
     """
     with _rlock:
 

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -89,7 +89,6 @@ def help_vars_text():
     TESTCASE                  Test function(s) to run (comma-separated list)
     COCOTB_RESULTS_FILE       File name for xUnit XML tests results
     COVERAGE                  Report Python coverage (also HDL for some simulators)
-    COCOTB_HOOKS              Comma-separated module list to be executed before test
 
     GPI
     ---

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -450,33 +450,6 @@ class _decorator_helper(type):
 
 
 @public
-class hook(coroutine, metaclass=_decorator_helper):
-    r"""
-    Decorator to mark a function as a hook for cocotb.
-
-    Used as ``@cocotb.hook()``.
-
-    All hooks are run at the beginning of a cocotb test suite, prior to any
-    test code being run.
-
-    .. deprecated:: 1.5
-        Hooks are deprecated.
-        Their functionality can be replaced with module-level Python code,
-        higher-priority tests using the ``stage`` argument to :func:`cocotb.test`\ s,
-        or custom decorators which perform work before and after the tests
-        they decorate.
-    """
-
-    def __init__(self, f):
-        super().__init__(f)
-        warnings.warn(
-            "Hooks have been deprecated. See the documentation for suggestions on alternatives.",
-            DeprecationWarning, stacklevel=2)
-        self.im_hook = True
-        self.name = self._func.__name__
-
-
-@public
 class test(coroutine, metaclass=_decorator_helper):
     """Decorator to mark a function as a test.
 

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -174,14 +174,6 @@ Regression Manager
 
     This needs the :mod:`coverage` Python module to be installed.
 
-.. envvar:: COCOTB_HOOKS
-
-    A comma-separated list of modules that should be executed before the first test.
-    You can also use the :class:`cocotb.hook` decorator to mark a function to be run before test code.
-
-    .. deprecated:: 1.5
-        :class:`cocotb.hook` is deprecated, and in the future this variable will be ignored.
-
 .. envvar:: COCOTB_PDB_ON_EXCEPTION
 
    If defined, cocotb will drop into the Python debugger (:mod:`pdb`) if a test fails with an exception.

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -38,8 +38,6 @@ Writing and Generating tests
 
 .. autoclass:: cocotb.function
 
-.. autoclass:: cocotb.hook
-
 .. autoclass:: cocotb.regression.TestFactory
     :members:
     :member-order: bysource

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -85,14 +85,6 @@ async def test_raise_error_deprecated(dut):
 
 
 @cocotb.test()
-async def test_hook_deprecated(_):
-    async def example():
-        pass
-    with assert_deprecated():
-        cocotb.hook()(example)
-
-
-@cocotb.test()
 async def test_handle_compat_mapping(dut):
     """
     Test DeprecationWarnings for _compat_mapping.


### PR DESCRIPTION
`hook`s have been deprecated, with 2.0 they should be removed. 