### PR TITLE
Fixup #2493

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -316,7 +316,7 @@ class HierarchyObject(RegionObject):
         sub = self.__get_sub_handle_by_name(name)
         if sub is not None:
             warnings.warn(
-                "Setting values on handles using the ``dut.handle = value`` syntax is deprecated."
+                "Setting values on handles using the ``dut.handle = value`` syntax is deprecated. "
                 "Instead use the ``handle.value = value`` or ``handle <= value`` syntax",
                 DeprecationWarning, stacklevel=2)
             sub.value = value
@@ -585,11 +585,11 @@ class NonHierarchyIndexableObject(NonHierarchyObject):
 
     def __setitem__(self, index, value):
         """Provide transparent assignment to indexed array handles."""
-        self[index].value = value
         warnings.warn(
-            "Setting values on handles using the ``dut.handle[i] = value`` syntax is deprecated."
+            "Setting values on handles using the ``dut.handle[i] = value`` syntax is deprecated. "
             "Instead use the ``handle[i].value = value`` or ``handle[i] <= value`` syntax",
             DeprecationWarning, stacklevel=2)
+        self[index].value = value
 
     def __getitem__(self, index):
         if isinstance(index, slice):

--- a/documentation/source/newsfragments/2490.removal.1.rst
+++ b/documentation/source/newsfragments/2490.removal.1.rst
@@ -1,0 +1,2 @@
+Setting values on indexed handles using the ``handle[i] = value`` syntax is deprecated.
+Instead use the ``handle[i].value = value`` or ``handle[i] <= value`` syntax.

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -191,6 +191,7 @@ icarus_under_11 = cocotb.SIM_NAME.lower().startswith("icarus") and (IcarusVersio
 async def test_assigning_setitem_syntax_deprecated(dut):
     with assert_deprecated():
         dut.stream_in_data[0] = 1
-    with assert_raises(IndexError):
-        # attempt to use __setitem__ syntax on signal that doesn't exist
-        dut.stream_in_data[800000] = 1
+    with assert_deprecated():
+        with assert_raises(IndexError):
+            # attempt to use __setitem__ syntax on signal that doesn't exist
+            dut.stream_in_data[800000] = 1


### PR DESCRIPTION
Fixes issues noted in #2493 after the merge occurred. Added a newsfragment stating that `__setitem__` syntax was similar being deprecated. And moved the warning to before the setting, so when warnings are error the value setting never occurs.