### PR TITLE
Docs: TestFailure() is deprecated, avoid using it

### DIFF
--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -48,8 +48,7 @@ Coroutines can :keyword:`return` a value, so that they can be used by other coro
     async def check_signal_changes(dut):
         first = await get_signal(dut.clk, dut.signal)
         second = await get_signal(dut.clk, dut.signal)
-        if first == second:
-            raise TestFailure("Signal did not change")
+        assert first != second, "Signal did not change"
 
 Concurrent Execution
 ====================


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->