### PR TITLE
Remove `TestComplete`'s from tests

### DIFF
--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -7,7 +7,6 @@ import cocotb
 
 from cocotb.clock import Clock
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
 from cocotb.handle import HierarchyObject, HierarchyArrayObject, ModifiableObject, NonHierarchyIndexableObject, ConstantObject
 
 SIM_NAME = cocotb.SIM_NAME.lower()
@@ -208,14 +207,9 @@ async def test_gen_loop(dut):
     asc_gen_20  = dut.asc_gen[20]
     desc_gen    = dut.desc_gen
 
-    if not isinstance(dut.asc_gen, HierarchyArrayObject):
-        raise TestFailure(f"Generate Loop parent >{dut.asc_gen!r}< should be HierarchyArrayObject")
-
-    if not isinstance(desc_gen, HierarchyArrayObject):
-        raise TestFailure(f"Generate Loop parent >{desc_gen!r}< should be HierarchyArrayObject")
-
-    if not isinstance(asc_gen_20, HierarchyObject):
-        raise TestFailure(f"Generate Loop child >{asc_gen_20!r}< should be HierarchyObject")
+    assert isinstance(dut.asc_gen, HierarchyArrayObject)
+    assert isinstance(desc_gen, HierarchyArrayObject)
+    assert isinstance(asc_gen_20, HierarchyObject)
 
     tlog.info("Direct access found %s", asc_gen_20)
     tlog.info("Direct access found %s", desc_gen)
@@ -223,15 +217,11 @@ async def test_gen_loop(dut):
     for gens in desc_gen:
         tlog.info("Iterate access found %s", gens)
 
-    if len(desc_gen) != 8:
-        raise TestError("Length of desc_gen is >{}< and should be 8".format(len(desc_gen)))
-    else:
-        tlog.info("Length of desc_gen is %d", len(desc_gen))
+    assert len(desc_gen) == 8
+    tlog.info("Length of desc_gen is %d", len(desc_gen))
 
-    if len(dut.asc_gen) != 8:
-        raise TestError("Length of asc_gen is >{}< and should be 8".format(len(dut.asc_gen)))
-    else:
-        tlog.info("Length of asc_gen is %d", len(dut.asc_gen))
+    assert len(dut.asc_gen) == 8
+    tlog.info("Length of asc_gen is %d", len(dut.asc_gen))
 
     for gens in dut.asc_gen:
         tlog.info("Iterate access found %s", gens)
@@ -374,8 +364,7 @@ async def test_discover_all(dut):
     tlog.info("Iterating over %r (%s)", dut, dut._type)
     total = _discover(dut, "")
     tlog.info("Found a total of %d things", total)
-    if total != pass_total:
-        raise TestFailure(f"Expected {pass_total} objects but found {total}")
+    assert total == pass_total
 
 
 # GHDL unable to access std_logic_vector generics (gh-2593)
@@ -433,21 +422,15 @@ async def test_direct_signal_indexing(dut):
     await Timer(20, "ns")
 
     tlog.info("Checking bit mapping from input to generate loops.")
-    if int(dut.desc_gen[2].sig) != 1:
-        raise TestFailure("Expected {!r} to be a 1 but got {}".format(dut.desc_gen[2].sig, int(dut.desc_gen[2].sig)))
-    else:
-        tlog.info("   %r = %d", dut.desc_gen[2].sig, int(dut.desc_gen[2].sig))
+    assert int(dut.desc_gen[2].sig) == 1
+    tlog.info("   %r = %d", dut.desc_gen[2].sig, int(dut.desc_gen[2].sig))
 
-    if int(dut.asc_gen[18].sig) != 1:
-        raise TestFailure("Expected {!r} to be a 1 but got {}".format(dut.asc_gen[18].sig, int(dut.asc_gen[18].sig)))
-    else:
-        tlog.info("   %r = %d", dut.asc_gen[18].sig, int(dut.asc_gen[18].sig))
+    assert int(dut.asc_gen[18].sig) == 1
+    tlog.info("   %r = %d", dut.asc_gen[18].sig, int(dut.asc_gen[18].sig))
 
     tlog.info("Checking indexing of data with offset index.")
-    if int(dut.port_ofst_out) != 64:
-        raise TestFailure("Expected {!r} to be a 64 but got {}".format(dut.port_ofst_out, int(dut.port_ofst_out)))
-    else:
-        tlog.info("   %r = %d (%s)", dut.port_ofst_out, int(dut.port_ofst_out), dut.port_ofst_out.value.binstr)
+    assert int(dut.port_ofst_out) == 64
+    tlog.info("   %r = %d (%s)", dut.port_ofst_out, int(dut.port_ofst_out), dut.port_ofst_out.value.binstr)
 
     tlog.info("Checking Types of complex array structures in signals.")
     _check_type(tlog, dut.sig_desc[20], ModifiableObject)

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -7,17 +7,14 @@ import logging
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.result import TestFailure
 from cocotb.triggers import Timer
 
 tlog = logging.getLogger("cocotb.test")
 
 
 def _check_value(tlog, hdl, expected):
