### PR TITLE
Add coverage exclusions 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,4 @@ omit =
 exclude_lines =
     pragma: no cover
     \.\.\.
+    raise\s+NotImplementedError

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,9 @@ testpaths =
 omit =
     cocotb/config.py
     cocotb/_vendor/*
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    pass
+    \.\.\.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,4 @@ omit =
 [coverage:report]
 exclude_lines =
     pragma: no cover
-    pass
     \.\.\.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,5 @@ omit =
 [coverage:report]
 exclude_lines =
     pragma: no cover
-    \.\.\.
-    raise\s+NotImplementedError
+    \.\.\.                          # for excluding typing stubs
+    raise\s+NotImplementedError     # for excluding abstractmethods


### PR DESCRIPTION
Just for `pass` and `...` statements right now. But that could extend so we have less `# pragma: no cover` comments strewn about.