### PR TITLE
Update C++ local log level whenever Python logger level changes

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -35,6 +35,7 @@ import sys
 import warnings
 
 import cocotb.ANSI as ANSI
+from cocotb import simulator
 from cocotb.utils import get_sim_time, get_time_from_sim_steps, want_color_output
 
 try:
@@ -109,8 +110,6 @@ def default_config():
 
     # Notify GPI of log level, which it uses as an optimization to avoid
     # calling into Python.
-    from cocotb import simulator
-
     simulator.log_level(log.getEffectiveLevel())
 
 
@@ -136,6 +135,11 @@ class SimBaseLog(logging.getLoggerClass()):
             stacklevel=2,
         )
         return want_color_output()
+
+    def setLevel(self, level: int) -> None:
+        super().setLevel(level)
+        if self.name == "gpi":
+            simulator.log_level(level)
 
 
 # this used to be a class, hence the unusual capitalization

--- a/cocotb/share/include/gpi_logging.h
+++ b/cocotb/share/include/gpi_logging.h
@@ -69,7 +69,7 @@ enum gpi_log_levels {
     @param level The level at which to log the message
  */
 #define LOG_(level, ...) \
-    gpi_log("cocotb.gpi", level, __FILE__, __func__, __LINE__, __VA_ARGS__);
+    gpi_log("gpi", level, __FILE__, __func__, __LINE__, __VA_ARGS__);
 
 /** Logs a message at TRACE log level using the current log handler.
     Automatically populates arguments using information in the called context.

--- a/tests/test_cases/test_cocotb/test_logging.py
+++ b/tests/test_cases/test_cocotb/test_logging.py
@@ -78,6 +78,8 @@ async def test_logging_default_config(dut):
         os.environ = os_environ_prev
         cocotb_log.level = log_level_prev
 
+        logging.getLogger("gpi").setLevel(logging.INFO)
+
 
 @cocotb.test()
 async def test_custom_logging_levels(dut):


### PR DESCRIPTION
Closes #2021. The test change ensures there are no longer any TRACE logs after test_cocotb runs.

There is a local logger level in C++ for the GPI logger. This is done to
improve performance. The logger level must be updated to represent the
current *effective* log level of the Python logger whenever the logger
changes in Python. The effective level changes whenever Python changes
the "cocotb.gpi" logger, or it's parent logger "cocotb",

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
