### PR TITLE
Cleanup cocotb.result

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -350,11 +350,11 @@ def _sim_event(level, message):
     # SIM_INFO = 0
     SIM_TEST_FAIL = 1
     SIM_FAIL = 2
-    from cocotb.result import TestFailure, SimFailure
+    from cocotb.result import SimFailure
 
     if level is SIM_TEST_FAIL:
         scheduler.log.error("Failing test at simulator request")
-        scheduler._finish_test(TestFailure(f"Failure from external source: {message}"))
+        scheduler._finish_test(AssertionError(f"Failure from external source: {message}"))
     elif level is SIM_FAIL:
         # We simply return here as the simulator will exit
         # so no cleanup is needed

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -163,8 +163,20 @@ class TestError(TestComplete):
 
 
 class TestFailure(TestComplete, AssertionError):
-    """Exception showing that the test was completed with severity Failure."""
-    pass
+    """
+    Exception showing that the test was completed with severity Failure.
+
+    .. deprecated:: 1.6.0
+        Use a standard ``assert`` statement instead of raising this exception.
+        Use ``expect_fail`` rather than ``expect_error`` with this exception in the
+        :class:`cocotb.test` decorator.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "TestFailure is deprecated, use an ``assert`` statement instead",
+            DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
 
 
 class TestSuccess(TestComplete):

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -100,12 +100,43 @@ class ReturnValue(Exception):
 
 
 class TestComplete(Exception):
-    """Exception showing that the test was completed. Sub-exceptions detail the exit status."""
+    """
+    Exception showing that the test was completed. Sub-exceptions detail the exit status.
+
+    .. deprecated:: 1.6.0
+        The ``stdout`` and ``stderr`` attributes.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.stdout = StringIO()
-        self.stderr = StringIO()
+        self.__stdout = StringIO()
+        self.__stderr = StringIO()
+
+    @staticmethod
+    def __deprecated(which: str) -> None:
+        warnings.warn(
+            f"Attribute {which} is deprecated and will be removed in the next major release",
+            DeprecationWarning, stacklevel=3)
+
+    @property
+    def stdout(self) -> StringIO:
+        self.__deprecated("stdout")
+        return self.__stdout
+
+    @stdout.setter
+    def stdout(self, new_value: StringIO) -> None:
+        self.__deprecated("stdout")
+        self.__stdout = new_value
+
+    @property
+    def stderr(self) -> StringIO:
+        self.__deprecated("stderr")
+        return self.__stderr
+
+    @stderr.setter
+    def stderr(self, new_value: StringIO) -> None:
+        self.__deprecated("stderr")
+        self.__stderr = new_value
 
 
 class ExternalException(Exception):

--- a/documentation/source/newsfragments/2692.removal.1.rst
+++ b/documentation/source/newsfragments/2692.removal.1.rst
@@ -1,0 +1,1 @@
+The ``stdout`` and ``stderr`` attributes on :class:`cocotb.result.TestComplete` and subclasses are deprecated.

--- a/documentation/source/newsfragments/2692.removal.rst
+++ b/documentation/source/newsfragments/2692.removal.rst
@@ -1,0 +1,1 @@
+:exc:`cocotb.result.TestFailure` is deprecated, use an ``assert`` statement instead.

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -7,7 +7,6 @@ import cocotb
 
 from cocotb.clock import Clock
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
 from cocotb.handle import HierarchyObject, HierarchyArrayObject, ModifiableObject, NonHierarchyIndexableObject, ConstantObject
 
 SIM_NAME = cocotb.SIM_NAME.lower()
@@ -208,14 +207,9 @@ async def test_gen_loop(dut):
     asc_gen_20  = dut.asc_gen[20]
     desc_gen    = dut.desc_gen
 
-    if not isinstance(dut.asc_gen, HierarchyArrayObject):
-        raise TestFailure(f"Generate Loop parent >{dut.asc_gen!r}< should be HierarchyArrayObject")
-
-    if not isinstance(desc_gen, HierarchyArrayObject):
-        raise TestFailure(f"Generate Loop parent >{desc_gen!r}< should be HierarchyArrayObject")
-
-    if not isinstance(asc_gen_20, HierarchyObject):
-        raise TestFailure(f"Generate Loop child >{asc_gen_20!r}< should be HierarchyObject")
+    assert isinstance(dut.asc_gen, HierarchyArrayObject)
+    assert isinstance(desc_gen, HierarchyArrayObject)
+    assert isinstance(asc_gen_20, HierarchyObject)
 
     tlog.info("Direct access found %s", asc_gen_20)
     tlog.info("Direct access found %s", desc_gen)
