### PR TITLE
Pass VHDL_GPI_INTERFACE through tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ setenv =
 passenv =
     SIM
     TOPLEVEL_LANG
+    VHDL_GPI_INTERFACE
     # allow tuning of matrix_multiplier test length
     NUM_SAMPLES
     # License server configuration for proprietary simulators, e.g.


### PR DESCRIPTION
Enable users to set VHDL_GPI_INTERFACE to select VHPI or FLI for Questa
when testing cocotb.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->