### PR TITLE
Fix example doc reference to TestFactory

### DIFF
--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -49,7 +49,7 @@ and finally compares the module output to the expected for correctness.
 The main test coroutine stimulates the matrix multiplier DUT with the test data.
 Once all the test inputs have been applied it decides when the test is done.
 
-The testbench makes use of :class:`.TestFactory` and random data generators to test many sets of matrices.
+The testbench makes use of random data generators to test many sets of matrices.
 
 The number of data bits for each entry in the matrices,
 as well as the row and column counts for each matrix,


### PR DESCRIPTION
TestFactory was removed from matrix multiplier example by ad981341

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