@@ -223,15 +217,11 @@ async def test_gen_loop(dut):
     for gens in desc_gen:
         tlog.info("Iterate access found %s", gens)
 
-    if len(desc_gen) != 8:
-        raise TestError("Length of desc_gen is >{}< and should be 8".format(len(desc_gen)))
-    else:
-        tlog.info("Length of desc_gen is %d", len(desc_gen))
+    assert len(desc_gen) == 8
+    tlog.info("Length of desc_gen is %d", len(desc_gen))
 
-    if len(dut.asc_gen) != 8:
-        raise TestError("Length of asc_gen is >{}< and should be 8".format(len(dut.asc_gen)))
-    else:
-        tlog.info("Length of asc_gen is %d", len(dut.asc_gen))
+    assert len(dut.asc_gen) == 8
+    tlog.info("Length of asc_gen is %d", len(dut.asc_gen))
 
     for gens in dut.asc_gen:
         tlog.info("Iterate access found %s", gens)
@@ -374,8 +364,7 @@ async def test_discover_all(dut):
     tlog.info("Iterating over %r (%s)", dut, dut._type)
     total = _discover(dut, "")
     tlog.info("Found a total of %d things", total)
-    if total != pass_total:
-        raise TestFailure(f"Expected {pass_total} objects but found {total}")
+    assert total == pass_total
 
 
 # GHDL unable to access std_logic_vector generics (gh-2593)
@@ -433,21 +422,15 @@ async def test_direct_signal_indexing(dut):
     await Timer(20, "ns")
 
     tlog.info("Checking bit mapping from input to generate loops.")
-    if int(dut.desc_gen[2].sig) != 1:
-        raise TestFailure("Expected {!r} to be a 1 but got {}".format(dut.desc_gen[2].sig, int(dut.desc_gen[2].sig)))
-    else:
-        tlog.info("   %r = %d", dut.desc_gen[2].sig, int(dut.desc_gen[2].sig))
+    assert int(dut.desc_gen[2].sig) == 1
+    tlog.info("   %r = %d", dut.desc_gen[2].sig, int(dut.desc_gen[2].sig))
 
-    if int(dut.asc_gen[18].sig) != 1:
-        raise TestFailure("Expected {!r} to be a 1 but got {}".format(dut.asc_gen[18].sig, int(dut.asc_gen[18].sig)))
-    else:
-        tlog.info("   %r = %d", dut.asc_gen[18].sig, int(dut.asc_gen[18].sig))
+    assert int(dut.asc_gen[18].sig) == 1
+    tlog.info("   %r = %d", dut.asc_gen[18].sig, int(dut.asc_gen[18].sig))
 
     tlog.info("Checking indexing of data with offset index.")
-    if int(dut.port_ofst_out) != 64:
-        raise TestFailure("Expected {!r} to be a 64 but got {}".format(dut.port_ofst_out, int(dut.port_ofst_out)))
-    else:
-        tlog.info("   %r = %d (%s)", dut.port_ofst_out, int(dut.port_ofst_out), dut.port_ofst_out.value.binstr)
+    assert int(dut.port_ofst_out) == 64
+    tlog.info("   %r = %d (%s)", dut.port_ofst_out, int(dut.port_ofst_out), dut.port_ofst_out.value.binstr)
 
     tlog.info("Checking Types of complex array structures in signals.")
     _check_type(tlog, dut.sig_desc[20], ModifiableObject)

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -7,17 +7,14 @@ import logging
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.result import TestFailure
 from cocotb.triggers import Timer
 
 tlog = logging.getLogger("cocotb.test")
 
 
 def _check_value(tlog, hdl, expected):
