### PR TITLE
Add section about queues to refcard

### DIFF
--- a/documentation/source/refcard.rst
+++ b/documentation/source/refcard.rst
@@ -28,7 +28,7 @@ Reference Card
 | Assign metavalue       | ``dut.mysignal <= BinaryValue("X")``                            |
 +------------------------+-----------------------------------------------------------------+
 | Read                   | | ``val = dut.mysignal.value``                                  |
-|                        | | (``mysig = dut.mysignal`` *creates an alias/reference)*       |
+|                        | | (``mysig = dut.mysignal`` *creates an alias/reference*)       |
 +------------------------+-----------------------------------------------------------------+
 | Bit slice              | | ``mybit = dut.myarray[0].value``                              |
 |                        | | ``mybits = dut.mysignal.value[0]``                            |
@@ -59,6 +59,21 @@ Reference Card
 | Resume on Task 0 and 1 | ``await cocotb.triggers.Combine(task_0, task_1)``               |
 +------------------------+-----------------------------------------------------------------+
 | Kill coro              | ``task_0.kill()``                                               |
++------------------------+-----------------------------------------------------------------+
+|                                                                                          |
++------------------------+-----------------------------------------------------------------+
+| Queue write            | | ``await cocotb.queue.Queue.put(item)``                        |
+|                        | | ``cocotb.queue.Queue.put_nowait(item)``                       |
++------------------------+-----------------------------------------------------------------+
+| Queue read             | | ``item = await cocotb.queue.Queue.get()``                     |
+|                        | | ``item = cocotb.queue.Queue.get_nowait()``                    |
++------------------------+-----------------------------------------------------------------+
+| Queue attributes       | | ``queue.maxsize``  (``None`` *== unlimited*)                  |
+|                        | | ``queue.qsize()``                                             |
+|                        | | ``queue.empty()``                                             |
+|                        | | ``queue.full()``                                              |
++------------------------+-----------------------------------------------------------------+
+| Specialized queues     | ``.PriorityQueue``, ``.LifoQueue``                              |
 +------------------------+-----------------------------------------------------------------+
 |                                                                                          |
 +------------------------+-----------------------------------------------------------------+


### PR DESCRIPTION
Rendered: https://cocotb--2512.org.readthedocs.build/en/2512/refcard.html

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
