### PR TITLE
Add ghdl expected errors

### DIFF
--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -141,7 +141,10 @@ class MatrixMultiplierTester:
             assert actual['C'] == expected
 
 
-async def test_multiply(dut, a_data, b_data):
+@cocotb.test(
+    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ()
+)
+async def test_multiply(dut):
     """Test multiplication of many matrices."""
 
     cocotb.fork(Clock(dut.clk_i, 10, units='ns').start())
@@ -166,7 +169,7 @@ async def test_multiply(dut, a_data, b_data):
     dut._log.info("Test multiplication operations")
 
     # Do multiplication operations
-    for i, (A, B) in enumerate(zip(a_data(), b_data())):
+    for i, (A, B) in enumerate(zip(gen_a(), gen_b())):
         await RisingEdge(dut.clk_i)
         dut.a_i <= A
         dut.b_i <= B
@@ -203,9 +206,3 @@ def gen_b(num_samples=NUM_SAMPLES, func=getrandbits):
     """Generate random matrix data for B"""
     for _ in range(num_samples):
         yield create_b(func)
-
-
-factory = TestFactory(test_multiply)
-factory.add_option('a_data', [gen_a])
-factory.add_option('b_data', [gen_b])
-factory.generate_tests()

--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Any
 import cocotb
 from cocotb.binary import BinaryValue
 from cocotb.clock import Clock
-from cocotb.regression import TestFactory
 from cocotb.triggers import RisingEdge
 from cocotb.queue import Queue
 from cocotb.handle import SimHandleBase

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ ignore =
     E741  # ambiguous variable name 'l'
     F405  # ... may be undefined, or defined from star
     W504  # line break after binary operator
+    W503  # line break before binary operator
 
 per-file-ignores =
     # F841 - local variable ... is assigned to but never used

--- a/tests/test_cases/issue_330/issue_330.py
+++ b/tests/test_cases/issue_330/issue_330.py
@@ -3,8 +3,12 @@
 import cocotb
 import logging
 
+SIM_NAME = cocotb.SIM_NAME.lower()
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+
+# GHDL can't access record signals (gh-2591)
+# Icarus doesn't support structs (gh-2592)
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith(("icarus", "ghdl")) else ())
 async def issue_330_direct(dut):
     """
     Access a structure
@@ -17,7 +21,9 @@ async def issue_330_direct(dut):
     tlog.info(f"Value of inout_if => a_in = {structure.a_in.value} ; b_out = {structure.b_out.value}")
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+# GHDL can't access record signals (gh-2591)
+# Icarus doesn't support structs (gh-2592)
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith(("icarus", "ghdl")) else ())
 async def issue_330_iteration(dut):
     """
     Access a structure via issue_330_iteration

--- a/tests/test_cases/issue_330/issue_330.py
+++ b/tests/test_cases/issue_330/issue_330.py
@@ -6,7 +6,7 @@ import logging
 SIM_NAME = cocotb.SIM_NAME.lower()
 
 
-# GHDL can't access record signals (gh-2591)
+# GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
 @cocotb.test(expect_error=AttributeError if SIM_NAME.startswith(("icarus", "ghdl")) else ())
 async def issue_330_direct(dut):
@@ -21,7 +21,7 @@ async def issue_330_direct(dut):
     tlog.info(f"Value of inout_if => a_in = {structure.a_in.value} ; b_out = {structure.b_out.value}")
 
 
-# GHDL can't access record signals (gh-2591)
+# GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
 @cocotb.test(expect_error=AttributeError if SIM_NAME.startswith(("icarus", "ghdl")) else ())
 async def issue_330_iteration(dut):

--- a/tests/test_cases/test_array/Makefile
+++ b/tests/test_cases/test_array/Makefile
@@ -29,14 +29,14 @@
 
 ifeq ($(SIM),)
 all:
-	@echo "Skipping test_array since icarus doesn't support indexing"
+	@echo "Skipping test_array since icarus doesn't support structs"
 
 clean::
 # nothing to clean, just define target in this branch
 
 else ifeq ($(shell echo $(SIM) | tr A-Z a-z),icarus)
 all:
