### PR TITLE
Add MINGW64 shell and packages to regression

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -115,7 +115,6 @@ jobs:
             lang: vhdl
             python-version: 3.8
             os: ubuntu-latest
-            may_fail: true
 
             # Test Verilator on Ubuntu
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -325,3 +325,42 @@ jobs:
           -n "${{matrix.extra_name}}${{matrix.sim}} (${{matrix.sim-version}}) | ${{matrix.os}} | Python ${{matrix.python-version}}" \
           -e SIM,TOPLEVEL_LANG,CXX,OS,PYTHON_VERSION \
           -a "-rl"
+
+  mingw-env:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sim: verilator
+            lang: verilog
+            pkg: verilator
+            may_fail: true
+          - sim: icarus
+            lang: verilog
+            pkg: iverilog
+          - sim: ghdl
+            lang: vhdl
+            pkg: ghdl-llvm
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: |
+            git
+            make
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-python-pip
+            mingw-w64-x86_64-python-pytest
+            mingw-w64-x86_64-python-wheel
+            mingw-w64-x86_64-${{ matrix.pkg }}
+    - uses: actions/checkout@v2
+    - name: install cocotb
+      run: pip install --no-build-isolation .
+    - name: run regressions
+      run: make SIM=${{ matrix.sim }} TOPLEVEL_LANG=${{ matrix.lang }}
+      continue-on-error: ${{matrix.may_fail || false}}


### PR DESCRIPTION
Test cocotb using MINGW64 packages and shell to ensure it builds and runs in that environment. Pinging @umarcor. I took what you wrote in your fork, touched it up, and added the ability to fail.

Also, forgot to remove the `may_fail` tag in #2604.