### PR TITLE
Deprecate `cocotb.fork`

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -186,7 +186,19 @@ and in parameters to :class:`.TestFactory`\ s.
 
 
 def fork(coro: Union[RunningTask, Coroutine]) -> RunningTask:
-    """Schedule a coroutine to be run concurrently. See :ref:`coroutines` for details on its use."""
+    """
+    Schedule a coroutine to be run concurrently. See :ref:`coroutines` for details on its use.
+
+    .. deprecated:: 1.7.0
+    """
+    warnings.warn(
+        "cocotb.fork has been deprecated in favor of cocotb.start_soon and cocotb.start.\n"
+        "In most cases you can simply substitute cocotb.fork with cocotb.start_soon.\n"
+        "For more information about when you would want to use cocotb.start see the docs.\n"
+        "https://docs.cocotb.org/en/latest/coroutines.html#concurrent-execution",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return scheduler.add(coro)
 
 

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -190,6 +190,9 @@ def fork(coro: Union[RunningTask, Coroutine]) -> RunningTask:
     Schedule a coroutine to be run concurrently. See :ref:`coroutines` for details on its use.
 
     .. deprecated:: 1.7.0
+        This function has been deprecated in favor of :func:`cocotb.start_soon` and :func:`cocotb.start`.
+        In most cases you can simply substitute ``cocotb.fork`` with ``cocotb.start_soon``.
+        For more information on when to use ``start_soon`` vs ``start`` see :ref:`_coroutines`.
     """
     warnings.warn(
         "cocotb.fork has been deprecated in favor of cocotb.start_soon and cocotb.start.\n"

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -197,7 +197,7 @@ def fork(coro: Union[RunningTask, Coroutine]) -> RunningTask:
     warnings.warn(
         "cocotb.fork has been deprecated in favor of cocotb.start_soon and cocotb.start.\n"
         "In most cases you can simply substitute cocotb.fork with cocotb.start_soon.\n"
-        "For more information about when you would want to use cocotb.start see the docs.\n"
+        "For more information about when you would want to use cocotb.start see the docs,\n"
         "https://docs.cocotb.org/en/latest/coroutines.html#concurrent-execution",
         DeprecationWarning,
         stacklevel=2,

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -55,7 +55,7 @@ Concurrent Execution
 
 Coroutines can be scheduled for concurrent execution with :func:`~cocotb.fork`, :func:`~cocotb.start`, and :func:`~cocotb.start_soon`.
 
-:func:`~cocotb.fork` schedules and executes the new coroutine immediately,
+:func:`~cocotb.fork` (deprecated) schedules and executes the new coroutine immediately,
 returning control to the calling task after the new coroutine finishes or yields control.
 No other pending tasks are run.
 
@@ -68,8 +68,7 @@ after the calling task yields control.
 
 .. note::
     The preferred way to schedule tasks is with :func:`~cocotb.start` and :func:`~cocotb.start_soon`.
-    :func:`~cocotb.fork` remains for historical reasons,
-    but may be removed in a future version of cocotb.
+    :func:`~cocotb.fork` is deprecated and will be removed in a future version of cocotb.
 
 .. code-block:: python3
 
@@ -149,6 +148,9 @@ forcing their completion before they would naturally end.
 
 .. versionchanged:: 1.6
     Added :func:`cocotb.start` and :func:`cocotb.start_soon` scheduling functions.
+
+.. versionchanged:: 1.7
+    Deprecated :func:`cocotb.fork`.
 
 
 Async generators

--- a/documentation/source/newsfragments/2663.removal.rst
+++ b/documentation/source/newsfragments/2663.removal.rst
@@ -1,0 +1,1 @@
+:func:`cocotb.fork` has been deprecated in favor of :func:`cocotb.start_soon` or :func:`cocotb.start`.

--- a/tests/test_cases/test_cocotb/Makefile
+++ b/tests/test_cases/test_cocotb/Makefile
@@ -22,6 +22,7 @@ MODULE := "\
 	test_pytest,\
 	test_queues,\
 	test_utils,\
+	test_fork,\
 	"
 
 ifeq ($(SIM),questa)

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -137,7 +137,7 @@ async def test_fork_combine(dut):
     async def coro(delay):
         await Timer(delay, "ns")
 
-    tasks = [cocotb.fork(coro(dly)) for dly in [10, 30, 20]]
+    tasks = [cocotb.start_soon(coro(dly)) for dly in [10, 30, 20]]
 
     await Combine(*(t.join() for t in tasks))
 

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -197,3 +197,12 @@ async def test_lessthan_raises_error(dut):
         ret = dut.stream_in_data <= 0x12
     with pytest.raises(TypeError):
         bool(ret)
+
+
+@cocotb.test()
+async def test_fork_deprecated(_):
+    async def example_coro():
+        pass
+
+    with pytest.warns(DeprecationWarning):
+        cocotb.fork(example_coro())

--- a/tests/test_cases/test_cocotb/test_fork.py
+++ b/tests/test_cases/test_cocotb/test_fork.py
@@ -1,0 +1,63 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+import warnings
+
+from common import MyException
+
+import cocotb
+
+
+@cocotb.test()
+async def test_fork_start_immediately(_):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        a = 0
+
+        async def increments():
+            nonlocal a
+            a += 1
+
+        # fork runs the body of increments() up until the first await immediately, so "a" is incremented
+        cocotb.fork(increments())
+        assert a == 1
+
+
+@cocotb.test()
+async def test_start_soon_doesnt_start_immediately(_):
+    a = 0
+
+    async def increments():
+        nonlocal a
+        a += 1
+
+    # start_soon doesn't run incremenents() immediately, so "a" is never incremented
+    cocotb.start_soon(increments())
+    assert a == 0
+
+
+async def coro():
+    raise MyException()
+
+
+@cocotb.test(expect_error=RuntimeError)
+async def test_fork_keep_running(_):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        # failing task ends the test, but the test keeps running because fork causes re-entrancy
+        # so the next raise causes the test to fail with a different error
+        cocotb.fork(coro())
+        raise RuntimeError()
+
+
+@cocotb.test(expect_error=MyException)
+async def test_start_doesnt_keep_running(_):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        # failing task ends the test, but because we have to suspend the current task
+        # the next raise is never run again after the test fails because the test coro is not scheduled again
+        await cocotb.start(coro())
+        raise RuntimeError()

--- a/tests/test_cases/test_forked_exception/test_forked_exception.py
+++ b/tests/test_cases/test_forked_exception/test_forked_exception.py
@@ -25,5 +25,5 @@ async def test_fail(_):
         await Timer(10, "ns")
         raise MyException
 
-    cocotb.fork(fails())
+    cocotb.start_soon(fails())
     await Timer(20, "ns")


### PR DESCRIPTION
Closes #2663. Deprecates `cocotb.fork` in place of `cocotb.start_soon` and `cocotb.start`.