### PR TITLE
CI: Use setup-msys2 options 'location' and 'pacboy'

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -338,18 +338,19 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: msys2/setup-msys2@v2.4.2
+    - uses: msys2/setup-msys2@v2
       with:
+        # Workaround for https://github.com/cocotb/cocotb/issues/2739
+        location: D:/a/_temp/msys
         msystem: MINGW64
         update: true
-        install: |
-            git
-            make
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-python-pip
-            mingw-w64-x86_64-python-pytest
-            mingw-w64-x86_64-python-wheel
-            mingw-w64-x86_64-${{ matrix.pkg }}
+        install: git make
+        pacboy: >-
+          gcc:p
+          python-pip:p
+          python-pytest:p
+          python-wheel:p
+          ${{ matrix.pkg }}:p
     - uses: actions/checkout@v2
     - name: install cocotb
       run: pip install --no-build-isolation .


### PR DESCRIPTION
Reliance on the 'prefix' broke usage of cocotb with setup-msys2 v2.5.0, because the default installation location was changed.
As a workaround, setup-msys2 was pinned to v2.4.2 in this repo.
In release v2.6.0 of setup-msys2, two options were added:
* location: allows to specify the location of the MSYS2 installation.
* pacboy: allows simplifying the syntax for installing MINGW packages.

Having the Action pinned, prevents usage of pacboy. However, using option 'location' allows unpinning the Action, so that 'pacboy' can be used.

This PR uses both 'location' and 'pacboy'.

Refs:

- #2739
- #2740
- msys2/setup-msys2#167
- msys2-contrib/cpython-mingw#51
