### PR TITLE
Log the test description if it is available

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -38,6 +38,7 @@ from typing import Any, Optional, Tuple, Iterable
 from functools import wraps
 import random
 import hashlib
+import math
 
 import cocotb
 import cocotb.ANSI as ANSI
@@ -472,19 +473,26 @@ class RegressionManager:
                 return self._start_test()
 
     def _start_test(self) -> None:
+        # Want this to stand out a little bit
         start = ''
         end = ''
         if want_color_output():
             start = ANSI.COLOR_TEST
             end = ANSI.COLOR_DEFAULT
-        # Want this to stand out a little bit
+
+        if self._test.__doc__ is not None:
+            description = _trim(self._test.__doc__)
+        else:
+            description = ""
+
         self.log.info(
-            "{start}running{end} {name} ({i}/{total})".format(
+            "{start}running{end} {name} ({i}/{total}){description}".format(
                 start=start,
                 i=self.count,
                 total=self.ntests,
                 end=end,
                 name=self._test.__qualname__,
+                description=description,
             )
         )
 
@@ -791,3 +799,35 @@ class TestFactory:
                                "name_postfix" % (name, mod))
             setattr(mod, name, _create_test(self.test_function, name, doc, mod,
                                             *self.args, **kwargs))
+
+
+def _trim(docstring: str) -> str:
+    """Normalizes test docstrings
+
+    Based on https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation.
+    """
+    if not docstring:
+        return ""
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    # Determine minimum indentation (first line doesn't count):
+    indent = math.inf
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            indent = min(indent, len(line) - len(stripped))
+    # Remove indentation (first line is special):
+    trimmed = [lines[0].strip()]
+    if indent < math.inf:
+        for line in lines[1:]:
+            trimmed.append(line[indent:].rstrip())
+    # Strip off trailing and leading blank lines:
+    while trimmed and not trimmed[-1]:
+        trimmed.pop()
+    while trimmed and not trimmed[0]:
+        trimmed.pop(0)
+    # Add one newline back
+    trimmed.insert(0, "")
+    # Return a single string:
+    return "\n  ".join(trimmed)

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -479,12 +479,6 @@ class RegressionManager:
         if want_color_output():
             start = ANSI.COLOR_TEST
             end = ANSI.COLOR_DEFAULT
-
-        if self._test.__doc__ is not None:
-            description = _trim(self._test.__doc__)
-        else:
-            description = ""
-
         self.log.info(
             "{start}running{end} {name} ({i}/{total}){description}".format(
                 start=start,
@@ -492,7 +486,7 @@ class RegressionManager:
                 total=self.ntests,
                 end=end,
                 name=self._test.__qualname__,
-                description=description,
+                description=_trim(self._test.__doc__),
             )
         )
 
@@ -801,12 +795,12 @@ class TestFactory:
                                             *self.args, **kwargs))
 
 
-def _trim(docstring: str) -> str:
+def _trim(docstring: Optional[str]) -> str:
     """Normalizes test docstrings
 
     Based on https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation.
     """
-    if not docstring:
+    if docstring is None:
         return ""
     # Convert tabs to spaces (following the normal Python rules)
     # and split into a list of lines:


### PR DESCRIPTION
Fixes regression first reported [on gitter](https://gitter.im/cocotb/Lobby?at=61bf7839f20ff23319cc77a5) (ping @raysalemi). 

In cocotb 1.5 and prior, the test docstring was logged *verbatim* in the same message that contained the test start message. As Marlon pointed out, this was accidentally removed in #2507. This PR adds the message back, but handles the docstring a little smarter by normalizing the indentation using a [function provided in PEP257](https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation).