### PR TITLE
Release 1.6.1

### DIFF
--- a/cocotb/_version.py
+++ b/cocotb/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -7,6 +7,15 @@ Release Notes
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
+cocotb 1.6.1 (2021-12-01)
+=========================
+
+Bugfixes
+--------
+
+- Fix regression in :class:`~cocotb.regression.TestFactory` wrt unique test names. (:issue:`2781`)
+
+
 cocotb 1.6.0 (2021-10-20)
 =========================
 

--- a/tests/test_cases/test_cocotb/test_testfactory.py
+++ b/tests/test_cases/test_cocotb/test_testfactory.py
@@ -5,21 +5,27 @@
 Tests of cocotb.regression.TestFactory functionality
 """
 from collections.abc import Coroutine
+import random
+import string
 
 import cocotb
 from cocotb.regression import TestFactory
 
 
+testfactory_test_names = set()
 testfactory_test_args = set()
+prefix = "".join(random.choices(string.ascii_letters, k=4))
+postfix = "".join(random.choices(string.ascii_letters, k=4))
 
 
 async def run_testfactory_test(dut, arg1, arg2, arg3):
+    testfactory_test_names.add(cocotb.regression_manager._test.__qualname__)
     testfactory_test_args.add((arg1, arg2, arg3))
 
 factory = TestFactory(run_testfactory_test)
 factory.add_option("arg1", ["a1v1", "a1v2"])
 factory.add_option(("arg2", "arg3"), [("a2v1", "a3v1"), ("a2v2", "a3v2")])
-factory.generate_tests()
+factory.generate_tests(prefix=prefix, postfix=postfix)
 
 
 @cocotb.test()
@@ -29,6 +35,10 @@ async def test_testfactory_verify_args(dut):
         ("a1v2", "a2v1", "a3v1"),
         ("a1v1", "a2v2", "a3v2"),
         ("a1v2", "a2v2", "a3v2"),
+    }
+    assert testfactory_test_names == {
+        f"{prefix}run_testfactory_test{postfix}_{i:03}"
+        for i in range(1, 5)
     }
 
 


### PR DESCRIPTION
Includes
* a cherry-pick of the patches for the TestRegression change developed in #2788 
* release notes for 1.6.1

