### PR TITLE
Lock the setup-msys2 action to v2.4.2

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -351,7 +351,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: msys2/setup-msys2@v2
+    - uses: msys2/setup-msys2@v2.4.2
       with:
         msystem: MINGW64
         update: true


### PR DESCRIPTION
setup-msys2 v2.5.0 broke Python for yet unclear reasons, avoid it until
that's resolved.

See also cocotb#2739