### PR TITLE
Cleanup test_cocotb

### DIFF
--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -6,22 +6,9 @@ Common utilities shared by many tests in this directory
 """
 import re
 import traceback
-from contextlib import contextmanager
-
-from cocotb.triggers import Timer
 
 
-async def clock_gen(clock):
-    """Example clock gen for test use"""
-    for i in range(5):
-        clock.value = 0
-        await Timer(100, "ns")
-        clock.value = 1
-        await Timer(100, "ns")
-    clock._log.warning("Clock generator finished!")
-
-
-async def _check_traceback(running_coro, exc_type, pattern):
+async def _check_traceback(running_coro, exc_type, pattern, *match_args):
     try:
         await running_coro
     except exc_type:
@@ -29,7 +16,7 @@ async def _check_traceback(running_coro, exc_type, pattern):
     else:
         assert False, "Exception was not raised"
 
-    assert re.match(pattern, tb_text), (
+    assert re.match(pattern, tb_text, *match_args), (
         "Traceback didn't match - got:\n\n"
         "{}\n"
         "which did not match the pattern:\n\n"
@@ -37,15 +24,5 @@ async def _check_traceback(running_coro, exc_type, pattern):
     ).format(tb_text, pattern)
 
 
-@contextmanager
-def assert_raises(exc_type, pattern=None):
-    try:
-        yield
-    except exc_type as e:
-        if pattern:
-            assert re.match(
-                pattern, str(e)
-            ), "Correct exception type caught, but message did not match pattern"
-        pass
-    else:
-        assert False, f"{exc_type.__name__} was not raised"
+class MyException(Exception):
+    ...

--- a/tests/test_cases/test_cocotb/test_async_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_async_coroutines.py
@@ -4,8 +4,8 @@
 """
 Test function and substitutability of async coroutines
 """
-
-from common import assert_raises
+import pytest
+from common import MyException
 
 import cocotb
 from cocotb.outcomes import Error, Value
@@ -33,12 +33,6 @@ class produce:
         return outcome.get()
 
 
-class SomeException(Exception):
-    """Custom exception to test for that can't be thrown by internals"""
-
-    pass
-
-
 @cocotb.test()  # test yielding decorated async coroutine in legacy coroutine
 def test_annotated_async_from_coro(dut):
     """
@@ -49,8 +43,8 @@ def test_annotated_async_from_coro(dut):
     assert v == 1
 
     try:
-        yield produce.async_annotated(Error(SomeException))
-    except SomeException:
+        yield produce.async_annotated(Error(MyException))
+    except MyException:
         pass
     else:
         assert False
@@ -63,8 +57,8 @@ async def test_annotated_async_from_async(dut):
     assert v == 1
 
     try:
-        await produce.async_annotated(Error(SomeException))
-    except SomeException:
+        await produce.async_annotated(Error(MyException))
+    except MyException:
         pass
     else:
         assert False
@@ -77,8 +71,8 @@ async def test_async_from_async(dut):
     assert v == 1
 
     try:
-        await produce.async_(Error(SomeException))
-    except SomeException:
+        await produce.async_(Error(MyException))
+    except MyException:
         pass
     else:
         assert False
@@ -91,8 +85,8 @@ async def test_coro_from_async(dut):
     assert v == 1
 
     try:
-        await produce.coro(Error(SomeException))
-    except SomeException:
+        await produce.coro(Error(MyException))
+    except MyException:
         pass
     else:
         assert False
@@ -150,7 +144,7 @@ async def test_fork_coroutine_function_exception(dut):
         "Coroutine function {} should be called "
         "prior to being scheduled.".format(coro)
     )
-    with assert_raises(TypeError, pattern):
+    with pytest.raises(TypeError, match=pattern):
         cocotb.start_soon(coro)
 
 
@@ -163,5 +157,5 @@ async def test_task_coroutine_function_exception(dut):
         "Coroutine function {} should be called "
         "prior to being scheduled.".format(coro)
     )
-    with assert_raises(TypeError, pattern):
+    with pytest.raises(TypeError, match=pattern):
         cocotb.decorators.RunningTask(coro)

--- a/tests/test_cases/test_cocotb/test_clock.py
+++ b/tests/test_cases/test_cocotb/test_clock.py
@@ -58,14 +58,3 @@ async def test_clock_with_units(dut):
     assert isclose(edge_time_ns, start_time_ns + 4.0), "Expected a period of 4 ns"
 
     clk_gen.kill()
-
-
-@cocotb.test()
-async def test_external_clock(dut):
-    """Test awaiting on an external non-cocotb coroutine decorated function"""
-    clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
-    count = 0
-    while count != 100:
-        await RisingEdge(dut.clk)
-        count += 1
-    clk_gen.kill()

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -4,7 +4,7 @@
 """
 Tests for concurrency primitives like First and Combine
 """
-import textwrap
+import re
 from collections import deque
 from random import randint
 
@@ -111,27 +111,9 @@ async def test_exceptions_first(dut):
         await Timer(1, "ns")
         await cocotb.triggers.First(raise_inner())
 
-    # it's ok to change this value if the traceback changes - just make sure
-    # that when changed, it doesn't become harder to read.
-    expected = textwrap.dedent(
-        r"""
-    Traceback \(most recent call last\):
-      File ".*common\.py", line \d+, in _check_traceback
-        await running_coro
-      File ".*test_concurrency_primitives\.py", line \d+, in raise_soon
-        await cocotb\.triggers\.First\(raise_inner\(\)\)
-      File ".*triggers\.py", line \d+, in _wait
-        return await first_trigger[^\n]*
-      File ".*triggers.py", line \d+, in __await__
-        return \(yield self\)
-      File ".*triggers.py", line \d+, in __await__
-        return \(yield self\)
-      File ".*test_concurrency_primitives\.py", line \d+, in raise_inner
-        raise ValueError\("It is soon now"\)
-    ValueError: It is soon now"""
-    ).strip()
-
-    await _check_traceback(raise_soon(), ValueError, expected)
+    await _check_traceback(
+        raise_soon(), ValueError, r".*in raise_soon.*in raise_inner", re.DOTALL
+    )
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -7,7 +7,7 @@ Tests for handles
 import logging
 import random
 
-from common import assert_raises
+import pytest
 
 import cocotb
 from cocotb.handle import _Limits
@@ -20,7 +20,7 @@ SIM_NAME = cocotb.SIM_NAME.lower()
 @cocotb.test()
 async def test_bad_attr(dut):
 
-    with assert_raises(AttributeError):
+    with pytest.raises(AttributeError):
         dut.fake_signal
 
     try:
@@ -89,14 +89,14 @@ async def test_delayed_assignment_still_errors(dut):
 
     # note: all these fail because BinaryValue.assign rejects them
 
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         dut.stream_in_int.setimmediatevalue("1010 not a real binary string")
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         dut.stream_in_int.setimmediatevalue([])
 
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         dut.stream_in_int.value = "1010 not a real binary string"
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         dut.stream_in_int.value = []
 
 
@@ -142,7 +142,7 @@ async def int_overflow_test(signal, n_bits, test_mode, limits=_Limits.VECTOR_NBI
     else:
         value = None
 
-    with assert_raises(OverflowError):
+    with pytest.raises(OverflowError):
         signal.value = value
 
 
@@ -385,7 +385,7 @@ async def test_real_assign_int(dut):
 async def test_access_underscore_name(dut):
     """Test accessing HDL name starting with an underscore"""
     # direct access does not work because we consider such names cocotb-internal
-    with assert_raises(AttributeError):
+    with pytest.raises(AttributeError):
         dut._underscore_name
 
     # indirect access works

--- a/tests/test_cases/test_cocotb/test_logging.py
+++ b/tests/test_cases/test_cocotb/test_logging.py
@@ -8,7 +8,7 @@ Tests for the cocotb logger
 import logging
 import os
 
-from common import assert_raises
+import pytest
 
 import cocotb
 import cocotb.log
@@ -60,7 +60,7 @@ async def test_logging_default_config(dut):
 
         # Try to set log level to an invalid log level
         os.environ["COCOTB_LOG_LEVEL"] = "INVALID_LOG_LEVEL"
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             log_default_config()
 
         # Try to set log level to a valid log level with wrong capitalization

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -13,7 +13,6 @@ import re
 from typing import Coroutine
 
 import pytest
-from common import clock_gen
 
 import cocotb
 from cocotb.clock import Clock
@@ -43,7 +42,7 @@ async def clock_yield(generator):
 async def test_coroutine_kill(dut):
     """Test that killing a coroutine causes pending routine continue"""
     global test_flag
-    clk_gen = cocotb.scheduler.add(clock_gen(dut.clk))
+    clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
     await Timer(100, "ns")
     cocotb.fork(clock_yield(clk_gen))
     await Timer(100, "ns")

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -4,7 +4,7 @@
 """
 Tests for synchronization primitives like Lock and Event
 """
-from common import assert_raises
+import pytest
 
 import cocotb
 from cocotb.triggers import Lock, Timer, _InternalEvent
@@ -74,7 +74,7 @@ async def test_internalevent(dut):
     assert e.data == "data"
     assert get_sim_time(units="ns") == time_ns + 1
     # _InternalEvent can only be awaited once
-    with assert_raises(RuntimeError):
+    with pytest.raises(RuntimeError):
         await e
 
     e = _InternalEvent(None)
@@ -91,7 +91,7 @@ async def test_internalevent(dut):
     assert not e.is_set()
     assert not ran
     # _InternalEvent can only be awaited by one coroutine
-    with assert_raises(RuntimeError):
+    with pytest.raises(RuntimeError):
         await e
     e.set()
     await Timer(1)

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -10,7 +10,7 @@ Tests of cocotb.test functionality
 """
 from collections.abc import Coroutine
 
