### PR TITLE
Friendly pytest warning

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -325,7 +325,8 @@ def _initialise_testbench_(argv_):
     try:
         import pytest
     except ImportError:
-        log.warning("Pytest not found, assertion rewriting will not occur")
+        log.warning(
+            "Install pytest to enable better AssertionError messages")
     else:
         try:
             # Install the assertion rewriting hook, which must be done before we


### PR DESCRIPTION
I've changed the pytest warning to a less alarming warning:

```
0.00ns WARNING  Install pytest to enable better AssertionError messages
```

Is this a correct description?