### PR TITLE
Separate build and test for python runner

### DIFF
--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -28,43 +28,44 @@ module_name = [
     "test_timing_triggers",
 ]
 
+verilog_sources = []
+vhdl_sources = []
+toplevel_lang = os.getenv("TOPLEVEL_LANG", "verilog")
+
+if toplevel_lang == "verilog":
+    verilog_sources = [
+        os.path.join(tests_dir, "designs", "sample_module", "sample_module.sv")
+    ]
+else:
+    vhdl_sources = [
+        os.path.join(tests_dir, "designs", "sample_module", "sample_module_pack.vhdl"),
+        os.path.join(tests_dir, "designs", "sample_module", "sample_module_1.vhdl"),
+        os.path.join(tests_dir, "designs", "sample_module", "sample_module.vhdl"),
+    ]
+
+sim = os.getenv("SIM", "icarus")
+sim_args = ["-t", "ps"] if sim == "questa" else []
+compile_args = ["+acc"] if sim == "questa" else []
+toplevel = "sample_module"
+python_search = [os.path.join(tests_dir, "test_cases", "test_cocotb")]
+
 
 def test_cocotb():
-    verilog_sources = []
-    vhdl_sources = []
-    toplevel_lang = os.getenv("TOPLEVEL_LANG", "verilog")
 
-    if toplevel_lang == "verilog":
-        verilog_sources = [
-            os.path.join(tests_dir, "designs", "sample_module", "sample_module.sv")
-        ]
-    else:
-        vhdl_sources = [
-            os.path.join(
-                tests_dir, "designs", "sample_module", "sample_module_pack.vhdl"
-            ),
-            os.path.join(tests_dir, "designs", "sample_module", "sample_module_1.vhdl"),
-            os.path.join(tests_dir, "designs", "sample_module", "sample_module.vhdl"),
-        ]
-
-    sim = os.getenv("SIM", "icarus")
     runner = get_runner(sim)()
-
-    compile_args = ["+acc"] if sim == "questa" else []
 
     runner.build(
         verilog_sources=verilog_sources,
         vhdl_sources=vhdl_sources,
-        toplevel="sample_module",
+        toplevel=toplevel,
         build_dir=sim_build,
         extra_args=compile_args,
     )
-    sim_args = ["-t", "ps"] if sim == "questa" else []
 
     runner.test(
         toplevel_lang=toplevel_lang,
-        python_search=[os.path.join(tests_dir, "test_cases", "test_cocotb")],
-        toplevel="sample_module",
+        python_search=python_search,
+        toplevel=toplevel,
         py_module=module_name,
         extra_args=sim_args,
     )

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -1,0 +1,50 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+from test_cocotb import (
+    compile_args,
+    module_name,
+    python_search,
+    sim,
+    sim_args,
+    sim_build,
+    toplevel,
+    toplevel_lang,
+    verilog_sources,
+    vhdl_sources,
+)
+
+from cocotb.runner import get_runner
+
+
+@pytest.mark.compile
+def test_cocotb_parallel_compile():
+
+    runner = get_runner(sim)()
+
+    runner.build(
+        always=True,
+        verilog_sources=verilog_sources,
+        vhdl_sources=vhdl_sources,
+        toplevel=toplevel,
+        build_dir=sim_build,
+        extra_args=compile_args,
+    )
+
+
+@pytest.mark.parametrize("seed", list(range(4)))
+def test_cocotb_parallel(seed):
+
+    runner = get_runner(sim)()
+
+    runner.test(
+        seed=seed,
+        toplevel_lang=toplevel_lang,
+        python_search=python_search,
+        toplevel=toplevel,
+        py_module=module_name,
+        extra_args=sim_args,
+        build_dir=sim_build,
+    )


### PR DESCRIPTION
This allows to run the parallel example with `pytest-xdist`:
```bash
pytest -m compile
pytest -m "not compile" -n auto
```

~~Not sure if we should put all those arguments in `test()` like with `build_dir` , `library_name` or `parameters` ? @ktbarrett~~

Need to add some optional arguments to `test()`
- `build_dir`
- ~~`library_name` -> needed for Icarus executable file name could use some generic name and not touch this.~~
- `parameters` -> needed for GHDL/Questa/Riviera