-    if hdl.value != expected:
-        raise TestFailure(f"{hdl!r}: Expected >{expected}< but got >{hdl.value}<")
-    else:
-        tlog.info(f"   Found {hdl!r} ({hdl._type}) with value={hdl.value}")
+    assert hdl.value == expected
+    tlog.info(f"   Found {hdl!r} ({hdl._type}) with value={hdl.value}")
 
 
 # GHDL unable to put values on nested array types (gh-2588)

--- a/tests/test_cases/test_cocotb/test_pytest.py
+++ b/tests/test_cases/test_cocotb/test_pytest.py
@@ -4,22 +4,12 @@
 """ Tests relating to pytest integration """
 
 import cocotb
-from cocotb.result import TestFailure
-
-# pytest is an optional dependency
-try:
-    import pytest
-except ImportError:
-    pytest = None
+import pytest
 
 
-@cocotb.test(skip=pytest is None)
-async def test_assertion_rewriting(dut):
+@cocotb.test()
+async def test_assertion_rewriting(_):
     """ Test that assertion rewriting hooks take effect in cocotb tests """
-    try:
+    with pytest.raises(AssertionError) as e:
         assert 1 == 42
-    except AssertionError as e:
-        assert "42" in str(e), (
-            f"Assertion rewriting seems not to work, message was {e}")
-    else:
-        raise TestFailure('AssertionError was not thrown')
+    assert "42" in str(e), f"Assertion rewriting seems not to work, message was {e}"

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -12,7 +12,6 @@ from collections.abc import Coroutine
 
 import cocotb
 from cocotb.triggers import Timer
-from cocotb.result import TestFailure
 from common import clock_gen
 
 
@@ -34,7 +33,7 @@ async def test_tests_are_tests(dut):
 # just to be sure...
 @cocotb.test(expect_fail=True)
 async def test_async_test_can_fail(dut):
-    raise TestFailure
+    assert False
 
 
 @cocotb.test()

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -26,11 +26,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import cocotb
-import logging
 import pytest
 from cocotb.binary import BinaryValue
 from cocotb.triggers import Timer
-from cocotb.result import TestError, TestFailure
 from cocotb.handle import IntegerObject, ConstantObject, HierarchyObject, StringObject
 from cocotb._sim_versions import IcarusVersion
 
@@ -45,10 +43,7 @@ async def pseudo_region_access(dut):
     if len(dut._sub_handles) != 0:
         dut._sub_handles = {}
 
-    pseudo_region = dut.genblk1
-    dut._log.info("Found %s (%s)", pseudo_region._name, type(pseudo_region))
-    first_generate_instance = pseudo_region[0]
-    dut._log.info("Found %s (%s)", first_generate_instance._name, type(first_generate_instance))
+    dut.genblk1[0]
 
 
 @cocotb.test()
@@ -56,7 +51,7 @@ async def recursive_discover(dut):
     """Discover absolutely everything in the DUT"""
     def _discover(obj):
         for thing in obj:
-            dut._log.info("Found %s (%s)", thing._name, type(thing))
+            dut._log.debug("Found %s (%s)", thing._name, type(thing))
             _discover(thing)
     _discover(dut)
 
@@ -66,32 +61,23 @@ async def discover_module_values(dut):
     """Discover everything in the DUT"""
     count = 0
     for thing in dut:
-        thing._log.info("Found something: %s" % thing._fullname)
         count += 1
-    if count < 2:
-        raise TestFailure("Expected to discover things in the DUT")
+    assert count >= 2, "Expected to discover things in the DUT"
 
 
 @cocotb.test()
 async def discover_value_not_in_dut(dut):
     """Try and get a value from the DUT that is not there"""
     with pytest.raises(AttributeError):
-        fake_signal = dut.fake_signal
+        dut.fake_signal
 
 
 @cocotb.test()
 async def access_signal(dut):
     """Access a signal using the assignment mechanism"""
-    tlog = logging.getLogger("cocotb.test")
-    signal = dut.stream_in_data
-
-    tlog.info("Signal is %s" % type(signal))
     dut.stream_in_data.setimmediatevalue(1)
     await Timer(1, "ns")
-    if dut.stream_in_data.value.integer != 1:
-        raise TestError("%s.%s != %d" %
-                        (dut.stream_in_data._path,
-                         dut.stream_in_data.value.integer, 1))
+    assert dut.stream_in_data.value.integer == 1
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"])
@@ -151,23 +137,16 @@ async def access_single_bit(dut):
     """Access a single bit in a vector of the DUT"""
     dut.stream_in_data.value = 0
     await Timer(1, "ns")
-    dut._log.info("%s = %d bits" %
-                  (dut.stream_in_data._path, len(dut.stream_in_data)))
     dut.stream_in_data[2].value = 1
     await Timer(1, "ns")
