### PR TITLE
Convert fork usage to start and start_soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ async def test_dff_simple(dut):
     """ Test that d propagates to q """
 
     clock = Clock(dut.clk, 10, units="us")  # Create a 10us period clock on port clk
-    cocotb.fork(clock.start())  # Start the clock
+    cocotb.start_soon(clock.start())  # Start the clock
 
     for i in range(10):
         val = random.randint(0, 1)

--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -51,8 +51,10 @@ class BaseClock:
 class Clock(BaseClock):
     r"""Simple 50:50 duty cycle clock driver.
 
-    Instances of this class should call its :meth:`start` method and :func:`fork` the
-    result.  This will create a clocking thread that drives the signal at the
+    Instances of this class should call its :meth:`start` method
+    and pass the coroutine object to one of the functions in :ref:`task-management`.
+
+    This will create a clocking task that drives the signal at the
     desired period/frequency.
 
     Example:
@@ -60,7 +62,7 @@ class Clock(BaseClock):
     .. code-block:: python
 
         c = Clock(dut.clk, 10, 'ns')
-        cocotb.fork(c.start())
+        await cocotb.start(c.start())
 
     Args:
         signal: The clock pin/signal to be driven.
@@ -72,7 +74,7 @@ class Clock(BaseClock):
             the timestep is determined by the simulator (see :make:var:`COCOTB_HDL_TIMEPRECISION`).
 
     If you need more features like a phase shift and an asymmetric duty cycle,
-    it is simple to create your own clock generator (that you then :func:`fork`):
+    it is simple to create your own clock generator (that you then :func:`~cocotb.start`):
 
     .. code-block:: python
 
@@ -102,7 +104,7 @@ class Clock(BaseClock):
                 await Timer(low_delay, units="ns")
 
         high_delay = low_delay = 100
-        cocotb.fork(custom_clock())
+        await cocotb.start(custom_clock())
         await Timer(1000, units="ns")
         high_delay = low_delay = 10  # change the clock speed
         await Timer(1000, units="ns")
@@ -130,7 +132,7 @@ class Clock(BaseClock):
         self.mcoro = None
 
     async def start(self, cycles=None, start_high=True):
-        r"""Clocking coroutine.  Start driving your clock by :func:`fork`\ ing a
+        r"""Clocking coroutine.  Start driving your clock by :func:`cocotb.start`\ ing a
         call to this.
 
         Args:

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -660,7 +660,7 @@ class NullTrigger(Trigger):
 
 
 class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
-    r"""Fires when a :func:`~cocotb.fork`\ ed coroutine completes.
+    r"""Fires when a task completes.
 
     The result of blocking on the trigger can be used to get the coroutine
     result::
@@ -669,7 +669,7 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
             await Timer(1, units='ns')
             return "Hello world"
 
-        task = cocotb.fork(coro_inner())
+        task = cocotb.start_soon(coro_inner())
         result = await Join(task)
         assert result == "Hello world"
 
@@ -698,14 +698,14 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
             Typically there is no need to use this attribute - the
             following code samples are equivalent::
 
-                forked = cocotb.fork(mycoro())
+                forked = cocotb.start_soon(mycoro())
                 j = Join(forked)
                 await j
                 result = j.retval
 
             ::
 
-                forked = cocotb.fork(mycoro())
+                forked = cocotb.start_soon(mycoro())
                 result = await Join(forked)
         """
         return self._coroutine.retval
@@ -807,7 +807,7 @@ class Combine(_AggregateWaitable):
                 if not triggers:
                     e.set()
                 ret.get()  # re-raise any exception
-            waiters.append(cocotb.fork(_wait_callback(t, on_done)))
+            waiters.append(cocotb.start_soon(_wait_callback(t, on_done)))
 
         # wait for the last waiter to complete
         await e
@@ -848,7 +848,7 @@ class First(_AggregateWaitable):
             def on_done(ret):
                 completed.append(ret)
                 e.set()
-            waiters.append(cocotb.fork(_wait_callback(t, on_done)))
+            waiters.append(cocotb.start_soon(_wait_callback(t, on_done)))
 
         # wait for a waiter to complete
         await e

--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -160,7 +160,7 @@ class trace:
         for sig in self._signals:
             sig.clear()
         self.enable()
