### PR TITLE
Suggest user to use WSL in Windows instructions

### DIFF
--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -34,8 +34,11 @@ The installation instructions vary depending on your operating system:
 
    .. group-tab:: Windows
 
-      `Conda <https://conda.io/>`_ is an open-source package and environment management system that we recommend for Windows.
+      We recommend users who are comfortable with a Unix shell and who are running Windows 10 or 11 use Windows Subsytem for Linux (WSL).
+      See `here <https://docs.microsoft.com/en-us/windows/wsl/install>`_ for installation instructions of WSL,
+      then follow the Linux installation instructions for cocotb.
 
+      `Conda <https://conda.io/>`_ is an open-source package and environment management system that we recommend for users who are more comfortable with Windows.
       Download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ from https://conda.io/.
       From an Anaconda Prompt, use the following line to install a compiler (GCC or Clang) and GNU Make:
 

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -37,7 +37,7 @@ The installation instructions vary depending on your operating system:
       We recommend users who are running Windows and who are more comfortable with a Unix shell,
       or who have legacy Makefile-based projects,
       to use Windows Subsystem for Linux (WSL).
-      After installing WSL or a Virtual Machine and a supported Linux distribution, follow the Linux installation instructions for cocotb.
+      After installing WSL and a supported Linux distribution, follow the Linux installation instructions for cocotb.
 
       `Conda <https://conda.io/>`_ is an open-source package and environment management system that we recommend for users who are more comfortable with native Windows development.
       Download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ from https://conda.io/.

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -34,8 +34,9 @@ The installation instructions vary depending on your operating system:
 
    .. group-tab:: Windows
 
-      We recommend users who are running Windows, and who are more comfortable with a Unix shell or who have legacy Makefile-based projects,
-      to use either Windows Subsystem for Linux (WSL) or a Virtual Machine, such as Oracle VirtualBox.
+      We recommend users who are running Windows and who are more comfortable with a Unix shell,
+      or who have legacy Makefile-based projects,
+      to use Windows Subsystem for Linux (WSL).
       After installing WSL or a Virtual Machine and a supported Linux distribution, follow the Linux installation instructions for cocotb.
 
       `Conda <https://conda.io/>`_ is an open-source package and environment management system that we recommend for users who are more comfortable with native Windows development.

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -34,11 +34,11 @@ The installation instructions vary depending on your operating system:
 
    .. group-tab:: Windows
 
-      We recommend users who are comfortable with a Unix shell and who are running Windows 10 or 11 use Windows Subsystem for Linux (WSL).
-      See `here <https://docs.microsoft.com/en-us/windows/wsl/install>`_ for instructions on installing WSL,
-      then follow the Linux installation instructions for cocotb.
+      We recommend users who are running Windows, and who are more comfortable with a Unix shell or who have legacy Makefile-based projects,
+      to use either Windows Subsystem for Linux (WSL) or a Virtual Machine, such as Oracle VirtualBox.
+      After installing WSL or a Virtual Machine and a supported Linux distribution, follow the Linux installation instructions for cocotb.
 
-      `Conda <https://conda.io/>`_ is an open-source package and environment management system that we recommend for users who are more comfortable with Windows.
+      `Conda <https://conda.io/>`_ is an open-source package and environment management system that we recommend for users who are more comfortable with native Windows development.
       Download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ from https://conda.io/.
       From an Anaconda Prompt, use the following line to install a compiler (GCC or Clang) and GNU Make:
 

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -34,8 +34,8 @@ The installation instructions vary depending on your operating system:
 
    .. group-tab:: Windows
 
-      We recommend users who are comfortable with a Unix shell and who are running Windows 10 or 11 use Windows Subsytem for Linux (WSL).
-      See `here <https://docs.microsoft.com/en-us/windows/wsl/install>`_ for installation instructions of WSL,
+      We recommend users who are comfortable with a Unix shell and who are running Windows 10 or 11 use Windows Subsystem for Linux (WSL).
+      See `here <https://docs.microsoft.com/en-us/windows/wsl/install>`_ for instructions on installing WSL,
       then follow the Linux installation instructions for cocotb.
 
       `Conda <https://conda.io/>`_ is an open-source package and environment management system that we recommend for users who are more comfortable with Windows.


### PR DESCRIPTION
Addresses some of #2843. This follows what we decided in the last meeting.

The second part of the instructions which recommend Conda + mingw compiler will be replaced with python.org installer once we have wheels and are happy with the python runner.