### PR TITLE
Revert "Change generated names of TestFactory tests"

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -637,9 +637,6 @@ class TestFactory:
 
     .. versionchanged:: 1.5
         Groups of options are now supported
-
-    .. versionchanged:: 2.0
-        Options are listed in test names instead of a counter
     """
 
     # Prevent warnings from collection of TestFactories by unit testing frameworks.
@@ -711,6 +708,9 @@ class TestFactory:
                 product(*d.values())
         ):
 
+            name = "%s%s%s_%03d" % (prefix, self.name, postfix, index + 1)
+            doc = "Automatically generated test\n\n"
+
             # preprocess testoptions to split tuples
             testoptions_split = {}
             for optname, optvalue in testoptions.items():
@@ -722,8 +722,6 @@ class TestFactory:
                     for n, v in zip(optname, optvalue):
                         testoptions_split[n] = v
 
-            doc = "Automatically generated test\n\n"
-
             for optname, optvalue in testoptions_split.items():
                 if callable(optvalue):
                     if not optvalue.__doc__:
@@ -734,19 +732,15 @@ class TestFactory:
                 else:
                     doc += "\t{}: {}\n".format(optname, repr(optvalue))
 
+            self.log.debug("Adding generated test \"%s\" to module \"%s\"" %
+                           (name, mod.__name__))
             kwargs = {}
             kwargs.update(self.kwargs_constant)
             kwargs.update(testoptions_split)
-
-            options_str = ",".join(f"{optname}={optvalue!r}" for optname, optvalue in kwargs.items())
-            name = f"{prefix}{self.name}{postfix}({options_str})"
-
             if hasattr(mod, name):
                 self.log.error("Overwriting %s in module %s. "
                                "This causes a previously defined testcase "
                                "not to be run. Consider setting/changing "
-                               "the postfix option" % (name, mod))
-
-            self.log.debug(f"Adding generated test {name!r} to module {mod.__name__!r}")
+                               "name_postfix" % (name, mod))
             setattr(mod, name, _create_test(self.test_function, name, doc, mod,
                                             *self.args, **kwargs))

--- a/documentation/source/newsfragments/2548.change.rst
+++ b/documentation/source/newsfragments/2548.change.rst
@@ -1,1 +1,0 @@
-Change the generated test name of :class:`TestFactory`\ -generated tests to include options used for that test.


### PR DESCRIPTION
Reverts cocotb/cocotb#2566. Reopens #2548.

Specifying `TESTCASE` for some generated tests is difficult to impossible.
* The use of commas in the generated test names overlaps with the use of commas in `TESTCASE` to split into several tests
* Quotation for strings must be escaped and is a pain in the ass to do correctly on the commandline
* use of values with `__repr__`s that can't be `eval`ed makes it impossible to specify those tests (e.g. it appears as `<A object at 0x7f06a566ce20>`)