-        self._coro = cocotb.fork(self._monitor())
+        self._coro = cocotb.start_soon(self._monitor())
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -208,7 +208,7 @@ including :func:`~cocotb.fork`.
     @cocotb.coroutine
     def start_clock(clk):
         # generator-based coroutines can still be forked
-        cocotb.fork(simple_clock(clk, 5, units='ns'))
+        cocotb.start_soon(simple_clock(clk, 5, units='ns'))
         yield RisingEdge(clk)
 
 :keyword:`async` coroutines can be yielded in generator-based coroutines.

--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -42,7 +42,7 @@ A reusable ``MatrixMultiplierTester`` is also defined.
 It instantiates two of the ``DataValidMonitor``\ s:
 one to monitor the matrix multiplier input,
 and another to monitor the output.
-The ``MatrixMultiplierTester`` :func:`~cocotb.fork`\ s a coroutine which consumes transactions from the input monitor,
+The ``MatrixMultiplierTester`` starts a task which consumes transactions from the input monitor,
 feeds them into a model to compute an expected output,
 and finally compares the module output to the expected for correctness.
 

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -45,16 +45,10 @@ Writing and Generating tests
 Interacting with the Simulator
 ==============================
 
-.. currentmodule:: cocotb.binary
+.. _task-management:
 
-.. autoclass:: BinaryRepresentation
-    :members:
-    :member-order: bysource
-
-.. autoclass:: BinaryValue
-    :members:
-    :member-order: bysource
-    :exclude-members: get_value, get_buff, get_binstr, get_value_signed
+Task Management
+---------------
 
 .. autofunction:: cocotb.fork
 
@@ -67,6 +61,20 @@ Interacting with the Simulator
 .. autofunction:: cocotb.decorators.RunningTask.join
 
 .. autofunction:: cocotb.decorators.RunningTask.kill
+
+Handle Values
+-------------
+
+.. currentmodule:: cocotb.binary
+
+.. autoclass:: BinaryRepresentation
+    :members:
+    :member-order: bysource
+
+.. autoclass:: BinaryValue
+    :members:
+    :member-order: bysource
+    :exclude-members: get_value, get_buff, get_binstr, get_value_signed
 
 HDL Datatypes
 -------------

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -74,7 +74,7 @@ control back to cocotb (see :ref:`simulator-triggers`).
 It's most likely that you will want to do several things "at the same time" however -
 think multiple ``always`` blocks in Verilog or ``process`` statements in VHDL.
 In cocotb, you might move the clock generation part of the example above into its own
-:keyword:`async` function and :func:`~cocotb.fork` it ("start it in the background")
+:keyword:`async` function and :func:`~cocotb.start` it ("start it in the background")
 from the test:
 
 .. code-block:: python3
@@ -102,7 +102,7 @@ from the test:
 
         dut._log.info("Running test...")
 
-        cocotb.fork(generate_clock(dut))  # run the clock "in the background"
+        await cocotb.start(generate_clock(dut))  # run the clock "in the background"
 
         await Timer(5, units="ns")  # wait a bit
         await FallingEdge(dut.clk)  # wait for falling edge/"negedge"
@@ -125,7 +125,7 @@ for more information on such concurrent processes.
    No need to write your own clock generator!
 
    You would start :class:`~cocotb.clock.Clock` with
-   ``cocotb.fork(Clock(dut.clk, 1, units="ns").start())`` near the top of your test,
+   ``cocotb.start_soon(Clock(dut.clk, 1, units="ns").start())`` near the top of your test,
    after importing it with ``from cocotb.clock import Clock``.
 
 

--- a/documentation/source/refcard.rst
+++ b/documentation/source/refcard.rst
@@ -44,14 +44,14 @@ Reference Card
 +------------------------+-----------------------------------------------------------------+
 | Wait time              | ``await cocotb.triggers.Timer(12, "ns")``                       |
 +------------------------+-----------------------------------------------------------------+
-| Generate clock         | ``clk = cocotb.fork(Clock(dut.clk, 12, "ns").start())``         |
+| Generate clock         | ``clk = await cocotb.start(Clock(dut.clk, 12, "ns").start())``  |
 +------------------------+-----------------------------------------------------------------+
 | Wait for signal edge   | | ``await cocotb.triggers.RisingEdge(dut.mysignal)``            |
 |                        | | ``await cocotb.triggers.FallingEdge(dut.mysignal)``           |
 |                        | | ``await cocotb.triggers.Edge(dut.mysignal)``                  |
 +------------------------+-----------------------------------------------------------------+
