### PR TITLE
Add Python 3.10 to CI

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -100,6 +100,13 @@ jobs:
             python-version: 3.9
             os: ubuntu-20.04
 
+          - sim: icarus
+            sim-version: apt
+            lang: verilog
+            python-version: "3.10.0-alpha - 3.10"
+            os: ubuntu-20.04
+            may_fail: true
+
             # Test Icarus dev on Ubuntu
 
           - sim: icarus

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ The regression does not end on the first failure, but continues until all tests 
 
 To run the tests locally with `tox`, you will need to select an appropriate test environment.
 Valid test environments are formatted as `{your python version}-{your OS}`.
-Valid python version values are `py36`, `py37`, `py38`, or `py39`;
+Valid python version values are `py36`, `py37`, `py38`, `py39` or `py310`;
 and valid OS values are `linux`, `macos`, or `windows`.
 For example, a valid test environment is `py38-linux`.
 You can see the list of valid test environments by running the below command:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # when changing this list, adapt CONTRIBUTING.md accordingly:
-envlist = py{36,37,38,39}-{linux,macos,windows},docs
+envlist = py{36,37,38,39,310}-{linux,macos,windows},docs
 
 # for the requires key
 minversion = 3.2.0
@@ -95,6 +95,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 OS =


### PR DESCRIPTION
rc1 is out: https://docs.python.org/3.10/whatsnew/3.10.html
This is with `may_fail` for now.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
