### PR TITLE
Adding support for net/wire discovery under SV interface

### DIFF
--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -545,11 +545,17 @@ VpiNextPhaseCbHdl::VpiNextPhaseCbHdl(GpiImplInterface *impl)
 
 decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
     /* for reused lists */
-    std::initializer_list<int32_t> module_options = {
+
+    // vpiInstance is the base class for module, program, interface, etc.
+    std::vector<int32_t> instance_options = {
+        vpiNet, vpiNetArray, vpiReg, vpiRegArray,
+    };
+
+    std::vector<int32_t> module_options = {
         // vpiModule,            // Aldec SEGV on mixed language
         // vpiModuleArray,       // Aldec SEGV on mixed language
         // vpiIODecl,            // Don't care about these
-        vpiNet, vpiNetArray, vpiReg, vpiRegArray, vpiMemory, vpiIntegerVar,
+        vpiMemory, vpiIntegerVar,
         vpiRealVar, vpiRealNet, vpiStructVar, vpiStructNet, vpiVariables,
         vpiNamedEvent, vpiNamedEventArray, vpiParameter,
         // vpiSpecParam,         // Don't care
@@ -562,7 +568,11 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
         // vpiInterface,         // Aldec SEGV on mixed language
         // vpiInterfaceArray,    // Aldec SEGV on mixed language
     };
-    std::initializer_list<int32_t> struct_options = {
+
+    // append base class vpiInstance members
+    module_options.insert(module_options.begin(), instance_options.begin(), instance_options.end());
+
+    std::vector<int32_t> struct_options = {
         vpiNet,
 #ifndef IUS
         vpiNetArray,
@@ -573,6 +583,7 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
 
     return decltype(VpiIterator::iterate_over){
         {vpiModule, module_options},
+        {vpiInterface, instance_options},
         {vpiGenScope, module_options},
 
         {vpiStructVar, struct_options},

--- a/tests/test_cases/test_sv_interface/Makefile
+++ b/tests/test_cases/test_sv_interface/Makefile
@@ -1,0 +1,14 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+TOPLEVEL_LANG ?= verilog
+VERILOG_SOURCES = $(shell pwd)/top.sv
+MODULE = test_sv_if
+TOPLEVEL = top
+
+ifneq ($(shell echo $(SIM) | tr A-Z a-z),verilator)
+all::
+clean::
+else
+include $(shell cocotb-config --makefiles)/Makefile.sim
+endif

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -1,0 +1,12 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+import cocotb
+
+@cocotb.test()
+async def test_sv_if(dut):
+    """ Test that signals in virtual interface are visible """
+
+    dut.sv_if_i.a.value = 1
+    dut.sv_if_i.b.value = 1
+    dut.sv_if_i.c.value = 1

--- a/tests/test_cases/test_sv_interface/top.sv
+++ b/tests/test_cases/test_sv_interface/top.sv
@@ -1,0 +1,19 @@
+// This file is public domain, it can be freely copied without restrictions.
+// SPDX-License-Identifier: CC0-1.0
+
+`timescale 1us/1us
+
+interface sv_if();
+  logic a;
+  reg b;
+  wire c;
+endinterface
+
+module top (
+  input x,
+  output y
+);
+
+sv_if sv_if_i();
+
+endmodule


### PR DESCRIPTION
Simulators such as vcs/ius return vpiInterface when they get to an SV interface. when the simulator was returning vpiInterface as the type of the underlying HDL object cocotb would give an error saying this type is not supported, and therefore the signals inside the interface could not be found/driven. Instead, map this type to the basic vpiInstance which is also shared with vpiModule. Moving forward we could move most of vpiModule members to vpiInstance, and add support for vpiProgram and other elements currently not supported.