-    if dut.stream_out_data_comb.value.integer != (1 << 2):
-        raise TestError("%s.%s != %d" %
-                        (dut.stream_out_data_comb._path,
-                         dut.stream_out_data_comb.value.integer, (1 << 2)))
+    assert dut.stream_out_data_comb.value.integer == (1 << 2)
 
 
-@cocotb.test(expect_error=IndexError)
+@cocotb.test()
 async def access_single_bit_erroneous(dut):
     """Access a non-existent single bit"""
-    dut._log.info("%s = %d bits" %
-                  (dut.stream_in_data._path, len(dut.stream_in_data)))
-    bit = len(dut.stream_in_data) + 4
-    dut.stream_in_data[bit].value = 1
+    with pytest.raises(IndexError):
+        dut.stream_in_data[100000]
 
 
 # Riviera discovers integers as nets (gh-2597)
@@ -185,30 +164,18 @@ async def access_single_bit_erroneous(dut):
 )
 async def access_integer(dut):
     """Integer should show as an IntegerObject"""
-    bitfail = False
-    tlog = logging.getLogger("cocotb.test")
-    test_int = dut.stream_in_int
-    if not isinstance(test_int, IntegerObject):
-        raise TestFailure("dut.stream_in_int is not an integer but {} instead".format(type(test_int)))
+    assert isinstance(dut.stream_in_int, IntegerObject)
 
-    try:
-        bit = test_int[3]
-    except IndexError as e:
-        tlog.info("Access to bit is an error as expected")
-        bitfail = True
+    with pytest.raises(IndexError):
+        dut.stream_in_int[3]
 
-    if not bitfail:
-        raise TestFailure("Access into an integer should be invalid")
-
-    length = len(test_int)
-    if length != 1:
-        raise TestFailure("Length should be 1 not %d" % length)
+    assert len(dut.stream_in_int) == 1
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["verilog"])
 async def access_ulogic(dut):
     """Access a std_ulogic as enum"""
-    constant_integer = dut.stream_in_valid
+    dut.stream_in_valid
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["verilog"])
@@ -216,206 +183,138 @@ async def access_constant_integer(dut):
     """
     Access a constant integer
     """
-    tlog = logging.getLogger("cocotb.test")
-    constant_integer = dut.isample_module1.EXAMPLE_WIDTH
-    tlog.info("Value of EXAMPLE_WIDTH is %d" % constant_integer)
-    if not isinstance(constant_integer, ConstantObject):
-        raise TestFailure("EXAMPLE_WIDTH was not constant")
-    if constant_integer != 7:
-        raise TestFailure("EXAMPLE_WIDTH was not 7")
+    assert isinstance(dut.isample_module1.EXAMPLE_WIDTH, ConstantObject)
+    assert dut.isample_module1.EXAMPLE_WIDTH == 7
 
 
 # GHDL inexplicably crashes, so we will skip this test for now
 # likely has to do with overall poor support of string over the VPI
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"] or cocotb.SIM_NAME.lower().startswith("ghdl"))
-async def access_string_vhdl(dut):
+async def access_constant_string_vhdl(dut):
     """Access to a string, both constant and signal."""
-    tlog = logging.getLogger("cocotb.test")
     constant_string = dut.isample_module1.EXAMPLE_STRING
-    tlog.info(f"{constant_string!r} is {constant_string.value}")
-    if not isinstance(constant_string, ConstantObject):
-        raise TestFailure("EXAMPLE_STRING was not constant")
-    if constant_string != b"TESTING":
-        raise TestFailure("EXAMPLE_STRING was not == \'TESTING\'")
+    assert isinstance(constant_string, ConstantObject)
+    assert constant_string.value == b"TESTING"
 
-    tlog.info("Test writing under size")
 
