### PR TITLE
Simplify and expand env var passthrough for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,12 +25,13 @@ setenv =
 passenv =
     SIM
     TOPLEVEL_LANG
-    ALDEC_LICENSE_FILE
-    SYNOPSYS_LICENSE_FILE
-    MGLS_LICENSE_FILE
-    LM_LICENSE_FILE
     # allow tuning of matrix_multiplier test length
     NUM_SAMPLES
+    # License server configuration for proprietary simulators, e.g.
+    # LM_LICENSE_FILE.
+    *_LICENSE_FILE
+    # Mentor-related environment variables, to be passed through to the tool.
+    MTI_*
 
 deps =
     coverage


### PR DESCRIPTION
* Instead of individually listing all possible vendor license daemon
  environment variables, simply pass through all environment variables
  that are typically used with a glob pattern.
* Pass through `MTI_*` environment variables, which are used by
  Quest/ModelSim, e.g. to choose between a 64 or 32 bit installation.
  Again, instead of choosing individual variables, simply pass through all
  of them to avoid playing whack-a-mole.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->