-| Run coros concurrently | | ``task_0 = cocotb.fork(coro_0())``                            |
-|                        | | ``task_1 = cocotb.scheduler.start_soon(coro)``                |
+| Run coros concurrently | | ``task_0 = await cocotb.start(coro_0())``  (start coro now)   |
+|                        | | ``task_1 = cocotb.start_soon(coro)``                          |
 |                        | | ``result = await task_0``                                     |
 +------------------------+-----------------------------------------------------------------+
 | Resume on Task 0 or 1  | ``await cocotb.triggers.First(task_0, task_1)``                 |

--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -140,7 +140,7 @@ Concurrent and sequential execution
 
 An :keyword:`await` will run an :keyword:`async` coroutine and wait for it to complete.
 The called coroutine "blocks" the execution of the current coroutine.
-Wrapping the call in :func:`~cocotb.fork` runs the coroutine concurrently,
+Wrapping the call in :func:`~cocotb.start` or :func:`~cocotb.start_soon` runs the coroutine concurrently,
 allowing the current coroutine to continue executing.
 At any time you can :keyword:`await` the result of the forked coroutine,
 which will block until the forked coroutine finishes.
@@ -165,7 +165,7 @@ The following example shows these in action:
         dut._log.debug("After reset")
 
         # Run reset_dut concurrently
-        reset_thread = cocotb.fork(reset_dut(reset_n, duration_ns=500))
+        reset_thread = cocotb.start_soon(reset_dut(reset_n, duration_ns=500))
 
         # This timer will complete before the timer in the concurrently executing "reset_thread"
         await Timer(250, units="ns")
@@ -240,14 +240,14 @@ Below are examples of `failing` tests.
     async def test(dut):
         async def fails_test():
             assert 1 > 2
-        cocotb.fork(fails_test())
+        cocotb.start_soon(fails_test())
         await Timer(10, 'ns')
 
     @cocotb.test()
     async def test(dut):
         async def fails_test():
             raise TestFailure("Reason")
-        cocotb.fork(fails_test())
+        cocotb.start_sson(fails_test())
         await Timer(10, 'ns')
 
 When a test fails, a stacktrace is printed.
@@ -279,7 +279,7 @@ Below are examples of `erroring` tests.
     async def test(dut):
         async def coro_with_an_error():
             dut.signal_that_does_not_exist.value = 1  # AttributeError
-        cocotb.fork(coro_with_an_error())
+        cocotb.start_soon(coro_with_an_error())
         await Timer(10, 'ns')
 
 When a test ends with an error, a stacktrace is printed.
@@ -316,7 +316,7 @@ Below are examples of `passing` tests.
     async def test(dut):
         async def ends_test_with_pass():
             raise TestSuccess("Reason")
-        cocotb.fork(ends_test_with_pass())
+        cocotb.start_soon(ends_test_with_pass())
         await Timer(10, 'ns')
 
 A passing test will print the following output.
@@ -335,7 +335,7 @@ and can be set to its own logging level.
 
 .. code-block:: python3
 
-    task = cocotb.fork(coro)
+    task = cocotb.start_soon(coro)
     task.log.setLevel(logging.DEBUG)
     task.log.debug("Running Task!")
 

--- a/examples/analog_model/afe.py
+++ b/examples/analog_model/afe.py
@@ -33,7 +33,7 @@ class PGA:
         self.in_queue = in_queue
         self.out_queue = out_queue
 
-        cocotb.fork(self.run())
+        cocotb.start_soon(self.run())
 
     @property
     def gain(self) -> float:
@@ -70,7 +70,7 @@ class ADC:
         self.in_queue = in_queue
         self.out_queue = out_queue
 
-        cocotb.fork(self.run())
+        cocotb.start_soon(self.run())
 
     async def run(self) -> None:
         while True:

--- a/examples/analog_model/test_analog_model.py
+++ b/examples/analog_model/test_analog_model.py
@@ -35,7 +35,7 @@ async def test_analog_model(digital) -> None:
     """Exercise an Analog Front-end and its digital controller."""
 
     clock = Clock(digital.clk, 1, units="us")  # create a 1us period clock on port clk
