### PR TITLE
Typing fixes

### DIFF
--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -257,14 +257,12 @@ def test_bit_invert():
 
 
 def test_logic_identity():
-    assert Logic._0 is Logic(False)
-    assert Logic._1 is Logic(1)
-    assert Logic("X") is Logic.X
-    assert Logic.Z is Logic("Z")
+    assert Logic(0) is Logic(False)
+    assert Logic("1") is Logic(1)
+    assert Logic("X") is Logic("x")
+    assert Logic("z") is Logic("Z")
 
 
 def test_bit_identity():
-    assert Bit._0 is Bit(False)
-    assert Bit(Logic(1)) is Bit._1
-    with pytest.raises(AttributeError):
-        Bit.X
+    assert Bit(0) is Bit(False)
+    assert Bit(Logic(1)) is Bit("1")

--- a/tests/pytest/test_range.py
+++ b/tests/pytest/test_range.py
@@ -65,6 +65,15 @@ def test_null_range():
     assert r.count(4) == 0
 
 
+def test_bad_arguments():
+    with pytest.raises(TypeError):
+        Range(1, "to")  # nowhere ...
+    with pytest.raises(TypeError):
+        Range("1", "to", 5)
+    with pytest.raises(ValueError):
+        Range(1, "BAD DIRECTION", 3)
+
+
 def test_equality():
     assert Range(7, 'downto', -7) == Range(7, 'downto', -7)
     assert Range(7, 'downto', -7) != Range(0, 'to', 8)
@@ -121,8 +130,3 @@ def test_bad_step():
 def test_bad_getitem():
     with pytest.raises(TypeError):
         Range(10, 'downto', 4)["8"]
-
-
-def test_range_index_bpo43836():
-    with pytest.raises(RuntimeError):
-        Range(10, 0).index(7, start=4, stop=10)


### PR DESCRIPTION
Fixes and improvements to `Logic`, `Bit`, and `Range` for type correctness and expressiveness. This has no effect on #2514, so feel free to take it or leave it.

* type correctness in `Logic`, `Bit`, and `Range`
* easier to create subtypes of `Logic`
* `Range.index` now supports `start` and `stop` arguments by using the `Sequence.index` ABC implementation.
* Had to remove `Logic` and `Bit` attribute literals (like `Logic._0`) because typing on the properties was extremely difficult.