-    if hdl.value != expected:
-        raise TestFailure(f"{hdl!r}: Expected >{expected}< but got >{hdl.value}<")
-    else:
-        tlog.info(f"   Found {hdl!r} ({hdl._type}) with value={hdl.value}")
+    assert hdl.value == expected
+    tlog.info(f"   Found {hdl!r} ({hdl._type}) with value={hdl.value}")
 
 
 # GHDL unable to put values on nested array types (gh-2588)

--- a/tests/test_cases/test_cocotb/test_pytest.py
+++ b/tests/test_cases/test_cocotb/test_pytest.py
@@ -4,22 +4,12 @@
 """ Tests relating to pytest integration """
 
 import cocotb
-from cocotb.result import TestFailure
-
-# pytest is an optional dependency
-try:
-    import pytest
-except ImportError:
-    pytest = None
+import pytest
 
 
-@cocotb.test(skip=pytest is None)
-async def test_assertion_rewriting(dut):
+@cocotb.test()
+async def test_assertion_rewriting(_):
     """ Test that assertion rewriting hooks take effect in cocotb tests """
-    try:
+    with pytest.raises(AssertionError) as e:
         assert 1 == 42
-    except AssertionError as e:
-        assert "42" in str(e), (
-            f"Assertion rewriting seems not to work, message was {e}")
-    else:
-        raise TestFailure('AssertionError was not thrown')
+    assert "42" in str(e), f"Assertion rewriting seems not to work, message was {e}"

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -12,7 +12,6 @@ from collections.abc import Coroutine
 
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.result import TestFailure
 from common import clock_gen
 
 
@@ -34,7 +33,7 @@ async def test_tests_are_tests(dut):
 # just to be sure...
 @cocotb.test(expect_fail=True)
 async def test_async_test_can_fail(dut):
-    raise TestFailure
+    assert False
 
 
 @cocotb.test()

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -27,7 +27,6 @@ import logging
 
 import cocotb
 from cocotb.triggers import First
-from cocotb.result import TestFailure
 
 
 @cocotb.test(expect_fail=cocotb.SIM_NAME in ["Icarus Verilog"])
@@ -55,8 +54,7 @@ async def recursive_discovery(dut):
         return count
     total = dump_all_the_things(dut)
     tlog.info("Found a total of %d things", total)
-    if total != pass_total:
-        raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
+    assert total == pass_total
 
 
 async def iteration_loop(dut):

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -27,7 +27,6 @@ import logging
 
 import cocotb
 from cocotb.triggers import Timer, Combine
-from cocotb.result import TestFailure
 
 
 def total_object_count():
@@ -82,8 +81,7 @@ async def recursive_discovery(dut):
         return count
     total = dump_all_the_things(dut)
     tlog.info("Found a total of %d things", total)
-    if total != pass_total:
-        raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
+    assert total == pass_total
 
 
 # GHDL unable to access signals in generate loops (gh-2594)

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -1,227 +1,169 @@
 import cocotb
-from cocotb.result import TestFailure
 from cocotb.triggers import Timer
 
 
 @cocotb.test()
 async def test_in_vect_packed(dut):
+    test_value = 0x5
+    dut.in_vect_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_packed type %s" % type(dut.in_vect_packed))
-    dut.in_vect_packed = 0x5
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_packed type %s" % type(dut.out_vect_packed))
-    if dut.out_vect_packed != 0x5:
-        raise TestFailure("Failed to readback dut.out_vect_packed")
+    assert dut.out_vect_packed.value == test_value
 
 
 @cocotb.test()
 async def test_in_vect_unpacked(dut):
