### PR TITLE
Backport release notes for 1.5.1 and 1.5.2

### DIFF
--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -12,6 +12,27 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 .. towncrier release notes start
 
 
+cocotb 1.5.2 (2021-05-03)
+=========================
+
+Bugfixes
+--------
+
+- Change some makefile syntax to support GNU Make 3 (:pr:`2496`)
+- Fix behavior of ``cocotb-config --libpython`` when finding libpython fails (:pr:`2522`)
+
+
+cocotb 1.5.1 (2021-03-20)
+=========================
+
+Bugfixes
+--------
+
+- Prevent pytest assertion rewriting (:pr:`2028`) from capturing stdin, which causes problems with IPython support (:pr:`1649`). (:pr:`2462`)
+- Add dependency on `cocotb_bus <https://github.com/cocotb/cocotb-bus>`_ to prevent breaking users that were previously using the bus and testbenching objects. (:pr:`2477`)
+- Add back functionality to :class:`cocotb.binary.BinaryValue` that allows the user to change ``binaryRepresentation`` after object creation. (:pr:`2480`)
+
+
 cocotb 1.5.0 (2021-03-11)
 =========================
 


### PR DESCRIPTION
Port those release notes to master to have a full history of releases
there.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->