### PR TITLE
Revert "Run test_cocotb with debugging to improve coverage"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,6 @@ do_tests::
 	$(MAKE) -k -C tests
 do_tests::
 	$(MAKE) -k -C examples
-# increase coverage
-do_tests::
-	$(MAKE) -k -C tests/test_cases/test_cocotb/ COCOTB_LOG_LEVEL=DEBUG > test_cocotb_DEBUG.log
-do_tests::
-	$(MAKE) -k -C tests/test_cases/test_cocotb/ COCOTB_SCHEDULER_DEBUG=1 > test_cocotb_SCHEDULER_DEBUG.log
 
 # For Jenkins we use the exit code to detect compile errors or catastrophic
 # failures and the XML to track test results


### PR DESCRIPTION
This reverts commit aa849aa6975dea101ddbed512e823c9245f05ff2.

This commit roughly doubles Private CI build time. Backing out until we
find a less resource-intensive solution.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->