+# GHDL discovers strings a vpiNetArray (gh-2584)
+@cocotb.test(skip=cocotb.LANGUAGE in ["verilog"],
+             expect_error=TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+async def test_writing_string_undersized(dut):
     test_string = b"cocotb"
     dut.stream_in_string.setimmediatevalue(test_string)
-
-    variable_string = dut.stream_out_string
-    if variable_string != b'':
-        raise TestFailure("%r not \'\'" % variable_string)
-
+    assert dut.stream_out_string == b''
     await Timer(1, "ns")
+    assert dut.stream_out_string.value == test_string
 
-    if variable_string != test_string:
-        raise TestFailure(f"{variable_string!r} {variable_string.value} != '{test_string}'")
 
+# GHDL discovers strings a vpiNetArray (gh-2584)
+@cocotb.test(skip=cocotb.LANGUAGE in ["verilog"],
+             expect_error=TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+async def test_writing_string_oversized(dut):
     test_string = b"longer_than_the_array"
-    tlog.info("Test writing over size with '%s'" % test_string)
-
     dut.stream_in_string.setimmediatevalue(test_string)
-    variable_string = dut.stream_out_string
-
     await Timer(1, "ns")
+    assert dut.stream_out_string.value == test_string[:len(dut.stream_out_string)]
 
-    test_string = test_string[:len(variable_string)]
 
-    if variable_string != test_string:
-        raise TestFailure(f"{variable_string!r} {variable_string.value} != '{test_string}'")
-
-    tlog.info("Test read access to a string character")
-
-    await Timer(1, "ns")
-
+# GHDL discovers strings a vpiNetArray (gh-2584)
+@cocotb.test(skip=cocotb.LANGUAGE in ["verilog"],
+             expect_error=TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+async def test_read_single_character(dut):
+    test_string = b"cocotb!!!"
     idx = 3
-
-    result_slice = variable_string[idx]
-
+    dut.stream_in_string.setimmediatevalue(test_string)
+    await Timer(1, "ns")
     # String is defined as string(1 to 8) so idx=3 will access the 3rd character
-    if result_slice != test_string[idx - 1]:
-        raise TestFailure("Single character did not match {} != {}".format(result_slice, test_string[idx - 1]))
+    assert dut.stream_out_string[idx].value == test_string[idx - 1]
 
-    tlog.info("Test write access to a string character")
 
+# GHDL discovers strings a vpiNetArray (gh-2584)
+@cocotb.test(skip=cocotb.LANGUAGE in ["verilog"],
+             expect_error=TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else ())
+async def test_write_single_character(dut):
+    # set initial value
+    test_string = b"verilog0"
+    dut.stream_in_string.setimmediatevalue(test_string)
     await Timer(1, "ns")
 
-    for i in variable_string:
-        lower = chr(i)
-        upper = lower.upper()
-        i.setimmediatevalue(ord(upper))
-
+    # iterate over each character handle and uppercase it
+    for c in dut.stream_in_string:
+        lowercase = chr(c)
+        uppercase = lowercase.upper()
+        uppercase_as_int = ord(uppercase)
+        c.setimmediatevalue(uppercase_as_int)
     await Timer(1, "ns")
 
-    test_string = test_string.upper()
-
-    result = variable_string.value
-    tlog.info("After setting bytes of string value is %s" % result)
-    if variable_string != test_string:
-        raise TestFailure(f"{variable_string!r} {result} != '{test_string}'")
+    # test the output is uppercased
+    assert dut.stream_out_string.value == test_string.upper()
 
 
 # TODO: add tests for Verilog "string_input_port" and "STRING_LOCALPARAM" (see issue #802)
 
-@cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"] or cocotb.SIM_NAME.lower().startswith(("icarus", "riviera")),
-             expect_error=cocotb.result.TestFailure if cocotb.SIM_NAME.lower().startswith(("xmsim", "ncsim", "modelsim", "chronologic simulation vcs")) else ())
+@cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"] or cocotb.SIM_NAME.lower().startswith("riviera"),
+             expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("icarus") else ())
 async def access_const_string_verilog(dut):
     """Access to a const Verilog string."""
-    tlog = logging.getLogger("cocotb.test")
-    string_const = dut.STRING_CONST
 
     await Timer(10, "ns")
-    tlog.info(f"{string_const!r} is {string_const.value}")
-    if not isinstance(string_const, StringObject):
-        raise TestFailure("STRING_CONST was not StringObject")
-    if string_const != b"TESTING_CONST":
-        raise TestFailure(f"Initial value of STRING_CONST was not == b\'TESTING_CONST\' but {string_const.value} instead")
+    assert isinstance(dut.STRING_CONST, StringObject)
+    assert dut.STRING_CONST == b"TESTING_CONST"
 
-    tlog.info("Modifying const string")
-    string_const.value = b"MODIFIED"
+    dut.STRING_CONST.value = b"MODIFIED"
     await Timer(10, "ns")
-    if string_const != b"TESTING_CONST":
-        raise TestFailure(f"STRING_CONST was not still b\'TESTING_CONST\' after modification but {string_const.value} instead")
+    assert dut.STRING_CONST != b"TESTING_CONST"
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"],
              expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("icarus") else ())
 async def access_var_string_verilog(dut):
     """Access to a var Verilog string."""
-    tlog = logging.getLogger("cocotb.test")
-    string_var = dut.STRING_VAR
 
     await Timer(10, "ns")
-    tlog.info(f"{string_var!r} is {string_var.value}")
-    if not isinstance(string_var, StringObject):
-        raise TestFailure("STRING_VAR was not StringObject")
-    if string_var != b"TESTING_VAR":
-        raise TestFailure(f"Initial value of STRING_VAR was not == b\'TESTING_VAR\' but {string_var.value} instead")
+    assert isinstance(dut.STRING_VAR, StringObject)
+    assert dut.STRING_VAR == b"TESTING_VAR"
 
-    tlog.info("Modifying var string")
-    string_var.value = b"MODIFIED"
+    dut.STRING_VAR.value = b"MODIFIED"
     await Timer(10, "ns")
-    if string_var != b"MODIFIED":
-        raise TestFailure(f"STRING_VAR was not == b\'MODIFIED\' after modification but {string_var.value} instead")
+    assert dut.STRING_VAR == b"MODIFIED"
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["verilog"])
 async def access_constant_boolean(dut):
     """Test access to a constant boolean"""
