### PR TITLE
Cherry-pick bugfixes for 1.5 for 1.5.2 patch release

### DIFF
--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -156,6 +156,13 @@ def lib_name_path(interface, simulator):
     return library_name_path
 
 
+def _findlibpython():
+    libpython_path = find_libpython.find_libpython()
+    if libpython_path is None:
+        sys.exit(1)
+    return libpython_path
+
+
 class PrintAction(argparse.Action):
     def __init__(self, option_strings, dest, text=None, **kwargs):
         super(PrintAction, self).__init__(option_strings, dest, nargs=0, **kwargs)
@@ -218,8 +225,10 @@ def get_parser():
     parser.add_argument(
         "--libpython",
         help="Print the absolute path to the libpython associated with the current Python installation",
-        action=PrintAction,
-        text=find_libpython.find_libpython(),
+        nargs=0,
+        metavar=(),
+        action=PrintFuncAction,
+        function=_findlibpython,
     )
     parser.add_argument(
         "--lib-dir",

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -108,10 +108,14 @@ regression: $(COCOTB_RESULTS_FILE)
 # Attempt to detect TOPLEVEL_LANG based on available sources if not set
 ifeq ($(TOPLEVEL_LANG),)
 
-ifneq ($(and $(VHDL_SOURCES),$(if $(VERILOG_SOURCES),,1),)
+ifneq ($(VHDL_SOURCES),)
+ifeq ($(VERILOG_SOURCES),)
 	TOPLEVEL_LANG := vhdl
-else ifneq ($(and $(VERILOG_SOURCES),$(if $(VHDL_SOURCES),,1),)
+endif
+else ifneq ($(VERILOG_SOURCES),)
+ifeq ($(VHDL_SOURCES),)
 	TOPLEVEL_LANG := verilog
+endif
 endif
 
 endif

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -131,6 +131,8 @@ manually override the LIBPYTHON_LOC make variable with the absolute path to libp
 
 endef
 
+ifndef LIBPYTHON_LOC
+
 # get the path to libpython and the return code from the script
 # adapted from https://stackoverflow.com/a/24658961/6614127
 FIND_LIBPYTHON_RES := $(shell cocotb-config --libpython; echo $$?)
@@ -141,6 +143,9 @@ LIBPYTHON_LOC := $(strip $(subst $(FIND_LIBPYTHON_RC)QQQQ,,$(FIND_LIBPYTHON_RES)
 ifneq ($(FIND_LIBPYTHON_RC),0)
     $(error $(find_libpython_errmsg))
 endif
+
+endif
+
 export LIBPYTHON_LOC
 
 else

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -8,6 +8,16 @@ Release Notes
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
 
+cocotb 1.5.2 (upcoming)
+=========================
+
+Bugfixes
+--------
+
+- Change some makefile syntax to support GNU Make 3 (:pr:`2496`)
+- Fix behavior of ``cocotb-config --libpython`` when finding libpython fails (:pr:`2522`)
+
+
 cocotb 1.5.1 (2021-03-20)
 =========================
 


### PR DESCRIPTION
Cherry-picks #2515 and #2523 which are regressions introduced in 1.5.