### PR TITLE
cocotb.types.Array improvements

### DIFF
--- a/cocotb/types/__init__.py
+++ b/cocotb/types/__init__.py
@@ -1,12 +1,14 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from .logic import Logic, Bit  # noqa: F401
-from .range import Range  # noqa: F401
+import typing
+
 from .array import Array  # noqa: F401
+from .logic import Bit, Logic  # noqa: F401
+from .range import Range  # noqa: F401
 
 
-def concat(a: Array, b: Array) -> Array:
+def concat(a: typing.Any, b: typing.Any) -> typing.Any:
     """
     Create a new array that is the concatenation of one array with another.
 
@@ -25,13 +27,13 @@ def concat(a: Array, b: Array) -> Array:
 
     if type_a is not type_b and issubclass(type_b, type_a) and a_rconcat != b_rconcat:
         # 'b' is a subclass of 'a' with a more specific implementation of 'concat(a, b)'
-        call_order = ((b, b_rconcat, a), (a, a_concat, b))
+        call_order = [(b, b_rconcat, a), (a, a_concat, b)]
     elif type_a is not type_b:
         # normal call order
-        call_order = ((a, a_concat, b), (b, b_rconcat, a))
+        call_order = [(a, a_concat, b), (b, b_rconcat, a)]
     else:
         # types are the same, we expect implementation of 'concat(a, b)' to be in 'a.__concat__'
-        call_order = ((a, a_concat, b),)
+        call_order = [(a, a_concat, b)]
 
     for lhs, method, rhs in call_order:
         if method is MISSING:

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,7 @@ omit =
 [coverage:report]
 exclude_lines =
     pragma: no cover
-    \.\.\.                          # for excluding typing stubs
-    raise\s+NotImplementedError     # for excluding abstractmethods
+    # for excluding typing stubs
+    \.\.\.
+    # for excluding abstractmethods
+    raise\s+NotImplementedError


### PR DESCRIPTION
* Made Array a generic homogenous type, like list
* Split out an ABC (for use later)
* ~~replaced concat() with unused binary operator '@' (better typing, no import necessary)~~
* improved typing support
* fixed a couple documentation issues

#2514 Will use the ABC split, so this PR is necessary. Other changes could be contested.