### PR TITLE
Codecov: Make reporting more reliable

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,3 +18,10 @@ codecov:
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
         after_n_builds: 14
+
+coverage:
+    status:
+        project:
+            default:
+                # Report a CI failure if coverage drops by more than 1 percent.
+                threshold: 1%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,4 +17,4 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 13
+        after_n_builds: 14


### PR DESCRIPTION
* Report failures only for drops >= 1%
* Update the number of expected tests with coverage


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->