### PR TITLE
Inject regression manager into scheduler rather than reaching

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -323,9 +323,6 @@ def _initialise_testbench_(argv_):
 
     process_plusargs()
 
-    global scheduler
-    scheduler = Scheduler()
-
     # Seed the Python random number generator to make this repeatable
     global RANDOM_SEED
     RANDOM_SEED = os.getenv("RANDOM_SEED")
@@ -374,9 +371,13 @@ def _initialise_testbench_(argv_):
                 "Please file a bug report!".format(pytest.__version__)
             )
 
-    # start Regression Manager
     global regression_manager
     regression_manager = RegressionManager.from_discovery(top)
+
+    global scheduler
+    scheduler = Scheduler(handle_result=regression_manager.handle_result)
+
+    # start Regression Manager
     regression_manager.execute()
 
 

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -41,7 +41,7 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Coroutine
 from contextlib import contextmanager
-from typing import Any, Union
+from typing import Any, Callable, Union
 
 import cocotb
 import cocotb.decorators
@@ -239,7 +239,8 @@ class Scheduler:
     _read_only = ReadOnly()
     _timer1 = Timer(1)
 
-    def __init__(self):
+    def __init__(self, handle_result: Callable[[Task], None]) -> None:
+        self._handle_result = handle_result
 
         self.log = SimLog("cocotb.scheduler")
         if _debug:
@@ -343,7 +344,7 @@ class Scheduler:
                 self.log.debug("Issue test result to regression object")
 
             # this may schedule another test
-            cocotb.regression_manager.handle_result(test)
+            self._handle_result(test)
 
             # if it did, make sure we handle the test completing
             self._check_termination()
@@ -1040,7 +1041,7 @@ class Scheduler:
         if not self._test.done():
             self.log.debug("Issue sim closedown result to regression object")
             self._abort_test(exc)
-            cocotb.regression_manager.handle_result(self._test)
+            self._handle_result(self._test)
 
     def cleanup(self):
         """


### PR DESCRIPTION
This allows for the potential of using the scheduler with another regression manager. An alternative regression manager is a serious amount of work, so I didn't test whether this made such a use case possible, but it definitely doesn't work as long as there is hardcoded path from the scheduler to the regression manager. 

I tried doing additional cleanup, but the scheduler/regression manager interaction is a house of cards. I got a lot of things to mostly work, but the recursive scheduling and the lack of proper guards in the scheduler to exit when put in a terminating state always through a bomb into the mix.