### PR TITLE
Fix regression tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -256,7 +256,8 @@ jobs:
     - name: Install cocotb (Windows, mingw)
       if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'mingw'
       run: |
-        python -m pip install --global-option build_ext --global-option --compiler=mingw32 -v -e .[bus]
+        python ./setup.py build_ext --compiler=mingw32 develop
+        pip install cocotb-bus
       continue-on-error: ${{matrix.may_fail || false}}
     - name: Install cocotb (Windows, msvc)
       if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'msvc'

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -71,7 +71,7 @@ ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)
 endif
 
 # Set PYTHONHOME to properly populate sys.path in embedded python interpreter
-export PYTHONHOME := $(shell $(PYTHON_BIN) -c 'from sysconfig import get_config_var; print(get_config_var("prefix"))')
+export PYTHONHOME := $(shell $(PYTHON_BIN) -c 'import sys; print(sys.prefix)')
 
 ifeq ($(OS),Msys)
     to_tcl_path = $(shell cygpath -m $(1) )


### PR DESCRIPTION
Closes #2739.

* Changes how PYTHONHOME is set to use the site package
* Calls setup.py directly to install cocotb in Windows/Anaconda/gcc CI test since pip doesn't pass `--global-options` through in PEP517 mode :/