### PR TITLE
Add VHDL library support to Xcelium

### DIFF
--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -57,7 +57,7 @@ SIM                       Selects which simulator Makefile to use
 WAVES                     Enable wave traces dump for Riviera-PRO and Questa
 VERILOG_SOURCES           A list of the Verilog source files to include
 VHDL_SOURCES              A list of the VHDL source files to include
-VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/ModelSim/Questa only)
+VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/ModelSim/Questa/Xcelium only)
 COMPILE_ARGS              Arguments to pass to compile stage of simulation
 SIM_ARGS                  Arguments to pass to execution of compiled simulation
 EXTRA_ARGS                Arguments for compile and execute phases

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -103,13 +103,21 @@ else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
+# Returns arguments to compile single VHDL library
+define add_lib
+	-makelib $(SOURCES_VAR:VHDL_SOURCES_%=%) $($(SOURCES_VAR)) -endlib
+endef
+
+# Builds a list of arguments to support VHDL libraries specified in VHDL_SOURCES_*:
+LIBS := $(foreach SOURCES_VAR, $(filter VHDL_SOURCES_%, $(.VARIABLES)),$(add_lib))
+
 $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)
 	-@rm -f $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(CMD) -timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) $(GPI_ARGS) $(INCDIRS) -access +rwc -createdebugdb $(MAKE_LIB) $(HDL_SOURCES) $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
+	$(EXTRA_ARGS) $(GPI_ARGS) $(INCDIRS) -access +rwc -createdebugdb $(LIBS) $(MAKE_LIB) $(HDL_SOURCES) $(PLUSARGS) 2>&1 | tee $(SIM_BUILD)/sim.log
 
 	$(call check_for_results_file)
 

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -261,7 +261,7 @@ The following variables are makefile variables, not environment variables.
 
 .. make:var:: VHDL_SOURCES_<lib>
 
-      A list of the VHDL source files to include in the VHDL library *lib* (currently for GHDL/ModelSim/Questa only).
+      A list of the VHDL source files to include in the VHDL library *lib* (currently for GHDL/ModelSim/Questa/Xcelium only).
 
 .. make:var:: COMPILE_ARGS
 

--- a/documentation/source/newsfragments/2614.feature.rst
+++ b/documentation/source/newsfragments/2614.feature.rst
@@ -1,0 +1,1 @@
+Xcelium now supports compilation into a named VHDL library ``lib`` using ``VHDL_SOURCES_<lib>``.

--- a/tests/test_cases/test_vhdl_libraries/Makefile
+++ b/tests/test_cases/test_vhdl_libraries/Makefile
@@ -5,13 +5,17 @@ VHDL_SOURCES := a.vhdl
 TOPLEVEL := a
 MODULE := test_ab
 
+ifneq ($(filter $(SIM),xcelium),)
+    COMPILE_ARGS += -v93
+endif
+
 ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),vhdl)
 all:
 	@echo "Skipping test since only VHDL is supported"
 clean::
-else ifeq ($(filter ghdl questa modelsim,$(shell echo $(SIM) | tr A-Z a-z)),)
+else ifeq ($(filter ghdl questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
 all:
-	@echo "Skipping test since only GHDL and Questa/Modelsim is supported"
+	@echo "Skipping test since only GHDL, Questa/ModelSim and Xcelium are supported"
 clean::
 else
 include $(shell cocotb-config --makefiles)/Makefile.sim


### PR DESCRIPTION
For GHDL/ModelSim/Questa users can specify:

```
VHDL_SOURCES_a = [..]
```

To compile a bunch of VHDL files into a library called `a`. This PR adds support for this feature for Xcelium.