-	@echo "Skipping test_array since icarus doesn't support indexing"
+	@echo "Skipping test_array since icarus doesn't support structs"
 
 clean::
 # nothing to clean, just define target in this branch

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -44,7 +44,7 @@ def _check_value(tlog, hdl, expected):
 
 
 # NOTE: simulator-specific handling is done in this test itself, not via expect_error in the decorator
-# GHDL cannot access std_logic_vector generics (gh-2593) (hard crash, so skip)
+# GHDL unable to access std_logic_vector generics (gh-2593) (hard crash, so skip)
 @cocotb.test(skip=SIM_NAME.startswith("ghdl"))
 async def test_read_write(dut):
     """Test handle inheritance"""

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -10,6 +10,8 @@ from cocotb.triggers import Timer
 from cocotb.result import TestError, TestFailure
 from cocotb.handle import HierarchyObject, HierarchyArrayObject, ModifiableObject, NonHierarchyIndexableObject, ConstantObject
 
+SIM_NAME = cocotb.SIM_NAME.lower()
+
 
 def _check_type(tlog, hdl, expected):
     assert isinstance(hdl, expected), f">{hdl!r} ({hdl._type})< should be >{expected}<"
@@ -42,7 +44,8 @@ def _check_value(tlog, hdl, expected):
 
 
 # NOTE: simulator-specific handling is done in this test itself, not via expect_error in the decorator
-@cocotb.test()
+# GHDL cannot access std_logic_vector generics (gh-2593) (hard crash, so skip)
+@cocotb.test(skip=SIM_NAME.startswith("ghdl"))
 async def test_read_write(dut):
     """Test handle inheritance"""
     tlog = logging.getLogger("cocotb.test")
@@ -196,7 +199,8 @@ async def test_read_write(dut):
         _check_logic(tlog, dut.port_cmplx_out[1].b[1], 0xEE)
 
 
-@cocotb.test()
+# GHDL unable to access signals in generate loops (gh-2594)
+@cocotb.test(expect_error=IndexError if SIM_NAME.startswith("ghdl") else ())
 async def test_gen_loop(dut):
     """Test accessing Generate Loops"""
     tlog = logging.getLogger("cocotb.test")
@@ -336,6 +340,8 @@ async def test_discover_all(dut):
 
     if cocotb.LANGUAGE in ["vhdl"] and cocotb.SIM_NAME.lower().startswith("riviera"):
         pass_total = 571
+    elif cocotb.SIM_NAME.lower().startswith("ghdl"):
+        pass_total = 56
     elif cocotb.LANGUAGE in ["vhdl"]:
         pass_total = 856
     elif cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
@@ -372,7 +378,10 @@ async def test_discover_all(dut):
         raise TestFailure(f"Expected {pass_total} objects but found {total}")
 
 
-@cocotb.test(skip=(cocotb.LANGUAGE in ["verilog"] or cocotb.SIM_NAME.lower().startswith("riviera")))
+# GHDL unable to access std_logic_vector generics (gh-2593)
+@cocotb.test(
+    skip=(cocotb.LANGUAGE in ["verilog"] or cocotb.SIM_NAME.lower().startswith("riviera")),
+    expect_error=AttributeError if SIM_NAME.startswith("ghdl") else ())
 async def test_direct_constant_indexing(dut):
     """Test directly accessing constant/parameter data in arrays, i.e. not iterating"""
 
@@ -402,7 +411,8 @@ async def test_direct_constant_indexing(dut):
     _check_type(tlog, dut.const_cmplx[1].b[1], ConstantObject)
 
 
-@cocotb.test()
+# GHDL unable to index packed arrays (gh-2587)
+@cocotb.test(expect_error=IndexError if SIM_NAME.startswith("ghdl") else ())
 async def test_direct_signal_indexing(dut):
     """Test directly accessing signal/net data in arrays, i.e. not iterating"""
 

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -20,7 +20,8 @@ def _check_value(tlog, hdl, expected):
         tlog.info(f"   Found {hdl!r} ({hdl._type}) with value={hdl.value}")
 
 
