### PR TITLE
Add PyPi Trove classifier

### DIFF
--- a/documentation/source/extensions.rst
+++ b/documentation/source/extensions.rst
@@ -84,7 +84,8 @@ All packaging metadata goes into :file:`setup.py`.
         classifiers = [
           "Programming Language :: Python :: 3",
           "Operating System :: OS Independent",
-          "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)"])
+          "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+          "Framework :: cocotb"])
 
 With this file structure in place the cocotb extension can be installed through ``pip`` in development mode ::
 

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: BSD License",
         "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+        "Framework :: cocotb",
     ],
 
     # these appear in the sidebar on PyPI


### PR DESCRIPTION
The classifier has been added in https://github.com/pypa/trove-classifiers/pull/24

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
