### PR TITLE
Move code in quickstart doc to its own example

### DIFF
--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -12,6 +12,14 @@ Please install the :ref:`prerequisites<install-prerequisites>`
 and cocotb itself (``pip install cocotb``) now.
 Run ``cocotb-config --version`` in a terminal window to check that cocotb is correctly installed.
 
+The code for the following example is available as
+:reposrc:`examples/doc_examples/quickstart <examples/doc_examples/quickstart>`
+in the cocotb sources.
+You can also download the files here:
+:download:`my_design.sv <../../examples/doc_examples/quickstart/my_design.sv>`,
+:download:`test_my_design.py <../../examples/doc_examples/quickstart/test_my_design.py>`,
+:download:`Makefile <../../examples/doc_examples/quickstart/Makefile>`.
+
 
 .. _quickstart_creating_a_test:
 
@@ -30,30 +38,10 @@ In the following we'll call this object ``dut``.
 
 Let's create a test file ``test_my_design.py`` containing the following:
 
-.. code-block:: python3
-
-    # test_my_design.py
-
-    import cocotb
-    from cocotb.triggers import Timer
-
-
-    @cocotb.test()
-    async def my_first_test(dut):
-        """Try accessing the design."""
-
-        dut._log.info("Running test...")
-        for cycle in range(10):
-            dut.clk <= 0
-            await Timer(1, units="ns")
-            dut.clk <= 1
-            await Timer(1, units="ns")
-
-        dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)
-        assert dut.my_signal_2.value[0] == 0, "my_signal_2[0] is not 0!"
-
-        dut._log.info("Running test...done")
-
+.. literalinclude:: ../../examples/doc_examples/quickstart/test_my_design.py
+   :language: python3
+   :start-at: # test_my_design.py (simple)
+   :end-before: # test_my_design.py (extended)
 
 This will first drive 10 periods of a square wave clock onto a port ``clk`` of the toplevel.
 After this, the clock stops,
@@ -63,7 +51,7 @@ and the value of index ``0`` of ``my_signal_2`` is checked to be ``0``.
 Things to note:
 
 * Use the ``@cocotb.test()`` decorator to mark the test function to be run.
-* Use ``<=`` to assign a value to a signal (alternatively, use ``.value =``).
+* Use ``.value = value`` to assign a value to a signal.
 * Use ``.value`` to get a signal's current value.
 
 The test shown is running sequentially, from start to end.
@@ -77,41 +65,9 @@ In cocotb, you might move the clock generation part of the example above into it
 :keyword:`async` function and :func:`~cocotb.start` it ("start it in the background")
 from the test:
 
-.. code-block:: python3
-
-    # test_my_design.py (extended)
-
-    import cocotb
-    from cocotb.triggers import Timer
-    from cocotb.triggers import FallingEdge
-
-
-    async def generate_clock(dut):
-        """Generate clock pulses."""
-
-        for cycle in range(10):
-            dut.clk <= 0
-            await Timer(1, units="ns")
-            dut.clk <= 1
-            await Timer(1, units="ns")
-
-
-    @cocotb.test()
-    async def my_second_test(dut):
-        """Try accessing the design."""
-
-        dut._log.info("Running test...")
-
-        await cocotb.start(generate_clock(dut))  # run the clock "in the background"
-
-        await Timer(5, units="ns")  # wait a bit
-        await FallingEdge(dut.clk)  # wait for falling edge/"negedge"
-
-        dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)
-        assert dut.my_signal_2.value[0] == 0, "my_signal_2[0] is not 0!"
-
-        dut._log.info("Running test...done")
-
+.. literalinclude:: ../../examples/doc_examples/quickstart/test_my_design.py
+   :language: python3
+   :start-at: # test_my_design.py (extended)
 
 Note that the ``generate_clock()`` function is *not* marked with ``@cocotb.test()``
 since this is not a test on its own, just a helper function.
@@ -147,25 +103,9 @@ In the ``Makefile`` shown below we specify:
 * and a Python module that contains our cocotb tests (:envvar:`MODULE`.
   The file containing the test without the `.py` extension, ``test_my_design`` in our case).
 