-    tlog = logging.getLogger("cocotb.test")
-
-    constant_boolean = dut.isample_module1.EXAMPLE_BOOL
-    if not isinstance(constant_boolean, ConstantObject):
-        raise TestFailure("dut.stream_in_int.EXAMPLE_BOOL is not a ConstantObject")
-
-    tlog.info("Value of %s is %d" % (constant_boolean._path, constant_boolean.value))
+    assert isinstance(dut.isample_module1.EXAMPLE_BOOL, ConstantObject)
+    assert dut.isample_module1.EXAMPLE_BOOL.value == True  # noqa
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["verilog"])
 async def access_boolean(dut):
     """Test access to a boolean"""
-    tlog = logging.getLogger("cocotb.test")
 
-    boolean = dut.stream_in_bool
+    with pytest.raises(IndexError):
+        dut.stream_in_bool[3]
 
-    return
+    assert len(dut.stream_in_bool) == 1
 
-    # if not isinstance(boolean, IntegerObject):
-    #     raise TestFailure("dut.stream_in_boolean is not a IntegerObject is %s" % type(boolean))
-
-    try:
-        bit = boolean[3]
-    except TestError as e:
-        tlog.info("Access to bit is an error as expected")
-        bitfail = True
-
-    if not bitfail:
-        raise TestFailure("Access into an integer should be invalid")
-
-    length = len(boolean)
-    if length != 1:
-        raise TestFailure("Length should be 1 not %d" % length)
-
-    tlog.info("Value of %s is %d" % (boolean._path, boolean.value))
-
-    curr_val = int(boolean)
-    output_bool = dut.stream_out_bool
-
-    tlog.info("Before  %d After = %d" % (curr_val, (not curr_val)))
-
-    boolean.setimmediatevalue(not curr_val)
-
+    curr_val = dut.stream_in_bool.value
+    dut.stream_in_bool.setimmediatevalue(not curr_val)
     await Timer(1, "ns")
-
-    tlog.info("Value of %s is now %d" % (output_bool._path, output_bool.value))
-    if (int(curr_val) == int(output_bool)):
-        raise TestFailure("Value did not propagate")
+    assert curr_val != dut.stream_out_bool.value
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"])
 async def access_internal_register_array(dut):
     """Test access to an internal register array"""
 
-    if (dut.register_array[0].value.binstr != "xxxxxxxx"):
-        raise TestFailure("Failed to access internal register array value")
+    assert dut.register_array[0].value.binstr == "xxxxxxxx", \
+        "Failed to access internal register array value"
 
     dut.register_array[1].setimmediatevalue(4)
-
     await Timer(1, "ns")
-
-    if (dut.register_array[1].value != 4):
-        raise TestFailure("Failed to set internal register array value")
-
-
-@cocotb.test(skip=True)
-async def skip_a_test(dut):
-    """This test shouldn't execute"""
-    dut._log.info("%s = %d bits" %
-                  (dut.stream_in_data._path, len(dut.stream_in_data)))
-    bit = len(dut.stream_in_data) + 4
-    dut.stream_in_data[bit].value = 1
+    assert dut.register_array[1].value == 4, \
+        "Failed to set internal register array value"
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"],
@@ -424,10 +323,7 @@ async def access_gate(dut):
     """
     Test access to a gate Object
     """
-    gate = dut.test_and_gate
-
-    if not isinstance(gate, HierarchyObject):
-        raise TestFailure("Gate should be HierarchyObject")
+    assert isinstance(dut.test_and_gate, HierarchyObject)
 
 
 # GHDL unable to access record types (gh-2591)
@@ -438,11 +334,6 @@ async def custom_type(dut):
     """
     Test iteration over a custom type
     """
-    tlog = logging.getLogger("cocotb.test")
-
-    new_type = dut.cosLut
-    tlog.info("cosLut object {} {}".format(new_type, type(new_type)))
-
     expected_sub = 84
     expected_top = 4
 
@@ -455,15 +346,12 @@ async def custom_type(dut):
             iter_count += _discover(elem)
         return iter_count
 
-    for sub in new_type:
-        tlog.info("Sub object {} {}".format(sub, type(sub)))
+    for sub in dut.cosLut:
         sub_count = _discover(sub)
-        if sub_count != expected_sub:
-            raise TestFailure("Expected %d found %d under %s" % (expected_sub, sub_count, sub))
+        assert sub_count == expected_sub
         count += 1
 
-    if expected_top != count:
-        raise TestFailure("Expected %d found %d for cosLut" % (expected_top, count))
+    assert expected_top == count
 
 
 @cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"])
@@ -471,8 +359,6 @@ async def type_check_verilog(dut):
     """
     Test if types are recognized
     """
