### PR TITLE
Add git blame ignore rev file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,11 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# The following command will configure your local git repo to ignore these commits
+# when doing git-blame.
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+
 # clang-format
 78e69fa428477b73808d08aec0e6702a924497f8
 # black and isort

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# clang-format
+78e69fa428477b73808d08aec0e6702a924497f8
+# black and isort
+720b0e1071d0c720e61fa50fcb1813fd99198f20


### PR DESCRIPTION
Addresses https://github.com/cocotb/cocotb/pull/2855#issuecomment-1033386580. 

Based on [this comment](https://github.com/github/feedback/discussions/5033#discussioncomment-1549036), GH will likely add support soon at the given file path. But local support can be added by issuing the command `git config blame.ignoreRevsFile .git-blame-ignore-revs`.