### PR TITLE
ci: generate list of tasks through a Python script

### DIFF
--- a/.github/generate-tasks.py
+++ b/.github/generate-tasks.py
@@ -2,104 +2,76 @@
 
 
 tasks = [
-  # Test different Python versions with package managed Icarus on Ubuntu
-  {
-    'sim': 'icarus',
-    'sim-version': 'apt',
-    'lang': 'verilog',
-    # lowest version according to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-    'python-version': '3.6.7',
-    'os': 'ubuntu-20.04'
-  },
-  {
-    'sim': 'icarus',
-    'sim-version': 'apt',
-    'lang': 'verilog',
-    # lowest version according to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-    'python-version': '3.7.1',
-    'os': 'ubuntu-20.04'
-  },
-  {
-    'sim': 'icarus',
-    'sim-version': 'apt',
-    'lang': 'verilog',
-    'python-version': '3.8',
-    'os': 'ubuntu-20.04'
-  },
-  {
-    'sim': 'icarus',
-    'sim-version': 'apt',
-    'lang': 'verilog',
-    'python-version': '3.9',
-    'os': 'ubuntu-20.04'
-  },
-  {
-    'sim': 'icarus',
-    'sim-version': 'apt',
-    'lang': 'verilog',
-    'python-version': '3.10',
-    'os': 'ubuntu-20.04'
-  },
-  # Test Icarus dev on Ubuntu
-  {
-    'sim': 'icarus',
-    'sim-version': 'master',
-    'lang': 'verilog',
-    'python-version': '3.8',
-    'os': 'ubuntu-20.04',
-  },
-  # Test GHDL on Ubuntu
-  {
-    'sim': 'ghdl',
-    'sim-version': 'nightly',
-    'lang': 'vhdl',
-    'python-version': '3.8',
-    'os': 'ubuntu-latest',
-  },
-  # Test Verilator on Ubuntu
-  {
-    'sim': 'verilator',
-    'sim-version': 'master',
-    'lang': 'verilog',
-    'python-version': '3.8',
-    'os': 'ubuntu-20.04',
-    'may_fail': 'true',
-  },
-  # Test other OSes
-  {
-   'sim': 'icarus',  # Icarus homebrew --HEAD
-   'sim-version': 'homebrew-HEAD',
-   'lang': 'verilog',
-   'python-version': '3.8',
-   'os': 'macos-latest',
-  },{
-    'sim': 'icarus',  # Icarus windows master from source
-    'sim-version': 'master',
-    'lang': 'verilog',
-    'python-version': '3.8',
-    'os': 'windows-latest',
-    'toolchain': 'mingw',
-    'extra_name': 'mingw | ',
-  },{
-    'sim': 'icarus',  # use msvc instead of mingw
-    'sim-version': 'master',
-    'lang': 'verilog',
-    'python-version': '3.8',
-    'os': 'windows-latest',
-    'toolchain': 'msvc',
-    'extra_name': 'msvc | ',
-  },
-  # Other
-  {
-    'sim': 'icarus',  # use clang instead of gcc
-    'sim-version': 'v11_0',
-    'lang': 'verilog',
-    'python-version': '3.8"',
-    'os': 'ubuntu-20.04',
-    'cxx': 'clang++',
-    'cc': 'clang',
-    'extra_name': 'clang | ',
-  }
+    # Test different Python versions with package managed Icarus on Ubuntu
+    {
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'apt',
+        # lowest version according to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+        'os': 'ubuntu-20.04', 'python-version': '3.6.7'
+    },
+    {
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'apt',
+        # lowest version according to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+        'os': 'ubuntu-20.04', 'python-version': '3.7.1'
+    },
+    {
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'apt',
+        'os': 'ubuntu-20.04', 'python-version': '3.8'
+    },
+    {
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'apt',
+        'os': 'ubuntu-20.04', 'python-version': '3.9'
+    },
+    {
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'apt',
+        'os': 'ubuntu-20.04', 'python-version': '3.10'
+    },
+    # Test Icarus dev on Ubuntu
+    {
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'master',
+        'os': 'ubuntu-20.04', 'python-version': '3.8'
+    },
+    # Test GHDL on Ubuntu
+    {
+        'lang': 'vhdl',
+        'sim': 'ghdl', 'sim-version': 'nightly',
+        'os': 'ubuntu-latest', 'python-version': '3.8'
+    },
+    # Test Verilator on Ubuntu
+    {
+        'lang': 'verilog',
+        'sim': 'verilator', 'sim-version': 'master',
+        'os': 'ubuntu-20.04', 'python-version': '3.8',
+        'may_fail': 'true'
+    },
+    # Test other OSes
+    {
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'homebrew-HEAD',    # Icarus homebrew --HEAD
+        'os': 'macos-latest', 'python-version': '3.8'
+    },{
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'master',    # Icarus windows master from source
+        'os': 'windows-latest', 'python-version': '3.8',
+        'toolchain': 'mingw', 'extra_name': 'mingw | '
+    },{
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'master',    # use msvc instead of mingw
+        'os': 'windows-latest', 'python-version': '3.8',
+        'toolchain': 'msvc', 'extra_name': 'msvc | '
+    },
+    # Other
+    {
+        'lang': 'verilog',
+        'sim': 'icarus', 'sim-version': 'v11_0',    # use clang instead of gcc
+        'os': 'ubuntu-20.04', 'python-version': '3.8"',
+        'cxx': 'clang++', 'cc': 'clang', 'extra_name': 'clang | '
+    }
 ]
 
 print(f"::set-output name=tasks::{tasks!s}")

