### PR TITLE
Show logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![cocotb logo](/../../../../cocotb-web/blob/master/assets/img/cocotb-logo.svg#gh-light-mode-only)
+![cocotb logo](/../../../../cocotb-web/blob/master/assets/img/cocotb-logo-dark.svg#gh-dark-mode-only)
 
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cocotb logo](/../../../../cocotb-web/assets/img/cocotb-logo.svg#gh-light-mode-only)
+![cocotb logo](/../../../../cocotb-web/blob/master/assets/img/cocotb-logo.svg#gh-light-mode-only)
 
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cocotb logo](https://www.cocotb.org/assets/img/cocotb-logo.svg#gh-light-mode-only)
+![cocotb logo](/../../../../cocotb-web/cocotb-logo.svg#gh-light-mode-only)
 
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cocotb logo](/../../../../cocotb-web/cocotb-logo.svg#gh-light-mode-only)
+![cocotb logo](/../../../../cocotb-web/assets/img/cocotb-logo.svg#gh-light-mode-only)
 
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![cocotb logo](https://www.cocotb.org/assets/img/cocotb-logo.svg#gh-light-mode-only)
+
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 
 [![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=latest)](https://docs.cocotb.org/en/latest/)


### PR DESCRIPTION
To show a logo in dark mode, we need to upload a dark mode image to the `cocotb-web` repo (https://github.com/cocotb/cocotb-web/pull/15)

Edit: done

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