-    cocotb.fork(clock.start())  # start the clock
+    cocotb.start_soon(clock.start())  # start the clock
 
     afe_in_queue = Queue()
     afe_out_queue = Queue()
@@ -43,7 +43,7 @@ async def test_analog_model(digital) -> None:
         in_queue=afe_in_queue, out_queue=afe_out_queue
     )  # instantiate the analog front-end
 
-    cocotb.fork(gain_select(digital, afe))
+    cocotb.start_soon(gain_select(digital, afe))
 
     for in_V in [0.1, 0.1, 0.0, 0.25, 0.25]:
         # set the input voltage

--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -41,7 +41,7 @@ class DataValidMonitor:
         """Start monitor"""
         if self._coro is not None:
             raise RuntimeError("Monitor already started")
-        self._coro = cocotb.fork(self._run())
+        self._coro = cocotb.start_soon(self._run())
 
     def stop(self) -> None:
         """Stop monitor"""
@@ -98,7 +98,7 @@ class MatrixMultiplierTester:
             raise RuntimeError("Monitor already started")
         self.input_mon.start()
         self.output_mon.start()
-        self._checker = cocotb.fork(self._check())
+        self._checker = cocotb.start_soon(self._check())
 
     def stop(self) -> None:
         """Stops everything"""
@@ -146,7 +146,7 @@ class MatrixMultiplierTester:
 async def test_multiply(dut):
     """Test multiplication of many matrices."""
 
-    cocotb.fork(Clock(dut.clk_i, 10, units='ns').start())
+    cocotb.start_soon(Clock(dut.clk_i, 10, units='ns').start())
     tester = MatrixMultiplierTester(dut)
 
     dut._log.info("Initialize and reset model")

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -12,7 +12,7 @@ async def test_dff_simple(dut):
     """ Test that d propagates to q """
 
     clock = Clock(dut.clk, 10, units="us")  # Create a 10us period clock on port clk
-    cocotb.fork(clock.start())  # Start the clock
+    cocotb.start_soon(clock.start())  # Start the clock
 
     await FallingEdge(dut.clk)  # Synchronize with the clock
     for i in range(10):

