### PR TITLE
Add Range and Array modeling types

### DIFF
--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -69,12 +69,3 @@ if sys.version_info < (3, 9):
         return lru_cache(maxsize=None)(f)
 else:
     from functools import cache  # noqa: F401
-
-
-# Emulates Python 3.8's functools.cached_property decorator.
-# Uses lru_cache with LRU functionality, otherwise the cache could hold references to
-# dead objects and grow infinitely.
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    cached_property = property

--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -78,4 +78,4 @@ if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     def cached_property(method):
-        return property(lru_cache(method))
+        return property(lru_cache()(method))

--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -77,5 +77,4 @@ else:
 if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
-    def cached_property(method):
-        return property(lru_cache()(method))
+    cached_property = property

--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -29,6 +29,7 @@ These are for internal use - users should use a third party library like `six`
 if they want to use these shims in their own code
 """
 import sys
+from functools import lru_cache
 
 
 # backport of Python 3.7's contextlib.nullcontext
@@ -60,3 +61,21 @@ if sys.version_info[:2] >= (3, 7):
 else:
     import collections
     insertion_ordered_dict = collections.OrderedDict
+
+
+# backport of Python 3.9's functools.cache decorator
+if sys.version_info < (3, 9):
+    def cache(f):
+        return lru_cache(maxsize=None)(f)
+else:
+    from functools import cache  # noqa: F401
+
+
+# Emulates Python 3.8's functools.cached_property decorator.
+# Uses lru_cache with LRU functionality, otherwise the cache could hold references to
+# dead objects and grow infinitely.
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    def cached_property(method):
+        return property(lru_cache(method))

--- a/cocotb/_py_compat.py
+++ b/cocotb/_py_compat.py
@@ -29,7 +29,6 @@ These are for internal use - users should use a third party library like `six`
 if they want to use these shims in their own code
 """
 import sys
-from functools import lru_cache
 
 
 # backport of Python 3.7's contextlib.nullcontext
@@ -61,11 +60,3 @@ if sys.version_info[:2] >= (3, 7):
 else:
     import collections
     insertion_ordered_dict = collections.OrderedDict
-
-
-# backport of Python 3.9's functools.cache decorator
-if sys.version_info < (3, 9):
-    def cache(f):
-        return lru_cache(maxsize=None)(f)
-else:
-    from functools import cache  # noqa: F401

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from .logic import Logic, Bit  # noqa: F401
 from .range import Range  # noqa: F401
+from .array import Array  # noqa: F401

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -16,14 +16,27 @@ def concat(a: Array, b: Array) -> Array:
     Raises:
         TypeError: when the arguments do not support concatenation in the given order.
     """
-    if hasattr(a, '__concat__'):
-        res = a.__concat__(b)
+    a_concat = getattr(a.__class__, "__concat__", None)
+    a_rconcat = getattr(a.__class__, "__rconcat__", None)
+    b_rconcat = getattr(b.__class__, "__rconcat__", None)
+
+    if isinstance(b, a.__class__) and a_rconcat != b_rconcat:
+        # 'b' is a subclass of 'a' with a more specific implementation of 'concat(a, b)'
+        call_order = ((b, b_rconcat, a), (a, a_concat, b))
+    elif a.__class__ != b.__class__:
+        # normal call order
+        call_order = ((a, a_concat, b), (b, b_rconcat, a))
+    else:
+        # types are the same, we expect implementation of 'concat(a, b)' to be in 'a.__concat__'
+        call_order = ((a, a_concat, b),)
+
+    for lhs, method, rhs in call_order:
+        if method is None:
+            continue
+        res = method(lhs, rhs)
         if res is not NotImplemented:
             return res
-    if hasattr(b, '__rconcat__'):
-        res = b.__rconcat__(a)
-        if res is not NotImplemented:
-            return res
+
     raise TypeError(
         "cannot concatenate {!r} with {!r}".format(
             a.__class__.__qualname__, b.__class__.__qualname__

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -2,3 +2,4 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 from .logic import Logic, Bit  # noqa: F401
+from .range import Range  # noqa: F401

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -4,3 +4,28 @@
 from .logic import Logic, Bit  # noqa: F401
 from .range import Range  # noqa: F401
 from .array import Array  # noqa: F401
+
+
+def concat(a: Array, b: Array) -> Array:
+    """
+    Create a new array that is the concatenation of one array with another.
+
+    Uses the :meth:`__concat__` or :meth:`__rconcat__` special methods to dispatch to a particular implementation,
+    exactly like other binary operations in Python.
+
+    Raises:
+        TypeError: when *other* is an object of dissimilar type.
+    """
+    if hasattr(a, '__concat__'):
+        res = a.__concat__(b)
+        if res is not NotImplemented:
+            return res
+    if hasattr(b, '__rconcat__'):
+        res = b.__rconcat__(a)
+        if res is not NotImplemented:
+            return res
+    raise TypeError(
+        "can't concat value of type {!r} with value of type {!r}".format(
+            a.__class__.__qualname__, b.__class__.__qualname__
+        )
+    )

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -16,14 +16,16 @@ def concat(a: Array, b: Array) -> Array:
     Raises:
         TypeError: when the arguments do not support concatenation in the given order.
     """
-    a_concat = getattr(a.__class__, "__concat__", None)
-    a_rconcat = getattr(a.__class__, "__rconcat__", None)
-    b_rconcat = getattr(b.__class__, "__rconcat__", None)
+    type_a = type(a)
+    type_b = type(b)
+    a_concat = getattr(type_a, "__concat__", None)
+    a_rconcat = getattr(type_a, "__rconcat__", None)
+    b_rconcat = getattr(type_b, "__rconcat__", None)
 
-    if isinstance(b, a.__class__) and a_rconcat != b_rconcat:
+    if type_a is not type_b and issubclass(type_b, type_a) and a_rconcat != b_rconcat:
         # 'b' is a subclass of 'a' with a more specific implementation of 'concat(a, b)'
         call_order = ((b, b_rconcat, a), (a, a_concat, b))
-    elif a.__class__ != b.__class__:
+    elif type_a is not type_b:
         # normal call order
         call_order = ((a, a_concat, b), (b, b_rconcat, a))
     else:
@@ -39,6 +41,6 @@ def concat(a: Array, b: Array) -> Array:
 
     raise TypeError(
         "cannot concatenate {!r} with {!r}".format(
-            a.__class__.__qualname__, b.__class__.__qualname__
+            type_a.__qualname__, type_b.__qualname__
         )
     )

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -16,11 +16,12 @@ def concat(a: Array, b: Array) -> Array:
     Raises:
         TypeError: when the arguments do not support concatenation in the given order.
     """
+    MISSING = object()
     type_a = type(a)
     type_b = type(b)
-    a_concat = getattr(type_a, "__concat__", None)
-    a_rconcat = getattr(type_a, "__rconcat__", None)
-    b_rconcat = getattr(type_b, "__rconcat__", None)
+    a_concat = getattr(type_a, "__concat__", MISSING)
+    a_rconcat = getattr(type_a, "__rconcat__", MISSING)
+    b_rconcat = getattr(type_b, "__rconcat__", MISSING)
 
     if type_a is not type_b and issubclass(type_b, type_a) and a_rconcat != b_rconcat:
         # 'b' is a subclass of 'a' with a more specific implementation of 'concat(a, b)'
@@ -33,7 +34,7 @@ def concat(a: Array, b: Array) -> Array:
         call_order = ((a, a_concat, b),)
 
     for lhs, method, rhs in call_order:
-        if method is None:
+        if method is MISSING:
             continue
         res = method(lhs, rhs)
         if res is not NotImplemented:

--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -14,7 +14,7 @@ def concat(a: Array, b: Array) -> Array:
     exactly like other binary operations in Python.
 
     Raises:
-        TypeError: when *other* is an object of dissimilar type.
+        TypeError: when the arguments do not support concatenation in the given order.
     """
     if hasattr(a, '__concat__'):
         res = a.__concat__(b)
@@ -25,7 +25,7 @@ def concat(a: Array, b: Array) -> Array:
         if res is not NotImplemented:
             return res
     raise TypeError(
-        "can't concat value of type {!r} with value of type {!r}".format(
+        "cannot concatenate {!r} with {!r}".format(
             a.__class__.__qualname__, b.__class__.__qualname__
         )
     )

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -212,10 +212,16 @@ class Array(Sequence):
         return item in self._value
 
     def __eq__(self, other: Any) -> bool:
+        sentinel = object()
         try:
-            return all(a == b for a, b in zip_longest(self, other, fillvalue=object()))
+            it = zip_longest(self, other, fillvalue=sentinel)
         except TypeError:
             return NotImplemented
+        for a, b in it:
+            # sentinel check MUST come before element equality check
+            if b == sentinel or a != b:
+                return False
+        return True
 
     @overload
     def __getitem__(self, item: int) -> Any:

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -1,3 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 from typing import Optional, Any, Iterable, Iterator, overload
 from collections.abc import Sequence
 from .range import Range

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -1,7 +1,7 @@
 from typing import Optional, Any, Iterable, Iterator, overload
 from collections.abc import Sequence
 from .range import Range
-from functools import cached_property
+from cocotb._py_compat import cached_property
 from itertools import zip_longest
 from sys import maxsize
 

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -5,7 +5,6 @@ from typing import Optional, Any, Iterable, Iterator, overload
 from collections.abc import Sequence
 from .range import Range
 from sys import maxsize
-from itertools import chain
 
 
 class Array(Sequence):
@@ -292,7 +291,7 @@ class Array(Sequence):
                     other.__class__.__qualname__
                 )
             )
-        return self.__class__(chain(self, other))
+        return self.__class__(self._value + other._value)
 
     def index(
         self, value: Any, start: Optional[int] = None, stop: Optional[int] = None

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -204,7 +204,11 @@ class Array(Sequence):
                 raise IndexError("slice direction does not match array direction")
             value = list(value)
             if len(value) != (stop_i - start_i + 1):
-                raise ValueError("value is not the same length as the slice")
+                raise ValueError(
+                    "value  of length {!r} will not fit in slice [{}:{}]".format(
+                        len(value), start, stop
+                    )
+                )
             self._value[start_i : stop_i + 1] = value
         else:
             raise TypeError(

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -289,14 +289,14 @@ class Array(Sequence):
         return "{}({!r}, {!r})".format(type(self).__name__, self._value, self._range)
 
     def __concat__(self, other: "Array") -> "Array":
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, type(self)):
             return NotImplemented
-        return self.__class__(self._value + other._value)
+        return type(self)(self._value + other._value)
 
     def __rconcat__(self, other: "Array") -> "Array":
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, type(self)):
             return NotImplemented
