### PR TITLE
Add test for recursive Combine calls

### DIFF
--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -205,6 +205,7 @@ async def test_recursive_combine(_):
     """ Tests pass a `Combine` trigger directly to another `Combine` trigger. """
 
     done = set()
+
     async def waiter(N):
         await Timer(N, 'ns')
         done.add(N)

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -171,6 +171,9 @@ async def test_combine_start_soon(_):
 
 @cocotb.test()
 async def test_recursive_combine(_):
+    """ Test using `Combine` on forked coroutines that themselves use `Combine`.
+    
+    This does not test passing `Combine` triggers into `Combine`. """
 
     async def mergesort(n):
         if len(n) == 1:

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -202,7 +202,7 @@ async def test_recursive_combine_and_fork(_):
 
 @cocotb.test()
 async def test_recursive_combine(_):
-    """ Tests pass a `Combine` trigger directly to another `Combine` trigger. """
+    """ Test passing a `Combine` trigger directly to another `Combine` trigger. """
 
     done = set()
 

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -172,9 +172,7 @@ async def test_combine_start_soon(_):
 
 @cocotb.test()
 async def test_recursive_combine_and_fork(_):
-    """ Test using `Combine` on forked coroutines that themselves use `Combine`.
-
-    This does not test passing `Combine` triggers into `Combine`. """
+    """ Test using `Combine` on forked coroutines that themselves use `Combine`. """
 
     async def mergesort(n):
         if len(n) == 1:
@@ -204,10 +202,12 @@ async def test_recursive_combine_and_fork(_):
 
 @cocotb.test()
 async def test_recursive_combine(_):
-    """Tests using a `Combine` trigger in another `Combine` trigger"""
+    """ Tests pass a `Combine` trigger directly to another `Combine` trigger. """
 
+    done = set()
     async def waiter(N):
         await Timer(N, 'ns')
+        done.add(N)
 
     start_time = get_sim_time('ns')
     await Combine(
@@ -220,3 +220,4 @@ async def test_recursive_combine(_):
     end_time = get_sim_time('ns')
 
     assert end_time - start_time == 30
+    assert done == {10, 20, 30}


### PR DESCRIPTION
I (thought) had an issue with recursive calls to `Combine`, so I made a test for it. The test worked so I guess my issues is elsewhere. Figured since I already wrote it, why not add it?