### PR TITLE
Fix missing libpython

### DIFF
--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -156,7 +156,7 @@ def lib_name_path(interface, simulator):
     return library_name_path
 
 
-def findlibpython():
+def _findlibpython():
     libpython_path = find_libpython.find_libpython()
     if libpython_path is None:
         sys.exit(1)

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -156,6 +156,13 @@ def lib_name_path(interface, simulator):
     return library_name_path
 
 
+def findlibpython():
+    libpython_path = find_libpython.find_libpython()
+    if libpython_path is None:
+        sys.exit(1)
+    return libpython_path
+
+
 class PrintAction(argparse.Action):
     def __init__(self, option_strings, dest, text=None, **kwargs):
         super().__init__(option_strings, dest, nargs=0, **kwargs)
@@ -218,8 +225,10 @@ def get_parser():
     parser.add_argument(
         "--libpython",
         help="Print the absolute path to the libpython associated with the current Python installation",
-        action=PrintAction,
-        text=find_libpython.find_libpython(),
+        nargs=0,
+        metavar=(),
+        action=PrintFuncAction,
+        function=findlibpython,
     )
     parser.add_argument(
         "--lib-dir",

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -228,7 +228,7 @@ def get_parser():
         nargs=0,
         metavar=(),
         action=PrintFuncAction,
-        function=findlibpython,
+        function=_findlibpython,
     )
     parser.add_argument(
         "--lib-dir",

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -133,6 +133,8 @@ manually override the LIBPYTHON_LOC make variable with the absolute path to libp
 
 endef
 
+ifndef LIBPYTHON_LOC
+
 # get the path to libpython and the return code from the script
 # adapted from https://stackoverflow.com/a/24658961/6614127
 FIND_LIBPYTHON_RES := $(shell cocotb-config --libpython; echo $$?)
@@ -143,6 +145,9 @@ LIBPYTHON_LOC := $(strip $(subst $(FIND_LIBPYTHON_RC)QQQQ,,$(FIND_LIBPYTHON_RES)
 ifneq ($(FIND_LIBPYTHON_RC),0)
     $(error $(find_libpython_errmsg))
 endif
+
+endif
+
 export LIBPYTHON_LOC
 
 else


### PR DESCRIPTION
`find_libpython` returns a non-0 exit code when a libpython isn't found, we need to do the same since the makefiles expect that and will print and appropriate error message. The refactor to this module accidentally removed that behavior. xref #2522.