-from common import clock_gen
+from common import MyException
 
 import cocotb
 from cocotb.triggers import Timer
@@ -19,7 +19,7 @@ from cocotb.triggers import Timer
 @cocotb.test(expect_error=NameError)
 async def test_error(dut):
     """Error in the test"""
-    await clock_gen(dut.clk)
+    await Timer(100, "ns")
     fail  # noqa
 
 
@@ -46,10 +46,6 @@ async def test_immediate_test(dut):
 @cocotb.test(expect_fail=True)
 async def test_assertion_is_failure(dut):
     assert False
-
-
-class MyException(Exception):
-    pass
 
 
 @cocotb.test(expect_error=MyException)

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -15,7 +15,6 @@ from decimal import Decimal
 from fractions import Fraction
 
 import pytest
-from common import assert_raises
 
 import cocotb
 from cocotb.clock import Clock
@@ -53,7 +52,7 @@ async def test_timer_with_units(dut):
     time_step = get_sim_time(units="fs") - time_fs
 
     pattern = "Unable to accurately represent .* with the simulator precision of .*"
-    with assert_raises(ValueError, pattern):
+    with pytest.raises(ValueError, match=pattern):
         await Timer(2.5 * time_step, units="fs")
     dut._log.info("As expected, unable to create a timer of 2.5 simulator time steps")
 
