### PR TITLE
WIP: Set expect_error for tests run with GHDL

### DIFF
--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -40,8 +40,9 @@ async def test_returnvalue_deprecated(dut):
     assert "return statement instead" in str(warns[0].message)
 
 
-# strings are not supported on Icarus
-@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
+# strings are not supported on Icarus or GHDL
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"),
+             expect_error=AssertionError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_unicode_handle_assignment_deprecated(dut):
     with assert_deprecated() as warns:
         dut.stream_in_string <= "Bad idea"
@@ -179,7 +180,7 @@ async def test_assigning_setattr_syntax_deprecated(dut):
 icarus_under_11 = cocotb.SIM_NAME.lower().startswith("icarus") and (IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"))
 
 
-@cocotb.test(expect_error=Exception if icarus_under_11 else ())
+@cocotb.test(expect_error=Exception if icarus_under_11 else IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_assigning_setitem_syntax_deprecated(dut):
     with assert_deprecated():
         dut.stream_in_data[0] = 1

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -287,7 +287,7 @@ async def test_integer_underflow(dut):
     await int_overflow_test(dut.stream_in_int, 32, "unfl", limits)
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_real_assign_double(dut):
     """
     Assign a random floating point value, read it back from the DUT and check
@@ -306,7 +306,7 @@ async def test_real_assign_double(dut):
     assert got == val, "Values didn't match!"
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else OverflowError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_real_assign_int(dut):
     """Assign a random integer value to ensure we can write types convertible to
     int, read it back from the DUT and check it matches what we assigned.


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