+    test_value = [0x1, 0x0, 0x1]
+    dut.in_vect_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_unpacked type %s" % type(dut.in_vect_unpacked))
-    dut.in_vect_unpacked = [0x1, 0x0, 0x1]
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_unpacked type %s" % type(dut.out_vect_unpacked))
-    if dut.out_vect_unpacked != [0x1, 0x0, 0x1]:
-        raise TestFailure("Failed to readback dut.out_vect_unpacked")
+    assert dut.out_vect_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr(dut):
+    test_value = 0x5
+    dut.in_arr.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr type %s" % type(dut.in_arr))
-    dut.in_arr = 0x5
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr type %s" % type(dut.out_arr))
-    if dut.out_arr != 0x5:
-        raise TestFailure("Failed to readback dut.out_arr")
+    assert dut.out_arr.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_vect_packed_packed(dut):
+    test_value = (0x5 << 6) | (0x5 << 3) | 0x5
+    dut.in_2d_vect_packed_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_vect_packed_packed type %s" % type(dut.in_2d_vect_packed_packed))
-    dut.in_2d_vect_packed_packed = (0x5 << 6) | (0x5 << 3) | 0x5
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_vect_packed_packed type %s" % type(dut.out_2d_vect_packed_packed))
-    if dut.out_2d_vect_packed_packed != (0x5 << 6) | (0x5 << 3) | 0x5:
-        raise TestFailure("Failed to readback dut.out_2d_vect_packed_packed")
+    assert dut.out_2d_vect_packed_packed.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_vect_packed_unpacked(dut):
+    test_value = [0x5, 0x5, 0x5]
+    dut.in_2d_vect_packed_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_vect_packed_unpacked type %s" % type(dut.in_2d_vect_packed_unpacked))
-    dut.in_2d_vect_packed_unpacked = [0x5, 0x5, 0x5]
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_vect_packed_unpacked type %s" % type(dut.out_2d_vect_packed_unpacked))
-    if dut.out_2d_vect_packed_unpacked != [0x5, 0x5, 0x5]:
-        raise TestFailure("Failed to readback dut.out_2d_vect_packed_unpacked")
+    assert dut.out_2d_vect_packed_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_vect_unpacked_unpacked(dut):
+    test_value = 3*[[0x1, 0x0, 0x1]]
+    dut.in_2d_vect_unpacked_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_vect_unpacked_unpacked type %s" % type(dut.in_2d_vect_unpacked_unpacked))
-    dut.in_2d_vect_unpacked_unpacked = 3*[[0x1, 0x0, 0x1]]
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_vect_unpacked_unpacked type %s" % type(dut.out_2d_vect_unpacked_unpacked))
-    if dut.out_2d_vect_unpacked_unpacked != 3*[[0x1, 0x0, 0x1]]:
-        raise TestFailure("Failed to readback dut.out_2d_vect_unpacked_unpacked")
+    assert dut.out_2d_vect_unpacked_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr_packed(dut):
+    test_value = 365
+    dut.in_arr_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_packed type %s" % type(dut.in_arr_packed))
-    dut.in_arr_packed = 365
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_packed type %s" % type(dut.out_arr_packed))
-    if dut.out_arr_packed != 365:
-        raise TestFailure("Failed to readback dut.out_arr_packed")
+    assert dut.out_arr_packed.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr_unpacked(dut):
+    test_value = [0x5, 0x5, 0x5]
+    dut.in_arr_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_unpackedtype %s" % type(dut.in_arr_unpacked))
-    dut.in_arr_unpacked = [0x5, 0x5, 0x5]
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_unpackedtype %s" % type(dut.out_arr_unpacked))
-    if dut.out_arr_unpacked != [0x5, 0x5, 0x5]:
-        raise TestFailure("Failed to readback dut.out_arr_unpacked")
+    assert dut.out_arr_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_arr(dut):
+    test_value = 365
+    dut.in_2d_arr.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_arr type %s" % type(dut.in_2d_arr))
-    dut.in_2d_arr = 365
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_arr type %s" % type(dut.out_2d_arr))
-    if dut.out_2d_arr != 365:
-        raise TestFailure("Failed to readback dut.out_2d_arr")
+    assert dut.out_2d_arr.value == test_value
 
 
 @cocotb.test()
 async def test_in_vect_packed_packed_packed(dut):
+    test_value = 95869805
+    dut.in_vect_packed_packed_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_packed_packed_packed type %s" % type(dut.in_vect_packed_packed_packed))
-    dut.in_vect_packed_packed_packed = 95869805
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_packed_packed_packed type %s" % type(dut.out_vect_packed_packed_packed))
-    if dut.out_vect_packed_packed_packed != 95869805:
-        raise TestFailure("Failed to readback dut.out_vect_packed_packed_packed")
+    assert dut.out_vect_packed_packed_packed.value == test_value
 
 
-# Questa unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
+# Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
 @cocotb.test(
     expect_error=IndexError
     if cocotb.LANGUAGE == "verilog" and cocotb.SIM_NAME.lower().startswith("modelsim")
     else ()
 )
 async def test_in_vect_packed_packed_unpacked(dut):