@@ -253,7 +252,7 @@ async def test_singleton_isinstance(dut):
 @cocotb.test()
 async def test_neg_timer(dut):
     """Test negative timer values are forbidden"""
-    with assert_raises(TriggerException):
+    with pytest.raises(TriggerException):
         Timer(-42)  # no need to even `await`, constructing it is an error
     # handle 0 special case
     with warnings.catch_warnings(record=True) as w:
@@ -306,9 +305,8 @@ async def test_time_units_eq_None(dut):
 async def test_timer_round_mode(_):
 
     # test invalid round_mode specifier
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="^Invalid round_mode specifier: notvalid"):
         Timer(1, "step", round_mode="notvalid")
-    assert "invalid" in str(e).lower()
 
     # test default, update if default changes
     with pytest.raises(ValueError):

--- a/tests/test_cases/test_cocotb/test_utils.py
+++ b/tests/test_cases/test_cocotb/test_utils.py
@@ -11,9 +11,8 @@ import cocotb.utils as utils
 async def test_get_sim_steps(_):
 
     # test invalid round_mode specifier
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="^Invalid round_mode specifier: notvalid"):
         utils.get_sim_steps(1, "step", round_mode="notvalid")
-    assert "invalid" in str(e).lower()
 
     # test default, update if default changes
     with pytest.raises(ValueError):


### PR DESCRIPTION
* replaced assert_deprecated with pytest.warns
* replaced assert_raises with pytest.raises
* removed _check_traceback from tests, checking tracebacks textually is
  too fragile
* removed mostly useless clock_gen routine

Should unblock #2857.