-@cocotb.test()
+# GHDL cannot put values on nested array types (gh-2588)
+@cocotb.test(expect_error=Exception if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_1dim_array_handles(dut):
     """Test getting and setting array values using the handle of the full array."""
 
@@ -40,7 +41,13 @@ async def test_1dim_array_handles(dut):
     _check_value(tlog, dut.array_0_to_3    , [0x30, 0x20, 0x10, 0x00])
 
 
-@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")))
+# GHDL cannot put values on nested array types (gh-2588)
+# iverilog flattens multi-dimensional unpacked arrays (gh-2595)
+@cocotb.test(
+    expect_error=Exception
+    if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl"))
+    else ()
+)
 async def test_ndim_array_handles(dut):
     """Test getting and setting multi-dimensional array values using the handle of the full array."""
 
@@ -57,7 +64,8 @@ async def test_ndim_array_handles(dut):
     _check_value(tlog, dut.array_2d, [[0xF0, 0xE0, 0xD0, 0xC0], [0xB0, 0xA0, 0x90, 0x80]])
 
 
-@cocotb.test()
+# GHDL cannot put values on nested array types (gh-2588)
+@cocotb.test(expect_error=Exception if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_1dim_array_indexes(dut):
     """Test getting and setting values of array indexes."""
 
@@ -97,7 +105,13 @@ async def test_1dim_array_indexes(dut):
     _check_value(tlog, dut.array_0_to_3[3]    , 0x42)
 
 
-@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")))
+# GHDL cannot put values on nested array types (gh-2588)
+# iverilog flattens multi-dimensional unpacked arrays (gh-2595)
+@cocotb.test(
+    expect_error=Exception
+    if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl"))
+    else ()
+)
 async def test_ndim_array_indexes(dut):
     """Test getting and setting values of multi-dimensional array indexes."""
 
@@ -128,6 +142,8 @@ async def test_ndim_array_indexes(dut):
     _check_value(tlog, dut.array_2d[1][28], 0xEF)
 
 
+# GHDL can't access record signals (gh-2591)
+# Icarus doesn't support structs (gh-2592)
 @cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")) else ())
 async def test_struct(dut):
     """Test setting and getting values of structs."""

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -20,7 +20,7 @@ def _check_value(tlog, hdl, expected):
         tlog.info(f"   Found {hdl!r} ({hdl._type}) with value={hdl.value}")
 
 
-# GHDL cannot put values on nested array types (gh-2588)
+# GHDL unable to put values on nested array types (gh-2588)
 @cocotb.test(expect_error=Exception if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_1dim_array_handles(dut):
     """Test getting and setting array values using the handle of the full array."""
@@ -41,7 +41,7 @@ async def test_1dim_array_handles(dut):
     _check_value(tlog, dut.array_0_to_3    , [0x30, 0x20, 0x10, 0x00])
 
 
-# GHDL cannot put values on nested array types (gh-2588)
+# GHDL unable to put values on nested array types (gh-2588)
 # iverilog flattens multi-dimensional unpacked arrays (gh-2595)
 @cocotb.test(
     expect_error=Exception
@@ -64,7 +64,7 @@ async def test_ndim_array_handles(dut):
     _check_value(tlog, dut.array_2d, [[0xF0, 0xE0, 0xD0, 0xC0], [0xB0, 0xA0, 0x90, 0x80]])
 
 
-# GHDL cannot put values on nested array types (gh-2588)
+# GHDL unable to put values on nested array types (gh-2588)
 @cocotb.test(expect_error=Exception if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_1dim_array_indexes(dut):
     """Test getting and setting values of array indexes."""
@@ -105,7 +105,7 @@ async def test_1dim_array_indexes(dut):
     _check_value(tlog, dut.array_0_to_3[3]    , 0x42)
 
 
-# GHDL cannot put values on nested array types (gh-2588)
+# GHDL unable to put values on nested array types (gh-2588)
 # iverilog flattens multi-dimensional unpacked arrays (gh-2595)
 @cocotb.test(
     expect_error=Exception
@@ -142,7 +142,7 @@ async def test_ndim_array_indexes(dut):
     _check_value(tlog, dut.array_2d[1][28], 0xEF)
 
 
-# GHDL can't access record signals (gh-2591)
+# GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
 @cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")) else ())
 async def test_struct(dut):

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -40,9 +40,8 @@ async def test_returnvalue_deprecated(dut):
     assert "return statement instead" in str(warns[0].message)
 
 
-# strings are not supported on Icarus or GHDL
-@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"),
-             expect_error=AssertionError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+# strings are not supported on Icarus (gh-2585) or GHDL (gh-2584)
+@cocotb.test(expect_error=AssertionError if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")) else ())
 async def test_unicode_handle_assignment_deprecated(dut):
     with assert_deprecated() as warns:
         dut.stream_in_string <= "Bad idea"
@@ -180,7 +179,8 @@ async def test_assigning_setattr_syntax_deprecated(dut):
 icarus_under_11 = cocotb.SIM_NAME.lower().startswith("icarus") and (IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"))
 
 
-@cocotb.test(expect_error=Exception if icarus_under_11 else IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+# indexing packed arrays is not supported in iverilog < 11 (gh-2586) or GHDL (gh-2587)
+@cocotb.test(expect_error=IndexError if icarus_under_11 or cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_assigning_setitem_syntax_deprecated(dut):
     with assert_deprecated():
         dut.stream_in_data[0] = 1

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -40,8 +40,9 @@ async def test_returnvalue_deprecated(dut):
     assert "return statement instead" in str(warns[0].message)
 
 
-# strings are not supported on Icarus
-@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
+# strings are not supported on Icarus or GHDL
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"),
+             expect_error=AssertionError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_unicode_handle_assignment_deprecated(dut):
     with assert_deprecated() as warns:
         dut.stream_in_string <= "Bad idea"
@@ -179,7 +180,7 @@ async def test_assigning_setattr_syntax_deprecated(dut):
 icarus_under_11 = cocotb.SIM_NAME.lower().startswith("icarus") and (IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"))
 
 
-@cocotb.test(expect_error=Exception if icarus_under_11 else ())
+@cocotb.test(expect_error=Exception if icarus_under_11 else IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_assigning_setitem_syntax_deprecated(dut):
     with assert_deprecated():
         dut.stream_in_data[0] = 1

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -304,8 +304,8 @@ async def test_integer_underflow(dut):
     await int_overflow_test(dut.stream_in_int, 32, "unfl", limits)
 
 
-# GHDL cannot find real signals (gh-2589)
-# iverilog cannot find real signals (gh-2590)
+# GHDL unable to find real signals (gh-2589)
+# iverilog unable to find real signals (gh-2590)
 @cocotb.test(
     expect_error=AttributeError
     if SIM_NAME.startswith("icarus")
@@ -331,8 +331,8 @@ async def test_real_assign_double(dut):
     assert got == val, "Values didn't match!"
 
 
-# GHDL cannot find real signals (gh-2589)
-# iverilog cannot find real signals (gh-2590)
+# GHDL unable to find real signals (gh-2589)
+# iverilog unable to find real signals (gh-2590)
 @cocotb.test(
     expect_error=AttributeError
     if SIM_NAME.startswith("icarus")

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -287,7 +287,7 @@ async def test_integer_underflow(dut):
     await int_overflow_test(dut.stream_in_int, 32, "unfl", limits)
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_real_assign_double(dut):
     """
     Assign a random floating point value, read it back from the DUT and check
@@ -306,7 +306,7 @@ async def test_real_assign_double(dut):
     assert got == val, "Values didn't match!"
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else OverflowError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_real_assign_int(dut):
     """Assign a random integer value to ensure we can write types convertible to
     int, read it back from the DUT and check it matches what we assigned.

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -51,6 +51,7 @@ async def test_string_handle_takes_bytes(dut):
     assert val == b"bytes"
 
 
+# GHDL fails to discover string input properly (gh-2584)
 @cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")) or
              cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"))
 async def test_string_ansi_color(dut):
@@ -287,7 +288,9 @@ async def test_integer_underflow(dut):
     await int_overflow_test(dut.stream_in_int, 32, "unfl", limits)
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+# GHDL cannot find real signals (gh-2589)
+# iverilog cannot find real signals (gh-2590)
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_real_assign_double(dut):
     """
     Assign a random floating point value, read it back from the DUT and check
@@ -306,7 +309,9 @@ async def test_real_assign_double(dut):
     assert got == val, "Values didn't match!"
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else OverflowError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+# GHDL cannot find real signals (gh-2589)
+# iverilog cannot find real signals (gh-2590)
+@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_real_assign_int(dut):
     """Assign a random integer value to ensure we can write types convertible to
     int, read it back from the DUT and check it matches what we assigned.

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -12,6 +12,8 @@ from cocotb.triggers import Timer
 from common import assert_raises
 from cocotb.handle import _Limits
 
+SIM_NAME = cocotb.SIM_NAME.lower()
+
 
 @cocotb.test()
 async def test_lessthan_raises_error(dut):
@@ -41,8 +43,15 @@ async def test_bad_attr(dut):
         assert False, "Expected AttributeError"
 
 
-# strings are not supported on Icarus
-@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
+# iverilog fails to discover string inputs (gh-2585)
+# GHDL fails to discover string input properly (gh-2584)
+@cocotb.test(
+    expect_error=AttributeError
+    if SIM_NAME.startswith("icarus")
+    else TypeError
+    if SIM_NAME.startswith("ghdl")
+    else ()
+)
 async def test_string_handle_takes_bytes(dut):
     dut.stream_in_string.value = b"bytes"
     await cocotb.triggers.Timer(10, 'ns')
@@ -51,9 +60,16 @@ async def test_string_handle_takes_bytes(dut):
     assert val == b"bytes"
 
 
+# iverilog fails to discover string inputs (gh-2585)
 # GHDL fails to discover string input properly (gh-2584)
-@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")) or
-             cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"))
+@cocotb.test(
+    expect_error=AttributeError
+    if SIM_NAME.startswith("icarus")
+    else TypeError
+    if SIM_NAME.startswith("ghdl")
+    else (),
+    skip=cocotb.LANGUAGE in ["verilog"] and SIM_NAME.startswith("riviera")
+)
 async def test_string_ansi_color(dut):
     """Check how different simulators treat ANSI-colored strings, see gh-2328"""
     teststr = "\x1b[33myellow\x1b[49m\x1b[39m"
@@ -63,12 +79,12 @@ async def test_string_ansi_color(dut):
     await cocotb.triggers.Timer(10, 'ns')
     val = dut.stream_in_string.value
     assert isinstance(val, bytes)
-    if cocotb.LANGUAGE in ["vhdl"] and cocotb.SIM_NAME.lower().startswith("riviera"):
+    if cocotb.LANGUAGE in ["vhdl"] and SIM_NAME.startswith("riviera"):
         # Riviera-PRO doesn't return anything with VHDL:
         assert val == b""
         # ...and the value shows up differently in the HDL:
         assert dut.stream_in_string_asciival_sum.value == sum(ord(char) for char in teststr.replace('\x1b', '\0'))
-    elif cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
+    elif cocotb.LANGUAGE in ["verilog"] and SIM_NAME.startswith(("ncsim", "xmsim")):
         # Xcelium with VPI strips the escape char when reading:
         assert val == bytes(teststr.replace('\x1b', '').encode("ascii"))
         # the HDL gets the correct value though:
@@ -110,7 +126,7 @@ async def int_values_test(signal, n_bits, limits=_Limits.VECTOR_NBIT):
         else:
             got = signal.value
 
-        assert got == val, f"Expected value {val}, got value {got}!"
+        assert got == val
 
 
 def gen_int_test_values(n_bits, limits=_Limits.VECTOR_NBIT):
@@ -255,33 +271,33 @@ async def test_int_128bit_underflow(dut):
     await int_overflow_test(dut.stream_in_data_dqword, len(dut.stream_in_data_dqword), "unfl")
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith("icarus") else ())
 async def test_integer(dut):
     """Test access to integers."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
+    if cocotb.LANGUAGE in ["verilog"] and SIM_NAME.startswith("riviera") or SIM_NAME.startswith("ghdl"):
+        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in Riviera and GHDL, not IntegerObject
     else:
         limits = _Limits.SIGNED_NBIT
 
     await int_values_test(dut.stream_in_int, 32, limits)
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith("icarus") else ())
 async def test_integer_overflow(dut):
     """Test integer overflow."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
+    if cocotb.LANGUAGE in ["verilog"] and SIM_NAME.startswith("riviera") or SIM_NAME.startswith("ghdl"):
+        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in Riviera and GHDL, not IntegerObject
     else:
         limits = _Limits.SIGNED_NBIT
 
     await int_overflow_test(dut.stream_in_int, 32, "ovfl", limits)
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else ())
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith("icarus") else ())
 async def test_integer_underflow(dut):
     """Test integer underflow."""
-    if cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
-        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in riviera, not IntegerObject
+    if cocotb.LANGUAGE in ["verilog"] and SIM_NAME.startswith("riviera") or SIM_NAME.startswith("ghdl"):
+        limits = _Limits.VECTOR_NBIT  # stream_in_int is ModifiableObject in Riviera and GHDL, not IntegerObject
     else:
         limits = _Limits.SIGNED_NBIT
 
@@ -290,7 +306,13 @@ async def test_integer_underflow(dut):
 
 # GHDL cannot find real signals (gh-2589)
 # iverilog cannot find real signals (gh-2590)
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+@cocotb.test(
+    expect_error=AttributeError
+    if SIM_NAME.startswith("icarus")
+    else AttributeError
+    if SIM_NAME.startswith("ghdl")
+    else ()
+)
 async def test_real_assign_double(dut):
     """
     Assign a random floating point value, read it back from the DUT and check
@@ -311,7 +333,13 @@ async def test_real_assign_double(dut):
 
 # GHDL cannot find real signals (gh-2589)
 # iverilog cannot find real signals (gh-2590)
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME in ["Icarus Verilog"] else AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+@cocotb.test(
+    expect_error=AttributeError
+    if SIM_NAME.startswith("icarus")
+    else AttributeError
+    if SIM_NAME.startswith("ghdl")
+    else ()
+)
 async def test_real_assign_int(dut):
     """Assign a random integer value to ensure we can write types convertible to
     int, read it back from the DUT and check it matches what we assigned.

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -304,7 +304,7 @@ async def test_last_scheduled_write_wins(dut):
     assert dut.stream_in_data.value.integer == 2
 
 
-# GHDL cannot put values on nested array types (gh-2588)
+# GHDL unable to put values on nested array types (gh-2588)
 @cocotb.test(expect_error=Exception if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def test_last_scheduled_write_wins_array(dut):
     """

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -303,7 +303,13 @@ async def test_last_scheduled_write_wins(dut):
 
     assert dut.stream_in_data.value.integer == 2
 
-    await Timer(1, "ns")
+
+# GHDL cannot put values on nested array types (gh-2588)
+@cocotb.test(expect_error=Exception if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+async def test_last_scheduled_write_wins_array(dut):
+    """
+    Test that the last scheduled write for an *arrayed* signal handle is the value that is written.
+    """
     dut.array_7_downto_4 <= [1, 2, 3, 4]
     dut.array_7_downto_4[7] <= 10
 

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -246,6 +246,6 @@ async def test_time_units_eq_None(dut):
         assert 'Using units=None is deprecated, use units="step" instead.' in str(w[-1].message)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        await cocotb.triggers.with_timeout(example(), timeout_time=222222, timeout_unit=None)
+        await cocotb.triggers.with_timeout(example(), timeout_time=12_000_000, timeout_unit=None)
         assert issubclass(w[-1].category, DeprecationWarning)
         assert 'Using timeout_unit=None is deprecated, use timeout_unit="step" instead.' in str(w[-1].message)

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -72,6 +72,7 @@ async def discover_module_values(dut):
         raise TestFailure("Expected to discover things in the DUT")
 
 
+@cocotb.test()
 async def discover_value_not_in_dut(dut):
     """Try and get a value from the DUT that is not there"""
     with pytest.raises(AttributeError):
@@ -429,7 +430,7 @@ async def access_gate(dut):
         raise TestFailure("Gate should be HierarchyObject")
 
 
-# GHDL doesn't support accessing record types (gh-2591)
+# GHDL unable to access record types (gh-2591)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
     expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -27,6 +27,7 @@
 
 import cocotb
 import logging
+import pytest
 from cocotb.binary import BinaryValue
 from cocotb.triggers import Timer
 from cocotb.result import TestError, TestFailure
@@ -34,7 +35,9 @@ from cocotb.handle import IntegerObject, ConstantObject, HierarchyObject, String
 from cocotb._sim_versions import IcarusVersion
 
 
-@cocotb.test()
+# GHDL unable to access signals in generate loops (gh-2594)
+@cocotb.test(
+    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def pseudo_region_access(dut):
     """Test that pseudo-regions are accessible before iteration"""
 
@@ -69,10 +72,10 @@ async def discover_module_values(dut):
         raise TestFailure("Expected to discover things in the DUT")
 
 
-@cocotb.test(expect_error=AttributeError)
 async def discover_value_not_in_dut(dut):
     """Try and get a value from the DUT that is not there"""
-    fake_signal = dut.fake_signal
+    with pytest.raises(AttributeError):
+        fake_signal = dut.fake_signal
 
 
 @cocotb.test()
@@ -166,8 +169,19 @@ async def access_single_bit_erroneous(dut):
     dut.stream_in_data[bit] <= 1
 
 
-@cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith(("icarus", "chronologic simulation vcs")) else (),
-             expect_fail=cocotb.SIM_NAME.lower().startswith("riviera") and cocotb.LANGUAGE in ["verilog"])
+# Riviera discovers integers as nets (gh-2597)
+# GHDL discovers integers as nets (gh-2596)
+# Icarus does not support integer signals (gh-2598)
+@cocotb.test(
+    expect_error=AttributeError
+    if cocotb.SIM_NAME.lower().startswith(("icarus", "chronologic simulation vcs"))
+    else (),
+    expect_fail=(
+        cocotb.SIM_NAME.lower().startswith("riviera")
+        and cocotb.LANGUAGE in ["verilog"]
+        or cocotb.SIM_NAME.lower().startswith("ghdl")
+    ),
+)
 async def access_integer(dut):
     """Integer should show as an IntegerObject"""
     bitfail = False
@@ -210,7 +224,10 @@ async def access_constant_integer(dut):
         raise TestFailure("EXAMPLE_WIDTH was not 7")
 
 
-@cocotb.test(skip=cocotb.LANGUAGE in ["verilog"])
+# GHDL inexplicably crashes, so we will skip this test for now
+# likely has to do with overall poor support of string over the VPI
+@cocotb.test(
+    skip=cocotb.LANGUAGE in ["verilog"] or cocotb.SIM_NAME.lower().startswith("ghdl"))
 async def access_string_vhdl(dut):
     """Access to a string, both constant and signal."""
     tlog = logging.getLogger("cocotb.test")
@@ -412,7 +429,10 @@ async def access_gate(dut):
         raise TestFailure("Gate should be HierarchyObject")
 
 
-@cocotb.test(skip=cocotb.LANGUAGE in ["verilog"])
+# GHDL doesn't support accessing record types (gh-2591)
+@cocotb.test(
+    skip=cocotb.LANGUAGE in ["verilog"],
+    expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def custom_type(dut):
     """
     Test iteration over a custom type

--- a/tests/test_cases/test_discovery/test_vhdl_block.py
+++ b/tests/test_cases/test_discovery/test_vhdl_block.py
@@ -26,17 +26,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import cocotb
-from cocotb.result import TestFailure
 
 
-@cocotb.test()
+# GHDL cannot find signal in "block" statement, may be related to (gh-2594)
+@cocotb.test(
+    expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def block_iter(dut):
     """Access a VHDL block statement"""
 
-    try:
-        dut._log.info("Block: {} ({})".format(dut.isample_module1.SAMPLE_BLOCK._name,
-                                              type(dut.isample_module1.SAMPLE_BLOCK)))
-        dut._log.info("Signal inside Block: {} ({})".format(dut.isample_module1.SAMPLE_BLOCK.clk_inv._name,
-                                                            type(dut.isample_module1.SAMPLE_BLOCK.clk_inv)))
-    except AttributeError:
-        raise TestFailure("Could not traverse into vhpiBlockStmtK")
+    dut._log.info("Block: {} ({})".format(dut.isample_module1.SAMPLE_BLOCK._name,
+                                          type(dut.isample_module1.SAMPLE_BLOCK)))
+    dut._log.info("Signal inside Block: {} ({})".format(dut.isample_module1.SAMPLE_BLOCK.clk_inv._name,
+                                                        type(dut.isample_module1.SAMPLE_BLOCK.clk_inv)))

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -86,7 +86,7 @@ async def recursive_discovery(dut):
         raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
 
 
-# GHDL cannot access into generate loop (gh-2594)
+# GHDL unable to access signals in generate loops (gh-2594)
 @cocotb.test(expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def discovery_all(dut):
     """Discover everything on top-level."""
@@ -113,7 +113,7 @@ async def dual_iteration(dut):
     await Combine(loop_one, loop_two)
 
 
-# GHDL cannot access record types (gh-2591)
+# GHDL unable to access record types (gh-2591)
 @cocotb.test(
     expect_fail=(
         cocotb.SIM_NAME.lower().startswith("riviera")

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -86,7 +86,8 @@ async def recursive_discovery(dut):
         raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
 
 
-@cocotb.test()
+# GHDL cannot access into generate loop (gh-2594)
+@cocotb.test(expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def discovery_all(dut):
     """Discover everything on top-level."""
     dut._log.info("Iterating over top-level to discover objects")
@@ -112,7 +113,15 @@ async def dual_iteration(dut):
     await Combine(loop_one, loop_two)
 
 
-@cocotb.test(expect_fail=(cocotb.SIM_NAME.lower().startswith("riviera") and cocotb.SIM_VERSION.startswith(("2019.10", "2020."))) or cocotb.SIM_NAME.lower().startswith("aldec"))
+# GHDL cannot access record types (gh-2591)
+@cocotb.test(
+    expect_fail=(
+        cocotb.SIM_NAME.lower().startswith("riviera")
+        and cocotb.SIM_VERSION.startswith(("2019.10", "2020."))
+    )
+    or cocotb.SIM_NAME.lower().startswith("aldec"),
+    expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else (),
+)
 async def test_n_dimension_array(dut):
     """Test iteration over multi-dimensional array."""
     tlog = logging.getLogger("cocotb.test")

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -30,7 +30,8 @@ from cocotb.handle import HierarchyObject, ModifiableObject, IntegerObject, Cons
 from cocotb.result import TestFailure
 
 
-@cocotb.test()
+# GHDL discovers enum as `vpiNet` (gh-2600)
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("ghdl"))
 async def check_enum_object(dut):
     """
     Enumerations currently behave as normal signals
@@ -41,7 +42,8 @@ async def check_enum_object(dut):
         raise TestFailure("Expected the FSM enum to be an EnumObject")
 
 
-@cocotb.test()
+# GHDL cannot access generate loops (gh-2594)
+@cocotb.test(expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def check_objects(dut):
     """
     Check the types of objects that are returned

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -42,7 +42,7 @@ async def check_enum_object(dut):
         raise TestFailure("Expected the FSM enum to be an EnumObject")
 
 
-# GHDL cannot access generate loops (gh-2594)
+# GHDL unable to access signals in generate loops (gh-2594)
 @cocotb.test(expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
 async def check_objects(dut):
     """


### PR DESCRIPTION
Supersedes #2532. Pinging @umarcor. Hopefully the regression should now pass with GHDL.

Add expected errors/fails to tests that GHDL is currently failing. Also, fixed some exemptions for Icarus. Filed [several issues](https://github.com/cocotb/cocotb/issues?q=is%3Aopen+is%3Aissue+label%3Acategory%3Asimulators%3Aghdl+label%3Aupstream).