-.. code-block:: makefile
-
-    # Makefile
-
-    # defaults
-    SIM ?= icarus
-    TOPLEVEL_LANG ?= verilog
-
-    VERILOG_SOURCES += $(PWD)/my_design.sv
-    # use VHDL_SOURCES for VHDL files
-
-    # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
-    TOPLEVEL = my_design
-
-    # MODULE is the basename of the Python test file
-    MODULE = test_my_design
-
-    # include cocotb's make rules to take care of the simulator setup
-    include $(shell cocotb-config --makefiles)/Makefile.sim
+.. literalinclude:: ../../examples/doc_examples/quickstart/Makefile
+   :language: make
+   :start-at: # Makefile
 
 
 .. _quickstart_running_a_test:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -30,7 +30,11 @@
 EXAMPLES := adder/tests \
             simple_dff \
             matrix_multiplier/tests \
-            mixed_language/tests
+            mixed_language/tests \
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+EXAMPLES += doc_examples/quickstart
+endif
 
 .PHONY: $(EXAMPLES)
 

--- a/examples/doc_examples/quickstart/Makefile
+++ b/examples/doc_examples/quickstart/Makefile
@@ -1,0 +1,20 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+# Makefile
+
+# defaults
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+
+VERILOG_SOURCES += $(PWD)/my_design.sv
+# use VHDL_SOURCES for VHDL files
+
+# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
+TOPLEVEL = my_design
+
+# MODULE is the basename of the Python test file
+MODULE = test_my_design
+
+# include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/examples/doc_examples/quickstart/my_design.sv
+++ b/examples/doc_examples/quickstart/my_design.sv
@@ -1,0 +1,15 @@
+// This file is public domain, it can be freely copied without restrictions.
+// SPDX-License-Identifier: CC0-1.0
+
+module my_design(input logic clk);
+
+  timeunit 1s;
+  timeprecision 1ns;
+
+  logic my_signal_1;
+  logic my_signal_2;
+
+  assign my_signal_1 = 1'bx;
+  assign my_signal_2 = 0;
+
+endmodule

--- a/examples/doc_examples/quickstart/test_my_design.py
+++ b/examples/doc_examples/quickstart/test_my_design.py
@@ -1,0 +1,51 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+# test_my_design.py (simple)
+
+import cocotb
+from cocotb.triggers import Timer
+
+
+@cocotb.test()
+async def my_first_test(dut):
+    """Try accessing the design."""
+
+    for cycle in range(10):
+        dut.clk.value = 0
+        await Timer(1, units="ns")
+        dut.clk.value = 1
+        await Timer(1, units="ns")
+
+    dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)
+    assert dut.my_signal_2.value[0] == 0, "my_signal_2[0] is not 0!"
+
+
+# test_my_design.py (extended)
+
+import cocotb
+from cocotb.triggers import Timer
+from cocotb.triggers import FallingEdge
+
+
+async def generate_clock(dut):
+    """Generate clock pulses."""
+
+    for cycle in range(10):
+        dut.clk.value = 0
+        await Timer(1, units="ns")
+        dut.clk.value = 1
+        await Timer(1, units="ns")
+
+
+@cocotb.test()
+async def my_second_test(dut):
+    """Try accessing the design."""
+
+    await cocotb.start(generate_clock(dut))  # run the clock "in the background"
+
+    await Timer(5, units="ns")  # wait a bit
+    await FallingEdge(dut.clk)  # wait for falling edge/"negedge"
+
+    dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)
+    assert dut.my_signal_2.value[0] == 0, "my_signal_2[0] is not 0!"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ per-file-ignores =
     # F841 - local variable ... is assigned to but never used
     tests/*: F841
     examples/*: F841
+    # redefinition of unused '...' from line ...
+    examples/doc_examples/quickstart/test_my_design.py: F811
 
 [tool:pytest]
 addopts = -v --cov=cocotb --cov-branch --doctest-modules


### PR DESCRIPTION
This makes the code testable in CI.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
