### PR TITLE
Fix MSVC build with Win11 SDK

### DIFF
--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -121,7 +121,7 @@ def create_rc_file(rc_filename, name, filename, libraries, runtime_libraries):
 
     rc_body = textwrap.dedent('''\
         #pragma code_page(65001) // UTF-8
-        #include <WinUser.h>
+        #include <Windows.h>
 
         LANGUAGE 0x00, 0x00
 


### PR DESCRIPTION
Based on a hint from here: https://social.msdn.microsoft.com/Forums/vstudio/en-US/a13d3328-7e14-40de-b5ce-83194ac24b58/vs-2010-rc-error-rc4011