-
-    tlog = logging.getLogger("cocotb.test")
 
     test_handles = [
         (dut.stream_in_ready, "GPI_REGISTER"),
@@ -493,6 +379,4 @@ async def type_check_verilog(dut):
         test_handles.append((dut.logic_a, "GPI_REGISTER"))
 
     for handle in test_handles:
-        tlog.info("Handle {}".format(handle[0]._fullname))
-        if handle[0]._type != handle[1]:
-            raise TestFailure("Expected {} found {} for {}".format(handle[1], handle[0]._type, handle[0]._fullname))
+        assert handle[0]._type == handle[1]

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -27,7 +27,6 @@ import logging
 
 import cocotb
 from cocotb.triggers import First
-from cocotb.result import TestFailure
 
 
 @cocotb.test(expect_fail=cocotb.SIM_NAME in ["Icarus Verilog"])
@@ -55,8 +54,7 @@ async def recursive_discovery(dut):
         return count
     total = dump_all_the_things(dut)
     tlog.info("Found a total of %d things", total)
-    if total != pass_total:
-        raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
+    assert total == pass_total
 
 
 async def iteration_loop(dut):

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -27,7 +27,6 @@ import logging
 
 import cocotb
 from cocotb.triggers import Timer, Combine
-from cocotb.result import TestFailure
 
 
 def total_object_count():
@@ -82,8 +81,7 @@ async def recursive_discovery(dut):
         return count
     total = dump_all_the_things(dut)
     tlog.info("Found a total of %d things", total)
-    if total != pass_total:
-        raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
+    assert total == pass_total
 
 
 # GHDL unable to access signals in generate loops (gh-2594)

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -1,165 +1,122 @@
 import cocotb
-from cocotb.result import TestFailure
 from cocotb.triggers import Timer
 
 
 @cocotb.test()
 async def test_in_vect_packed(dut):
+    test_value = 0x5
+    dut.in_vect_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_packed type %s" % type(dut.in_vect_packed))
-    dut.in_vect_packed = 0x5
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_packed type %s" % type(dut.out_vect_packed))
-    if dut.out_vect_packed != 0x5:
-        raise TestFailure("Failed to readback dut.out_vect_packed")
+    assert dut.out_vect_packed.value == test_value
 
 
 @cocotb.test()
 async def test_in_vect_unpacked(dut):
+    test_value = [0x1, 0x0, 0x1]
+    dut.in_vect_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_unpacked type %s" % type(dut.in_vect_unpacked))
-    dut.in_vect_unpacked = [0x1, 0x0, 0x1]
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_unpacked type %s" % type(dut.out_vect_unpacked))
-    if dut.out_vect_unpacked != [0x1, 0x0, 0x1]:
-        raise TestFailure("Failed to readback dut.out_vect_unpacked")
+    assert dut.out_vect_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr(dut):
+    test_value = 0x5
+    dut.in_arr.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr type %s" % type(dut.in_arr))
-    dut.in_arr = 0x5
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr type %s" % type(dut.out_arr))
-    if dut.out_arr != 0x5:
-        raise TestFailure("Failed to readback dut.out_arr")
+    assert dut.out_arr.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_vect_packed_packed(dut):
+    test_value = (0x5 << 6) | (0x5 << 3) | 0x5
+    dut.in_2d_vect_packed_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_vect_packed_packed type %s" % type(dut.in_2d_vect_packed_packed))
-    dut.in_2d_vect_packed_packed = (0x5 << 6) | (0x5 << 3) | 0x5
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_vect_packed_packed type %s" % type(dut.out_2d_vect_packed_packed))
-    if dut.out_2d_vect_packed_packed != (0x5 << 6) | (0x5 << 3) | 0x5:
-        raise TestFailure("Failed to readback dut.out_2d_vect_packed_packed")
+    assert dut.out_2d_vect_packed_packed.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_vect_packed_unpacked(dut):
+    test_value = [0x5, 0x5, 0x5]
+    dut.in_2d_vect_packed_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_vect_packed_unpacked type %s" % type(dut.in_2d_vect_packed_unpacked))
-    dut.in_2d_vect_packed_unpacked = [0x5, 0x5, 0x5]
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_vect_packed_unpacked type %s" % type(dut.out_2d_vect_packed_unpacked))
-    if dut.out_2d_vect_packed_unpacked != [0x5, 0x5, 0x5]:
-        raise TestFailure("Failed to readback dut.out_2d_vect_packed_unpacked")
+    assert dut.out_2d_vect_packed_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_vect_unpacked_unpacked(dut):
+    test_value = 3*[[0x1, 0x0, 0x1]]
+    dut.in_2d_vect_unpacked_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_vect_unpacked_unpacked type %s" % type(dut.in_2d_vect_unpacked_unpacked))
-    dut.in_2d_vect_unpacked_unpacked = 3*[[0x1, 0x0, 0x1]]
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_vect_unpacked_unpacked type %s" % type(dut.out_2d_vect_unpacked_unpacked))
-    if dut.out_2d_vect_unpacked_unpacked != 3*[[0x1, 0x0, 0x1]]:
-        raise TestFailure("Failed to readback dut.out_2d_vect_unpacked_unpacked")
+    assert dut.out_2d_vect_unpacked_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr_packed(dut):
+    test_value = 365
+    dut.in_arr_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_packed type %s" % type(dut.in_arr_packed))
-    dut.in_arr_packed = 365
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_packed type %s" % type(dut.out_arr_packed))
-    if dut.out_arr_packed != 365:
-        raise TestFailure("Failed to readback dut.out_arr_packed")
+    assert dut.out_arr_packed.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr_unpacked(dut):
+    test_value = [0x5, 0x5, 0x5]
+    dut.in_arr_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_unpackedtype %s" % type(dut.in_arr_unpacked))
-    dut.in_arr_unpacked = [0x5, 0x5, 0x5]
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_unpackedtype %s" % type(dut.out_arr_unpacked))
-    if dut.out_arr_unpacked != [0x5, 0x5, 0x5]:
-        raise TestFailure("Failed to readback dut.out_arr_unpacked")
+    assert dut.out_arr_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_arr(dut):
+    test_value = 365
+    dut.in_2d_arr.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_arr type %s" % type(dut.in_2d_arr))
-    dut.in_2d_arr = 365
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_arr type %s" % type(dut.out_2d_arr))
-    if dut.out_2d_arr != 365:
-        raise TestFailure("Failed to readback dut.out_2d_arr")
+    assert dut.out_2d_arr.value == test_value
 
 
 @cocotb.test()
 async def test_in_vect_packed_packed_packed(dut):
+    test_value = 95869805
+    dut.in_vect_packed_packed_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_packed_packed_packed type %s" % type(dut.in_vect_packed_packed_packed))
-    dut.in_vect_packed_packed_packed = 95869805
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_packed_packed_packed type %s" % type(dut.out_vect_packed_packed_packed))
-    if dut.out_vect_packed_packed_packed != 95869805:
-        raise TestFailure("Failed to readback dut.out_vect_packed_packed_packed")
+    assert dut.out_vect_packed_packed_packed.value == test_value
 
 
-# Questa unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
+# Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
 @cocotb.test(
     expect_error=IndexError
     if cocotb.LANGUAGE == "verilog" and cocotb.SIM_NAME.lower().startswith("modelsim")
     else ()
 )
 async def test_in_vect_packed_packed_unpacked(dut):
+    test_value = [365, 365, 365]
+    dut.in_vect_packed_packed_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_packed_packed_unpacked type %s" % type(dut.in_vect_packed_packed_unpacked))
-    dut.in_vect_packed_packed_unpacked = [365, 365, 365]
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_packed_packed_unpacked type %s" % type(dut.out_vect_packed_packed_unpacked))
-    if dut.out_vect_packed_packed_unpacked != [365, 365, 365]:
-        raise TestFailure("Failed to readback dut.out_vect_packed_packed_unpacked")
+    assert dut.out_vect_packed_packed_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_vect_packed_unpacked_unpacked(dut):
+    test_value = 3 *[3 * [5] ]
+    dut.in_vect_packed_unpacked_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_packed_unpacked_unpacked type %s" % type(dut.in_vect_packed_unpacked_unpacked))
-    dut.in_vect_packed_unpacked_unpacked = 3 *[3 * [5] ]
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_packed_unpacked_unpacked type %s" % type(dut.out_vect_packed_unpacked_unpacked))
-    if dut.out_vect_packed_unpacked_unpacked != 3 *[3 * [5] ]:
-        raise TestFailure("Failed to readback dut.out_vect_packed_unpacked_unpacked")
+    assert dut.out_vect_packed_unpacked_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_vect_unpacked_unpacked_unpacked(dut):
+    test_value = 3 *[3 * [[1, 0, 1]]]
+    dut.in_vect_unpacked_unpacked_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_vect_unpacked_unpacked_unpacked type %s" % type(dut.in_vect_unpacked_unpacked_unpacked))
-    dut.in_vect_unpacked_unpacked_unpacked = 3 *[3 * [[1, 0, 1]]]
-    await Timer(1, "ns")
-    print("Getting: dut.out_vect_unpacked_unpacked_unpacked type %s" % type(dut.out_vect_unpacked_unpacked_unpacked))
-    if dut.out_vect_unpacked_unpacked_unpacked != 3 *[3 * [[1, 0, 1]]]:
-        raise TestFailure("Failed to readback dut.out_vect_unpacked_unpacked_unpacked")
+    assert dut.out_vect_unpacked_unpacked_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr_packed_packed(dut):
+    test_value = (365 << 18) | (365 << 9) | (365)
+    dut.in_arr_packed_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_packed_packed type %s" % type(dut.in_arr_packed_packed))
-    dut.in_arr_packed_packed = (365 << 18) | (365 << 9) | (365)
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_packed_packed type %s" % type(dut.out_arr_packed_packed))
-    if dut.out_arr_packed_packed != (365 << 18) | (365 << 9) | (365):
-        raise TestFailure("Failed to readback dut.out_arr_packed_packed")
+    assert dut.out_arr_packed_packed.value == test_value
 
 
 # Questa unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
@@ -169,35 +126,26 @@ async def test_in_arr_packed_packed(dut):
     else ()
 )
 async def test_in_arr_packed_unpacked(dut):
