### PR TITLE
Add doc for len()/__len__ on handles

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -156,7 +156,7 @@ class SimHandleBase:
         return self._len
 
     def __eq__(self, other):
-        """Equality comparator for handles
+        """Compare equality of handles.
 
         Example usage::
 

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -189,6 +189,7 @@ Simulation Object Handles
     :show-inheritance:
     :synopsis: Classes for simulation objects.
     :exclude-members: Deposit, Force, Freeze, Release
+    :special-members: __len__
 ..
    Excluding the Assignment Methods that are getting their own section below
 
@@ -206,6 +207,18 @@ Assignment Methods
 .. autoclass:: Freeze
 
 .. autoclass:: Release
+
+Other Handle Methods
+--------------------
+
+.. currentmodule:: None
+
+.. function:: len(handle)
+
+   Return the "length" (the number of elements) of the underlying object.
+
+   For vectors this is the number of bits.
+
 
 Miscellaneous
 =============

--- a/documentation/source/refcard.rst
+++ b/documentation/source/refcard.rst
@@ -36,6 +36,8 @@ Reference Card
 | Convert                | | ``val = dut.mysignal.value.integer``                          |
 |                        | | ``val = dut.mysignal.value.binstr``                           |
 +------------------------+-----------------------------------------------------------------+
+| Vector length          | ``num_bits = len(dut.mysignal)``                                |
++------------------------+-----------------------------------------------------------------+
 | Check                  | ``assert dut.mysignal.value == exp, "Not as expected!"``        |
 +------------------------+-----------------------------------------------------------------+
 | Logging                | ``dut._log.info("Value is", dut.mysignal.value)``               |


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
