### PR TITLE
Fix compilation error on manylinux1

### DIFF
--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -21,8 +21,19 @@ logger = logging.getLogger(__name__)
 cocotb_share_dir = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "cocotb", "share")
 )
-
-_base_warns = ["-Wall", "-Wextra", "-Wcast-qual", "-Wwrite-strings", "-Wconversion"]
+_base_warns = [
+    "-Wall",
+    "-Wextra",
+    "-Wcast-qual",
+    "-Wwrite-strings",
+    "-Wconversion",
+    # -Wno-missing-field-initializers is required on GCC 4.x to prevent a
+    # spurious warning `error: missing initializer for member ...` when
+    # compiling `PyTypeObject type = {};` in `simulatormodule.cpp`.
+    # (See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36750.) This flag can be
+    # removed once we require later GCC versions.
+    "-Wno-missing-field-initializers",
+]
 _ccx_warns = _base_warns + ["-Wnon-virtual-dtor", "-Woverloaded-virtual"]
 _extra_cxx_compile_args = [
     "-std=c++11",


### PR DESCRIPTION
When compiling cocotb with "-Werror" on manylinux1 (Python 3.6/GCC 4.8.2) we get:

```
cocotb/share/lib/simulator/simulatormodule.cpp: In instantiation of ‘PyTypeObject {anonymous}::fill_common_slots() [with gpi_hdl = GpiCbHdl*; PyTypeObject = _typeobject]’:
  cocotb/share/lib/simulator/simulatormodule.cpp:1269:47:   required from here
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_object::ob_type’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘PyVarObject::ob_size’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_name’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_basicsize’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_itemsize’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_dealloc’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_print’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_getattr’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_setattr’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_as_async’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_repr’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_as_number’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_as_sequence’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_as_mapping’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_hash’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_call’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_str’ [-Werror=missing-field-initializers]
  cocotb/share/lib/simulator/simulatormodule.cpp:142:27: error: missing initializer for member ‘_typeobject::tp_getattro’ [-Werror=missing-field-initializers]
...
```


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->