--- a/tests/test_cases/issue_120/issue_120.py
+++ b/tests/test_cases/issue_120/issue_120.py
@@ -22,8 +22,8 @@ async def monitor(dut):
 @cocotb.test(expect_error=cocotb.triggers.TriggerException if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"] else ())
 async def issue_120_scheduling(dut):
 
-    cocotb.fork(Clock(dut.clk, 10, 'ns').start())
-    cocotb.fork(monitor(dut))
+    cocotb.start_soon(Clock(dut.clk, 10, 'ns').start())
+    cocotb.start_soon(monitor(dut))
     await RisingEdge(dut.clk)
 
     # First attempt, not from coroutine - works as expected

--- a/tests/test_cases/issue_142/issue_142.py
+++ b/tests/test_cases/issue_142/issue_142.py
@@ -11,7 +11,7 @@ from cocotb.binary import BinaryValue
 async def issue_142_overflow_error(dut):
     """Tranparently convert ints too long to pass
        through the GPI interface natively into BinaryValues"""
-    cocotb.fork(Clock(dut.clk, 10, 'ns').start())
+    cocotb.start_soon(Clock(dut.clk, 10, 'ns').start())
 
     def _compare(value):
         assert int(dut.stream_in_data_wide.value) == int(value), "Expecting 0x{:x} but got 0x{:x} on {}".format(

--- a/tests/test_cases/issue_348/issue_348.py
+++ b/tests/test_cases/issue_348/issue_348.py
@@ -38,9 +38,9 @@ class DualMonitor:
     async def start(self):
         clock_edges = 10
 
-        cocotb.fork(clock_gen(self.signal, clock_edges))
-        _ = cocotb.fork(self.signal_mon(self.signal, 0, self.edge_type))
-        _ = cocotb.fork(self.signal_mon(self.signal, 1, self.edge_type))
+        cocotb.start_soon(clock_gen(self.signal, clock_edges))
+        _ = cocotb.start_soon(self.signal_mon(self.signal, 0, self.edge_type))
+        _ = cocotb.start_soon(self.signal_mon(self.signal, 1, self.edge_type))
 
         await Timer(100, 'ns')
 

--- a/tests/test_cases/issue_588/issue_588.py
+++ b/tests/test_cases/issue_588/issue_588.py
@@ -19,7 +19,7 @@ async def issue_588_coroutine_list(dut):
     current_time = utils.get_sim_time("ns")
 
     # Yield a list, containing a RisingEdge trigger and a coroutine.
-    coro = cocotb.fork(sample_coroutine(dut))
+    coro = cocotb.start_soon(sample_coroutine(dut))
     await triggers.First(coro, triggers.Timer(100, "ns"))
     coro.kill()
 

--- a/tests/test_cases/issue_892/issue_892.py
+++ b/tests/test_cases/issue_892/issue_892.py
@@ -10,5 +10,5 @@ async def raise_test_success():
 
 @cocotb.test()
 async def error_test(dut):
-    cocotb.fork(raise_test_success())
+    cocotb.start_soon(raise_test_success())
     await Timer(10, units='ns')

--- a/tests/test_cases/issue_957/issue_957.py
+++ b/tests/test_cases/issue_957/issue_957.py
@@ -9,7 +9,7 @@ async def wait_edge(dut):
 
 @cocotb.test()
 async def test1(dut):
-    cocotb.fork(wait_edge(dut))
+    cocotb.start_soon(wait_edge(dut))
     await Timer(10, 'ns')
 
 

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -49,7 +49,7 @@ async def test_read_write(dut):
     """Test handle inheritance"""
     tlog = logging.getLogger("cocotb.test")
 
-    cocotb.fork(Clock(dut.clk, 10, "ns").start())
+    cocotb.start_soon(Clock(dut.clk, 10, "ns").start())
 
     await Timer(10, "ns")
 
@@ -407,7 +407,7 @@ async def test_direct_signal_indexing(dut):
 
     tlog = logging.getLogger("cocotb.test")
 
-    cocotb.fork(Clock(dut.clk, 10, "ns").start())
+    cocotb.start_soon(Clock(dut.clk, 10, "ns").start())
 
     dut.port_desc_in.value = 0
     dut.port_asc_in .value = 0

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -22,7 +22,7 @@ def _check_value(tlog, hdl, expected):
 async def test_1dim_array_handles(dut):
     """Test getting and setting array values using the handle of the full array."""
 
-    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+    cocotb.start_soon(Clock(dut.clk, 1000, 'ns').start())
 
     dut.array_7_downto_4.value = [0xF0, 0xE0, 0xD0, 0xC0]
     dut.array_4_to_7.value = [0xB0, 0xA0, 0x90, 0x80]
@@ -47,7 +47,7 @@ async def test_1dim_array_handles(dut):
 async def test_ndim_array_handles(dut):
     """Test getting and setting multi-dimensional array values using the handle of the full array."""
 
-    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+    cocotb.start_soon(Clock(dut.clk, 1000, 'ns').start())
 
     dut.array_2d.value = [
         [0xF0, 0xE0, 0xD0, 0xC0],
@@ -64,7 +64,7 @@ async def test_ndim_array_handles(dut):
 async def test_1dim_array_indexes(dut):
     """Test getting and setting values of array indexes."""
 
-    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+    cocotb.start_soon(Clock(dut.clk, 1000, 'ns').start())
 
     dut.array_7_downto_4.value = [0xF0, 0xE0, 0xD0, 0xC0]
     dut.array_4_to_7.value = [0xB0, 0xA0, 0x90, 0x80]
@@ -110,7 +110,7 @@ async def test_1dim_array_indexes(dut):
 async def test_ndim_array_indexes(dut):
     """Test getting and setting values of multi-dimensional array indexes."""
 
-    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+    cocotb.start_soon(Clock(dut.clk, 1000, 'ns').start())
 
     dut.array_2d.value = [
         [0xF0, 0xE0, 0xD0, 0xC0],
@@ -142,7 +142,7 @@ async def test_ndim_array_indexes(dut):
 @cocotb.test(expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")) else ())
 async def test_struct(dut):
     """Test setting and getting values of structs."""
-    cocotb.fork(Clock(dut.clk, 1000, 'ns').start())
+    cocotb.start_soon(Clock(dut.clk, 1000, 'ns').start())
     dut.inout_if.a_in.value = 1
     await Timer(1000, 'ns')
     _check_value(tlog, dut.inout_if.a_in, 1)

--- a/tests/test_cases/test_cocotb/test_async_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_async_coroutines.py
@@ -113,7 +113,7 @@ async def test_await_causes_start(dut):
 
 
 @cocotb.test()  # test forking undecorated async coroutine in legacy coroutine
-def test_undecorated_coroutine_fork(dut):
+def test_undecorated_coroutine_start_soon(dut):
     ran = False
 
     async def example():
@@ -121,7 +121,7 @@ def test_undecorated_coroutine_fork(dut):
         await cocotb.triggers.Timer(1, 'ns')
         ran = True
 
-    yield cocotb.fork(example()).join()
+    yield cocotb.start_soon(example()).join()
     assert ran
 
 
@@ -146,7 +146,7 @@ async def test_fork_coroutine_function_exception(dut):
     pattern = "Coroutine function {} should be called " \
         "prior to being scheduled.".format(coro)
     with assert_raises(TypeError, pattern):
-        cocotb.fork(coro)
+        cocotb.start_soon(coro)
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_async_generators.py
+++ b/tests/test_cases/test_cocotb/test_async_generators.py
@@ -24,7 +24,7 @@ def test_yielding_accidental_async_generator(dut):
 @cocotb.test()
 async def test_forking_accidental_async_generator(dut):
     try:
-        cocotb.fork(whoops_async_generator())
+        cocotb.start_soon(whoops_async_generator())
     except TypeError as e:
         assert "async generator" in str(e)
     else:

--- a/tests/test_cases/test_cocotb/test_clock.py
+++ b/tests/test_cases/test_cocotb/test_clock.py
@@ -22,7 +22,7 @@ async def test_clock_with_units(dut):
     assert str(clk_250mhz) == "Clock(250.0 MHz)"
     dut._log.info('Created clock >{}<'.format(str(clk_250mhz)))
 
-    clk_gen = cocotb.fork(clk_1mhz.start())
+    clk_gen = cocotb.start_soon(clk_1mhz.start())
 
     start_time_ns = get_sim_time(units='ns')
 
@@ -40,7 +40,7 @@ async def test_clock_with_units(dut):
 
     clk_gen.kill()
 
-    clk_gen = cocotb.fork(clk_250mhz.start())
+    clk_gen = await cocotb.start(clk_250mhz.start())
 
     start_time_ns = get_sim_time(units='ns')
 
@@ -62,7 +62,7 @@ async def test_clock_with_units(dut):
 @cocotb.test()
 async def test_external_clock(dut):
     """Test awaiting on an external non-cocotb coroutine decorated function"""
-    clk_gen = cocotb.fork(Clock(dut.clk, 100, "ns").start())
+    clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
     count = 0
     while count != 100:
         await RisingEdge(dut.clk)

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -39,8 +39,8 @@ async def test_unfired_first_triggers(dut):
             await Timer(1, "ns")
             e.set()
 
-    fire_task = cocotb.fork(fire_events())
-    e1_task = cocotb.fork(wait_for_e1())
+    fire_task = cocotb.start_soon(fire_events())
+    e1_task = cocotb.start_soon(wait_for_e1())
     await wait_for_firsts()
 
     # make sure the other tasks finish
@@ -68,7 +68,7 @@ async def test_nested_first(dut):
         assert ret is not inner_first
         assert ret is waiters[0]
 
-    fire_task = cocotb.fork(fire_events())
+    fire_task = cocotb.start_soon(fire_events())
     await wait_for_nested_first()
     await fire_task.join()
 
@@ -135,12 +135,25 @@ async def test_combine(dut):
     """ Test the Combine trigger. """
     # gh-852
 
-    async def do_something(delay):
+    async def coro(delay):
         await Timer(delay, "ns")
 
-    crs = [cocotb.fork(do_something(dly)) for dly in [10, 30, 20]]
+    tasks = [await cocotb.start(coro(dly)) for dly in [10, 30, 20]]
 
-    await Combine(*(cr.join() for cr in crs))
+    await Combine(*(t.join() for t in tasks))
+
+
+@cocotb.test()
+async def test_fork_combine(dut):
+    """ Test the Combine trigger with forked coroutines. """
+    # gh-852
+
+    async def coro(delay):
+        await Timer(delay, "ns")
+
+    tasks = [cocotb.fork(coro(dly)) for dly in [10, 30, 20]]
+
+    await Combine(*(t.join() for t in tasks))
 
 
 @cocotb.test()
@@ -163,15 +176,15 @@ async def test_combine_start_soon(_):
 
     max_delay = 10
 
-    coros = [cocotb.scheduler.start_soon(coro(d)) for d in range(1, max_delay + 1)]
+    tasks = [cocotb.start_soon(coro(d)) for d in range(1, max_delay + 1)]
 
     test_start = cocotb.utils.get_sim_time(units="ns")
-    await Combine(*coros)
+    await Combine(*tasks)
     assert cocotb.utils.get_sim_time(units="ns") == test_start + max_delay
 
 
 @cocotb.test()
-async def test_recursive_combine_and_fork(_):
+async def test_recursive_combine_and_start_soon(_):
     """ Test using `Combine` on forked coroutines that themselves use `Combine`. """
 
     async def mergesort(n):
@@ -179,8 +192,8 @@ async def test_recursive_combine_and_fork(_):
             return n
         part1 = n[:len(n) // 2]
         part2 = n[len(n) // 2:]
-        sort1 = cocotb.fork(mergesort(part1))
-        sort2 = cocotb.fork(mergesort(part2))
+        sort1 = cocotb.start_soon(mergesort(part1))
+        sort2 = cocotb.start_soon(mergesort(part2))
         await Combine(sort1, sort2)
         res1 = deque(sort1.retval)
         res2 = deque(sort2.retval)
@@ -213,10 +226,10 @@ async def test_recursive_combine(_):
     start_time = get_sim_time('ns')
     await Combine(
         Combine(
-            cocotb.fork(waiter(10)),
-            cocotb.fork(waiter(20))
+            cocotb.start_soon(waiter(10)),
+            cocotb.start_soon(waiter(20))
         ),
-        cocotb.fork(waiter(30))
+        cocotb.start_soon(waiter(30))
     )
     end_time = get_sim_time('ns')
 

--- a/tests/test_cases/test_cocotb/test_generator_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_generator_coroutines.py
@@ -54,11 +54,11 @@ def test_function_not_decorated(dut):
 
 
 @cocotb.test()
-def test_function_not_decorated_fork(dut):
+def test_function_not_decorated_start_soon(dut):
     """Example of trying to fork a coroutine that isn't a coroutine"""
     yield Timer(500)
     try:
-        cocotb.fork(normal_function(dut))
+        cocotb.start_soon(normal_function(dut))
     except TypeError as exc:
         assert "isn't a coroutine" in str(exc)
     else:
@@ -78,7 +78,7 @@ def test_adding_a_coroutine_without_starting(dut):
     incorrectly"""
     yield Timer(100)
     try:
-        cocotb.fork(example)
+        cocotb.start_soon(example)
     except TypeError as exc:
         assert "a coroutine that hasn't started" in str(exc)
     else:
@@ -189,7 +189,7 @@ def test_exceptions_forked(dut):
     @cocotb.coroutine
     def raise_soon():
         yield Timer(1)
-        coro = cocotb.fork(raise_inner())
+        coro = cocotb.start_soon(raise_inner())
         yield coro.join()
 
     # it's ok to change this value if the traceback changes - just make sure

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -29,7 +29,7 @@ async def test_trigger_lock(dut):
                 await Timer(10, "ns")
                 resource += 1
 
-    cocotb.fork(co())
+    cocotb.start_soon(co())
     async with lock:
         for i in range(4):
             resource += 1
@@ -67,7 +67,7 @@ async def test_internalevent(dut):
         e.set('data')
 
     # Test waiting more than once
-    cocotb.fork(set_internalevent())
+    cocotb.start_soon(set_internalevent())
     time_ns = get_sim_time(units='ns')
     await e
     assert e.is_set()
@@ -87,7 +87,7 @@ async def test_internalevent(dut):
         ran = True
 
     # Test multiple coroutines waiting
-    cocotb.fork(await_internalevent())
+    await cocotb.start(await_internalevent())
     assert not e.is_set()
     assert not ran
     # _InternalEvent can only be awaited by one coroutine
@@ -101,7 +101,7 @@ async def test_internalevent(dut):
     # Test waiting after set
     e = _InternalEvent(None)
     assert not e.is_set()
-    cocotb.fork(set_internalevent())
+    cocotb.start_soon(set_internalevent())
     await Timer(2, units='ns')
     assert e.is_set()
     time_ns = get_sim_time(units='ns')

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -126,8 +126,8 @@ async def test_readwrite_in_readonly(dut):
     """Test doing invalid sim operation"""
     global exited
     exited = False
-    clk_gen = cocotb.fork(Clock(dut.clk, 100, "ns").start())
-    coro = cocotb.fork(do_test_readwrite_in_readonly(dut))
+    clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
+    coro = cocotb.start_soon(do_test_readwrite_in_readonly(dut))
     await First(Join(coro), Timer(10_000, "ns"))
     clk_gen.kill()
     assert exited
@@ -138,8 +138,8 @@ async def test_cached_write_in_readonly(dut):
     """Test doing invalid sim operation"""
     global exited
     exited = False
-    clk_gen = cocotb.fork(Clock(dut.clk, 100, "ns").start())
-    coro = cocotb.fork(do_test_cached_write_in_readonly(dut))
+    clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
+    coro = cocotb.start_soon(do_test_cached_write_in_readonly(dut))
     await First(Join(coro), Timer(10_000, "ns"))
     clk_gen.kill()
     assert exited
@@ -150,8 +150,8 @@ async def test_afterdelay_in_readonly_valid(dut):
     """Test Timer delay after ReadOnly phase"""
     global exited
     exited = False
-    clk_gen = cocotb.fork(Clock(dut.clk, 100, "ns").start())
-    coro = cocotb.fork(do_test_afterdelay_in_readonly(dut, 1))
+    clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
+    coro = cocotb.start_soon(do_test_afterdelay_in_readonly(dut, 1))
     await First(Join(coro), Timer(100_000, "ns"))
     clk_gen.kill()
     assert exited
@@ -168,7 +168,7 @@ async def test_writes_have_taken_effect_after_readwrite(dut):
         dut.stream_in_data.setimmediatevalue(2)
 
     # queue a background task to do a manual write
-    waiter = cocotb.fork(write_manually())
+    waiter = cocotb.start_soon(write_manually())
 
     # do a delayed write. This will be overwritten
     dut.stream_in_data.value = 3

--- a/tests/test_cases/test_compare/test_compare.py
+++ b/tests/test_cases/test_compare/test_compare.py
@@ -19,7 +19,7 @@ class Testbench:
 
     async def initialise(self):
         """Initalise the testbench"""
-        cocotb.fork(Clock(self.dut.clk, 10).start())
+        cocotb.start_soon(Clock(self.dut.clk, 10).start())
         self.dut.reset.value = 0
         for _ in range(2):
             await self.clkedge

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -64,7 +64,7 @@ async def iteration_loop(dut):
 
 @cocotb.test()
 async def dual_iteration(dut):
-    loop_one = cocotb.fork(iteration_loop(dut))
-    loop_two = cocotb.fork(iteration_loop(dut))
+    loop_one = cocotb.start_soon(iteration_loop(dut))
+    loop_two = cocotb.start_soon(iteration_loop(dut))
 
     await First(loop_one.join(), loop_two.join())

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -105,8 +105,8 @@ async def dual_iteration(dut):
             thing._log.info("Found something: %s", thing._fullname)
             await Timer(1)
 
-    loop_one = cocotb.fork(iteration_loop())
-    loop_two = cocotb.fork(iteration_loop())
+    loop_one = cocotb.start_soon(iteration_loop())
+    loop_two = cocotb.start_soon(iteration_loop())
 
     await Combine(loop_one, loop_two)
 


### PR DESCRIPTION
Replace almost all instances of `cocotb.fork` with `cocotb.start` or `cocotb.start_soon`.

I'm looking for feedback on the following:
1. We probably want to keep some of the scheduler tests using fork, or add new ones.
2. I'm not sure if it's better to recommend `start` or `start_soon` in the docs. For clocks there is mixed usage that we may want to change to be consistent.