### PR TITLE
Now with QueueFull and QueueEmpty exceptions and peek functions in Queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ __pycache__
 
 # VSCode project files
 .vscode/
+*.code-workspace
+
 
 # Emacs tmp files
 \#*\#
@@ -105,3 +107,4 @@ examples/*/tests/compile
 # Tachyon DA CVC
 tests/test_cases/*/verilog.log
 examples/*/tests/verilog.log
+

--- a/tests/test_cases/test_cocotb/test_queues.py
+++ b/tests/test_cases/test_cocotb/test_queues.py
@@ -5,6 +5,7 @@
 Tests relating to cocotb.queue.Queue, cocotb.queue.LifoQueue, cocotb.queue.PriorityQueue
 """
 import cocotb
+from cocotb.clock import Clock
 from cocotb.queue import Queue, PriorityQueue, LifoQueue, QueueFull, QueueEmpty
 from cocotb.regression import TestFactory
 from cocotb.triggers import Combine
@@ -22,12 +23,18 @@ async def run_queue_nonblocking_test(dut, queue_type):
     assert q.empty()
     assert not q.full()
 
+    with pytest.raises(QueueEmpty):
+        xx = q.peek_nowait()
     # put one item
     q.put_nowait(0)
+
+    zero = q.peek_nowait()
+    assert zero == 0
 
     assert q.qsize() == 1
     assert not q.empty()
     assert not q.full()
+
 
     # fill queue
     if queue_type is PriorityQueue:
@@ -180,10 +187,13 @@ async def run_queue_blocking_test(dut, queue_type):
         lst.append(item)
 
     async def getter(lst, num):
+        item = await q.peek()
+        assert ref_q.peek_nowait() == item
         item = await q.get()
         assert ref_q.get_nowait() == item
         lst.append(num)
 
+    
     coro_list = []
     putter_list = []
     getter_list = []
@@ -256,3 +266,5 @@ async def test_str_and_repr(_):
     s = repr(q)
     assert "_getters" not in s
     assert str(q)[:-1] in s
+
+


### PR DESCRIPTION
This pull request contains two minor enhancements to queues:
#2626 
* It adds a peek function to the queue both the coroutine `peek()` and function `peek_nowait()`
* It rolls tests for peek into existing tests

#2628 
Now extends asyncio.queues.QueueFull and asyncio.queues.QueueEmpty to create cocotb.queue versions
