### PR TITLE
Better document simulator support

### DIFF
--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -248,8 +248,9 @@ Issues for this simulator
 -------------------------
 
 * `All issues with label category:simulators:questa <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Aquesta>`_
-* Questa 2021.1 and later added experimental support the VHPI interface in addition to the proprietary FLI interface.
-  However, this support is not complete yet and users of cocotb should continue to use FLI for the time being.
+* Questa 2021.1 and later added experimental support the VHPI interface in addition to the proprietary FLI interface, which can be enabled by setting the :envvar:`VHDL_GPI_INTERFACE` environment variable to ``vhpi`` before running cocotb.
+  **However, VHPI support in Questa is not complete yet and users of cocotb should continue to use FLI for the time being.**
+
 
 .. _sim-modelsim:
 


### PR DESCRIPTION
* Be more explicit about Questa VHPI support.
* Be very explicit about the only supported Verilator version, instead of giving conflicting advise.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->