### PR TITLE
Fix logo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![cocotb logo](/../../../../cocotb-web/blob/master/assets/img/cocotb-logo.svg#gh-light-mode-only)
-![cocotb logo](/../../../../cocotb-web/blob/master/assets/img/cocotb-logo-dark.svg#gh-dark-mode-only)
+![cocotb logo](/../../../../cocotb/cocotb-web/blob/master/assets/img/cocotb-logo.svg#gh-light-mode-only)
+![cocotb logo](/../../../../cocotb/cocotb-web/blob/master/assets/img/cocotb-logo-dark.svg#gh-dark-mode-only)
 
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 


### PR DESCRIPTION
Looks like something went wrong with the preview, this seems like it should work.

Proof this now works: https://github.com/cocotb/cocotb/blob/eric-wieser-fix-logo/README.md

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
