### PR TITLE
Fix write scheduling problem

### DIFF
--- a/documentation/source/newsfragments/2792.bugfix.rst
+++ b/documentation/source/newsfragments/2792.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed write scheduling to apply writes oldest to newest.

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -331,6 +331,23 @@ async def test_last_scheduled_write_wins_array(dut):
     assert dut.array_7_downto_4.value == [10, 2, 3, 4]
 
 
+# Most simulators do not support setting the value of a single bit of a packed array
+@cocotb.test(
+    skip=not cocotb.SIM_NAME.lower().startswith(("modelsim", "riviera"))
+    or cocotb.LANGUAGE != "vhdl"
+)
+async def test_last_scheduled_write_wins_array_handle_alias(dut):
+    """
+    Tests case where handles in the scheduled writes cache in the scheduler alias
+    """
+    dut.array_7_downto_4.value = [0, 0, 0, 0]
+    dut.array_7_downto_4[7][0].value = 1
+
+    await ReadOnly()
+
+    assert dut.array_7_downto_4.value == [1, 0, 0, 0]
+
+
 @cocotb.test()
 async def test_task_repr(dut):
     """Test RunningTask.__repr__."""


### PR DESCRIPTION
Closes #2792 

The previous solution did not guarantee that writes were applied oldest to newest. This causes problems when two handles alias the same value, such as setting a logic vector with an int, then later setting a single element of that vector. The previous solution counted on no two handles in the write cache aliasing; however this assumption is false.

The fix works by using `.popitem(last=False)` which iterates over the value in the dict in insertion order (rather than reverse insertion ordered like the previous solution). We guarantee that forward insertion order is equivalent to oldest to newest write by deleting and re-adding the scheduled write to the cache if the handle is already in the cache.

This most certainly will cause a performance regression in code that performs lots of writes, though I'm unsure how much yet.

### TODO
- [x] add test (may be possible with Icarus, Questa or Riviera?)