### PR TITLE
Cleanup to cocotb.utils

### DIFF
--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -99,13 +99,13 @@ def _ldexp10(frac, exp):
         return frac / (10 ** -exp)
 
 
-def get_time_from_sim_steps(steps, units):
+def get_time_from_sim_steps(steps: int, units: str) -> int:
     """Calculates simulation time in the specified *units* from the *steps* based
     on the simulator precision.
 
     Args:
-        steps (int): Number of simulation steps.
-        units (str): String specifying the units of the result
+        steps: Number of simulation steps.
+        units: String specifying the units of the result
             (one of ``'fs'``, ``'ps'``, ``'ns'``, ``'us'``, ``'ms'``, ``'sec'``).
 
     Returns:

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -53,7 +53,7 @@ def _get_simulator_precision():
 def get_python_integer_types():
     warnings.warn(
         "This is an internal cocotb function, use six.integer_types instead",
-        DeprecationWarning)
+        DeprecationWarning, stacklevel=2)
     return (int,)
 
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -58,23 +58,33 @@ def get_python_integer_types():
 
 
 # Simulator helper functions
-def get_sim_time(units=None):
+def get_sim_time(units: str = "step") -> int:
     """Retrieves the simulation time from the simulator.
 
     Args:
-        units (str or None, optional): String specifying the units of the result
-            (one of ``None``, ``'fs'``, ``'ps'``, ``'ns'``, ``'us'``, ``'ms'``, ``'sec'``).
-            ``None`` will return the raw simulation time.
+        units: String specifying the units of the result
+            (one of ``'step'``, ``'fs'``, ``'ps'``, ``'ns'``, ``'us'``, ``'ms'``, ``'sec'``).
+            ``'step'`` will return the raw simulation time.
+
+            .. deprecated:: 1.6.0
+                Using ``None`` as the *units* argument is deprecated, use ``'step'`` instead.
 
     Returns:
         The simulation time in the specified units.
+
+    .. versionchanged:: 1.6.0
+        Support ``'step'`` as the the *units* argument to mean "simulator time step".
     """
     timeh, timel = simulator.get_sim_time()
 
     result = (timeh << 32 | timel)
 
-    if units is not None:
+    if units not in (None, "step"):
         result = get_time_from_sim_steps(result, units)
+    if units is None:
+        warnings.warn(
+            'Using units=None is deprecated, use units="step" instead.',
+            DeprecationWarning, stacklevel=2)
 
     return result
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -298,6 +298,10 @@ def hexdump(x: bytes) -> str:
         is not an appropriate type for binary data. Doing so anyway
         will encode the string to ``latin1``.
 
+    .. deprecated:: 1.6.0
+        The function will be removed in the next major version.
+        Use :func:`scapy.utils.hexdump` instead.
+
     Example:
         >>> print(hexdump(b'this somewhat long string'))
         0000   74 68 69 73 20 73 6F 6D 65 77 68 61 74 20 6C 6F   this somewhat lo
@@ -305,6 +309,9 @@ def hexdump(x: bytes) -> str:
         <BLANKLINE>
     """
     # adapted from scapy.utils.hexdump
+    warnings.warn(
+        "cocotb.utils.hexdump is deprecated. Use scapy.utils.hexdump instead.",
+        DeprecationWarning, stacklevel=2)
     rs = ""
     if isinstance(x, str):
         warnings.warn(
@@ -341,6 +348,10 @@ def hexdiffs(x: bytes, y: bytes) -> str:
         is not an appropriate type for binary data. Doing so anyway
         will encode the string to ``latin1``.
 
+    .. deprecated:: 1.6.0
+        The function will be removed in the next major version.
+        Use :func:`scapy.utils.hexdiff` instead.
+
     Example:
         >>> print(hexdiffs(b'a', b'b'))
         0000      61                                               a
@@ -352,6 +363,9 @@ def hexdiffs(x: bytes, y: bytes) -> str:
         <BLANKLINE>
     """
     # adapted from scapy.utils.hexdiff
+    warnings.warn(
+        "cocotb.utils.hexdiffs is deprecated. Use scapy.utils.hexdiff instead.",
+        DeprecationWarning, stacklevel=2)
 
     def highlight(string: str, colour=ANSI.COLOR_HILITE_HEXDIFF_DEFAULT) -> str:
         """Highlight with ANSI colors if possible/requested and not running in GUI."""

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -50,7 +50,8 @@ extensions = [
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'ghdl': ('https://ghdl.readthedocs.io/en/latest', None)
+    'ghdl': ('https://ghdl.readthedocs.io/en/latest', None),
+    'scapy': ('https://scapy.readthedocs.io/en/latest', None),
 }
 
 # Github repo

--- a/documentation/source/newsfragments/2691.feature.rst
+++ b/documentation/source/newsfragments/2691.feature.rst
@@ -1,0 +1,1 @@
+Support passing ``'step'`` as a time unit in :func:`cocotb.utils.get_sim_time`.

--- a/documentation/source/newsfragments/2691.removal.1.rst
+++ b/documentation/source/newsfragments/2691.removal.1.rst
@@ -1,0 +1,1 @@
+:func:`cocotb.utils.hexdump` is deprecated; use :func:`scapy.utils.hexdump` instead.

--- a/documentation/source/newsfragments/2691.removal.2.rst
+++ b/documentation/source/newsfragments/2691.removal.2.rst
@@ -1,0 +1,1 @@
+:func:`cocotb.utils.hexdiffs` is deprecated; use :func:`scapy.utils.hexdiff` instead.

--- a/documentation/source/newsfragments/2691.removal.rst
+++ b/documentation/source/newsfragments/2691.removal.rst
@@ -1,0 +1,1 @@
+Passing ``None`` to :func:`cocotb.utils.get_sim_time` is deprecated; use ``'step'`` as the time unit instead.


### PR DESCRIPTION
* Add support for `units="step"` to `cocotb.utils.get_sim_time`
* Deprecate hexdiffs and hexdump totally. They were used by Scoreboard, which we are no longer supporting in 2.0, and are available in the `scapy` package
* nitpicks