### PR TITLE
Python based runner

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -166,7 +166,7 @@ class Simulator(abc.ABC):
         # list.
         self.python_search = list(python_search)
         self.sim_toplevel = toplevel
-        self.toplevel_lang = self.check_toplevel_lang(toplevel)
+        self.toplevel_lang = self.check_toplevel_lang(toplevel_lang)
         self.sim_args = list(extra_args)
         self.plus_args = list(plus_args)
         self.env = dict(extra_env)

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -1,0 +1,696 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import subprocess
+import os
+import sys
+import tempfile
+import re
+import shutil
+import warnings
+from xml.etree import cElementTree as ET
+import threading
+import signal
+import cocotb.config
+import sysconfig
+from distutils.spawn import find_executable
+
+warnings.warn(
+    "Python runners and associated APIs are an experimental feature and subject to change.", UserWarning, stacklevel=2
+)
+
+_magic_re = re.compile(r"([\\{}])")
+_space_re = re.compile(r"([\s])", re.ASCII)
+
+
+def as_tcl_value(value):
+    # add '\' before special characters and spaces
+    value = _magic_re.sub(r"\\\1", value)
+    value = value.replace("\n", r"\n")
+    value = _space_re.sub(r"\\\1", value)
+    if value[0] == '"':
+        value = "\\" + value
+
+    return value
+
+
+class Simulator(object):
+    def __init__(self):
+
+        self.check_simulator()
+
+        self.env = {}
+
+        # Catch SIGINT and SIGTERM
+        self.old_sigint_h = signal.getsignal(signal.SIGINT)
+        self.old_sigterm_h = signal.getsignal(signal.SIGTERM)
+
+        # works only if main thread
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, self.exit_gracefully)
+            signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+        self.process = None
+
+    @staticmethod
+    def check_simulator():
+        raise NotImplementedError()
+
+    def init_dir(self, build_dir, work_dir):
+
+        if build_dir is not None:
+            self.build_dir = os.path.abspath(build_dir)
+
+        self.work_dir = self.build_dir
+
+        if work_dir is not None:
+            absworkdir = os.path.abspath(work_dir)
+            if os.path.isdir(absworkdir):
+                self.work_dir = absworkdir
+
+    def set_env(self):
+
+        for e in os.environ:
+            self.env[e] = os.environ[e]
+
+        if "LIBPYTHON_LOC" not in self.env:
+            self.env["LIBPYTHON_LOC"] = cocotb._vendor.find_libpython.find_libpython()
+
+        self.env["PATH"] += os.pathsep + cocotb.config.libs_dir
+
+        self.env["PYTHONPATH"] = os.pathsep.join(sys.path)
+        for path in self.python_search:
+            self.env["PYTHONPATH"] += os.pathsep + path
+
+        self.env["PYTHONHOME"] = sysconfig.get_config_var("prefix")
+
+        self.env["TOPLEVEL"] = self.hdl_topmodule
+        self.env["MODULE"] = self.module
+
+        if not os.path.exists(self.build_dir):
+            os.makedirs(self.build_dir)
+
+    def build_command(self):
+        raise NotImplementedError()
+
+    def test_command(self):
+        raise NotImplementedError()
+
+    def build(
+        self,
+        library_name="work",
+        verilog_sources=[],
+        vhdl_sources=[],
+        includes=[],
+        defines=[],
+        parameters={},
+        extra_args=[],
+        hdl_topmodule=None,
+        always=False,
+        build_dir="sim_build",
+        work_dir=None,
+    ):
+        self.init_dir(build_dir, work_dir)
+        os.makedirs(self.build_dir, exist_ok=True)
+
+        # note: to avoid mutating argument defaults, we ensure that no value
+        # is written without a copy. This is much more concise and leads to
+        # a better docstring than using `None` as a default in the parameters
+        # list.
+        self.library_name = library_name
+        self.verilog_sources = self.get_abs_paths(verilog_sources)
+        self.vhdl_sources = self.get_abs_paths(vhdl_sources)
+        self.includes = self.get_abs_paths(includes)
+        self.defines = list(defines)
+        self.parameters = dict(parameters)
+        self.compile_args = extra_args
+        self.always = always
+        self.hdl_topmodule = hdl_topmodule
+
+        for e in os.environ:
+            self.env[e] = os.environ[e]
+
+        cmds = self.build_command()
+        self.execute(cmds)
+
+    def test(
+        self,
+        py_module,
+        hdl_topmodule,
+        toplevel_lang="verilog",
+        testcase=None,
+        seed=None,
+        python_search=[],
+        extra_args=[],
+        plus_args=[],
+        extra_env=None,
+        waves=None,
+        gui=None,
+        build_dir=None,
+        work_dir=None,
+    ):
+
+        self.init_dir(build_dir, work_dir)
+
+        if isinstance(py_module, str):
+            self.module = py_module
+        else:
+            self.module = ",".join(py_module)
+
+        # note: to avoid mutating argument defaults, we ensure that no value
+        # is written without a copy. This is much more concise and leads to
+        # a better docstring than using `None` as a default in the parameters
+        # list.
+        self.python_search = list(python_search)
+        self.hdl_topmodule = hdl_topmodule
+        self.toplevel_lang = toplevel_lang
+        self.sim_args = extra_args
+        self.plus_args = list(plus_args)
+        self.env = dict(extra_env) if extra_env is not None else {}
+
+        if testcase is not None:
+            self.env["TESTCASE"] = testcase
+
+        if seed is not None:
+            self.env["RANDOM_SEED"] = str(seed)
+
+        if waves is None:
+            self.waves = bool(int(os.getenv("WAVES", 0)))
+        else:
+            self.waves = bool(waves)
+
+        if gui is None:
+            self.gui = bool(int(os.getenv("GUI", 0)))
+        else:
+            self.gui = bool(gui)
+
+        results_xml_file = os.getenv("COCOTB_RESULTS_FILE", os.path.join(self.build_dir, "results.xml"))
+
+        try:
+            os.remove(results_xml_file)
+        except OSError:
+            pass
+
+        cmds = self.test_command()
+        self.set_env()
+        self.execute(cmds)
+
+        self.check_results_file(results_xml_file)
+
+        print("INFO: Results file: %s" % results_xml_file)
+        return results_xml_file
+
+    @staticmethod
+    def check_results_file(results_xml_file):
+
+        __tracebackhide__ = True  # Hide the traceback when using PyTest.
+
+        results_file_exist = os.path.isfile(results_xml_file)
+        if not results_file_exist:
+            raise SystemExit("ERROR: Simulation terminated abnormally. Results file not found.")
+
+        failed = 0
+
+        tree = ET.parse(results_xml_file)
+        for ts in tree.iter("testsuite"):
+            for tc in ts.iter("testcase"):
+                for _ in tc.iter("failure"):
+                    failed += 1
+
+        if failed:
+            raise SystemExit("ERROR: Failed %d tests." % failed)
+
+    @staticmethod
+    def get_include_commands(includes):
+        raise NotImplementedError()
+
+    @staticmethod
+    def get_define_commands(defines):
+        raise NotImplementedError()
+
+    def get_parameter_commands(self, parameters):
+        raise NotImplementedError()
+
+    @staticmethod
+    def get_abs_paths(paths):
+        paths_abs = []
+        for path in paths:
+            if os.path.isabs(path):
+                paths_abs.append(os.path.abspath(path))
+            else:
+                paths_abs.append(os.path.abspath(os.path.join(os.getcwd(), path)))
+
+        return paths_abs
+
+    def execute(self, cmds):
+
+        __tracebackhide__ = True  # Hide the traceback when using PyTest.
+
+        for cmd in cmds:
+            print("INFO: Running command: " + ' "'.join(cmd) + '" in directory:"' + self.work_dir + '"')
+
+            # TODO: create at thread to handle stderr and log as error?
+            # TODO: log forwarding
+
+            self.process = subprocess.run(cmd, cwd=self.work_dir, env=self.env)
+
+            if self.process.returncode != 0:
+                raise SystemExit(
+                    "Process '%s' termindated with error %d" % (self.process.args[0], self.process.returncode)
+                )
+
+            self.process = None
+
+    @staticmethod
+    def outdated(output, dependencies):
+
+        if not os.path.isfile(output):
+            return True
+
+        output_mtime = os.path.getmtime(output)
+
+        dep_mtime = 0
+        for file in dependencies:
+            mtime = os.path.getmtime(file)
+            if mtime > dep_mtime:
+                dep_mtime = mtime
+
+        if dep_mtime > output_mtime:
+            return True
+
+        return False
+
+    def exit_gracefully(self, signum, frame):
+        pid = None
+        if self.process is not None:
+            pid = self.process.pid
+            self.process.stdout.flush()
+            self.process.kill()
+            self.process.wait()
+        # Restore previous handlers
+        signal.signal(signal.SIGINT, self.old_sigint_h)
+        signal.signal(signal.SIGTERM, self.old_sigterm_h)
+        raise SystemExit("Exiting pid: {} with signum: {}".format(str(pid), str(signum)))
+
+
+class Icarus(Simulator):
+    def __init__(self, *argv, **kwargs):
+        super().__init__(*argv, **kwargs)
+
+    @staticmethod
+    def check_simulator():
+        if find_executable("iverilog") is None:
+            raise SystemExit("ERROR: iverilog exacutable not found!")
+
+    @staticmethod
+    def get_include_commands(includes):
+        return ["-I" + dir for dir in includes]
+
+    @staticmethod
+    def get_define_commands(defines):
+        return ["-D" + define for define in defines]
+
+    def get_parameter_commands(self, parameters):
+        return [
+            "-P" + self.hdl_topmodule + "." + name + "=" + str(value) for name, value in parameters.items()
+        ]
+
+    def test_command(self):
+
+        return [
+            [
+                "vvp",
+                "-M",
+                cocotb.config.libs_dir,
+                "-m",
+                cocotb.config.lib_name("vpi", "icarus"),
+            ]
+            + self.sim_args
+            + [self.sim_file]
+            + self.plus_args
+        ]
+
+    def build_command(self):
+
+        if self.vhdl_sources:
+            raise ValueError("This simulator does not support VHDL")
+
+        self.sim_file = os.path.join(self.build_dir, self.library_name + ".vvp")
+
+        cmd = []
+        if self.outdated(self.sim_file, self.verilog_sources) or self.always:
+
+            cmd = [
+                ["iverilog", "-o", self.sim_file, "-D", "COCOTB_SIM=1", "-g2012"]
+                + self.get_define_commands(self.defines)
+                + self.get_include_commands(self.includes)
+                + self.get_parameter_commands(self.parameters)
+                + self.compile_args
+                + self.verilog_sources
+            ]
+
+        else:
+            print("WARNING: Skipping compilation:" + self.sim_file)
+
+        return cmd
+
+
+class Questa(Simulator):
+    @staticmethod
+    def check_simulator():
+        if find_executable("vsim") is None:
+            raise SystemExit("ERROR: vsim exacutable not found!")
+
+    @staticmethod
+    def get_include_commands(includes):
+        return ["+incdir+" + as_tcl_value(dir) for dir in includes]
+
+    @staticmethod
+    def get_define_commands(defines):
+        return ["+define+" + as_tcl_value(define) for define in defines]
+
+    def get_parameter_commands(self, parameters):
+        return ["-g" + name + "=" + str(value) for name, value in parameters.items()]
+
+    def build_command(self):
+
+        cmd = []
+
+        if self.vhdl_sources:
+            cmd.append(["vlib", as_tcl_value(self.library_name)])
+            cmd.append(
+                ["vcom", "-mixedsvvh"]
+                + ["-work", as_tcl_value(self.library_name)]
+                + [as_tcl_value(v) for v in self.compile_args]
+                + [as_tcl_value(v) for v in self.vhdl_sources]
+            )
+
+        if self.verilog_sources:
+            cmd.append(["vlib", as_tcl_value(self.library_name)])
+            cmd.append(
+                ["vlog", "-mixedsvvh"]
+                + ([] if self.always else ["-incr"])
+                + ["-work", as_tcl_value(self.library_name)]
+                + ["+define+COCOTB_SIM"]
+                + ["-sv"]
+                + self.get_define_commands(self.defines)
+                + self.get_include_commands(self.includes)
+                + [as_tcl_value(v) for v in self.compile_args]
+                + [as_tcl_value(v) for v in self.verilog_sources]
+            )
+
+        return cmd
+
+    def test_command(self):
+
+        cmd = []
+
+        do_script = ""
+        if self.waves:
+            do_script += "log -recursive /*;"
+
+        if not self.gui:
+            do_script += "run -all; quit"
+
+        if self.toplevel_lang == "vhdl":
+            cmd.append(
+                ["vsim"]
+                + ["-gui" if self.gui else "-c"]
+                + ["-onfinish", "stop" if self.gui else "exit"]
+                + ["-foreign", "cocotb_init " + as_tcl_value(cocotb.config.lib_name_path("fli", "questa"))]
+                + [as_tcl_value(v) for v in self.sim_args]
+                + [as_tcl_value(v) for v in self.get_parameter_commands(self.parameters)]
+                + [as_tcl_value(self.hdl_topmodule)]
+                + ["-do", do_script]
+            )
+
+            if self.verilog_sources:
+                self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("vpi", "questa") + ":cocotbvpi_entry_point"
+
+        else:
+            cmd.append(
+                ["vsim"]
+                + ["-gui" if self.gui else "-c"]
+                + ["-onfinish", "stop" if self.gui else "exit"]
+                + ["-pli", as_tcl_value(cocotb.config.lib_name_path("vpi", "questa"))]
+                + [as_tcl_value(v) for v in self.sim_args]
+                + [as_tcl_value(v) for v in self.get_parameter_commands(self.parameters)]
+                + [as_tcl_value(self.hdl_topmodule)]
+                + [as_tcl_value(v) for v in self.plus_args]
+                + ["-do", do_script]
+            )
+
+            if self.vhdl_sources:
+                self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("fli", "questa") + ":cocotbfli_entry_point"
+
+        return cmd
+
+
+class Ghdl(Simulator):
+    @staticmethod
+    def check_simulator():
+        if find_executable("ghdl") is None:
+            raise SystemExit("ERROR: ghdl exacutable not found!")
+
+    @staticmethod
+    def get_include_commands(includes):
+        include_cmd = []
+        for dir in includes:
+            include_cmd.append("-I")
+            include_cmd.append(dir)
+
+        return include_cmd
+
+    @staticmethod
+    def get_define_commands(defines):
+        defines_cmd = []
+        for define in defines:
+            defines_cmd.append("-D")
+            defines_cmd.append(define)
+
+    def get_parameter_commands(self, parameters):
+        return ["-g" + name + "=" + str(value) for name, value in parameters.items()]
+
+    def build_command(self):
+
+        if self.verilog_sources:
+            raise ValueError("This simulator does not support Verilog")
+
+        return [
+            ["ghdl", "-i"] + ["--work=%s" % self.library_name] + self.compile_args + [source_file]
+            for source_file in self.vhdl_sources
+        ]
+
+    def test_command(self):
+
+        cmd_elaborate = ["ghdl", "-m"] + ["--work=%s" % self.library_name] + self.compile_args + [self.hdl_topmodule]
+
+        cmd = [cmd_elaborate]
+        cmd_run = (
+            ["ghdl", "-r"]
+            + self.compile_args
+            + [self.hdl_topmodule]
+            + ["--vpi=" + cocotb.config.lib_name_path("vpi", "ghdl")]
+            + self.sim_args
+            + self.get_parameter_commands(self.parameters)
+        )
+
+        cmd.append(cmd_run)
+
+        return cmd
+
+
+class Riviera(Simulator):
+    @staticmethod
+    def check_simulator():
+        if find_executable("vsimsa") is None:
+            raise SystemExit("ERROR: vsimsa exacutable not found!")
+
+    @staticmethod
+    def get_include_commands(includes):
+        return ["+incdir+" + as_tcl_value(dir) for dir in includes]
+
+    @staticmethod
+    def get_define_commands(defines):
+        return ["+define+" + as_tcl_value(define) for define in defines]
+
+    def get_parameter_commands(self, parameters):
+        return ["-g" + name + "=" + str(value) for name, value in parameters.items()]
+
+    def build_command(self):
+
+        do_script = "\nonerror {\n quit -code 1 \n} \n"
+
+        out_file = os.path.join(self.build_dir, self.library_name, self.library_name + ".lib")
+
+        if self.outdated(out_file, self.verilog_sources + self.vhdl_sources) or self.always:
+
+            do_script += "alib {RTL_LIBRARY} \n".format(RTL_LIBRARY=as_tcl_value(self.library_name))
+
+            if self.vhdl_sources:
+                do_script += "acom -work {RTL_LIBRARY} {EXTRA_ARGS} {VHDL_SOURCES}\n".format(
+                    RTL_LIBRARY=as_tcl_value(self.library_name),
+                    VHDL_SOURCES=" ".join(as_tcl_value(v) for v in self.vhdl_sources),
+                    EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
+                )
+
+            if self.verilog_sources:
+                do_script += "alog -work {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
+                    RTL_LIBRARY=as_tcl_value(self.library_name),
+                    VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in self.verilog_sources),
+                    DEFINES=" ".join(self.get_define_commands(self.defines)),
+                    INCDIR=" ".join(self.get_include_commands(self.includes)),
+                    EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
+                )
+        else:
+            print("WARNING: Skipping compilation:" + out_file)
+
+        do_file = tempfile.NamedTemporaryFile(delete=False)
+        do_file.write(do_script.encode())
+        do_file.close()
+
+        return [["vsimsa"] + ["-do"] + ["do"] + [do_file.name]]
+
+    def test_command(self):
+
+        do_script = "\nonerror {\n quit -code 1 \n} \n"
+
+        if self.toplevel_lang == "vhdl":
+            do_script += "asim +access +w -interceptcoutput -O2 -loadvhpi {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} \n".format(
+                TOPLEVEL=as_tcl_value(self.hdl_topmodule),
+                EXT_NAME=as_tcl_value(cocotb.config.lib_name_path("vhpi", "riviera")),
+                EXTRA_ARGS=" ".join(
+                    as_tcl_value(v) for v in (self.sim_args + self.get_parameter_commands(self.parameters))
+                ),
+            )
+            if self.verilog_sources:
+                self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("vpi", "riviera") + "cocotbvpi_entry_point"
+        else:
+            do_script += (
+                "asim +access +w -interceptcoutput -O2 -pli {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUS_ARGS} \n".format(
+                    TOPLEVEL=as_tcl_value(self.hdl_topmodule),
+                    EXT_NAME=as_tcl_value(cocotb.config.lib_name_path("vpi", "riviera")),
+                    EXTRA_ARGS=" ".join(
+                        as_tcl_value(v) for v in (self.sim_args + self.get_parameter_commands(self.parameters))
+                    ),
+                    PLUS_ARGS=" ".join(as_tcl_value(v) for v in self.plus_args),
+                )
+            )
+            if self.vhdl_sources:
+                self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("vhpi", "riviera") + ":cocotbvhpi_entry_point"
+
+        if self.waves:
+            do_script += "log -recursive /*;"
+
+        do_script += "run -all \nexit"
+
+        do_file = tempfile.NamedTemporaryFile(delete=False)
+        do_file.write(do_script.encode())
+        do_file.close()
+
+        return [["vsimsa"] + ["-do"] + ["do"] + [do_file.name]]
+
+
+class Verilator(Simulator):
+    def __init__(self, *argv, **kwargs):
+        super().__init__(*argv, **kwargs)
+
+    @staticmethod
+    def check_simulator():
+        if find_executable("verilator") is None:
+            raise SystemExit("ERROR: verilator exacutable not found!")
+
+    @staticmethod
+    def get_include_commands(includes):
+        return ["-I" + dir for dir in includes]
+
+    @staticmethod
+    def get_define_commands(defines):
+        return ["-D" + define for define in defines]
+
+    def get_parameter_commands(self, parameters):
+        return ["-G" + name + "=" + str(value) for name, value in parameters.items()]
+
+    def build_command(self):
+
+        if self.vhdl_sources:
+            raise ValueError("This simulator does not support VHDL")
+
+        if self.hdl_topmodule is None:
+            raise ValueError("This simulator requires hdl_topmodule parameter to be specified")
+
+        cmd = []
+
+        verilator_cpp = os.path.join(os.path.dirname(cocotb.__file__), "share", "lib", "verilator", "verilator.cpp")
+
+        verilator_exec = find_executable("verilator")
+
+        cmd.append(
+            [
+                "perl",
+                verilator_exec,
+                "-cc",
+                "--exe",
+                "-Mdir",
+                self.build_dir,
+                "-DCOCOTB_SIM=1",
+                "--top-module",
+                self.hdl_topmodule,
+                "--vpi",
+                "--public-flat-rw",
+                "--prefix",
+                "Vtop",
+                "-o",
+                self.hdl_topmodule,
+                "-LDFLAGS",
+                "-Wl,-rpath,{LIB_DIR} -L{LIB_DIR} -lcocotbvpi_verilator".format(LIB_DIR=cocotb.config.libs_dir),
+            ]
+            + self.compile_args
+            + self.get_define_commands(self.defines)
+            + self.get_include_commands(self.includes)
+            + self.get_parameter_commands(self.parameters)
+            + [verilator_cpp]
+            + self.verilog_sources
+        )
+
+        cmd.append(["make", "-C", self.build_dir, "-f", "Vtop.mk"])
+
+        return cmd
+
+    def test_command(self):
+        out_file = os.path.join(self.build_dir, self.hdl_topmodule)
+        return [[out_file] + self.plus_args]
+
+
+def get_runner(simulator_name):
+
+    sim_name = simulator_name.lower()
+    supported_sims = {
+        "icarus": Icarus,
+        "questa": Questa,
+        "ghdl": Ghdl,
+        "riviera": Riviera,
+        "verilator": Verilator,
+    }  # TODO: "ius", "xcelium", "vcs"
+    try:
+        return supported_sims[sim_name]
+    except KeyError:
+        raise NotImplementedError("Set SIM variable. Supported: " + ", ".join(supported_sims)) from None
+
+
+def clean(recursive=False):
+    dir = os.getcwd()
+
+    def rm_clean():
+        build_dir = os.path.join(dir, "sim_build")
+        if os.path.isdir(build_dir):
+            print("INFO: Removing:", build_dir)
+            shutil.rmtree(build_dir, ignore_errors=True)
+
+    rm_clean()
+
+    if recursive:
+        for dir, _, _ in os.walk(dir):
+            rm_clean()

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -302,8 +302,8 @@ class Icarus(Simulator):
 
     @staticmethod
     def check_toplevel_lang(toplevel_lang: Optional[str]) -> str:
-        if toplevel_lang == "verilog":
-            return toplevel_lang
+        if toplevel_lang is None or toplevel_lang == "verilog":
+            return "verilog"
         else:
             raise ValueError(
                 f"iverilog does not support {toplevel_lang!r} as a toplevel_lang"
@@ -494,8 +494,8 @@ class Ghdl(Simulator):
             raise SystemExit("ERROR: ghdl exacutable not found!")
 
     def check_toplevel_lang(self, toplevel_lang: Optional[str]) -> str:
-        if toplevel_lang == "vhdl":
-            return toplevel_lang
+        if toplevel_lang is None or toplevel_lang == "vhdl":
+            return "vhdl"
         else:
             raise ValueError(
                 f"GHDL does not support {toplevel_lang!r} as a toplevel_lang"
@@ -688,8 +688,8 @@ class Verilator(Simulator):
 
     @staticmethod
     def check_toplevel_lang(toplevel_lang: Optional[str]) -> str:
-        if toplevel_lang == "verilog":
-            return toplevel_lang
+        if toplevel_lang is None or toplevel_lang == "verilog":
+            return "verilog"
         else:
             raise ValueError(
                 f"Verilator does not support {toplevel_lang!r} as a toplevel_lang"

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -174,12 +174,12 @@ class Simulator(abc.ABC):
             self.env["RANDOM_SEED"] = str(seed)
 
         if waves is None:
-            self.waves = bool(int(os.getenv("WAVES", 0)))
+            self.waves = bool(int(os.getenv("COCOTB_WAVES", 0)))
         else:
             self.waves = bool(waves)
 
         if gui is None:
-            self.gui = bool(int(os.getenv("GUI", 0)))
+            self.gui = bool(int(os.getenv("COCOTB_GUI", 0)))
         else:
             self.gui = bool(gui)
 

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -514,7 +514,7 @@ class Ghdl(Simulator):
 
         cmd_elaborate = (
             ["ghdl", "-m"]
-            + [f"--work{self.library_name}"]
+            + [f"--work={self.library_name}"]
             + self.compile_args
             + [self.sim_toplevel]
         )

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -8,7 +8,6 @@ import re
 import shutil
 import subprocess
 import sys
-import sysconfig
 import tempfile
 import warnings
 from typing import Dict, List, Mapping, Optional, Sequence, Type, Union
@@ -188,7 +187,7 @@ class Simulator(abc.ABC):
 
         check_results_file(results_xml_file)
 
-        print("INFO: Results file: %s" % results_xml_file)
+        print(f"INFO: Results file: {results_xml_file}")
         return results_xml_file
 
     @abc.abstractmethod
@@ -223,8 +222,7 @@ class Simulator(abc.ABC):
 
             if process.returncode != 0:
                 raise SystemExit(
-                    "Process '%s' termindated with error %d"
-                    % (process.args[0], process.returncode)
+                    f"Process {process.args[0]!r} terminated with error {process.returncode}"
                 )
 
 
@@ -247,7 +245,7 @@ def check_results_file(results_xml_file: PathLike) -> None:
                 failed += 1
 
     if failed:
-        raise SystemExit("ERROR: Failed %d tests." % failed)
+        raise SystemExit("ERROR: Failed {failed} tests.")
 
 
 def outdated(output: PathLike, dependencies: Sequence[PathLike]) -> bool:
@@ -496,7 +494,7 @@ class Ghdl(Simulator):
         return [f"-D{define}" for define in defines]
 
     @staticmethod
-    def get_parameter_commands(parameters):
+    def get_parameter_commands(parameters: Mapping[str, object]) -> List[str]:
         return ["-g" + name + "=" + str(value) for name, value in parameters.items()]
 
     def build_command(self) -> List[Command]:
@@ -506,7 +504,7 @@ class Ghdl(Simulator):
 
         return [
             ["ghdl", "-i"]
-            + ["--work=%s" % self.library_name]
+            + [f"--work={self.library_name}"]
             + self.compile_args
             + [source_file]
             for source_file in self.vhdl_sources
@@ -516,7 +514,7 @@ class Ghdl(Simulator):
 
         cmd_elaborate = (
             ["ghdl", "-m"]
-            + ["--work=%s" % self.library_name]
+            + [f"--work{self.library_name}"]
             + self.compile_args
             + [self.sim_toplevel]
         )

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -81,9 +81,7 @@ class Simulator(abc.ABC):
         for path in self.python_search:
             self.env["PYTHONPATH"] += os.pathsep + str(path)
 
-        prefix = sysconfig.get_config_var("prefix")
-        if prefix is not None:
-            self.env["PYTHONHOME"] = prefix
+        self.env["PYTHONHOME"] = sys.prefix
 
         self.env["TOPLEVEL"] = self.sim_toplevel
         self.env["MODULE"] = self.module

--- a/tests/designs/runner/runner.v
+++ b/tests/designs/runner/runner.v
@@ -1,0 +1,15 @@
+
+`include "basic_hierarchy_module.v"
+
+module runner #(
+    parameter WIDTH_IN = 4,
+    parameter WIDTH_OUT = 8
+) (
+    input  [WIDTH_IN-1:0]   data_in,
+    output [WIDTH_OUT-1:0]  data_out,
+    output [`DEFINE-1:0] define_out
+);
+
+basic_hierarchy_module  basic_hierarchy_module(.clk(1'b0), .reset(1'b0));
+
+endmodule

--- a/tests/designs/runner/runner.v
+++ b/tests/designs/runner/runner.v
@@ -1,3 +1,6 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
 
 `include "basic_hierarchy_module.v"
 

--- a/tests/designs/runner/runner.vhdl
+++ b/tests/designs/runner/runner.vhdl
@@ -1,3 +1,6 @@
+-- Copyright cocotb contributors
+-- Licensed under the Revised BSD License, see LICENSE for details.
+-- SPDX-License-Identifier: BSD-3-Clause
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/tests/designs/runner/runner.vhdl
+++ b/tests/designs/runner/runner.vhdl
@@ -1,0 +1,18 @@
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity runner is
+generic(
+    WIDTH_IN : integer := 4;
+    WIDTH_OUT : integer := 8);
+port(
+    data_in : in signed(WIDTH_IN-1 downto 0);
+    data_out : out signed(WIDTH_OUT-1 downto 0));
+end entity;
+
+architecture rtl of runner is
+begin
+
+end architecture;

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -43,12 +43,14 @@ def test_cocotb():
     sim = os.getenv("SIM", "icarus")
     runner = get_runner(sim)()
 
+    compile_args = ["+acc"] if sim == "questa" else []
+
     runner.build(
         verilog_sources=verilog_sources,
         vhdl_sources=vhdl_sources,
         toplevel="sample_module",
-        build_dir=sim_build)
-
+        build_dir=sim_build,
+        extra_args=compile_args)
     sim_args = ["-t", "ps"] if sim == "questa" else []
 
     runner.test(

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -1,0 +1,64 @@
+import os
+from cocotb.runner import get_runner
+
+tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sim_build = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sim_build")
+
+module_name = [
+    "test_async_coroutines",
+    "test_async_generators",
+    "test_clock",
+    "test_concurrency_primitives",
+    "test_deprecated",
+    "test_edge_triggers",
+    "test_generator_coroutines",
+    "test_handle",
+    "test_logging",
+    "test_pytest",
+    "test_queues",
+    "test_scheduler",
+    "test_synchronization_primitives",
+    "test_testfactory",
+    "test_tests",
+    "test_timing_triggers"
+]
+
+
+def test_cocotb():
+    verilog_sources = []
+    vhdl_sources = []
+    toplevel_lang = os.getenv("TOPLEVEL_LANG", "verilog")
+
+    if toplevel_lang == "verilog":
+        verilog_sources=[
+            os.path.join(tests_dir, "designs", "sample_module", "sample_module.sv")
+        ]
+    else:
+        vhdl_sources=[
+            os.path.join(tests_dir, "designs", "sample_module", "sample_module_pack.vhdl"),
+            os.path.join(tests_dir, "designs", "sample_module", "sample_module_1.vhdl"),
+            os.path.join(tests_dir, "designs", "sample_module", "sample_module.vhdl")
+        ]
+
+    sim = os.getenv("SIM", "icarus")
+    runner = get_runner(sim)()
+
+    runner.build(
+        verilog_sources=verilog_sources,
+        vhdl_sources=vhdl_sources,
+        hdl_topmodule="sample_module",
+        build_dir=sim_build)
+
+    sim_args = ["-t", "ps"] if sim == "questa" else []
+
+    runner.test(
+        toplevel_lang=toplevel_lang,
+        python_search=[os.path.join(tests_dir, "test_cases", "test_cocotb")],
+        hdl_topmodule="sample_module",
+        py_module=module_name,
+        extra_args=sim_args,
+        build_dir=sim_build)
+
+
+if __name__ == "__main__":
+    test_cocotb()

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -56,8 +56,7 @@ def test_cocotb():
         python_search=[os.path.join(tests_dir, "test_cases", "test_cocotb")],
         toplevel="sample_module",
         py_module=module_name,
-        extra_args=sim_args,
-        build_dir=sim_build)
+        extra_args=sim_args)
 
 
 if __name__ == "__main__":

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -46,7 +46,7 @@ def test_cocotb():
     runner.build(
         verilog_sources=verilog_sources,
         vhdl_sources=vhdl_sources,
-        hdl_topmodule="sample_module",
+        toplevel="sample_module",
         build_dir=sim_build)
 
     sim_args = ["-t", "ps"] if sim == "questa" else []
@@ -54,7 +54,7 @@ def test_cocotb():
     runner.test(
         toplevel_lang=toplevel_lang,
         python_search=[os.path.join(tests_dir, "test_cases", "test_cocotb")],
-        hdl_topmodule="sample_module",
+        toplevel="sample_module",
         py_module=module_name,
         extra_args=sim_args,
         build_dir=sim_build)

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -1,3 +1,7 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 from cocotb.runner import get_runner
 

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -48,7 +48,6 @@ def test_runner(parameters):
     )
 
     runner.test(
-        toplevel_lang="verilog",
         python_search=[os.path.join(tests_dir, "pytest")],
         toplevel="runner",
         py_module="test_runner",

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -40,7 +40,7 @@ def test_runner(parameters):
     runner.build(
         verilog_sources=verilog_sources,
         vhdl_sources=vhdl_sources,
-        hdl_topmodule="runner",
+        toplevel="runner",
         parameters=parameters,
         defines=["DEFINE=4"],
         includes=[os.path.join(tests_dir, "designs", "basic_hierarchy_module")],
@@ -50,7 +50,7 @@ def test_runner(parameters):
     runner.test(
         toplevel_lang="verilog",
         python_search=[os.path.join(tests_dir, "pytest")],
-        hdl_topmodule="runner",
+        toplevel="runner",
         py_module="test_runner",
         extra_env=parameters,
     )

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -1,3 +1,7 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import pytest
 import os
 

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -1,0 +1,56 @@
+import pytest
+import os
+
+import cocotb
+from cocotb.runner import get_runner
+from cocotb.triggers import Timer
+
+tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sim_build = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sim_build")
+
+
+@cocotb.test()
+async def cocotb_runner_test(dut):
+
+    await Timer(1)
+
+    WIDTH_IN = int(os.environ.get("WIDTH_IN", "8"))
+    WIDTH_OUT = int(os.environ.get("WIDTH_OUT", "8"))
+
+    assert WIDTH_IN == len(dut.data_in)
+    assert WIDTH_OUT == len(dut.data_out)
+
+
+@pytest.mark.parametrize("parameters", [{"WIDTH_IN": "8", "WIDTH_OUT": "16"}, {"WIDTH_IN": "16"}])
+def test_runner(parameters):
+
+    toplevel_lang = os.getenv("TOPLEVEL_LANG", "verilog")
+
+    verilog_sources = []
+    vhdl_sources = []
+
+    if toplevel_lang == "verilog":
+        verilog_sources = [os.path.join(tests_dir, "designs", "runner", "runner.v")]
+    else:
+        vhdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.vhdl")]
+
+    sim = os.getenv("SIM", "icarus")
+    runner = get_runner(sim)()
+
+    runner.build(
+        verilog_sources=verilog_sources,
+        vhdl_sources=vhdl_sources,
+        hdl_topmodule="runner",
+        parameters=parameters,
+        defines=["DEFINE=4"],
+        includes=[os.path.join(tests_dir, "designs", "basic_hierarchy_module")],
+        build_dir=sim_build + "/test_runner/" + "_".join(("{}={}".format(*i) for i in parameters.items())),
+    )
+
+    runner.test(
+        toplevel_lang="verilog",
+        python_search=[os.path.join(tests_dir, "pytest")],
+        hdl_topmodule="runner",
+        py_module="test_runner",
+        extra_env=parameters,
+    )


### PR DESCRIPTION
Python-based runner based on https://github.com/themperek/cocotb-test/blob/master/cocotb_test/simulator.py see also: [cocotb-test slides](https://github.com/cocotb/cocotb/files/3908378/cocotb-test_WOSDV2019.pdf)

This is just something we can start with.

Trying to follow: https://github.com/cocotb/cocotb/wiki/Python-Test-Runner-Proposal

Issues:
- some simulators (GHDL, Verilator, maybe also Icarus) require `top HDL module name` for build/compilations
- some simulators (Verilator, maybe Icarus) require `wave` for build/compilations
