### PR TITLE
Introduce noxfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ develop-eggs
 .installed.cfg
 __pycache__
 .tox
+.nox
 .eggs
 
 # Vim tmp files

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,82 @@
+import glob
+
+import nox
+
+test_deps = ["coverage", "pytest", "pytest-cov"]
+
+dev_deps = [
+    "black",
+    "isort",
+    "mypy",
+    "pre-commit",
+    "nox",
+    "tox",
+]
+
+
+@nox.session
+def docs(session: nox.Session) -> None:
+    """invoke sphinx-build to build the HTML docs"""
+    session.install("-r", "documentation/requirements.txt")
+    session.install("-e", ".")
+    outdir = session.cache_dir / "docs_out"
+    session.run(
+        "sphinx-build", "./documentation/source", str(outdir), "--color", "-b", "html"
+    )
+    index = (outdir / "index.html").resolve().as_uri()
+    session.log(f"Documentation is available at {index}")
+
+
+@nox.session
+def docs_linkcheck(session: nox.Session) -> None:
+    """invoke sphinx-build to linkcheck the docs"""
+    session.install("-r", "documentation/requirements.txt")
+    session.install("-e", ".")
+    outdir = session.cache_dir / "docs_out"
+    session.run(
+        "sphinx-build",
+        "./documentation/source",
+        str(outdir),
+        "--color",
+        "-b",
+        "linkcheck",
+    )
+
+
+@nox.session
+def docs_spelling(session: nox.Session) -> None:
+    """invoke sphinx-build to spellcheck the docs"""
+    session.install("-r", "documentation/requirements.txt")
+    session.install("-e", ".")
+    outdir = session.cache_dir / "docs_out"
+    session.run(
+        "sphinx-build",
+        "./documentation/source",
+        str(outdir),
+        "--color",
+        "-b",
+        "spelling",
+    )
+
+
+@nox.session
+def tests(session: nox.Session) -> None:
+    session.env["CFLAGS"] = "-Werror -Wno-deprecated-declarations -g --coverage"
+    session.env["COCOTB_LIBRARY_COVERAGE"] = "1"
+    session.env["CXXFLAGS"] = "-Werror"
+    session.env["LDFLAGS"] = "--coverage"
+    session.install(*test_deps)
+    session.install("-e", ".")
+    session.run("pytest")
+    session.run("make", "test", external=True)
+    coverage_files = glob.glob("**/.coverage.cocotb", recursive=True)
+    session.run("coverage", "combine", "--append", *coverage_files)
+
+
+@nox.session(reuse_venv=True)
+def dev(session: nox.Session) -> None:
+    session.install(*test_deps)
+    session.install(*dev_deps)
+    session.install("-e", ".")
+    if session.posargs:
+        session.run(*session.posargs, external=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ extend-exclude =
     makefiles
     venv
     _vendor
+    .nox/
 
 ignore =
     E741  # ambiguous variable name (preference)


### PR DESCRIPTION
As a replacement for tox (currently they exist side by side). I find tox hard to use without staring at the config documentation for longer than I'd like, all while being less flexible.

nox includes a `tox-to-nox` utility I used to convert our existing tox.ini to a noxfile.py, then I touched it up to suit us a little better. I also added a "dev" session to build a development environment for cocotb. You can use it in one of the following ways.

```sh
# build env
nox -e dev
# activate environment
. .nox/dev/bin/activate
# do your business
# deactivate the environment
deactivate
```

Or...

```sh
nox -e dev -- bash
# you are now in a nested interactive bash shell
# you are only an `exit` away from cleanup
```

