### PR TITLE
Run only test_scheduler in CI with increased logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,13 @@ do_tests::
 	$(MAKE) -k -C examples
 # increase coverage
 do_tests::
-	$(MAKE) -k -C tests/test_cases/test_cocotb/ COCOTB_LOG_LEVEL=DEBUG > test_cocotb_DEBUG.log
+	$(MAKE) -k -C tests/test_cases/test_cocotb/ \
+		MODULE=test_scheduler TESTCASE=test_coroutine_kill,test_coroutine_close_down \
+		COCOTB_LOG_LEVEL=TRACE > /dev/null
 do_tests::
-	$(MAKE) -k -C tests/test_cases/test_cocotb/ COCOTB_SCHEDULER_DEBUG=1 > test_cocotb_SCHEDULER_DEBUG.log
+	$(MAKE) -k -C tests/test_cases/test_cocotb/ \
+		MODULE=test_scheduler TESTCASE=test_coroutine_kill,test_coroutine_close_down \
+		COCOTB_SCHEDULER_DEBUG=1 > /dev/null
 
 # For Jenkins we use the exit code to detect compile errors or catastrophic
 # failures and the XML to track test results


### PR DESCRIPTION
Aldec Riviera was unhappy with the long logs introduced by #2085.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