+    test_value = [365, 365, 365]
+    dut.in_vect_packed_packed_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_packed_packed_unpacked type %s" % type(dut.in_vect_packed_packed_unpacked))
-    dut.in_vect_packed_packed_unpacked = [365, 365, 365]
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_packed_packed_unpacked type %s" % type(dut.out_vect_packed_packed_unpacked))
-    if dut.out_vect_packed_packed_unpacked != [365, 365, 365]:
-        raise TestFailure("Failed to readback dut.out_vect_packed_packed_unpacked")
+    assert dut.out_vect_packed_packed_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_vect_packed_unpacked_unpacked(dut):
+    test_value = 3 *[3 * [5] ]
+    dut.in_vect_packed_unpacked_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_packed_unpacked_unpacked type %s" % type(dut.in_vect_packed_unpacked_unpacked))
-    dut.in_vect_packed_unpacked_unpacked = 3 *[3 * [5] ]
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_packed_unpacked_unpacked type %s" % type(dut.out_vect_packed_unpacked_unpacked))
-    if dut.out_vect_packed_unpacked_unpacked != 3 *[3 * [5] ]:
-        raise TestFailure("Failed to readback dut.out_vect_packed_unpacked_unpacked")
+    assert dut.out_vect_packed_unpacked_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_vect_unpacked_unpacked_unpacked(dut):
+    test_value = 3 *[3 * [[1, 0, 1]]]
+    dut.in_vect_unpacked_unpacked_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_unpacked_unpacked_unpacked type %s" % type(dut.in_vect_unpacked_unpacked_unpacked))
-    dut.in_vect_unpacked_unpacked_unpacked = 3 *[3 * [[1, 0, 1]]]
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_unpacked_unpacked_unpacked type %s" % type(dut.out_vect_unpacked_unpacked_unpacked))
-    if dut.out_vect_unpacked_unpacked_unpacked != 3 *[3 * [[1, 0, 1]]]:
-        raise TestFailure("Failed to readback dut.out_vect_unpacked_unpacked_unpacked")
+    assert dut.out_vect_unpacked_unpacked_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr_packed_packed(dut):
+    test_value = (365 << 18) | (365 << 9) | (365)
+    dut.in_arr_packed_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_packed_packed type %s" % type(dut.in_arr_packed_packed))
-    dut.in_arr_packed_packed = (365 << 18) | (365 << 9) | (365)
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_packed_packed type %s" % type(dut.out_arr_packed_packed))
-    if dut.out_arr_packed_packed != (365 << 18) | (365 << 9) | (365):
-        raise TestFailure("Failed to readback dut.out_arr_packed_packed")
+    assert dut.out_arr_packed_packed.value == test_value
 
 
-# Questa unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
+# Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
 @cocotb.test(
     expect_error=IndexError
     if cocotb.LANGUAGE == "verilog" and cocotb.SIM_NAME.lower().startswith("modelsim")
     else ()
 )
 async def test_in_arr_packed_unpacked(dut):