+    test_value = [365, 365, 365]
+    dut.in_arr_packed_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_packed_unpacked type %s" % type(dut.in_arr_packed_unpacked))
-    dut.in_arr_packed_unpacked = [365, 365, 365]
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_packed_unpacked type %s" % type(dut.out_arr_packed_unpacked))
-    if dut.out_arr_packed_unpacked != [365, 365, 365]:
-        raise TestFailure("Failed to readback dut.out_arr_packed_unpacked")
+    assert dut.out_arr_packed_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_arr_unpacked_unpacked(dut):
+    test_value = 3 *[3 * [5] ]
+    dut.in_arr_unpacked_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_arr_unpacked_unpacked type %s" % type(dut.in_arr_unpacked_unpacked))
-    dut.in_arr_unpacked_unpacked = 3 *[3 * [5] ]
-    await Timer(1, "ns")
-    print("Getting: dut.out_arr_unpacked_unpacked type %s" % type(dut.out_arr_unpacked_unpacked))
-    if dut.out_arr_unpacked_unpacked != 3 *[3 * [5] ]:
-        raise TestFailure("Failed to readback dut.out_arr_unpacked_unpacked")
+    assert dut.out_arr_unpacked_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_2d_arr_packed(dut):
+    test_value = (365 << 18) | (365 << 9) | (365)
+    dut.in_2d_arr_packed.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_arr_packed type %s" % type(dut.in_2d_arr_packed))
-    dut.in_2d_arr_packed = (365 << 18) | (365 << 9) | (365)
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_arr_packed type %s" % type(dut.out_2d_arr_packed))
-    if dut.out_2d_arr_packed != (365 << 18) | (365 << 9) | (365):
-        raise TestFailure("Failed to readback dut.out_2d_arr_packed")
+    assert dut.out_2d_arr_packed.value == test_value
 
 
 # Questa unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
