### PR TITLE
Allow use of make -f

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -37,7 +37,7 @@ COCOTB_MAKEFILE_INC_INCLUDED = 1
 .PHONY: sim
 sim:
 	-@rm -f $(COCOTB_RESULTS_FILE)
-	$(MAKE) $(COCOTB_RESULTS_FILE)
+	$(MAKE) -f $(firstword $(MAKEFILE_LIST)) $(COCOTB_RESULTS_FILE)
 
 # Make sure to use bash for the pipefail option used in many simulator Makefiles
 SHELL := bash


### PR DESCRIPTION
Following gitter discussion of the 1st of july 2021 (https://gitter.im/cocotb/Lobby?at=60dd54a0110daa37b115e09c),

This pull request allows to use a custom makefile through the use of  `make -f filename.mk`
As `filename.mk` name will be prepended to the special `MAKEFILE_LIST` variable, we select it through `firstword` and force its for the internal make call. 

The limitation might be if the user have one more level of makefile inclusion.