### PR TITLE
Questa mixedlang improvements

### DIFF
--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -335,6 +335,12 @@ GpiObjHdl *FliImpl::native_check_create(std::string &name, GpiObjHdl *parent) {
     } else if (search_rgn) {
         mtiRegionIdT rgn;
 
+        // Looking for generates should only occur if the parent is from this
+        // implementation
+        if (!parent->is_this_impl(fli_table)) {
+            return NULL;
+        }
+
         /* If not found, check to see if the name of a generate loop and create
          * a pseudo-region */
         for (rgn = mti_FirstLowerRegion(parent->get_handle<mtiRegionIdT>());

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -256,8 +256,8 @@ gpi_sim_hdl gpi_get_root_handle(const char *name) {
     }
 }
 
-static GpiObjHdl *__gpi_get_handle_by_name(GpiObjHdl *parent, std::string name,
-                                           GpiImplInterface *skip_impl) {
+static GpiObjHdl *gpi_get_handle_by_name_(GpiObjHdl *parent, std::string name,
+                                          GpiImplInterface *skip_impl) {
     LOG_DEBUG("Searching for %s", name.c_str());
 
     // check parent impl *first* if it's not skipped
@@ -303,8 +303,8 @@ static GpiObjHdl *__gpi_get_handle_by_name(GpiObjHdl *parent, std::string name,
     return NULL;
 }
 
-static GpiObjHdl *__gpi_get_handle_by_raw(GpiObjHdl *parent, void *raw_hdl,
-                                          GpiImplInterface *skip_impl) {
+static GpiObjHdl *gpi_get_handle_by_raw(GpiObjHdl *parent, void *raw_hdl,
+                                        GpiImplInterface *skip_impl) {
     vector<GpiImplInterface *>::iterator iter;
 
     GpiObjHdl *hdl = NULL;
@@ -335,7 +335,7 @@ static GpiObjHdl *__gpi_get_handle_by_raw(GpiObjHdl *parent, void *raw_hdl,
 
 gpi_sim_hdl gpi_get_handle_by_name(gpi_sim_hdl base, const char *name) {
     std::string s_name = name;
-    GpiObjHdl *hdl = __gpi_get_handle_by_name(base, s_name, NULL);
+    GpiObjHdl *hdl = gpi_get_handle_by_name_(base, s_name, NULL);
     if (!hdl) {
         LOG_DEBUG(
             "Failed to find a handle named %s via any registered "
@@ -398,7 +398,7 @@ gpi_sim_hdl gpi_next(gpi_iterator_hdl iter) {
                 LOG_DEBUG(
                     "Found a name but unable to create via native "
                     "implementation, trying others");
-                next = __gpi_get_handle_by_name(parent, name, iter->m_impl);
+                next = gpi_get_handle_by_name_(parent, name, iter->m_impl);
                 if (next) {
                     return next;
                 }
@@ -410,7 +410,7 @@ gpi_sim_hdl gpi_next(gpi_iterator_hdl iter) {
                 LOG_DEBUG(
                     "Found an object but not accessible via %s, trying others",
                     iter->m_impl->get_name_c());
-                next = __gpi_get_handle_by_raw(parent, raw_hdl, iter->m_impl);
+                next = gpi_get_handle_by_raw(parent, raw_hdl, iter->m_impl);
                 if (next) {
                     return next;
                 }


### PR DESCRIPTION
Cleans up some issues we found when running mixed language simulations that caused stack traces.
* tries to find handle using parent implementation first
* skips trying any implementation besides the parents when searching pseudo-regions

We are trying to avoid cases where, due to the way the GPI and the implementations were written, a handle from one implementation is simply cast into a handle from a different implementation. This is *extremely* dubious.