### PR TITLE
Prepare v1.6.2 release

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -256,7 +256,8 @@ jobs:
     - name: Install cocotb (Windows, mingw)
       if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'mingw'
       run: |
-        python -m pip install --global-option build_ext --global-option --compiler=mingw32 -v -e .[bus]
+        python ./setup.py build_ext --compiler=mingw32 develop
+        pip install cocotb-bus
       continue-on-error: ${{matrix.may_fail || false}}
     - name: Install cocotb (Windows, msvc)
       if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'msvc'

--- a/cocotb/_version.py
+++ b/cocotb/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '1.6.1'
+__version__ = '1.6.2'

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -71,7 +71,7 @@ ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)
 endif
 
 # Set PYTHONHOME to properly populate sys.path in embedded python interpreter
-export PYTHONHOME := $(shell $(PYTHON_BIN) -c 'from sysconfig import get_config_var; print(get_config_var("prefix"))')
+export PYTHONHOME := $(shell $(PYTHON_BIN) -c 'import sys; print(sys.prefix)')
 
 ifeq ($(OS),Msys)
     to_tcl_path = $(shell cygpath -m $(1) )

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -7,6 +7,20 @@ Release Notes
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
+cocotb 1.6.2 (2022-02-TBA)
+==========================
+
+Bugfixes
+--------
+
+- Fix regression in :class:`~cocotb.regression.TestFactory` when using generator-based test coroutines. (:issue:`2839`)
+
+Changes
+-------
+
+- Change how :envvar:`PYTHONHOME` is populated to work with broken mingw environments. (:issue:`2739`)
+
+
 cocotb 1.6.1 (2021-12-07)
 =========================
 


### PR DESCRIPTION
Includes: #2841 and cherry-pick of #2834. Also creates release notes and bumps version.