### PR TITLE
Make COCOTB_REDUCED_LOG_FMT enabled by default

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -40,10 +40,10 @@ from cocotb.utils import (
 
 import cocotb.ANSI as ANSI
 
-if "COCOTB_REDUCED_LOG_FMT" in os.environ:
-    _suppress = True
-else:
-    _suppress = False
+try:
+    _suppress = int(os.environ.get("COCOTB_REDUCED_LOG_FMT", "1"))
+except ValueError:
+    _suppress = 1
 
 # Column alignment
 _LEVEL_CHARS    = len("CRITICAL")  # noqa

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -91,8 +91,10 @@ Cocotb
 
 .. envvar:: COCOTB_REDUCED_LOG_FMT
 
-    If defined, log lines displayed in the terminal will be shorter. It will print only
-    time, message type (``INFO``, ``WARNING``, ``ERROR``, ...) and the log message itself.
+    Defaults internally to ``1``.
+    If the value is ``1``, log lines displayed in the terminal will be shorter.
+    It will print only time, message type (``INFO``, ``WARNING``, ``ERROR``, ...) and the log message itself.
+    Set to ``0`` if you wish to have the full format message.
 
 .. envvar:: COCOTB_ATTACH
 

--- a/documentation/source/newsfragments/2564.change.rst
+++ b/documentation/source/newsfragments/2564.change.rst
@@ -1,1 +1,1 @@
-Make :envvar:`COCOTB_REDUCED_LOG_FMT` enabled by default.
+Shorter log lines (configurable with :envvar:`COCOTB_REDUCED_LOG_FMT`) are now the default. For wider log output, similar to previous cocotb releases, set the :envvar:`COCOTB_REDUCED_LOG_FMT` environment variable to ``0``.

--- a/documentation/source/newsfragments/2564.change.rst
+++ b/documentation/source/newsfragments/2564.change.rst
@@ -1,0 +1,1 @@
+Make :envvar:`COCOTB_REDUCED_LOG_FMT` enabled by default.


### PR DESCRIPTION
xref #2564. Turns `COCOTB_REDUCED_LOG_FMT` from an existential flag into a boolean option. The option defaults to `1`, so the reduced format is the new standard format, and the old full format can be selected by setting the variable to `0`.