### PR TITLE
Bump codecov after-n-builds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,4 +17,4 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 9
+        after_n_builds: 12


### PR DESCRIPTION
We have 8 GHA tests that produce coverage info (discounting the mingw-w64 env tests, and the Clang and Mac OS tests) and now 4 Pipelines tests that produce coverage.