-        return self.__class__(other._value + self._value)
+        return type(self)(other._value + self._value)
 
     def index(
         self, value: Any, start: Optional[int] = None, stop: Optional[int] = None

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -302,7 +302,12 @@ class Array(Sequence):
     def index(
         self, value: Any, start: Optional[int] = None, stop: Optional[int] = None
     ) -> int:
-        """Return index of first occurrence of *value*."""
+        """
+        Return index of first occurrence of *value*.
+
+        Raises :exc:`ValueError` if the value is not found.
+        Search only within *start* and *stop* if given.
+        """
         if start is not None:
             start = self._translate_index(start)
         else:

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -25,19 +25,19 @@ class Array(Sequence):
     .. code-block:: python3
 
         >>> Array("1234")  # the 0-based range `(0, len(value)-1)` is inferred
-        Array(['1', '2', '3', '4'], Range(0, 3))
+        Array(['1', '2', '3', '4'], Range(0, 'to', 3))
 
         >>> Array(range=Range(0, 'downto', -3))  # the initial values are `None`
-        Array([None, None, None, None], Range(0, -3))
+        Array([None, None, None, None], Range(0, 'downto', -3))
 
-        >>> Array([1, True, object(), 'example'], Range(-2, 1))  # initial value and range lengths must be equal
-        Array([1, True, <object object at 0x7f4cff7b5570>, 'example'], Range(-2, 'to', 1))
+        >>> Array([1, True, None, 'example'], Range(-2, 1))  # initial value and range lengths must be equal
+        Array([1, True, None, 'example'], Range(-2, 'to', 1))
 
     Arrays also support "null" ranges; "null" arrays have zero length and cannot be indexed.
 
     .. code-block:: python3
 
-        >>> Array(range=Range(0, 'to', 1))
+        >>> Array(range=Range(1, 'to', 0))
         Array([], Range(1, 'to', 0))
 
     Indexing and slicing is very similar to :class:`list`\ s, but it uses the indexing scheme specified.
@@ -55,7 +55,7 @@ class Array(Sequence):
         >>> ''.join(a)
         '12ba43cd'
 
-        >>> b = Array("1234", Range(0, 'downto', -3))
+        >>> b = Array("1234", Range(0, -3))
         >>> b[-2]
         '3'
         >>> b[-1:]
@@ -144,7 +144,7 @@ class Array(Sequence):
     def __contains__(self, item: Any) -> bool:
         return item in self._value
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other: Any) -> bool:
         try:
             return all(a == b for a, b in zip_longest(self, other, fillvalue=object()))
         except TypeError:

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -236,8 +236,8 @@ class Array(Sequence):
             idx = self._translate_index(item)
             return self._value[idx]
         elif isinstance(item, slice):
-            start = item.start or self.left
-            stop = item.stop or self.right
+            start = item.start if item.start is not None else self.left
+            stop = item.stop if item.stop is not None else self.right
             if item.step is not None:
                 raise IndexError("do not specify step")
             start_i = self._translate_index(start)
@@ -269,8 +269,8 @@ class Array(Sequence):
             value = self._construct_element(value)
             self._value[idx] = value
         elif isinstance(item, slice):
-            start = item.start or self.left
-            stop = item.stop or self.right
+            start = item.start if item.start is not None else self.left
+            stop = item.stop if item.stop is not None else self.right
             if item.step is not None:
                 raise IndexError("do not specify step")
             start_i = self._translate_index(start)

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -83,6 +83,18 @@ class Array(Sequence):
         >>> a == b
         True
 
+    You can change the bounds of an array by setting the :attr:`range` to a new value.
+    The new bounds must be the same length of the array.
+
+    .. code-block:: python3
+
+        >>> a = Array("1234")
+        >>> a.range
+        Range(0, 'to', 3)
+        >>> a.range = Range(3, 'downto', 0)
+        >>> a.range
+        Range(3, 'downto', 0)
+
     Arrays support the methods and semantics defined by :class:`collections.abc.Sequence`.
 
     .. code-block:: python
@@ -185,6 +197,15 @@ class Array(Sequence):
     def range(self) -> Range:
         """:class:`Range` of the indexes of the array."""
         return self._range
+
+    @range.setter
+    def range(self, new_range: Range) -> None:
+        """Sets a new indexing scheme on the array, must be the same size"""
+        if not isinstance(new_range, Range):
+            raise TypeError("range argument must be of type 'Range'")
+        if len(new_range) != len(self):
+            raise ValueError(f"{new_range!r} not the same length as old range ({self._range!r}).")
+        self._range = new_range
 
     def __len__(self) -> int:
         return len(self.range)

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -4,7 +4,6 @@
 from typing import Optional, Any, Iterable, Iterator, overload, List
 from collections.abc import Sequence
 from .range import Range
-from cocotb._py_compat import cached_property
 from itertools import zip_longest
 from sys import maxsize
 
