### PR TITLE
doc: add ref to Maintainers section in CONTRIBUTING.md through extlinks

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.makedomain',
     'sphinx.ext.inheritance_diagram',
@@ -347,3 +348,11 @@ in_progress_notes = subprocess.check_output(['towncrier', '--draft', '--name', '
                                             universal_newlines=True)
 with open('master-notes.rst', 'w') as f:
     f.write(in_progress_notes)
+
+# -- External link helpers -----------------------------------------------------
+
+extlinks = {
+   'wikipedia': ('https://en.wikipedia.org/wiki/%s', None),
+   'reposharp': ('https://github.com/cocotb/cocotb/issues/%s', '#'),
+   'reposrc':   ('https://github.com/cocotb/cocotb/blob/master/%s', None)
+}

--- a/documentation/source/contributors.rst
+++ b/documentation/source/contributors.rst
@@ -9,7 +9,8 @@ Contributors
    Solarflare
 
 cocotb is developed and maintained by an active community.
-Our GitHub repository contains a list of all `contributors <https://github.com/cocotb/cocotb/graphs/contributors>`_.
+Our GitHub repository contains a list of the :reposrc:`Maintainers <CONTRIBUTING.md#maintainers>` and all
+`contributors <https://github.com/cocotb/cocotb/graphs/contributors>`_.
 
 Since mid-2018 cocotb is an independent project under the umbrella of the
 `Free and Open Source Silicon Foundation <https://www.fossi-foundation.org>`_.


### PR DESCRIPTION
As discussed in gitter, this adds a reference to the list of maintainers in the contributors section of the docs.

I could not test this because `tox -e docs` does not work on MSYS2, and it seems that CI for documentation is not triggered in GitHub Actions of the forks. I hope it is triggered by this PR.