### PR TITLE
Fix additional dependencies

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -93,21 +93,13 @@ COCOTB_HDL_TIMEPRECISION ?= 1ps
 
 export COCOTB_RESULTS_FILE
 
-ifeq ($(OS), Msys)
-    # Depend on all Python from the cocotb package. This triggers a
-    # recompilation of the simulation if cocotb is updated.
-    CUSTOM_SIM_DEPS += $(shell dir $(COCOTB_PY_DIR)/cocotb/*.py -b)
+# Depend on all Python from the cocotb package. This triggers a
+# recompilation of the simulation if cocotb is updated.
+CUSTOM_SIM_DEPS += $(shell $(PYTHON_BIN) -c 'import glob; print(" ".join(glob.glob("$(COCOTB_PY_DIR)/cocotb/*.py")))')
 
-    # This triggers a recompilation of the simulation if cocotb library is updated.
-    CUSTOM_SIM_DEPS += $(shell dir $(LIB_DIR)/* -b)
-else
-    # Depend on all Python from the cocotb package. This triggers a
-    # recompilation of the simulation if cocotb is updated.
-    CUSTOM_SIM_DEPS += $(shell find $(COCOTB_PY_DIR)/cocotb/ -name "*.py")
+# This triggers a recompilation of the simulation if cocotb library is updated.
+CUSTOM_SIM_DEPS += $(shell $(PYTHON_BIN) -c 'import glob; print(" ".join(glob.glob("$(LIB_DIR)/*")))')
 
-    # This triggers a recompilation of the simulation if cocotb library is updated.
-    CUSTOM_SIM_DEPS += $(shell find $(LIB_DIR)/ -name "*")
-endif
 
 $(SIM_BUILD):
 	mkdir -p $@

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -93,12 +93,21 @@ COCOTB_HDL_TIMEPRECISION ?= 1ps
 
 export COCOTB_RESULTS_FILE
 
-# Depend on all Python from the cocotb package. This triggers a
-# recompilation of the simulation if cocotb is updated.
-CUSTOM_SIM_DEPS += $(shell find $(COCOTB_PY_DIR)/cocotb/ -name "*.py")
+ifeq ($(OS), Msys)
+    # Depend on all Python from the cocotb package. This triggers a
+    # recompilation of the simulation if cocotb is updated.
+    CUSTOM_SIM_DEPS += $(shell dir $(COCOTB_PY_DIR)/cocotb/*.py -b)
 
-# This triggers a recompilation of the simulation if cocotb library is updated.
-CUSTOM_SIM_DEPS += $(shell find $(LIB_DIR)/ -name "*")
+    # This triggers a recompilation of the simulation if cocotb library is updated.
+    CUSTOM_SIM_DEPS += $(shell dir $(LIB_DIR)/* -b)
+else
+    # Depend on all Python from the cocotb package. This triggers a
+    # recompilation of the simulation if cocotb is updated.
+    CUSTOM_SIM_DEPS += $(shell find $(COCOTB_PY_DIR)/cocotb/ -name "*.py")
+
+    # This triggers a recompilation of the simulation if cocotb library is updated.
+    CUSTOM_SIM_DEPS += $(shell find $(LIB_DIR)/ -name "*")
+endif
 
 $(SIM_BUILD):
 	mkdir -p $@


### PR DESCRIPTION
Fix additional dependencies to the simulation target for windows

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
