### PR TITLE
Change documentation referencing release 2.0 to 1.6

### DIFF
--- a/documentation/source/analog_model.rst
+++ b/documentation/source/analog_model.rst
@@ -2,7 +2,7 @@
 Models of Analog Circuits
 #########################
 
-.. versionadded:: 2.0
+.. versionadded:: 1.6.0
 
 This is the example :mod:`analog_model` showing how to use Python models
 for analog circuits together with a digital part.

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -52,7 +52,7 @@ Cocotb
     The DUT is available in cocotb tests as a Python object at :data:`cocotb.top`;
     and is also passed to all cocotb tests as the :ref:`first and only parameter <quickstart_creating_a_test>`.
 
-    .. versionchanged:: 2.0 Strip leading and trailing whitespace
+    .. versionchanged:: 1.6.0 Strip leading and trailing whitespace
 
 .. envvar:: RANDOM_SEED
 

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -22,7 +22,7 @@ The current stable version of cocotb requires:
 * GNU Make 3+
 * A Verilog or VHDL simulator, depending on your :term:`RTL` source code
 
-.. versionchanged:: 2.0 Dropped Python 3.5 support
+.. versionchanged:: 1.6.0 Dropped Python 3.5 support
 
 .. versionchanged:: 1.4 Dropped Python 2 support
 

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -75,7 +75,7 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
 They can be used independently of cocotb for modeling and will replace :class:`BinaryValue`
 as the types used by cocotb's `simulator handles <#simulation-object-handles>`_.
 
-.. versionadded:: 2.0
+.. versionadded:: 1.6.0
 
 .. autoclass:: cocotb.types.Logic
 


### PR DESCRIPTION
As I mentioned in #2702, there are some references to 2.0 in the docs that need to be changed to 1.6.