@@ -88,7 +87,6 @@ class Array(Sequence):
     __slots__ = (
         "_value",
         "_range",
-        "__dict__",  # necessary for cached_property
     )
 
     def __init__(
@@ -176,27 +174,27 @@ class Array(Sequence):
             return rng
         raise TypeError("range argument must be of type 'Range'")
 
-    @cached_property
+    @property
     def left(self) -> int:
         """Leftmost index of the array."""
-        return self._range.left
+        return self.range.left
 
-    @cached_property
+    @property
     def direction(self) -> str:
         """``'to'`` if indexes are ascending, ``'downto'`` otherwise."""
-        return self._range.direction
+        return self.range.direction
 
-    @cached_property
+    @property
     def right(self) -> int:
         """Rightmost index of the array."""
-        return self._range.right
+        return self.range.right
 
-    @cached_property
+    @property
     def length(self):
         """Length of the array."""
-        return self._range.length
+        return self.range.length
 
-    @cached_property
+    @property
     def range(self) -> Range:
         """:class:`Range` of the indexes of the array."""
         return self._range

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -243,7 +243,11 @@ class Array(Sequence):
             start_i = self._translate_index(start)
             stop_i = self._translate_index(stop)
             if start_i > stop_i:
-                raise IndexError("slice direction does not match array direction")
+                raise IndexError(
+                    "slice [{}:{}] direction does not match array direction [{}:{}]".format(
+                        start, stop, self.left, self.right
+                    )
+                )
             value = self._value[start_i : stop_i + 1]
             range = Range(start, self.direction, stop)
             return type(self)(value=value, range=range)
@@ -272,7 +276,11 @@ class Array(Sequence):
             start_i = self._translate_index(start)
             stop_i = self._translate_index(stop)
             if start_i > stop_i:
-                raise IndexError("slice direction does not match array direction")
+                raise IndexError(
+                    "slice [{}:{}] direction does not match array direction [{}:{}]".format(
+                        start, stop, self.left, self.right
+                    )
+                )
             value = self._construct_value(value)
             if len(value) != (stop_i - start_i + 1):
                 raise ValueError(

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -65,13 +65,10 @@ class Array(Sequence):
         Array(['4', '3', '2', '1'], Range(0, 'downto', -3))
 
     .. note::
-        Slice indexes must be specified in the same direction as the array and do not support specifying a "step".
 
-    .. note::
-        When setting a slice, the new value must be an iterable of the same size as the slice.
-
-    .. note::
-        Negative indexes are *not* treated as an offset from the end of the array, but are treated literally.
+        - Slice indexes must be specified in the same direction as the array and do not support specifying a "step".
+        - When setting a slice, the new value must be an iterable of the same size as the slice.
+        - Negative indexes are *not* treated as an offset from the end of the array, but are treated literally.
 
     Arrays support the methods and semantics defined by :class:`collections.abc.Sequence` including, but not limited to:
 

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -37,8 +37,8 @@ class Array(Sequence):
         >>> Array(range=Range(0, 'to', 1))
         Array([], Range(1, 'to', 0))
 
-    Indexing and slicing is very similar to :class:`list`\ s, except you use the indexing scheme you specified.
-    Like :class:`list`\ s, you don't have to specify a start or stop, and the start or end of the array are inferred.
+    Indexing and slicing is very similar to :class:`list`\ s, but it uses the indexing scheme specified.
+    Like :class:`list`\ s, if a start or stop index is not specified, it is inferred as the start or end of the array.
     Slicing an array returns a new :class:`~cocotb.types.Array` object, whose bounds are the slice indexes.
 
     .. code-block:: python3
@@ -65,7 +65,7 @@ class Array(Sequence):
         Slice indexes must be specified in the same direction as the array and do not support specifying a "step".
 
     .. note::
-        When setting a slice, the new value must be an iterable of the same size as the slice you are selecting.
+        When setting a slice, the new value must be an iterable of the same size as the slice.
 
     .. note::
         Negative indexes are *not* treated as an offset from the end of the array, but are treated literally.

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -204,7 +204,9 @@ class Array(Sequence):
         if not isinstance(new_range, Range):
             raise TypeError("range argument must be of type 'Range'")
         if len(new_range) != len(self):
-            raise ValueError(f"{new_range!r} not the same length as old range ({self._range!r}).")
+            raise ValueError(
+                f"{new_range!r} not the same length as old range ({self._range!r})."
+            )
         self._range = new_range
 
     def __len__(self) -> int:
@@ -308,8 +310,7 @@ class Array(Sequence):
         if not isinstance(other, self.__class__):
             raise TypeError(
                 "unsupported operand types for concat() {!r} and {!r}".format(
-                    self.__class__.__qualname__,
-                    other.__class__.__qualname__
+                    self.__class__.__qualname__, other.__class__.__qualname__
                 )
             )
         return self.__class__(self._value + other._value)

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -105,7 +105,7 @@ class Array(Sequence):
             self._range = self._construct_range(range)
             if len(self._value) != len(self._range):
                 raise ValueError(
-                    "init value of length {!r} not fit in {!r}".format(
+                    "init value of length {!r} does not fit in {!r}".format(
                         len(self._value), self._range
                     )
                 )
@@ -275,7 +275,7 @@ class Array(Sequence):
             value = self._construct_value(value)
             if len(value) != (stop_i - start_i + 1):
                 raise ValueError(
-                    "value  of length {!r} will not fit in slice [{}:{}]".format(
+                    "value of length {!r} will not fit in slice [{}:{}]".format(
                         len(value), start, stop
                     )
                 )

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -40,6 +40,8 @@ class Array(Sequence):
         Array([], Range(1, 'to', 0))
 
     Indexing and slicing is very similar to :class:`list`\ s, but it uses the indexing scheme specified.
+    Slicing, just like the :class:`~cocotb.types.Range` object uses an inclusive right bound,
+    which is commonly seen in HDLs.
     Like :class:`list`\ s, if a start or stop index is not specified, it is inferred as the start or end of the array.
     Slicing an array returns a new :class:`~cocotb.types.Array` object, whose bounds are the slice indexes.
 

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -94,11 +94,11 @@ class Array(Sequence):
         self, value: Optional[Iterable[Any]] = None, range: Optional[Range] = None
     ):
         if value is not None and range is None:
-            self._value = list(value)
-            self._range = Range(0, "to", len(self._value) - 1)
+            self._value = self._construct_value(value)
+            self._range = self._construct_range(Range(0, "to", len(self._value) - 1))
         elif value is not None and range is not None:
-            self._value = list(value)
-            self._range = range
+            self._value = self._construct_value(value)
+            self._range = self._construct_range(range)
             if len(self._value) != len(self._range):
                 raise ValueError(
                     "init value of length {!r} not fit in {!r}".format(
@@ -106,10 +106,18 @@ class Array(Sequence):
                     )
                 )
         elif value is None and range is not None:
-            self._value = [None] * len(range)
-            self._range = range
+            self._value = self._construct_value(None for _ in range)
+            self._range = self._construct_range(range)
         else:
             raise TypeError("must pass a value, range, or both")
+
+    _construct_value = list
+
+    @staticmethod
+    def _construct_range(rng: Any) -> Range:
+        if isinstance(rng, Range):
+            return rng
+        raise TypeError("range argument must be of type 'Range'")
 
     @cached_property
     def left(self) -> int:

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -64,8 +64,11 @@ class Array(Sequence):
         >>> b
         Array(['4', '3', '2', '1'], Range(0, 'downto', -3))
 
-    .. note::
+    .. warning::
+        Arrays behave differently in certain situations than Python's builtin sequence types (:class:`list`, :class:`tuple`, etc.).
 
+        - Arrays are not necessarily 0-based and slices use inclusive right bounds,
+          so many functions that work on Python sequences by index (like :mod:`bisect`) may not work on arrays.
         - Slice indexes must be specified in the same direction as the array and do not support specifying a "step".
         - When setting a slice, the new value must be an iterable of the same size as the slice.
         - Negative indexes are *not* treated as an offset from the end of the array, but are treated literally.

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -128,6 +128,20 @@ class Array(Sequence):
         "_range",
     )
 
+    _value: Sequence
+    """
+    Private interface for subclasses to access the value as a :class:`~collections.abc.Sequence`
+
+    Subclasses that don't use a Sequence as their main representation should emulate this object,
+    or override *all* :class:`~cocotb.types.Array` methods *except*:
+        - :attr:`left`
+        - :attr:`direction`
+        - :attr:`right`
+        - :attr:`range`
+        - :attr:`__len__`
+        - :attr:`_translate_index`
+    """
+
     def __init__(
         self, value: Optional[Iterable[Any]] = None, range: Optional[Range] = None
     ):
@@ -274,19 +288,15 @@ class Array(Sequence):
     def __repr__(self) -> str:
         return "{}({!r}, {!r})".format(type(self).__name__, self._value, self._range)
 
-    def concat(self, other: Any) -> "Array":
-        """
-        Create a new array that is the concatenation of one array with another.
-        Raises:
-            TypeError: when *other* is an object of dissimilar type.
-        """
+    def __concat__(self, other: "Array") -> "Array":
         if not isinstance(other, self.__class__):
-            raise TypeError(
-                "unsupported operand types for concat() {!r} and {!r}".format(
-                    self.__class__.__qualname__, other.__class__.__qualname__
-                )
-            )
+            return NotImplemented
         return self.__class__(self._value + other._value)
+
+    def __rconcat__(self, other: "Array") -> "Array":
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.__class__(other._value + self._value)
 
     def index(
         self, value: Any, start: Optional[int] = None, stop: Optional[int] = None

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -234,4 +234,4 @@ class Array(Sequence):
         try:
             return self._range.index(item)
         except ValueError:
-            raise IndexError("index {} out of range".format(item)) from None
+            raise IndexError(f"index {item} out of range") from None

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -150,8 +150,8 @@ class Array(Sequence):
         Construct a single element of an array.
 
         Will be fed elements of the *value* iterable if given to the constructor,
-        :data:`None` when no *value* is given to the constuctor,
-        the *value* in __setitem__ when assigning to a single index,
+        :data:`None` when no *value* is given to the constructor,
+        the *value* in ``__setitem__`` when assigning to a single index,
         and elements of the *value* iterable when assigning to a slice.
 
         Args:

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -81,7 +81,11 @@ class Array(Sequence):
         range: Indexing scheme of the array.
     """
 
-    __slots__ = ("_value", "_range", "__dict__")  # __dict__ necessary for cached_property
+    __slots__ = (
+        "_value",
+        "_range",
+        "__dict__",  # necessary for cached_property
+    )
 
     def __init__(
         self, value: Optional[Iterable[Any]] = None, range: Optional[Range] = None
@@ -201,15 +205,15 @@ class Array(Sequence):
             self._value[start_i : stop_i + 1] = value
         else:
             raise TypeError(
-                "indexes must be ints or slices, not {}".format(
-                    type(item).__name__
-                )
+                "indexes must be ints or slices, not {}".format(type(item).__name__)
             )
 
     def __repr__(self) -> str:
         return "{}({!r}, {!r})".format(type(self).__name__, self._value, self._range)
 
-    def index(self, value: Any, start: Optional[int] = None, stop: Optional[int] = None) -> int:
+    def index(
+        self, value: Any, start: Optional[int] = None, stop: Optional[int] = None
+    ) -> int:
         """Return index of first occurrence of *value*."""
         if start is not None:
             start = self._translate_index(start)

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -8,26 +8,26 @@ from sys import maxsize
 
 class Array(Sequence):
     r"""
-    Fixed-size, arbitrarily-indexed, heterogenous sequence type.
+    Fixed-size, arbitrarily-indexed, heterogeneous sequence type.
 
-    Arrays are similar, but different from Python :class:`list`\ s.
+    Arrays are similar to, but different from Python :class:`list`\ s.
     An array can store values of any type or values of multiple types at a time, just like a :class:`list`.
     Unlike :class:`list`\ s, an array's size cannot change.
 
     The indexes of an array can start or end at any integer value, they are not limited to 0-based indexing.
     Indexing schemes can be either ascending or descending in value.
-    An array's indexes are described using a :class:`~cocotb.types.Range` objects.
+    An array's indexes are described using a :class:`~cocotb.types.Range` object.
     Initial values are treated as iterables, which are copied into an internal buffer.
 
     .. code-block:: python3
 
-        >>> Array("1234")  # the 0-based range `(0, len(value)-1)` is infered
+        >>> Array("1234")  # the 0-based range `(0, len(value)-1)` is inferred
         Array(['1', '2', '3', '4'], Range(0, 3))
 
         >>> Array(range=Range(0, 'downto', -3))  # the initial values are `None`
         Array([None, None, None, None], Range(0, -3))
 
-        >>> Array([1, True, object(), 'example'], Range(-2, 1))  # inital value and range lengths must be equal
+        >>> Array([1, True, object(), 'example'], Range(-2, 1))  # initial value and range lengths must be equal
         Array([1, True, <object object at 0x7f4cff7b5570>, 'example'], Range(-2, 'to', 1))
 
     Arrays also support "null" ranges; "null" arrays have zero length and cannot be indexed.
@@ -38,7 +38,7 @@ class Array(Sequence):
         Array([], Range(1, 'to', 0))
 
     Indexing and slicing is very similar to :class:`list`\ s, except you use the indexing scheme you specified.
-    Like :class:`list`\ s, you don't have to specify a start or stop, and the start or end of the array are infered.
+    Like :class:`list`\ s, you don't have to specify a start or stop, and the start or end of the array are inferred.
     Slicing an array returns a new :class:`~cocotb.types.Array` object, whose bounds are the slice indexes.
 
     .. code-block:: python3
@@ -65,7 +65,7 @@ class Array(Sequence):
         Slice indexes must be specified in the same direction as the array and do not support specifying a "step".
 
     .. note::
-        When setting a slice, the new value must be an iterable the same size as the slice you are selecting.
+        When setting a slice, the new value must be an iterable of the same size as the slice you are selecting.
 
     .. note::
         Negative indexes are *not* treated as an offset from the end of the array, but are treated literally.
@@ -74,9 +74,9 @@ class Array(Sequence):
 
     - ``len(array)`` for getting the length of the array,
     - ``value in array`` to check if an array contains a value,
-    - ``array.index(value)`` to find the index of the first occurences of a value in the array.
+    - ``array.index(value)`` to find the index of the first occurrence of a value in the array.
 
-    Args
+    Args:
         value: Initial value for the array.
         range: Indexing scheme of the array.
     """
@@ -102,27 +102,27 @@ class Array(Sequence):
 
     @cached_property
     def left(self) -> int:
-        """Leftmost index of the array"""
+        """Leftmost index of the array."""
         return self._range.left
 
     @cached_property
     def direction(self) -> str:
-        """``'to'`` if indexes are ascending, ``'downto'`` otherwise"""
+        """``'to'`` if indexes are ascending, ``'downto'`` otherwise."""
         return self._range.direction
 
     @cached_property
     def right(self) -> int:
-        """Rightmost index of the array"""
+        """Rightmost index of the array."""
         return self._range.right
 
     @cached_property
     def length(self):
-        """Length of the array"""
+        """Length of the array."""
         return self._range.length
 
     @cached_property
     def range(self) -> Range:
-        """:class:`Range` of the indexes of the array"""
+        """:class:`Range` of the indexes of the array."""
         return self._range
 
     def __len__(self) -> int:
@@ -210,7 +210,7 @@ class Array(Sequence):
         return "{}({!r}, {!r})".format(type(self).__name__, self._value, self._range)
 
     def index(self, value: Any, start: Optional[int] = None, stop: Optional[int] = None) -> int:
-        """Return index of first occurence of value."""
+        """Return index of first occurrence of *value*."""
         if start is not None:
             start = self._translate_index(start)
         else:
@@ -223,7 +223,7 @@ class Array(Sequence):
         return self._range[idx]
 
     def count(self, value: Any) -> int:
-        """Return number of occurences of value."""
+        """Return number of occurrences of *value*."""
         return self._value.count(value)
 
     def _translate_index(self, item: int) -> int:

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -115,7 +115,7 @@ class Array(Sequence):
     @staticmethod
     def _construct_value(value: Iterable[Any]) -> List[Any]:
         """
-        Constructs the value portion of the array.
+        Construct the value portion of the array.
 
         For overriding by subclasses.
         Used by constructor when values are given
@@ -136,7 +136,7 @@ class Array(Sequence):
     @staticmethod
     def _construct_element(elem: Any) -> Any:
         """
-        Constructs a single element of an array.
+        Construct a single element of an array.
 
         For overriding by subclasses.
         Used by __setitem__ when setting a single element.
@@ -156,7 +156,7 @@ class Array(Sequence):
     @staticmethod
     def _construct_range(rng: Any) -> Range:
         """
-        Constructs the range portion of the array.
+        Construct the range portion of the array.
 
         For overriding by subclasses.
         Used by the constructor when setting the range

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -25,17 +25,17 @@ class Array(Sequence):
         >>> Array("1234")  # the 0-based range `(0, len(value)-1)` is inferred
         Array(['1', '2', '3', '4'], Range(0, 'to', 3))
 
-        >>> Array(range=Range(0, 'downto', -3))  # the initial values are `None`
+        >>> Array(range=Range(0, "downto", -3))  # the initial values are `None`
         Array([None, None, None, None], Range(0, 'downto', -3))
 
-        >>> Array([1, True, None, 'example'], Range(-2, 1))  # initial value and range lengths must be equal
+        >>> Array([1, True, None, "example"], Range(-2, 1))  # initial value and range lengths must be equal
         Array([1, True, None, 'example'], Range(-2, 'to', 1))
 
     Arrays also support "null" ranges; "null" arrays have zero length and cannot be indexed.
 
     .. code-block:: python3
 
-        >>> Array(range=Range(1, 'to', 0))
+        >>> Array(range=Range(1, "to", 0))
         Array([], Range(1, 'to', 0))
 
     Indexing and slicing is very similar to :class:`list`\ s, but it uses the indexing scheme specified.
@@ -52,7 +52,7 @@ class Array(Sequence):
         >>> a[2:5]
         Array(['3', '4', 'a', 'b'], Range(2, 'to', 5))
         >>> a[2:5] = reversed(a[2:5])
-        >>> ''.join(a)
+        >>> "".join(a)
         '12ba43cd'
 
         >>> b = Array("1234", Range(0, -3))
@@ -205,7 +205,7 @@ class Array(Sequence):
 
     @property
     def direction(self) -> str:
-        """``'to'`` if indexes are ascending, ``'downto'`` otherwise."""
+        """``"to"`` if indexes are ascending, ``"downto"`` otherwise."""
         return self.range.direction
 
     @property

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -70,11 +70,34 @@ class Array(Sequence):
         - When setting a slice, the new value must be an iterable of the same size as the slice.
         - Negative indexes are *not* treated as an offset from the end of the array, but are treated literally.
 
-    Arrays support the methods and semantics defined by :class:`collections.abc.Sequence` including, but not limited to:
+    Arrays are equal to other arrays of the same length with the same values (structural equality).
+    Bounds do not matter for equality.
 
-    - ``len(array)`` for getting the length of the array,
-    - ``value in array`` to check if an array contains a value,
-    - ``array.index(value)`` to find the index of the first occurrence of a value in the array.
+    .. code-block:: python3
+
+        >>> a = Array([1, 1, 2, 3, 5], Range(4, "downto", 0))
+        >>> b = Array([1, 1, 2, 3, 5], Range(-2, "to", 2))
+        >>> a == b
+        True
+
+    Arrays support the methods and semantics defined by :class:`collections.abc.Sequence`.
+
+    .. code-block:: python
+
+        >>> a = Array("stuff", Range(2, "downto", -2))
+        >>> len(a)
+        5
+        >>> "t" in a
+        True
+        >>> a.index("u")
+        0
+        >>> for c in a:
+        ...     print(c)
+        s
+        t
+        u
+        f
+        f
 
     Args:
         value: Initial value for the array.

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -182,17 +182,12 @@ class Array(Sequence):
         return self.range.right
 
     @property
-    def length(self):
-        """Length of the array."""
-        return self.range.length
-
-    @property
     def range(self) -> Range:
         """:class:`Range` of the indexes of the array."""
         return self._range
 
     def __len__(self) -> int:
-        return self.length
+        return len(self.range)
 
     def __iter__(self) -> Iterator[Any]:
         return iter(self._value)

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import Optional, Any, Iterable, Iterator, overload, List
+from typing import Optional, Any, Iterable, Iterator, overload
 from collections.abc import Sequence
 from .range import Range
 from sys import maxsize

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -132,14 +132,12 @@ class Array(Sequence):
         self, value: Optional[Iterable[Any]] = None, range: Optional[Range] = None
     ):
         if value is not None and range is None:
-            constructor = self._construct_element
-            self._value = [constructor(v) for v in value]
+            self._value = list(value)
             self._range = Range(0, "to", len(self._value) - 1)
         elif value is not None and range is not None:
             if not isinstance(range, Range):
                 raise TypeError("range argument must be of type 'Range'")
-            constructor = self._construct_element
-            self._value = [constructor(v) for v in value]
+            self._value = list(value)
             self._range = range
             if len(self._value) != len(self._range):
                 raise ValueError(
@@ -150,33 +148,10 @@ class Array(Sequence):
         elif value is None and range is not None:
             if not isinstance(range, Range):
                 raise TypeError("range argument must be of type 'Range'")
-            constructor = self._construct_element
-            self._value = [constructor(None) for _ in range]
+            self._value = [None] * len(range)
             self._range = range
         else:
             raise TypeError("must pass a value, range, or both")
-
-    @staticmethod
-    def _construct_element(elem: Any) -> Any:
-        """
-        Construct a single element of an array.
-
-        Will be fed elements of the *value* iterable if given to the constructor,
-        :data:`None` when no *value* is given to the constructor,
-        the *value* in ``__setitem__`` when assigning to a single index,
-        and elements of the *value* iterable when assigning to a slice.
-
-        Args:
-            elem: Any object that the implementation can turn into an array element.
-
-        Returns:
-            An array element.
-
-        Raises:
-            TypeError: When the type isn't supported.
-            ValueError: When the value prevents construction into an element.
-        """
-        return elem
 
     @property
     def left(self) -> int:
@@ -269,7 +244,6 @@ class Array(Sequence):
     def __setitem__(self, item, value):
         if isinstance(item, int):
             idx = self._translate_index(item)
-            value = self._construct_element(value)
             self._value[idx] = value
         elif isinstance(item, slice):
             start = item.start if item.start is not None else self.left
@@ -284,8 +258,7 @@ class Array(Sequence):
                         start, stop, self.left, self.right
                     )
                 )
-            constructor = self._construct_element
-            value = [constructor(v) for v in value]
+            value = list(value)
             if len(value) != (stop_i - start_i + 1):
                 raise ValueError(
                     "value of length {!r} will not fit in slice [{}:{}]".format(

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -4,7 +4,6 @@
 from typing import Optional, Any, Iterable, Iterator, overload, List
 from collections.abc import Sequence
 from .range import Range
-from itertools import zip_longest
 from sys import maxsize
 
 
@@ -214,16 +213,9 @@ class Array(Sequence):
         return item in self._value
 
     def __eq__(self, other: Any) -> bool:
-        sentinel = object()
-        try:
-            it = zip_longest(self, other, fillvalue=sentinel)
-        except TypeError:
+        if not isinstance(other, type(self)):
             return NotImplemented
-        for a, b in it:
-            # sentinel check MUST come before element equality check
-            if b == sentinel or a != b:
-                return False
-        return True
+        return self._value == other._value
 
     @overload
     def __getitem__(self, item: int) -> Any:

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -5,6 +5,7 @@ from typing import Optional, Any, Iterable, Iterator, overload
 from collections.abc import Sequence
 from .range import Range
 from sys import maxsize
+from itertools import chain
 
 
 class Array(Sequence):
@@ -277,6 +278,21 @@ class Array(Sequence):
 
     def __repr__(self) -> str:
         return "{}({!r}, {!r})".format(type(self).__name__, self._value, self._range)
+
+    def concat(self, other: Any) -> "Array":
+        """
+        Create a new array that is the concatenation of one array with another.
+        Raises:
+            TypeError: when *other* is an object of dissimilar type.
+        """
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                "unsupported operand types for concat() {!r} and {!r}".format(
+                    self.__class__.__qualname__,
+                    other.__class__.__qualname__
+                )
+            )
+        return self.__class__(chain(self, other))
 
     def index(
         self, value: Any, start: Optional[int] = None, stop: Optional[int] = None

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -1,0 +1,233 @@
+from typing import Optional, Any, Iterable, Iterator, overload
+from collections.abc import Sequence
+from .range import Range
+from functools import cached_property
+from itertools import zip_longest
+from sys import maxsize
+
+
+class Array(Sequence):
+    r"""
+    Fixed-size, arbitrarily-indexed, heterogenous sequence type.
+
+    Arrays are similar, but different from Python :class:`list`\ s.
+    An array can store values of any type or values of multiple types at a time, just like a :class:`list`.
+    Unlike :class:`list`\ s, an array's size cannot change.
+
+    The indexes of an array can start or end at any integer value, they are not limited to 0-based indexing.
+    Indexing schemes can be either ascending or descending in value.
+    An array's indexes are described using a :class:`~cocotb.types.Range` objects.
+    Initial values are treated as iterables, which are copied into an internal buffer.
+
+    .. code-block:: python3
+
+        >>> Array("1234")  # the 0-based range `(0, len(value)-1)` is infered
+        Array(['1', '2', '3', '4'], Range(0, 3))
+
+        >>> Array(range=Range(0, 'downto', -3))  # the initial values are `None`
+        Array([None, None, None, None], Range(0, -3))
+
+        >>> Array([1, True, object(), 'example'], Range(-2, 1))  # inital value and range lengths must be equal
+        Array([1, True, <object object at 0x7f4cff7b5570>, 'example'], Range(-2, 'to', 1))
+
+    Arrays also support "null" ranges; "null" arrays have zero length and cannot be indexed.
+
+    .. code-block:: python3
+
+        >>> Array(range=Range(0, 'to', 1))
+        Array([], Range(1, 'to', 0))
+
+    Indexing and slicing is very similar to :class:`list`\ s, except you use the indexing scheme you specified.
+    Like :class:`list`\ s, you don't have to specify a start or stop, and the start or end of the array are infered.
+    Slicing an array returns a new :class:`~cocotb.types.Array` object, whose bounds are the slice indexes.
+
+    .. code-block:: python3
+
+        >>> a = Array("1234abcd")
+        >>> a[7]
+        'd'
+        >>> a[2:5]
+        Array(['3', '4', 'a', 'b'], Range(2, 'to', 5))
+        >>> a[2:5] = reversed(a[2:5])
+        >>> ''.join(a)
+        '12ba43cd'
+
+        >>> b = Array("1234", Range(0, 'downto', -3))
+        >>> b[-2]
+        '3'
+        >>> b[-1:]
+        Array(['2', '3', '4'], Range(-1, 'downto', -3))
+        >>> b[:] = reversed(b)
+        >>> b
+        Array(['4', '3', '2', '1'], Range(0, 'downto', -3))
+
+    .. note::
+        Slice indexes must be specified in the same direction as the array and do not support specifying a "step".
+
+    .. note::
+        When setting a slice, the new value must be an iterable the same size as the slice you are selecting.
+
+    .. note::
+        Negative indexes are *not* treated as an offset from the end of the array, but are treated literally.
+
+    Arrays support the methods and semantics defined by :class:`collections.abc.Sequence` including, but not limited to:
+
+    - ``len(array)`` for getting the length of the array,
+    - ``value in array`` to check if an array contains a value,
+    - ``array.index(value)`` to find the index of the first occurences of a value in the array.
+
+    Args
+        value: Initial value for the array.
+        range: Indexing scheme of the array.
+    """
+
+    __slots__ = ("_value", "_range", "__dict__")  # __dict__ necessary for cached_property
+
+    def __init__(
+        self, value: Optional[Iterable[Any]] = None, range: Optional[Range] = None
+    ):
+        if value is not None and range is None:
+            self._value = list(value)
+            self._range = Range(0, "to", len(self._value) - 1)
+        elif value is not None and range is not None:
+            self._value = list(value)
+            self._range = range
+            if len(self._value) != len(self._range):
+                raise ValueError("Init value does not fit in given range")
+        elif value is None and range is not None:
+            self._value = [None] * len(range)
+            self._range = range
+        else:
+            raise TypeError("must pass a value, range, or both")
+
+    @cached_property
+    def left(self) -> int:
+        """Leftmost index of the array"""
+        return self._range.left
+
+    @cached_property
+    def direction(self) -> str:
+        """``'to'`` if indexes are ascending, ``'downto'`` otherwise"""
+        return self._range.direction
+
+    @cached_property
+    def right(self) -> int:
+        """Rightmost index of the array"""
+        return self._range.right
+
+    @cached_property
+    def length(self):
+        """Length of the array"""
+        return self._range.length
+
+    @cached_property
+    def range(self) -> Range:
+        """:class:`Range` of the indexes of the array"""
+        return self._range
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._value)
+
+    def __reversed__(self) -> Iterator[Any]:
+        return reversed(self._value)
+
+    def __contains__(self, item: Any) -> bool:
+        return item in self._value
+
+    def __eq__(self, other: object) -> bool:
+        try:
+            return all(a == b for a, b in zip_longest(self, other, fillvalue=object()))
+        except TypeError:
+            return NotImplemented
+
+    @overload
+    def __getitem__(self, item: int) -> Any:
+        pass  # pragma: no cover
+
+    @overload
+    def __getitem__(self, item: slice) -> "Array":
+        pass  # pragma: no cover
+
+    def __getitem__(self, item):
+        if isinstance(item, int):
+            idx = self._translate_index(item)
+            return self._value[idx]
+        elif isinstance(item, slice):
+            start = item.start or self.left
+            stop = item.stop or self.right
+            if item.step is not None:
+                raise IndexError("do not specify step")
+            start_i = self._translate_index(start)
+            stop_i = self._translate_index(stop)
+            if start_i > stop_i:
+                raise IndexError("slice direction does not match array direction")
+            # avoid second copy
+            cls = type(self)
+            val = cls.__new__(cls)
+            val._value = self._value[start_i : stop_i + 1]
+            val._range = Range(start, self.direction, stop)
+            return val
+        raise TypeError(
+            "indexes must be ints or slices, not {}".format(type(item).__name__)
+        )
+
+    @overload
+    def __setitem__(self, item: int, value: Any) -> None:
+        pass  # pragma: no cover
+
+    @overload
+    def __setitem__(self, item: slice, value: Iterable[Any]) -> None:
+        pass  # pragma: no cover
+
+    def __setitem__(self, item, value):
+        if isinstance(item, int):
+            idx = self._translate_index(item)
+            self._value[idx] = value
+        elif isinstance(item, slice):
+            start = item.start or self.left
+            stop = item.stop or self.right
+            if item.step is not None:
+                raise IndexError("do not specify step")
+            start_i = self._translate_index(start)
+            stop_i = self._translate_index(stop)
+            if start_i > stop_i:
+                raise IndexError("slice direction does not match array direction")
+            value = list(value)
+            if len(value) != (stop_i - start_i + 1):
+                raise ValueError("value is not the same length as the slice")
+            self._value[start_i : stop_i + 1] = value
+        else:
+            raise TypeError(
+                "indexes must be ints or slices, not {}".format(
+                    type(item).__name__
+                )
+            )
+
+    def __repr__(self) -> str:
+        return "{}({!r}, {!r})".format(type(self).__name__, self._value, self._range)
+
+    def index(self, value: Any, start: Optional[int] = None, stop: Optional[int] = None) -> int:
+        """Return index of first occurence of value."""
+        if start is not None:
+            start = self._translate_index(start)
+        else:
+            start = 0
+        if stop is not None:
+            stop = self._translate_index(stop)
+        else:
+            stop = maxsize  # same default value used by Python lists
+        idx = self._value.index(value, start, stop)
+        return self._range[idx]
+
+    def count(self, value: Any) -> int:
+        """Return number of occurences of value."""
+        return self._value.count(value)
+
+    def _translate_index(self, item: int) -> int:
+        try:
+            return self._range.index(item)
+        except ValueError:
+            raise IndexError("index {} out of range".format(item)) from None

--- a/cocotb/types/array.py
+++ b/cocotb/types/array.py
@@ -100,7 +100,11 @@ class Array(Sequence):
             self._value = list(value)
             self._range = range
             if len(self._value) != len(self._range):
-                raise ValueError("Init value does not fit in given range")
+                raise ValueError(
+                    "init value of length {!r} not fit in {!r}".format(
+                        len(self._value), self._range
+                    )
+                )
         elif value is None and range is not None:
             self._value = [None] * len(range)
             self._range = range

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from typing import Any, Iterator, overload
 from collections.abc import Sequence
-from cocotb._py_compat import cached_property, cache
+from cocotb._py_compat import cache
 
 
 class Range(Sequence):
@@ -62,7 +62,7 @@ class Range(Sequence):
         right: rightmost bound of range (inclusive)
     """
 
-    __slots__ = ("_range", "__dict__")  # __dict__ necessary for cached_property
+    __slots__ = ("_range",)
 
     @overload
     def __init__(self, left: int, right: int):
@@ -109,22 +109,22 @@ class Range(Sequence):
         """Convert :class:`Range` to :class:`range`."""
         return self._range
 
-    @cached_property
+    @property
     def left(self) -> int:
         """Leftmost value in a range."""
         return self._range.start
 
-    @cached_property
+    @property
     def direction(self) -> str:
         """``'to'`` if values are meant to be ascending, ``'downto'`` otherwise."""
         return "to" if self._range.step == 1 else "downto"
 
-    @cached_property
+    @property
     def right(self) -> int:
         """Rightmost value in a range."""
         return self._range.stop - self._range.step
 
-    @cached_property
+    @property
     def length(self) -> int:
         """Length of range."""
         return len(self._range)

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -174,5 +174,5 @@ class Range(Sequence):
 
     def __repr__(self) -> str:
         return "{}({!r}, {!r}, {!r})".format(
-            type(self).__name__, self.left, self.direction, self.right
+            type(self).__qualname__, self.left, self.direction, self.right
         )

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -12,7 +12,8 @@ class Range(Sequence):
     In Python, :class:`range` and :class:`slice` have a non-inclusive right bound.
     In both Verilog and VHDL, ranges and arrays have an inclusive right bound.
     This type mimics Python's :class:`range` type, but implements HDL-like inclusive right bounds,
-    and also supports :attr:`left`, :attr:`right`, and :attr:`length` attributes as seen in VHDL.
+    using the names :attr:`left` and :attr:`right` as replacements for ``start`` and ``stop`` to
+    match VHDL.
 
     .. code-block:: python3
 

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -1,3 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 from typing import Any, Iterator, overload
 from collections.abc import Sequence
 from cocotb._py_compat import cached_property, cache

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -100,7 +100,7 @@ class Range(Sequence):
     def from_range(cls, rng: range) -> "Range":
         """Convert :class:`range` to :class:`Range`."""
         if rng.step not in (1, -1):
-            raise ValueError("step must be 1 or -1")
+            raise ValueError("step must be '1' or '-1'")
         obj = cls.__new__(cls)
         obj._range = rng
         return obj

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -35,7 +35,7 @@ class Range(Sequence):
 
     :class:`Range` supports "null" ranges as seen in VHDL.
     "null" ranges occur when a left bound cannot reach a right bound with the given direction.
-    They have a length of 0, but the left, right, and direction values remain as given.
+    They have a length of 0, but the :attr:`left`, :attr:`right`, and :attr:`direction` values remain as given.
 
     .. code-block:: python3
 
@@ -98,7 +98,7 @@ class Range(Sequence):
 
     @classmethod
     def from_range(cls, rng: range) -> "Range":
-        """Converts :class:`range` to :class:`Range`."""
+        """Convert :class:`range` to :class:`Range`."""
         if rng.step not in (1, -1):
             raise ValueError("step must be 1 or -1")
         obj = cls.__new__(cls)

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -1,6 +1,6 @@
 from typing import Any, Iterator, overload
 from collections.abc import Sequence
-from functools import cached_property, lru_cache
+from cocotb._py_compat import cached_property, cache
 
 
 class Range(Sequence):
@@ -83,7 +83,7 @@ class Range(Sequence):
         self._range = range(left, right + step, step)
 
     @staticmethod
-    @lru_cache(maxsize=None)
+    @cache
     def _translate_direction(direction) -> int:
         direction = direction.lower()
         if direction == "to":

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -14,6 +14,9 @@ class Range(Sequence):
     This type mimics Python's :class:`range` type, but implements HDL-like inclusive right bounds,
     using the names :attr:`left` and :attr:`right` as replacements for ``start`` and ``stop`` to
     match VHDL.
+    Range directionality can be specified using ``'to'`` or ``'downto'`` between the
+    left and right bounds.
+    Not specifying directionality will cause the directionality to be inferred.
 
     .. code-block:: python3
 

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -157,7 +157,9 @@ class Range(Sequence):
     ) -> int:
         if start is not None or stop is not None:
             # bpo-43836
-            raise RuntimeError("'range.index' does not currently support the 'start' or 'stop' arguments")
+            raise RuntimeError(
+                "'range.index' does not currently support the 'start' or 'stop' arguments"
+            )
         return self._range.index(value)
 
     def count(self, item: Any) -> int:

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -9,7 +9,7 @@ class Range(Sequence):
 
     In Python, :class:`range` and :class:`slice` have a non-inclusive right bound.
     In both Verilog and VHDL, ranges and arrays have an inclusive right bound.
-    This type mimic's Python's :class:`range` type, but supports HDL-like inclusive right bounds.
+    This type mimic's Python's :class:`range` type, but implements HDL-like inclusive right bounds.
     Also supports :attr:`left`, :attr:`right`, and :attr:`length` attributes as seen in VHDL.
 
     .. code-block:: python3
@@ -47,15 +47,15 @@ class Range(Sequence):
 
     Ranges also support all the features of :class:`range` including, but not limited to:
 
-    - ``value in range`` to see if a vlaue is in the range,
+    - ``value in range`` to see if a value is in the range,
     - ``range.index(value)`` to see what position in the range the value is,
     - ``len(range)`` which is equivalent to :attr:`length`.
 
     The typical use case of this type is in conjunction with :class:`~cocotb.types.Array`.
 
-    Args
+    Args:
         left: leftmost bound of range
-        direction: 'to' if values are ascending or 'downto' if decending
+        direction: 'to' if values are ascending or 'downto' if descending
         right: rightmost bound of range (inclusive)
     """
 
@@ -95,7 +95,7 @@ class Range(Sequence):
 
     @classmethod
     def from_range(cls, rng: range) -> "Range":
-        """Converts :class:`range` to :class:`Range`"""
+        """Converts :class:`range` to :class:`Range`."""
         if rng.step not in (1, -1):
             raise ValueError("step must be 1 or -1")
         obj = cls.__new__(cls)
@@ -103,27 +103,27 @@ class Range(Sequence):
         return obj
 
     def to_range(self) -> range:
-        """Converts :class:`Range` to :class:`range`"""
+        """Convert :class:`Range` to :class:`range`."""
         return self._range
 
     @cached_property
     def left(self) -> int:
-        """Leftmost value in a range"""
+        """Leftmost value in a range."""
         return self._range.start
 
     @cached_property
     def direction(self) -> str:
-        """``'to'`` if values are meant to be ascending, ``'downto'`` otherwise"""
+        """``'to'`` if values are meant to be ascending, ``'downto'`` otherwise."""
         return "to" if self._range.step == 1 else "downto"
 
     @cached_property
     def right(self) -> int:
-        """Rightmost value in a range"""
+        """Rightmost value in a range."""
         return self._range.stop - self._range.step
 
     @cached_property
     def length(self) -> int:
-        """Length of range"""
+        """Length of range."""
         return len(self._range)
 
     def __len__(self) -> int:

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -18,11 +18,11 @@ class Range(Sequence):
     .. code-block:: python3
 
         >>> r = Range(-2, 3)
-        >>> r.left, r.right, r.length
+        >>> r.left, r.right, len(r)
         (-2, 3, 6)
 
         >>> s = Range(8, 'downto', 1)
-        >>> s.left, s.right, s.length
+        >>> s.left, s.right, len(s)
         (8, 1, 8)
 
     :meth:`from_range` and :meth:`to_range` can be used to convert from and to :class:`range`.
@@ -42,7 +42,7 @@ class Range(Sequence):
         >>> r = Range(1, 'to', 0)  # no way to count from 1 'to' 0
         >>> r.left, r.direction, r.right
         (1, 'to', 0)
-        >>> r.length
+        >>> len(r)
         0
 
     .. note::
@@ -52,7 +52,6 @@ class Range(Sequence):
 
     - ``value in range`` to see if a value is in the range,
     - ``range.index(value)`` to see what position in the range the value is,
-    - ``len(range)`` which is equivalent to :attr:`length`.
 
     The typical use case of this type is in conjunction with :class:`~cocotb.types.Array`.
 
@@ -120,13 +119,8 @@ class Range(Sequence):
         """Rightmost value in a range."""
         return self._range.stop - self._range.step
 
-    @property
-    def length(self) -> int:
-        """Length of range."""
-        return len(self._range)
-
     def __len__(self) -> int:
-        return self.length
+        return len(self._range)
 
     @overload
     def __getitem__(self, item: int) -> int:

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from typing import Any, Iterator, overload
 from collections.abc import Sequence
-from cocotb._py_compat import cache
 
 
 class Range(Sequence):
@@ -80,21 +79,17 @@ class Range(Sequence):
         if direction is not None and right is None:
             right, direction = direction, None
         if direction is None:
-            step = 1 if left < right else -1
+            # direction is 'to' if left == right
+            step = 1 if left <= right else -1
         else:
-            step = self._translate_direction(direction)
+            direction = direction.lower()
+            if direction == "to":
+                step = 1
+            elif direction == "downto":
+                step = -1
+            else:
+                raise ValueError("direction must be 'to' or 'downto'")
         self._range = range(left, right + step, step)
-
-    @staticmethod
-    @cache
-    def _translate_direction(direction) -> int:
-        direction = direction.lower()
-        if direction == "to":
-            return 1
-        elif direction == "downto":
-            return -1
-        else:
-            raise ValueError("direction must be 'to' or 'downto'")
 
     @classmethod
     def from_range(cls, rng: range) -> "Range":

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -155,7 +155,10 @@ class Range(Sequence):
     def index(
         self, value: Any, start: Optional[int] = None, stop: Optional[int] = None
     ) -> int:
-        return self._range.index(value, start, stop)
+        if start is not None or stop is not None:
+            # bpo-43836
+            raise RuntimeError("'range.index' does not currently support the 'start' or 'stop' arguments")
+        return self._range.index(value)
 
     def count(self, item: Any) -> int:
         return self._range.count(item)

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -9,8 +9,8 @@ class Range(Sequence):
 
     In Python, :class:`range` and :class:`slice` have a non-inclusive right bound.
     In both Verilog and VHDL, ranges and arrays have an inclusive right bound.
-    This type mimic's Python's :class:`range` type, but implements HDL-like inclusive right bounds.
-    Also supports :attr:`left`, :attr:`right`, and :attr:`length` attributes as seen in VHDL.
+    This type mimics Python's :class:`range` type, but implements HDL-like inclusive right bounds,
+    and also supports :attr:`left`, :attr:`right`, and :attr:`length` attributes as seen in VHDL.
 
     .. code-block:: python3
 
@@ -30,7 +30,7 @@ class Range(Sequence):
         >>> r.to_range()
         range(-2, 4)
 
-    Supports "null" ranges as seen in VHDL.
+    :class:`Range` supports "null" ranges as seen in VHDL.
     "null" ranges occur when a left bound cannot reach a right bound with the given direction.
     They have a length of 0, but the left, right, and direction values remain as given.
 
@@ -55,7 +55,7 @@ class Range(Sequence):
 
     Args:
         left: leftmost bound of range
-        direction: 'to' if values are ascending or 'downto' if descending
+        direction: ``'to'`` if values are ascending, ``'downto'`` if descending
         right: rightmost bound of range (inclusive)
     """
 

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import Any, Iterator, overload
+from typing import Any, Iterator, overload, Optional
 from collections.abc import Sequence
 
 
@@ -65,10 +65,6 @@ class Range(Sequence):
 
     @overload
     def __init__(self, left: int, right: int):
-        pass  # pragma: no cover
-
-    @overload
-    def __init__(self, *, left: int, right: int):
         pass  # pragma: no cover
 
     @overload
@@ -156,8 +152,10 @@ class Range(Sequence):
     def __hash__(self) -> int:
         return hash(self._range)
 
-    def index(self, item: Any) -> int:
-        return self._range.index(item)
+    def index(
+        self, value: Any, start: Optional[int] = None, stop: Optional[int] = None
+    ) -> int:
+        return self._range.index(value, start, stop)
 
     def count(self, item: Any) -> int:
         return self._range.count(item)

--- a/cocotb/types/range.py
+++ b/cocotb/types/range.py
@@ -1,0 +1,175 @@
+from typing import Any, Iterator, overload
+from collections.abc import Sequence
+from functools import cached_property, lru_cache
+
+
+class Range(Sequence):
+    r"""
+    Variant of :class:`range` with inclusive right bound.
+
+    In Python, :class:`range` and :class:`slice` have a non-inclusive right bound.
+    In both Verilog and VHDL, ranges and arrays have an inclusive right bound.
+    This type mimic's Python's :class:`range` type, but supports HDL-like inclusive right bounds.
+    Also supports :attr:`left`, :attr:`right`, and :attr:`length` attributes as seen in VHDL.
+
+    .. code-block:: python3
+
+        >>> r = Range(-2, 3)
+        >>> r.left, r.right, r.length
+        (-2, 3, 6)
+
+        >>> s = Range(8, 'downto', 1)
+        >>> s.left, s.right, s.length
+        (8, 1, 8)
+
+    :meth:`from_range` and :meth:`to_range` can be used to convert from and to :class:`range`.
+
+    .. code-block:: python3
+
+        >>> r = Range(-2, 3)
+        >>> r.to_range()
+        range(-2, 4)
+
+    Supports "null" ranges as seen in VHDL.
+    "null" ranges occur when a left bound cannot reach a right bound with the given direction.
+    They have a length of 0, but the left, right, and direction values remain as given.
+
+    .. code-block:: python3
+
+        >>> r = Range(1, 'to', 0)  # no way to count from 1 'to' 0
+        >>> r.left, r.direction, r.right
+        (1, 'to', 0)
+        >>> r.length
+        0
+
+    .. note::
+        This is only possible when specifying the direction.
+
+    Ranges also support all the features of :class:`range` including, but not limited to:
+
+    - ``value in range`` to see if a vlaue is in the range,
+    - ``range.index(value)`` to see what position in the range the value is,
+    - ``len(range)`` which is equivalent to :attr:`length`.
+
+    The typical use case of this type is in conjunction with :class:`~cocotb.types.Array`.
+
+    Args
+        left: leftmost bound of range
+        direction: 'to' if values are ascending or 'downto' if decending
+        right: rightmost bound of range (inclusive)
+    """
+
+    __slots__ = ("_range", "__dict__")  # __dict__ necessary for cached_property
+
+    @overload
+    def __init__(self, left: int, right: int):
+        pass  # pragma: no cover
+
+    @overload
+    def __init__(self, *, left: int, right: int):
+        pass  # pragma: no cover
+
+    @overload
+    def __init__(self, left: int, direction: str, right: int):
+        pass  # pragma: no cover
+
+    def __init__(self, left, direction=None, right=None):
+        if direction is not None and right is None:
+            right, direction = direction, None
+        if direction is None:
+            step = 1 if left < right else -1
+        else:
+            step = self._translate_direction(direction)
+        self._range = range(left, right + step, step)
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _translate_direction(direction) -> int:
+        direction = direction.lower()
+        if direction == "to":
+            return 1
+        elif direction == "downto":
+            return -1
+        else:
+            raise ValueError("direction must be 'to' or 'downto'")
+
+    @classmethod
+    def from_range(cls, rng: range) -> "Range":
+        """Converts :class:`range` to :class:`Range`"""
+        if rng.step not in (1, -1):
+            raise ValueError("step must be 1 or -1")
+        obj = cls.__new__(cls)
+        obj._range = rng
+        return obj
+
+    def to_range(self) -> range:
+        """Converts :class:`Range` to :class:`range`"""
+        return self._range
+
+    @cached_property
+    def left(self) -> int:
+        """Leftmost value in a range"""
+        return self._range.start
+
+    @cached_property
+    def direction(self) -> str:
+        """``'to'`` if values are meant to be ascending, ``'downto'`` otherwise"""
+        return "to" if self._range.step == 1 else "downto"
+
+    @cached_property
+    def right(self) -> int:
+        """Rightmost value in a range"""
+        return self._range.stop - self._range.step
+
+    @cached_property
+    def length(self) -> int:
+        """Length of range"""
+        return len(self._range)
+
+    def __len__(self) -> int:
+        return self.length
+
+    @overload
+    def __getitem__(self, item: int) -> int:
+        pass  # pragma: no cover
+
+    @overload
+    def __getitem__(self, item: slice) -> "Range":
+        pass  # pragma: no cover
+
+    def __getitem__(self, item):
+        if isinstance(item, int):
+            return self._range[item]
+        elif isinstance(item, slice):
+            return type(self).from_range(self._range[item])
+        raise TypeError(
+            "indices must be integers or slices, not {}".format(type(item).__name__)
+        )
+
+    def __contains__(self, item: Any) -> bool:
+        return item in self._range
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self._range)
+
+    def __reversed__(self) -> Iterator[int]:
+        return reversed(self._range)
+
+    def __eq__(self, other: Any) -> bool:
+        if type(self) is not type(other):
+            return NotImplemented
+        return self._range == other._range
+
+    def __hash__(self) -> int:
+        return hash(self._range)
+
+    def index(self, item: Any) -> int:
+        return self._range.index(item)
+
+    def count(self, item: Any) -> int:
+        return self._range.count(item)
+
+    def __repr__(self) -> str:
+        return "{}({!r}, {!r}, {!r})".format(
+            type(self).__name__, self.left, self.direction, self.right
+        )

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -75,6 +75,9 @@ as the types used by cocotb's `simulator handles <#simulation-object-handles>`_.
 
 .. autoclass:: cocotb.types.Bit
 
+.. autoclass:: cocotb.types.Range
+    :members:
+    :exclude-members: count, index
 
 Triggers
 --------

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -79,6 +79,10 @@ as the types used by cocotb's `simulator handles <#simulation-object-handles>`_.
     :members:
     :exclude-members: count, index
 
+.. autoclass:: cocotb.types.Array
+    :members:
+    :exclude-members: count, index
+
 Triggers
 --------
 See :ref:`simulator-triggers` for a list of sub-classes. Below are the internal

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -79,6 +79,8 @@ as the types used by cocotb's `simulator handles <#simulation-object-handles>`_.
     :members:
     :exclude-members: count, index
 
+.. autofunction:: cocotb.types.concat
+
 .. autoclass:: cocotb.types.Array
     :members:
     :exclude-members: count, index

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -37,6 +37,8 @@ def test_bad_construction():
         Array(value=1)
     with pytest.raises(TypeError):
         Array(range=tuple())
+    with pytest.raises(TypeError):
+        Array(value="1234", range=tuple())
 
 
 def test_length():

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -159,3 +159,12 @@ def test_slice_correct_infered():
     a = Array("1234")
     b = a[:0]
     assert b.right == 0
+
+
+def test_logic_array_concat():
+    l = Array("01ZX", Range(0, 'to', 3))
+    p = Array("1101")
+    r = l.concat(p)
+    assert r == Array("01ZX1101")
+    with pytest.raises(TypeError):
+        l.concat("nope")

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -167,12 +167,22 @@ def test_array_concat():
     r = concat(l, p)
     assert r == Array("01ZX1101")
 
+    rconcat_called = None
+
     class SpecialArray(Array):
-        pass
+
+        def __rconcat__(self, other):
+            nonlocal rconcat_called
+            rconcat_called = 3
+            return super().__rconcat__(other)
 
     q = SpecialArray("ABC")
+
     r2 = concat(q, l)
     assert r2 == Array("ABC01ZX")
+    r3 = concat(l, q)
+    assert r3 == Array("01ZXABC")
+    assert rconcat_called == 3
 
     with pytest.raises(TypeError):
         concat(l, "nope")

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -168,3 +168,13 @@ def test_logic_array_concat():
     assert r == Array("01ZX1101")
     with pytest.raises(TypeError):
         l.concat("nope")
+
+
+def test_changing_range():
+    a = Array("1234")
+    a.range = Range(3, 'downto', 0)
+    assert a.range == Range(3, 'downto', 0)
+    with pytest.raises(TypeError):
+        a.range = range(10)
+    with pytest.raises(ValueError):
+        a.range = Range(7, 'downto', 0)

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -152,3 +152,9 @@ def test_set_slice_wrong_length():
     a = Array("example")
     with pytest.raises(ValueError):
         a[2:4] = "real bad"
+
+
+def test_slice_correct_infered():
+    a = Array("1234")
+    b = a[:0]
+    assert b.right == 0

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -1,0 +1,147 @@
+from cocotb.types import Array, Range
+import pytest
+
+
+def test_value_only_construction():
+    a = Array("1234")
+    assert a.left == 0
+    assert a.direction == 'to'
+    assert a.right == 3
+
+
+def test_range_only_construction():
+    a = Array(range=Range(1, -2))
+    assert a.left == 1
+    assert a.direction == 'downto'
+    assert a.right == -2
+    assert all(v is None for v in a)
+
+
+def test_both_construction():
+    a = Array("1234", Range(-2, 1))
+    assert a.left == -2
+    assert a.direction == 'to'
+    assert a.right == 1
+
+    with pytest.raises(ValueError):
+        Array("1234", Range(0, 1))
+
+
+def test_bad_construction():
+    with pytest.raises(TypeError):
+        Array()
+
+
+def test_length():
+    a = Array(range=Range(1, 6))
+    assert a.length == 6
+    assert len(a) == 6
+
+
+def test_range():
+    r = Range(-2, 8)
+    a = Array(range=r)
+    assert a.range == r
+
+
+def test_equality():
+    assert Array("1234", Range(1, 4)) == Array("1234", Range(1, 4))
+    assert Array("1234", Range(1, 4)) == Array("1234", Range(0, -3))
+    assert Array("1234", Range(1, 4)) != Array("4321", Range(1, 4))
+    assert Array("1234") == "1234"
+    assert Array("1234") != 8
+
+
+def test_repr_eval():
+    r = Array("1234")
+    assert eval(repr(r)) == r
+
+
+def test_iter():
+    val = [7, True, object(), 'example']
+    a = Array(val)
+    assert list(a) == val
+
+
+def test_reversed():
+    val = [7, True, object(), 'example']
+    a = Array(val)
+    assert list(reversed(a)) == list(reversed(val))
+
+
+def test_contains():
+    a = Array([7, True, object(), 'example'])
+    assert True in a
+    assert 89 not in a
+
+
+def test_index():
+    r = Array((i for j in range(10) for i in range(10)))  # 0-9 repeated 10 times
+    assert r.index(5) == 5
+    assert r.index(5, 10, 20) == 15
+
+
+def test_count():
+    r = Array("111111")
+    assert r.count("1") == 6
+
+
+def test_indexing():
+    a = Array("1234", Range(8, 'to', 11))
+    assert a[8] == "1"
+    with pytest.raises(IndexError):
+        a[0]
+    a[11] = False
+    assert a[11] is False
+
+    b = Array("1234", Range(10, 'downto', 7))
+    assert b[8] == "3"
+    with pytest.raises(IndexError):
+        b[-2]
+    b[8] = 9
+    assert b[8] == 9
+
+
+def test_bad_indexing():
+    with pytest.raises(TypeError):
+        Array("1234")[list()]
+    with pytest.raises(TypeError):
+        Array("1234")[object()] = 9
+
+
+def test_slicing():
+    a = Array("testingstuff")
+    b = a[2:6]
+    assert b.left == 2
+    assert b.right == 6
+    assert b == "sting"
+    a[0:3] = "hack"
+    assert a == "hackingstuff"
+
+
+def test_slicing_infered_start_stop():
+    a = Array([1, 2, 3, 4])
+    assert a[:] == a
+    a[:] = "1234"
+    assert a == Array("1234")
+
+
+def test_dont_specify_step():
+    with pytest.raises(IndexError):
+        Array("1234")[::1]
+    with pytest.raises(IndexError):
+        Array("7896")[1:2:1] = [1, 2]
+
+
+def test_slice_direction_mismatch():
+    a = Array([1, 2, 3, 4], Range(10, 'downto', 7))
+    with pytest.raises(IndexError):
+        a[7:9]
+    with pytest.raises(IndexError):
+        a[9:10] = ['a', 'b']
+
+
+def test_set_slice_wrong_length():
+    a = Array("example")
+    with pytest.raises(ValueError):
+        a[2:4] = "real bad"

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -55,7 +55,7 @@ def test_equality():
     assert Array("1234", Range(1, 4)) == Array("1234", Range(1, 4))
     assert Array("1234", Range(1, 4)) == Array("1234", Range(0, -3))
     assert Array("1234", Range(1, 4)) != Array("4321", Range(1, 4))
-    assert Array("1234") == "1234"
+    assert Array("1234") != "1234"
     assert Array("1234") != 8
 
 
@@ -121,9 +121,9 @@ def test_slicing():
     b = a[2:6]
     assert b.left == 2
     assert b.right == 6
-    assert b == "sting"
+    assert b == Array("sting")
     a[0:3] = "hack"
-    assert a == "hackingstuff"
+    assert a == Array("hackingstuff")
 
 
 def test_slicing_infered_start_stop():

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -33,6 +33,10 @@ def test_both_construction():
 def test_bad_construction():
     with pytest.raises(TypeError):
         Array()
+    with pytest.raises(TypeError):
+        Array(value=1)
+    with pytest.raises(TypeError):
+        Array(range=tuple())
 
 
 def test_length():

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from cocotb.types import Array, Range
+from cocotb.types import Array, Range, concat
 import pytest
 
 
@@ -161,13 +161,23 @@ def test_slice_correct_infered():
     assert b.right == 0
 
 
-def test_logic_array_concat():
+def test_array_concat():
     l = Array("01ZX", Range(0, 'to', 3))
     p = Array("1101")
-    r = l.concat(p)
+    r = concat(l, p)
     assert r == Array("01ZX1101")
+
+    class SpecialArray(Array):
+        pass
+
+    q = SpecialArray("ABC")
+    r2 = concat(q, l)
+    assert r2 == Array("ABC01ZX")
+
     with pytest.raises(TypeError):
-        l.concat("nope")
+        concat(l, "nope")
+    with pytest.raises(TypeError):
+        concat("nope", l)
 
 
 def test_changing_range():

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -43,7 +43,6 @@ def test_bad_construction():
 
 def test_length():
     a = Array(range=Range(1, 6))
-    assert a.length == 6
     assert len(a) == 6
 
 

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -1,3 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 from cocotb.types import Array, Range
 import pytest
 

--- a/tests/pytest/test_range.py
+++ b/tests/pytest/test_range.py
@@ -121,3 +121,8 @@ def test_bad_step():
 def test_bad_getitem():
     with pytest.raises(TypeError):
         Range(10, 'downto', 4)["8"]
+
+
+def test_range_index_bpo43836():
+    with pytest.raises(RuntimeError):
+        Range(10, 0).index(7, start=4, stop=10)

--- a/tests/pytest/test_range.py
+++ b/tests/pytest/test_range.py
@@ -1,0 +1,125 @@
+from cocotb.types import Range
+import pytest
+
+
+def test_to_range():
+    r = Range(1, 'to', 8)
+    assert r.left == 1
+    assert r.direction == 'to'
+    assert r.right == 8
+    assert r.length == 8
+    assert len(r) == 8
+    assert list(r) == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert list(reversed(r)) == [8, 7, 6, 5, 4, 3, 2, 1]
+    assert r[0] == 1
+    assert r[7] == 8
+    with pytest.raises(IndexError):
+        r[8]
+    assert r[3:7] == Range(4, 'to', 7)
+    assert 8 in r
+    assert 10 not in r
+    assert r.index(7) == 6
+    with pytest.raises(ValueError):
+        r.index(9)
+    assert r.count(4) == 1
+    assert r.count(10) == 0
+
+
+def test_downto_range():
+    r = Range(4, 'downto', -3)
+    assert r.left == 4
+    assert r.direction == 'downto'
+    assert r.right == -3
+    assert r.length == 8
+    assert len(r) == 8
+    assert list(r) == [4, 3, 2, 1, 0, -1, -2, -3]
+    assert list(reversed(r)) == [-3, -2, -1, 0, 1, 2, 3, 4]
+    assert r[0] == 4
+    assert r[7] == -3
+    with pytest.raises(IndexError):
+        r[8]
+    assert r[3:7] == Range(1, 'downto', -2)
+    assert 0 in r
+    assert 10 not in r
+    assert r.index(2) == 2
+    with pytest.raises(ValueError):
+        r.index(9)
+    assert r.count(4) == 1
+    assert r.count(10) == 0
+
+
+def test_null_range():
+    r = Range(1, 'downto', 4)
+    assert r.left == 1
+    assert r.direction == 'downto'
+    assert r.right == 4
+    assert r.length == 0
+    assert len(r) == 0
+    assert list(r) == []
+    assert list(reversed(r)) == []
+    with pytest.raises(IndexError):
+        r[0]
+    assert 2 not in r
+    with pytest.raises(ValueError):
+        r.index(4)
+    assert r.count(4) == 0
+
+
+def test_equality():
+    assert Range(7, 'downto', -7) == Range(7, 'downto', -7)
+    assert Range(7, 'downto', -7) != Range(0, 'to', 8)
+    assert Range(1, 'to', 0) == Range(8, 'to', -8)  # null ranges are all equal?
+    assert Range(1, 'to', 4) != 789
+
+
+def test_other_constructors():
+    assert Range(1, 8) == Range(1, 'to', 8)
+    assert Range(3, -4) == Range(3, 'downto', -4)
+    assert Range(left=1, right=8) == Range(1, 'to', 8)
+    assert Range(left=3, right=-4) == Range(3, 'downto', -4)
+
+
+def test_use_in_set():
+    assert len({Range(1, 'to', 8), Range(1, 'to', 8)}) == 1
+    assert len({Range(1, 'to', 8), Range(8, 'downto', 1)}) == 2
+
+
+def test_conversions():
+    t = range(10, 1, -1)
+    r = Range.from_range(t)
+    assert r.left == 10
+    assert r.right == 2
+    assert r.direction == 'downto'
+    assert r.length == 9
+    assert r.to_range() == t
+
+
+def test_repr():
+    r = Range(5, 'to', 9)
+    assert eval(repr(r)) == r
+
+
+def test_uppercase_in_direction():
+    r = Range(1, 'TO', 8)
+    assert r.direction == 'to'
+    assert r.length == 8
+
+
+def test_bad_direction():
+    with pytest.raises(ValueError):
+        Range(1, 'nope', 8)
+
+
+def test_bad_bound():
+    with pytest.raises(TypeError):
+        Range(object(), 'to', 8)
+
+
+def test_bad_step():
+    with pytest.raises(ValueError):
+        Range.from_range(range(10, 5, -2))
+
+
+def test_bad_getitem():
+    with pytest.raises(TypeError):
+        Range(10, 'downto', 4)["8"]

--- a/tests/pytest/test_range.py
+++ b/tests/pytest/test_range.py
@@ -10,7 +10,6 @@ def test_to_range():
     assert r.left == 1
     assert r.direction == 'to'
     assert r.right == 8
-    assert r.length == 8
     assert len(r) == 8
     assert list(r) == [1, 2, 3, 4, 5, 6, 7, 8]
     assert list(reversed(r)) == [8, 7, 6, 5, 4, 3, 2, 1]
@@ -33,7 +32,6 @@ def test_downto_range():
     assert r.left == 4
     assert r.direction == 'downto'
     assert r.right == -3
-    assert r.length == 8
     assert len(r) == 8
     assert list(r) == [4, 3, 2, 1, 0, -1, -2, -3]
     assert list(reversed(r)) == [-3, -2, -1, 0, 1, 2, 3, 4]
@@ -56,7 +54,6 @@ def test_null_range():
     assert r.left == 1
     assert r.direction == 'downto'
     assert r.right == 4
-    assert r.length == 0
     assert len(r) == 0
     assert list(r) == []
     assert list(reversed(r)) == []
@@ -93,7 +90,6 @@ def test_conversions():
     assert r.left == 10
     assert r.right == 2
     assert r.direction == 'downto'
-    assert r.length == 9
     assert r.to_range() == t
 
 
@@ -105,7 +101,6 @@ def test_repr():
 def test_uppercase_in_direction():
     r = Range(1, 'TO', 8)
     assert r.direction == 'to'
-    assert r.length == 8
 
 
 def test_bad_direction():

--- a/tests/pytest/test_range.py
+++ b/tests/pytest/test_range.py
@@ -1,3 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 from cocotb.types import Range
 import pytest
 


### PR DESCRIPTION
Follow on to #2485. xref #2059. Adds a `Range` and `Array` type.

The `Range` type is much like Python's `range` type, but has an inclusive right bound like is seen in both Verilog and VHDL. It support's VHDL's `to` and `downto` directions, Verilog's automatic directionality by not specifying a direction, and VHDL's null ranges.

The `Array` type is a heterogenous fixed-length sequence type. It uses an initial value or a range to determine it's size at construction and it's size is fixed. It supports must of the same operations as a list that don't mutate the length. Uses a `Range` to describe the indexing scheme, which is arbitrary, like is seen in both Verilog and VHDL. Some indexing and slicing behavior had to change compared to a list to make something that behaved intuitively.