+    test_value = [365, 365, 365]
+    dut.in_arr_packed_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_packed_unpacked type %s" % type(dut.in_arr_packed_unpacked))
-    dut.in_arr_packed_unpacked = [365, 365, 365]
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_packed_unpacked type %s" % type(dut.out_arr_packed_unpacked))
-    if dut.out_arr_packed_unpacked != [365, 365, 365]:
-        raise TestFailure("Failed to readback dut.out_arr_packed_unpacked")
+    assert dut.out_arr_packed_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr_unpacked_unpacked(dut):
+    test_value = 3 *[3 * [5] ]
+    dut.in_arr_unpacked_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_unpacked_unpacked type %s" % type(dut.in_arr_unpacked_unpacked))
-    dut.in_arr_unpacked_unpacked = 3 *[3 * [5] ]
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_unpacked_unpacked type %s" % type(dut.out_arr_unpacked_unpacked))
-    if dut.out_arr_unpacked_unpacked != 3 *[3 * [5] ]:
-        raise TestFailure("Failed to readback dut.out_arr_unpacked_unpacked")
+    assert dut.out_arr_unpacked_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_arr_packed(dut):
+    test_value = (365 << 18) | (365 << 9) | (365)
+    dut.in_2d_arr_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_arr_packed type %s" % type(dut.in_2d_arr_packed))
-    dut.in_2d_arr_packed = (365 << 18) | (365 << 9) | (365)
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_arr_packed type %s" % type(dut.out_2d_arr_packed))
-    if dut.out_2d_arr_packed != (365 << 18) | (365 << 9) | (365):
-        raise TestFailure("Failed to readback dut.out_2d_arr_packed")
+    assert dut.out_2d_arr_packed.value == test_value
 
 
-# Questa unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
+# Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
 @cocotb.test(
     expect_error=IndexError
     if cocotb.LANGUAGE == "verilog" and cocotb.SIM_NAME.lower().startswith("modelsim")
     else ()
 )
 async def test_in_2d_arr_unpacked(dut):
+    test_value = [365, 365, 365]
+    dut.in_2d_arr_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_arr_unpacked type %s" % type(dut.in_2d_arr_unpacked))
-    dut.in_2d_arr_unpacked = [365, 365, 365]
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_arr_unpacked type %s" % type(dut.out_2d_arr_unpacked))
-    if dut.out_2d_arr_unpacked != [365, 365, 365]:
-        raise TestFailure("Failed to readback dut.out_2d_arr_unpacked")
+    assert dut.out_2d_arr_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_3d_arr(dut):
+    test_value = (365 << 18) | (365 << 9) | (365)
+    dut.in_3d_arr.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_3d_arr type %s" % type(dut.in_3d_arr))
-    dut.in_3d_arr = (365 << 18) | (365 << 9) | (365)
-    await Timer(1, "ns")
-    print("Getting: dut.out_3d_arr type %s" % type(dut.out_3d_arr))
-    if dut.out_3d_arr != (365 << 18) | (365 << 9) | (365):
-        raise TestFailure("Failed to readback dut.out_3d_arr")
+    assert dut.out_3d_arr.value == test_value

--- a/tests/test_cases/test_verilog_access/test_verilog_access.py
+++ b/tests/test_cases/test_verilog_access/test_verilog_access.py
@@ -27,7 +27,6 @@ import logging
 
 import cocotb
 from cocotb.handle import HierarchyObject, ModifiableObject
-from cocotb.result import TestFailure
 
 
 @cocotb.test()
@@ -63,5 +62,4 @@ async def port_not_hierarchy(dut):
     fails += check_instance(dut.i_verilog.clock, ModifiableObject)
     fails += check_instance(dut.i_verilog.tx_data, ModifiableObject)
 
-    if fails:
-        raise TestFailure("%d Failures during the test" % fails)
+    assert fails == 0

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -27,7 +27,6 @@ import logging
 
 import cocotb
 from cocotb.handle import HierarchyObject, ModifiableObject, IntegerObject, ConstantObject, EnumObject
-from cocotb.result import TestFailure
 
 
 # GHDL discovers enum as `vpiNet` (gh-2600)
@@ -38,8 +37,7 @@ async def check_enum_object(dut):
 
     TODO: Implement an EnumObject class and detect valid string mappings
     """
-    if not isinstance(dut.inst_ram_ctrl.write_ram_fsm, EnumObject):
-        raise TestFailure("Expected the FSM enum to be an EnumObject")
+    assert isinstance(dut.inst_ram_ctrl.write_ram_fsm, EnumObject)
 
 
 # GHDL unable to access signals in generate loops (gh-2594)
@@ -90,8 +88,7 @@ async def check_objects(dut):
     except TypeError as e:
         pass
 
-    if fails:
-        raise TestFailure("%d Failures during the test" % fails)
+    assert fails == 0
 
 
 @cocotb.test()


### PR DESCRIPTION
* Deprecates the stdout and stderr attributes on `TestComplete` exceptions
* Deprecates `TestFailure`

The stdout and stderr functions only seemed to be used by `_raise_error`, which is deprecated and otherwise unused.