### PR TITLE
Close file descriptors in test_custom_entry Makefile

### DIFF
--- a/tests/test_cases/test_custom_entry/Makefile
+++ b/tests/test_cases/test_custom_entry/Makefile
@@ -4,6 +4,6 @@ export PYGPI_ENTRY_POINT := custom_entry:entry_func
 .PHONY: override_for_this_test
 override_for_this_test:
 	-$(MAKE) all
-	python -c 'assert open("results.log").readlines() == open("expected_results.log").readlines()'
+	python -c 'import filecmp; assert filecmp.cmp("results.log", "expected_results.log")'
 
 include ../../designs/sample_module/Makefile


### PR DESCRIPTION
Python 3.8 is reporting the following when running test_custom_entry:

```
python -c 'assert open("results.log").readlines() == open("expected_results.log").readlines()'
Exception ignored in: <_io.FileIO name='results.log' mode='rb' closefd=True>
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ResourceWarning: unclosed file <_io.TextIOWrapper name='results.log' mode='r' encoding='UTF-8'>
Exception ignored in: <_io.FileIO name='expected_results.log' mode='rb' closefd=True>
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ResourceWarning: unclosed file <_io.TextIOWrapper name='expected_results.log' mode='r' encoding='UTF-8'>
```

That's not a functional problem, but we can easily work around that by
using `filecmp` instead.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->