### PR TITLE
Fix issue with msys2 environments

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -70,9 +70,6 @@ ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)
     $(error Unknown Python architecture: $(PYTHON_ARCH))
 endif
 
-# Set PYTHONHOME to properly populate sys.path in embedded python interpreter
-export PYTHONHOME := $(shell $(PYTHON_BIN) -c 'from sysconfig import get_config_var; print(get_config_var("prefix"))')
-
 ifeq ($(OS),Msys)
     to_tcl_path = $(shell cygpath -m $(1) )
 else


### PR DESCRIPTION
Removing line that is breaking in msys2 Python environments. The [recommendation that sparked this change](https://docs.python.org/3.9/using/windows.html#finding-modules) may not be necessary. Pinging @umarcor.