### PR TITLE
Deprecate gen tests options

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -34,6 +34,7 @@ import sys
 import os
 import traceback
 import pdb
+import warnings
 from typing import Any, Optional, Tuple, Iterable
 
 import cocotb
@@ -682,7 +683,7 @@ class TestFactory:
                     raise ValueError("Mismatch between number of options and number of option values in group")
         self.kwargs[name] = optionlist
 
-    def generate_tests(self, prefix="", postfix=""):
+    def generate_tests(self, prefix=None, postfix=None):
         """
         Generate an exhaustive set of tests using the cartesian product of the
         possible keyword arguments.
@@ -699,7 +700,18 @@ class TestFactory:
                      when naming generated test cases. This allows reuse of
                      a single ``test_function`` with multiple
                      :class:`TestFactories <.TestFactory>` without name clashes.
+
+        .. deprecated:: 2.0
+            The *prefix* and *postfix* argument.
         """
+
+        if prefix is not None or postfix is not None:
+            warnings.warn(
+                "The 'prefix' and 'postfix' options are no longer necessary to prevent "
+                "test name collisions. They will be removed in the future.",
+                DeprecationWarning, stacklevel=2)
+        prefix = "" if prefix is None else prefix
+        postfix = "" if postfix is None else postfix
 
         frm = inspect.stack()[1]
         mod = inspect.getmodule(frm[0])

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -754,10 +754,14 @@ class TestFactory:
             name = f"{prefix}{self.name}{postfix}({options_str})"
 
             if hasattr(mod, name):
-                self.log.error("Overwriting %s in module %s. "
-                               "This causes a previously defined testcase "
-                               "not to be run. Consider setting/changing "
-                               "the postfix option" % (name, mod))
+                warnings.warn(
+                    f"{name} is already defined in {mod}; "
+                    "overwriting the existing test definition. "
+                    "If you want to run the same test multiple times, "
+                    "add a loop option to the test and do so explicitly.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
             self.log.debug(f"Adding generated test {name!r} to module {mod.__name__!r}")
             setattr(mod, name, _create_test(self.test_function, name, doc, mod,

--- a/documentation/source/newsfragments/2575.removal.rst
+++ b/documentation/source/newsfragments/2575.removal.rst
@@ -1,0 +1,1 @@
+The ``prefix`` and ``postfix`` options to :meth:`TestFactory.generate_tests <cocotb.regression.TestFactory.generate_tests>` have been deprecated.

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from common import assert_raises
 from typing import List
 from cocotb._sim_versions import IcarusVersion
+from cocotb.regression import TestFactory
 
 
 @contextmanager
@@ -187,3 +188,17 @@ async def test_assigning_setitem_syntax_deprecated(dut):
         with assert_raises(IndexError):
             # attempt to use __setitem__ syntax on signal that doesn't exist
             dut.stream_in_data[800000] = 1
+
+
+async def test_stub(_):
+    """ Test that does nothing and always passes. """
+
+
+@cocotb.test()
+async def test_generate_test_options_deprecated(_):
+    """ Test that the `refix` and `postfix` options to `TestFactory.generate_tests`. """
+    tf = TestFactory(test_stub)
+
+    with assert_deprecated():
+        tf.generate_tests(prefix="1", postfix="1")
+    assert "1test_stub1()" in globals()

--- a/tests/test_cases/test_cocotb/test_testfactory.py
+++ b/tests/test_cases/test_cocotb/test_testfactory.py
@@ -6,6 +6,7 @@ Tests of cocotb.regression.TestFactory functionality
 """
 import cocotb
 from cocotb.regression import TestFactory
+import pytest
 
 
 testfactory_test_args = set()
@@ -28,3 +29,13 @@ async def test_testfactory_verify_args(dut):
         ("a1v1", "a2v2", "a3v2"),
         ("a1v2", "a2v2", "a3v2"),
     }
+
+
+@cocotb.test()
+async def test_testfactory_collision(_):
+    """ Test warning is thrown when there is a collision in generates test names with TestFactory. """
+    tf = TestFactory(run_testfactory_test)
+    tf.add_option(("arg1", "arg2", "arg3"), (("a1v1", "a2v1", "a3v1"),))
+    with pytest.warns(RuntimeWarning) as w:
+        tf.generate_tests()
+    assert "already defined" in str(w.pop())


### PR DESCRIPTION
Closes #2575. Deprecates the `prefix` and `postfix` options to `TestFactory.generate_tests`. Also changes how name collisions are handled since prefix and postfix are deprecated and collisions should be far less likely.