--- a/.github/generate-tasks.py
+++ b/.github/generate-tasks.py
@@ -47,7 +47,7 @@ tasks = [
         'lang': 'verilog',
         'sim': 'verilator', 'sim-version': 'master',
         'os': 'ubuntu-20.04', 'python-version': '3.8',
-        'may_fail': 'true'
+        'may_fail': 'True'
     },
     # Test other OSes
     {
@@ -69,7 +69,7 @@ tasks = [
     {
         'lang': 'verilog',
         'sim': 'icarus', 'sim-version': 'v11_0',    # use clang instead of gcc
-        'os': 'ubuntu-20.04', 'python-version': '3.8"',
+        'os': 'ubuntu-20.04', 'python-version': '3.8',
         'cxx': 'clang++', 'cc': 'clang', 'extra_name': 'clang | '
     }
 ]

--- a/.github/generate-tasks.py
+++ b/.github/generate-tasks.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+
+tasks = [
+  # Test different Python versions with package managed Icarus on Ubuntu
+  {
+    'sim': 'icarus',
+    'sim-version': 'apt',
+    'lang': 'verilog',
+    # lowest version according to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+    'python-version': '3.6.7',
+    'os': 'ubuntu-20.04'
+  },
+  {
+    'sim': 'icarus',
+    'sim-version': 'apt',
+    'lang': 'verilog',
+    # lowest version according to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+    'python-version': '3.7.1',
+    'os': 'ubuntu-20.04'
+  },
+  {
+    'sim': 'icarus',
+    'sim-version': 'apt',
+    'lang': 'verilog',
+    'python-version': '3.8',
+    'os': 'ubuntu-20.04'
+  },
+  {
+    'sim': 'icarus',
+    'sim-version': 'apt',
+    'lang': 'verilog',
+    'python-version': '3.9',
+    'os': 'ubuntu-20.04'
+  },
+  {
+    'sim': 'icarus',
+    'sim-version': 'apt',
+    'lang': 'verilog',
+    'python-version': '3.10',
+    'os': 'ubuntu-20.04'
+  },
+  # Test Icarus dev on Ubuntu
+  {
+    'sim': 'icarus',
+    'sim-version': 'master',
+    'lang': 'verilog',
+    'python-version': '3.8',
+    'os': 'ubuntu-20.04',
+  },
+  # Test GHDL on Ubuntu
+  {
+    'sim': 'ghdl',
+    'sim-version': 'nightly',
+    'lang': 'vhdl',
+    'python-version': '3.8',
+    'os': 'ubuntu-latest',
+  },
+  # Test Verilator on Ubuntu
+  {
+    'sim': 'verilator',
+    'sim-version': 'master',
+    'lang': 'verilog',
+    'python-version': '3.8',
+    'os': 'ubuntu-20.04',
+    'may_fail': 'true',
+  },
+  # Test other OSes
+  {
+   'sim': 'icarus',  # Icarus homebrew --HEAD
+   'sim-version': 'homebrew-HEAD',
+   'lang': 'verilog',
+   'python-version': '3.8',
+   'os': 'macos-latest',
+  },{
+    'sim': 'icarus',  # Icarus windows master from source
+    'sim-version': 'master',
+    'lang': 'verilog',
+    'python-version': '3.8',
+    'os': 'windows-latest',
+    'toolchain': 'mingw',
+    'extra_name': 'mingw | ',
+  },{
+    'sim': 'icarus',  # use msvc instead of mingw
+    'sim-version': 'master',
+    'lang': 'verilog',
+    'python-version': '3.8',
+    'os': 'windows-latest',
+    'toolchain': 'msvc',
+    'extra_name': 'msvc | ',
+  },
+  # Other
+  {
+    'sim': 'icarus',  # use clang instead of gcc
+    'sim-version': 'v11_0',
+    'lang': 'verilog',
+    'python-version': '3.8"',
+    'os': 'ubuntu-20.04',
+    'cxx': 'clang++',
+    'cc': 'clang',
+    'extra_name': 'clang | ',
+  }
+]
+
+print(f"::set-output name=tasks::{tasks!s}")

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -33,7 +33,19 @@ jobs:
         pip install pre-commit
         pre-commit run -a
 
+  tasks:
+    runs-on: ubuntu-latest
+    name: Generate list of tasks
+    outputs:
+      tasks: ${{ steps.tasks.outputs.tasks }}
+    steps:
+    - uses: actions/checkout@v2
+    - run: ./.github/generate-tasks.py
+      id: tasks
+
   tests:
+
+    needs: tasks
 
     name: ${{matrix.extra_name}}${{matrix.sim}} (${{matrix.sim-version}}) | ${{matrix.os}} | Python ${{matrix.python-version}} ${{matrix.may_fail && '| May Fail' || ''}}
     runs-on: ${{matrix.os}}
@@ -49,108 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-
-            # Test different Python versions with package managed Icarus on Ubuntu
-
-          - sim: icarus
-            sim-version: apt
-            lang: verilog
-            # lowest version according to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-            python-version: "3.6.7"
-            os: ubuntu-20.04
-
-          - sim: icarus
-            sim-version: apt
-            lang: verilog
-            # lowest version according to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-            python-version: "3.7.1"
-            os: ubuntu-20.04
-
-          - sim: icarus
-            sim-version: apt
-            lang: verilog
-            python-version: "3.8"
-            os: ubuntu-20.04
-
-          - sim: icarus
-            sim-version: apt
-            lang: verilog
-            python-version: "3.9"
-            os: ubuntu-20.04
-
-          - sim: icarus
-            sim-version: apt
-            lang: verilog
-            python-version: "3.10"
-            os: ubuntu-20.04
-
-          # A single test for the upcoming Python version.
-          - sim: icarus
-            sim-version: apt
-            lang: verilog
-            python-version: "3.11.0-alpha - 3.11.0"
-            os: ubuntu-20.04
-
-            # Test Icarus dev on Ubuntu
-
-          - sim: icarus
-            sim-version: master
-            lang: verilog
-            python-version: "3.8"
-            os: ubuntu-20.04
-
-            # Test GHDL on Ubuntu
-
-          - sim: ghdl
-            sim-version: nightly
-            lang: vhdl
-            python-version: "3.8"
-            os: ubuntu-latest
-
-            # Test Verilator on Ubuntu
-
-          - sim: verilator
-            sim-version: master
-            lang: verilog
-            python-version: "3.8"
-            os: ubuntu-20.04
-            may_fail: true
-
-            # Test other OSes
-
-          - sim: icarus             # Icarus homebrew --HEAD
-            sim-version: homebrew-HEAD
-            lang: verilog
-            python-version: "3.8"
-            os: macos-latest
-
-          - sim: icarus             # Icarus windows master from source
-            sim-version: master
-            lang: verilog
-            python-version: "3.8"
-            os: windows-latest
-            toolchain: mingw
-            extra_name: "mingw | "
-
-          - sim: icarus             # use msvc instead of mingw
-            sim-version: master
-            lang: verilog
-            python-version: 3.8
-            os: windows-latest
-            toolchain: msvc
-            extra_name: "msvc | "
-
-            # Other
-
-          - sim: icarus             # use clang instead of gcc
-            sim-version: v11_0
-            lang: verilog
-            python-version: "3.8"
-            os: ubuntu-20.04
-            cxx: clang++
-            cc: clang
-            extra_name: "clang | "
+        include: ${{ fromJson(needs.tasks.outputs.tasks) }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR is a draft to dynamically generate the GitHub Actions jobs/tests/tasks through a Python script. Currently, it is a plain conversion from the YAML fields into Python. However, it can be extended to read environment variables and/or context fields.

/cc @ktbarrett
