### PR TITLE
tox: Pass through Mentor license file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ passenv =
     TOPLEVEL_LANG
     ALDEC_LICENSE_FILE
     SYNOPSYS_LICENSE_FILE
+    MGLS_LICENSE_FILE
     LM_LICENSE_FILE
     # allow tuning of matrix_multiplier test length
     NUM_SAMPLES


### PR DESCRIPTION
The Mentor/Siemens license server environment variable is needed by
Questa and needs to be passed through tox.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->