### PR TITLE
Links added for Open Source simulators

### DIFF
--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -355,7 +355,7 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
     make SIM=ghdl
 
 .. note::
-    A working installation of `GHDL <http://ghdl.free.fr/>`_ is required. You can find installation intructions `here <http://ghdl.free.fr/site/pmwiki.php?n=Main.Installation>`_.
+    A working installation of `GHDL <https://ghdl.github.io/>`_ is required. You can find installation instructions `here <https://ghdl.github.io/ghdl/getting.html>`_.
 
 
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -98,7 +98,8 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
     make SIM=verilator
 
 .. note::
-    A working installation of `Verilator <https://www.veripool.org/verilator/>`_ is required. You can find installation instructions can  `here <https://verilator.org/guide/latest/install.html>`_.
+    A working installation of `Verilator <https://www.veripool.org/verilator/>`_ is required.
+    You can find installation instructions `here <https://verilator.org/guide/latest/install.html>`_.
 
 
 One major limitation compared to standard Verilog simulators is that it does not support delayed assignments when accessed from cocotb.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -355,7 +355,8 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
     make SIM=ghdl
 
 .. note::
-    A working installation of `GHDL <https://ghdl.github.io/>`_ is required. You can find installation instructions `here <https://ghdl.github.io/ghdl/getting.html>`_.
+    A working installation of `GHDL <https://ghdl.github.io/ghdl/about.html>`_ is required. 
+    You can find installation instructions `here <https://ghdl.github.io/ghdl/getting.html>`_.
 
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -25,6 +25,9 @@ In order to use this simulator, set :make:var:`SIM` to ``icarus``:
 
     make SIM=icarus
 
+.. note::
+    This section requires `installation <https://iverilog.fandom.com/wiki/Installation_Guide>`_ of `Icarus Verilog <http://iverilog.icarus.com/>`_.
+
 .. _sim-icarus-accessing-bits:
 
 Accessing bits in a vector
@@ -93,6 +96,10 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
 .. code-block:: bash
 
     make SIM=verilator
+
+.. note::
+    This section requires `installation <https://verilator.org/guide/latest/install.html>`_ of `Verilator <https://www.veripool.org/verilator/>`_.
+
 
 One major limitation compared to standard Verilog simulators is that it does not support delayed assignments when accessed from cocotb.
 
@@ -345,6 +352,10 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
 .. code-block:: bash
 
     make SIM=ghdl
+
+.. note::
+    This section requires `installation <http://ghdl.free.fr/site/pmwiki.php?n=Main.Installation>`_ of `GHDL <https://www.veripool.org/verilator/>`_.
+
 
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -26,7 +26,8 @@ In order to use this simulator, set :make:var:`SIM` to ``icarus``:
     make SIM=icarus
 
 .. note::
-    A working installation of `Icarus Verilog <http://iverilog.icarus.com/>`_ is required. You can find installation instructions `here <https://iverilog.fandom.com/wiki/Installation_Guide>`_.
+    A working installation of `Icarus Verilog <http://iverilog.icarus.com/>`_ is required.
+    You can find installation instructions `here <https://iverilog.fandom.com/wiki/Installation_Guide>`_.
 
 .. _sim-icarus-accessing-bits:
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -101,7 +101,6 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
     A working installation of `Verilator <https://www.veripool.org/verilator/>`_ is required.
     You can find installation instructions `here <https://verilator.org/guide/latest/install.html>`_.
 
-
 One major limitation compared to standard Verilog simulators is that it does not support delayed assignments when accessed from cocotb.
 
 To run cocotb with Verilator, you need ``verilator`` in your PATH.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -26,7 +26,7 @@ In order to use this simulator, set :make:var:`SIM` to ``icarus``:
     make SIM=icarus
 
 .. note::
-    This section requires `installation <https://iverilog.fandom.com/wiki/Installation_Guide>`_ of `Icarus Verilog <http://iverilog.icarus.com/>`_.
+    A working installation of `Icarus Verilog <http://iverilog.icarus.com/>`_ is required. You can find installation instructions `here <https://iverilog.fandom.com/wiki/Installation_Guide>`_.
 
 .. _sim-icarus-accessing-bits:
 
@@ -98,7 +98,7 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
     make SIM=verilator
 
 .. note::
-    This section requires `installation <https://verilator.org/guide/latest/install.html>`_ of `Verilator <https://www.veripool.org/verilator/>`_.
+    A working installation of `Verilator <https://www.veripool.org/verilator/>`_ is required. You can find installation instructions can  `here <https://verilator.org/guide/latest/install.html>`_.
 
 
 One major limitation compared to standard Verilog simulators is that it does not support delayed assignments when accessed from cocotb.
@@ -354,7 +354,7 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
     make SIM=ghdl
 
 .. note::
-    This section requires `installation <http://ghdl.free.fr/site/pmwiki.php?n=Main.Installation>`_ of `GHDL <https://www.veripool.org/verilator/>`_.
+    A working installation of `GHDL <http://ghdl.free.fr/>`_ is required. You can find installation intructions `here <http://ghdl.free.fr/site/pmwiki.php?n=Main.Installation>`_.
 
 
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -357,7 +357,6 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
 .. note::
     A working installation of `GHDL <https://ghdl.github.io/>`_ is required. You can find installation instructions `here <https://ghdl.github.io/ghdl/getting.html>`_.
 
-
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.
 
 .. _sim-ghdl-issues:


### PR DESCRIPTION
For Issue #1984, links are added for about us and installation instructions for Icarus Verilog, Verilator and GHDL.

Closes #1984.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