@@ -207,21 +155,15 @@ async def test_in_2d_arr_packed(dut):
     else ()
 )
 async def test_in_2d_arr_unpacked(dut):
+    test_value = [365, 365, 365]
+    dut.in_2d_arr_unpacked.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_2d_arr_unpacked type %s" % type(dut.in_2d_arr_unpacked))
-    dut.in_2d_arr_unpacked = [365, 365, 365]
-    await Timer(1, "ns")
-    print("Getting: dut.out_2d_arr_unpacked type %s" % type(dut.out_2d_arr_unpacked))
-    if dut.out_2d_arr_unpacked != [365, 365, 365]:
-        raise TestFailure("Failed to readback dut.out_2d_arr_unpacked")
+    assert dut.out_2d_arr_unpacked.value == test_value
 
 
 @cocotb.test()
 async def test_in_3d_arr(dut):
+    test_value = (365 << 18) | (365 << 9) | (365)
+    dut.in_3d_arr.value = test_value
     await Timer(1, "ns")
-    print("Setting: dut.in_3d_arr type %s" % type(dut.in_3d_arr))
-    dut.in_3d_arr = (365 << 18) | (365 << 9) | (365)
-    await Timer(1, "ns")
-    print("Getting: dut.out_3d_arr type %s" % type(dut.out_3d_arr))
-    if dut.out_3d_arr != (365 << 18) | (365 << 9) | (365):
-        raise TestFailure("Failed to readback dut.out_3d_arr")
+    assert dut.out_3d_arr.value == test_value

--- a/tests/test_cases/test_verilog_access/test_verilog_access.py
+++ b/tests/test_cases/test_verilog_access/test_verilog_access.py
@@ -27,7 +27,6 @@ import logging
 
 import cocotb
 from cocotb.handle import HierarchyObject, ModifiableObject
-from cocotb.result import TestFailure
 
 
 @cocotb.test()
@@ -63,5 +62,4 @@ async def port_not_hierarchy(dut):
     fails += check_instance(dut.i_verilog.clock, ModifiableObject)
     fails += check_instance(dut.i_verilog.tx_data, ModifiableObject)
 
-    if fails:
-        raise TestFailure("%d Failures during the test" % fails)
+    assert fails == 0

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -27,7 +27,6 @@ import logging
 
 import cocotb
 from cocotb.handle import HierarchyObject, ModifiableObject, IntegerObject, ConstantObject, EnumObject
-from cocotb.result import TestFailure
 
 
 # GHDL discovers enum as `vpiNet` (gh-2600)
@@ -38,8 +37,7 @@ async def check_enum_object(dut):
 
     TODO: Implement an EnumObject class and detect valid string mappings
     """
-    if not isinstance(dut.inst_ram_ctrl.write_ram_fsm, EnumObject):
-        raise TestFailure("Expected the FSM enum to be an EnumObject")
+    assert isinstance(dut.inst_ram_ctrl.write_ram_fsm, EnumObject)
 
 
 # GHDL unable to access signals in generate loops (gh-2594)
@@ -90,8 +88,7 @@ async def check_objects(dut):
     except TypeError as e:
         pass
 
-    if fails:
-        raise TestFailure("%d Failures during the test" % fails)
+    assert fails == 0
 
 
 @cocotb.test()


### PR DESCRIPTION
Replaces `raise TestError` and `raise TestFailure` with `assert` statements so that `TestFailure` can be deprecated.