### PR TITLE
Add start and start_soon scheduling functions

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -171,6 +171,31 @@ def fork(coro: Union[RunningTask, Coroutine]) -> RunningTask:
     return scheduler.add(coro)
 
 
+def start_soon(coro: Union[RunningTask, Coroutine]) -> RunningTask:
+    """
+    Schedule a coroutine to be run concurrently.
+
+    Note that this is not an async function,
+    and the new task will not execute until the calling task yields control.
+
+    .. versionadded:: 1.6.0
+    """
+    return scheduler.start_soon(coro)
+
+
+async def start(coro: Union[RunningTask, Coroutine]) -> RunningTask:
+    """
+    Schedule a coroutine to be run concurrently, then yield control to allow pending tasks to execute.
+
+    The calling task will resume execution before control is returned to the simulator.
+
+    .. versionadded:: 1.6.0
+    """
+    task = scheduler.start_soon(coro)
+    await cocotb.triggers.NullTrigger()
+    return task
+
+
 # FIXME is this really required?
 _rlock = threading.RLock()
 

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -746,6 +746,8 @@ class Scheduler:
         starts the given coroutine only after the current coroutine yields control.
         This is useful when the coroutine to be forked has logic before the first
         :keyword:`await` that may not be safe to execute immediately.
+
+        .. versionadded:: 1.5
         """
 
         task = self.create_task(coro)

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -5,18 +5,22 @@
    Async
 
 
-**********
-Coroutines
-**********
+********************
+Coroutines and Tasks
+********************
 
-Testbenches built using cocotb use coroutines. While the coroutine is executing
-the simulation is paused. The coroutine uses the :keyword:`await` keyword to
+Testbenches built using cocotb use Python coroutines.
+*Tasks* are cocotb objects that wrap coroutines
+and are used to schedule concurrent execution of the testbench coroutines.
+
+While active tasks are executing, the simulation is paused.
+The coroutine uses the :keyword:`await` keyword to
 block on another coroutine's execution or pass control of execution back to the
 simulator, allowing simulation time to advance.
 
 Typically coroutines :keyword:`await` a :class:`~cocotb.triggers.Trigger` object which
-indicates to the simulator some event which will cause the coroutine to be woken
-when it occurs.  For example:
+pauses the task, and indicates to the simulator some event which will cause the task resume execution.
+For example:
 
 .. code-block:: python3
 
@@ -47,8 +51,26 @@ Coroutines can :keyword:`return` a value, so that they can be used by other coro
         if first == second:
             raise TestFailure("Signal did not change")
 
+Concurrent Execution
+====================
 
-Coroutines can be used with :func:`~cocotb.fork` for concurrent operation.
+Coroutines can be scheduled for concurrent execution with :func:`~cocotb.fork`, :func:`~cocotb.start`, and :func:`~cocotb.start_soon`.
+
+:func:`~cocotb.fork` schedules and executes the new coroutine immediately,
+returning control to the calling task after the new coroutine finishes or yields control.
+No other pending tasks are run.
+
+The *async* function :func:`~cocotb.start` schedules the new coroutine to be executed concurrently,
+then yields control to allow the new task (and any other pending tasks) to run,
+before resuming the calling task.
+
+:func:`~cocotb.start_soon` schedules the new coroutine for future execution,
+after the calling task yields control.
+
+.. note::
+    The preferred way to schedule tasks is with :func:`~cocotb.start` and :func:`~cocotb.start_soon`.
+    :func:`~cocotb.fork` remains for historical reasons,
+    but may be removed in a future version of cocotb.
 
 .. code-block:: python3
 
@@ -57,28 +79,28 @@ Coroutines can be used with :func:`~cocotb.fork` for concurrent operation.
         """While reset is active, toggle signals"""
         tb = uart_tb(dut)
         # "Clock" is a built in class for toggling a clock signal
-        cocotb.fork(Clock(dut.clk, 1, units='ns').start())
+        cocotb.start_soon(Clock(dut.clk, 1, units='ns').start())
         # reset_dut is a function -
         # part of the user-generated "uart_tb" class
-        cocotb.fork(tb.reset_dut(dut.rstn, 20))
+        # run reset_dut immediately before continuing
+        await cocotb.start(tb.reset_dut(dut.rstn, 20))
 
         await Timer(10, units='ns')
         print("Reset is still active: %d" % dut.rstn)
         await Timer(15, units='ns')
         print("Reset has gone inactive: %d" % dut.rstn)
 
-
-Forked coroutines can be used in an :keyword:`await` statement to block until the forked coroutine finishes.
+Other tasks can be used in an :keyword:`await` statement to suspend the current task until the other task finishes.
 
 .. code-block:: python3
 
     @cocotb.test()
     async def test_count_edge_cycles(dut, period_ns=1, clocks=6):
-        cocotb.fork(Clock(dut.clk, period_ns, units='ns').start())
+        cocotb.start_soon(Clock(dut.clk, period_ns, units='ns').start())
         await RisingEdge(dut.clk)
 
         timer = Timer(period_ns + 10, 'ns')
-        task = cocotb.fork(count_edges_cycles(dut.clk, clocks))
+        task = cocotb.start_soon(count_edges_cycles(dut.clk, clocks))
         count = 0
         expect = clocks - 1
 
@@ -92,8 +114,8 @@ Forked coroutines can be used in an :keyword:`await` statement to block until th
             else:
                 break
 
-Forked coroutines can be killed before they complete, forcing their completion before
-they'd naturally end.
+Tasks can be killed before they complete,
+forcing their completion before they would naturally end.
 
 .. code-block:: python3
 
@@ -102,7 +124,7 @@ they'd naturally end.
         clk_1mhz   = Clock(dut.clk, 1.0, units='us')
         clk_250mhz = Clock(dut.clk, 4.0, units='ns')
 
-        clk_gen = cocotb.fork(clk_1mhz.start())
+        clk_gen = cocotb.start_soon(clk_1mhz.start())
         start_time_ns = get_sim_time(units='ns')
         await Timer(1, units='ns')
         await RisingEdge(dut.clk)
@@ -112,7 +134,7 @@ they'd naturally end.
 
         clk_gen.kill()  # kill clock coroutine here
 
-        clk_gen = cocotb.fork(clk_250mhz.start())
+        clk_gen = cocotb.start_soon(clk_250mhz.start())
         start_time_ns = get_sim_time(units='ns')
         await Timer(1, units='ns')
         await RisingEdge(dut.clk)
@@ -124,7 +146,11 @@ they'd naturally end.
 .. versionchanged:: 1.4
     The :any:`cocotb.coroutine` decorator is no longer necessary for ``async def`` coroutines.
     ``async def`` coroutines can be used, without the ``@cocotb.coroutine`` decorator, wherever decorated coroutines are accepted,
-    including :keyword:`yield` statements and :any:`cocotb.fork`.
+    including :keyword:`yield` statements and :func:`cocotb.fork`.
+
+.. versionchanged:: 1.6
+    Added :func:`cocotb.start` and :func:`cocotb.start_soon` scheduling functions.
+
 
 Async generators
 ================

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -19,7 +19,7 @@ block on another coroutine's execution or pass control of execution back to the
 simulator, allowing simulation time to advance.
 
 Typically coroutines :keyword:`await` a :class:`~cocotb.triggers.Trigger` object which
-pauses the task, and indicates to the simulator some event which will cause the task resume execution.
+pauses the task, and indicates to the simulator some event which will cause the task to resume execution.
 For example:
 
 .. code-block:: python3

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -58,6 +58,10 @@ Interacting with the Simulator
 
 .. autofunction:: cocotb.fork
 
+.. autofunction:: cocotb.start_soon
+
+.. autofunction:: cocotb.start
+
 .. autofunction:: cocotb.decorators.RunningTask.join
 
 .. autofunction:: cocotb.decorators.RunningTask.kill

--- a/documentation/source/newsfragments/2660.feature.rst
+++ b/documentation/source/newsfragments/2660.feature.rst
@@ -1,0 +1,1 @@
+Added :func:`cocotb.start` and :func:`cocotb.start_soon` scheduling functions.


### PR DESCRIPTION
Add `cocotb.start()` and `cocotb.start_soon()` for users to try now, before 2.0.

I updated the Coroutines page of the docs, but didn't change any other examples from `fork()`.
