### PR TITLE
Fix TestFactory to work with legacy-style tests

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -35,7 +35,6 @@ import os
 import traceback
 import pdb
 from typing import Any, Optional, Tuple, Iterable
-from functools import wraps
 import random
 import hashlib
 import math
@@ -631,7 +630,6 @@ def _create_test(function, name, documentation, mod, *args, **kwargs):
         Decorated test function
     """
 
-    @wraps(function)
     async def _my_test(dut):
         await function(dut, *args, **kwargs)
 

--- a/tests/test_cases/test_cocotb/test_testfactory.py
+++ b/tests/test_cases/test_cocotb/test_testfactory.py
@@ -10,6 +10,7 @@ import string
 
 import cocotb
 from cocotb.regression import TestFactory
+from cocotb.triggers import NullTrigger
 
 
 testfactory_test_names = set()
@@ -63,3 +64,22 @@ class TestClass(Coroutine):
 tf = TestFactory(TestClass)
 tf.add_option("myarg", [1])
 tf.generate_tests()
+
+
+generator_testfactory_args = set()
+
+
+@cocotb.coroutine
+def generator_test(dut, arg):
+    generator_testfactory_args.add(arg)
+    yield NullTrigger()
+
+
+generator_testfactory = TestFactory(generator_test)
+generator_testfactory.add_option("arg", [1, 2, 3, 4])
+generator_testfactory.generate_tests()
+
+
+@cocotb.test()
+async def test_generator_testfactory(_):
+    assert generator_testfactory_args == {1, 2, 3, 4}


### PR DESCRIPTION
Wrapping a wrapped function-like is breaking something. Going to not do that... Turns out it wasn't even needed. It should have been removed with the other TestFactory fix in v1.6.1. 

Addresses #2839. Will cherry-pick on top of v1.6.1 in a follow on, which will close the issue.