### PR TITLE
Update docs to use the `sig.value = value` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ async def test_dff_simple(dut):
 
     for i in range(10):
         val = random.randint(0, 1)
-        dut.d <= val  # Assign the random value val to the input port d
+        dut.d.value = val  # Assign the random value val to the input port d
         await FallingEdge(dut.clk)
         assert dut.q.value == val, "output q was incorrect on the {}th cycle".format(i)
 ```

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -193,12 +193,12 @@ including triggers like :class:`~cocotb.triggers.Timer`.
 
     @cocotb.coroutine
     def simple_clock(signal, half_period, half_period_units):
-        signal <= 0
+        signal.value = 0
         timer = Timer(half_period, half_period_units)
         while True:
             # in generator-based coroutines triggers are yielded
             yield timer
-            signal <= ~signal
+            signal.value = ~signal
 
 Likewise, any place that will accept :keyword:`async` coroutines will also accept generator-based coroutines;
 including :func:`~cocotb.fork`.

--- a/documentation/source/refcard.rst
+++ b/documentation/source/refcard.rst
@@ -21,11 +21,11 @@ Reference Card
 *coro*: a coroutine; *task*: a running coroutine
 
 +------------------------+-----------------------------------------------------------------+
-| Assign                 | ``dut.mysignal <= 0xFF00``                                      |
+| Assign                 | ``dut.mysignal.value = 0xFF00``                                 |
 +------------------------+-----------------------------------------------------------------+
 | Assign immediately     | ``dut.mysignal.setimmediatevalue(0xFF00)``                      |
 +------------------------+-----------------------------------------------------------------+
-| Assign metavalue       | ``dut.mysignal <= BinaryValue("X")``                            |
+| Assign metavalue       | ``dut.mysignal.value = BinaryValue("X")``                       |
 +------------------------+-----------------------------------------------------------------+
 | Read                   | | ``val = dut.mysignal.value``                                  |
 |                        | | (``mysig = dut.mysignal`` *creates an alias/reference*)       |
@@ -89,13 +89,13 @@ Reference Card
 +------------------------+-----------------------------------------------------------------+
 |                                                                                          |
 +------------------------+-----------------------------------------------------------------+
-| Force value            | ``dut.mysignal <= cocotb.handle.Force(0xFF00)``                 |
+| Force value            | ``dut.mysignal.value = cocotb.handle.Force(0xFF00)``            |
 +------------------------+-----------------------------------------------------------------+
-| Keep value             | ``dut.mysignal <= cocotb.handle.Freeze()``                      |
+| Keep value             | ``dut.mysignal.value = cocotb.handle.Freeze()``                 |
 +------------------------+-----------------------------------------------------------------+
-| Release Force/Freeze   | ``dut.mysignal <= cocotb.handle.Release()``                     |
+| Release Force/Freeze   | ``dut.mysignal.value = cocotb.handle.Release()``                |
 +------------------------+-----------------------------------------------------------------+
-| *Normal assignment with* ``<=`` *is a "deposit"* (``cocotb.handle.Deposit()``)           |
+| *Normal assignment is a "deposit"* (``cocotb.handle.Deposit()``)                         |
 +------------------------+-----------------------------------------------------------------+
 |                                                                                          |
 +------------------------+-----------------------------------------------------------------+

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -34,7 +34,7 @@ Accessing bits of a vector directly was not possible until (including) version 1
 
 .. code-block:: python3
 
-    dut.stream_in_data[2] <= 1
+    dut.stream_in_data[2].value = 1
 
 See also https://github.com/steveicarus/iverilog/issues/323.
 

--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -41,14 +41,13 @@ or using direct assignment while traversing the hierarchy.
     clk.value = 1
 
     # Direct assignment through the hierarchy
-    dut.input_signal <= 12
+    dut.input_signal.value = 12
 
     # Assign a value to a memory deep in the hierarchy
-    dut.sub_block.memory.array[4] <= 2
+    dut.sub_block.memory.array[4].value = 2
 
 
-The syntax ``sig <= new_value`` is a short form of ``sig.value = new_value``.
-It not only resembles :term:`HDL` syntax, but also has the same semantics:
+The assignment syntax ``sig.value = new_value`` has the same semantics as :term:`HDL`:
 writes are not applied immediately, but delayed until the next write cycle.
 Use ``sig.setimmediatevalue(new_val)`` to set a new value immediately
 (see :meth:`~cocotb.handle.NonHierarchyObject.setimmediatevalue`).
@@ -80,14 +79,14 @@ value to signals with more fine-grained control (e.g. signed values only).
 .. code-block:: python3
 
     # assignment of negative value
-    dut.data_in <= -4
+    dut.data_in.value = -4
 
     # assignment of positive value
-    dut.data_in <= 7
+    dut.data_in.value = 7
 
     # assignment of out-of-range values
-    dut.data_in <= 8   # raises OverflowError
-    dut.data_in <= -5  # raises OverflowError
+    dut.data_in.value = 8   # raises OverflowError
+    dut.data_in.value = -5  # raises OverflowError
 
 
 .. _writing_tbs_reading_values:
@@ -152,9 +151,9 @@ The following example shows these in action:
 
     # A coroutine
     async def reset_dut(reset_n, duration_ns):
-        reset_n <= 0
+        reset_n.value = 0
         await Timer(duration_ns, units="ns")
-        reset_n <= 1
+        reset_n.value = 1
         reset_n._log.debug("Reset complete")
 
     @cocotb.test()
@@ -191,17 +190,17 @@ the various actions described in :ref:`assignment-methods` can be used.
 .. code-block:: python3
 
     # Deposit action
-    dut.my_signal <= 12
-    dut.my_signal <= Deposit(12)  # equivalent syntax
+    dut.my_signal.value = 12
+    dut.my_signal.value = Deposit(12)  # equivalent syntax
 
     # Force action
-    dut.my_signal <= Force(12)    # my_signal stays 12 until released
+    dut.my_signal.value = Force(12)    # my_signal stays 12 until released
 
     # Release action
-    dut.my_signal <= Release()    # Reverts any force/freeze assignments
+    dut.my_signal.value = Release()    # Reverts any force/freeze assignments
 
     # Freeze action
-    dut.my_signal <= Freeze()     # my_signal stays at current value until released
+    dut.my_signal.value = Freeze()     # my_signal stays at current value until released
 
 
 .. _writing_tbs_accessing_underscore_identifiers:
@@ -279,7 +278,7 @@ Below are examples of `erroring` tests.
     @cocotb.test()
     async def test(dut):
         async def coro_with_an_error():
-            dut.signal_that_does_not_exist <= 1  # AttributeError
+            dut.signal_that_does_not_exist.value = 1  # AttributeError
         cocotb.fork(coro_with_an_error())
         await Timer(10, 'ns')
 
@@ -348,4 +347,4 @@ component with the Python logging functionality.
 .. code-block:: python3
 
     dut.my_signal._log.info("Setting signal")
-    dut.my_signal <= 1
+    dut.my_signal.value = 1

--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -35,7 +35,7 @@ def test_init_zero_length():
     assert bin4.integer == 0
 
     with pytest.warns(RuntimeWarning, match=TRUNCATION_MATCH):
-        bin4 <= 5
+        bin4.value = 5
     assert bin4._str == ""
     assert bin4.binstr == ""
     assert bin4.integer == 0

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -24,7 +24,6 @@ async def test_1dim_array_handles(dut):
 
     cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
 
-    # Set values with '<=' operator
     dut.array_7_downto_4.value = [0xF0, 0xE0, 0xD0, 0xC0]
     dut.array_4_to_7.value = [0xB0, 0xA0, 0x90, 0x80]
     dut.array_3_downto_0.value = [0x70, 0x60, 0x50, 0x40]
@@ -50,7 +49,6 @@ async def test_ndim_array_handles(dut):
 
     cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
 
-    # Set values with '<=' operator
     dut.array_2d.value = [
         [0xF0, 0xE0, 0xD0, 0xC0],
         [0xB0, 0xA0, 0x90, 0x80]


### PR DESCRIPTION
Refs #2667.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
