### PR TITLE
Add VHDL toplevel and a functional testcase in examples/mixed_language

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -94,7 +94,7 @@ endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     GPI_ARGS = -loadvhpi $(shell cocotb-config --lib-name-path vhpi riviera):vhpi_startup_routines_bootstrap
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = $(shell cocotb-config --lib-name-path vpi riviera)):cocotbvpi_entry_point
+    GPI_EXTRA = $(shell cocotb-config --lib-name-path vpi riviera):cocotbvpi_entry_point
 endif
 
 else

--- a/examples/mixed_language/hdl/toplevel.vhdl
+++ b/examples/mixed_language/hdl/toplevel.vhdl
@@ -1,7 +1,7 @@
 -- Example using mixed-language simulation
 --
 -- Here we have a VHDL toplevel that instantiates both SV and VHDL
---  sub entities
+-- sub entities
 library ieee;
 
 use ieee.std_logic_1164.all;
@@ -38,9 +38,12 @@ entity endian_swapper_mixed is
     );
 end;
 
-architecture impl of endian_swapper_mixed is 
+architecture impl of endian_swapper_mixed is
 
-    component endian_swapper_sv 
+    -- The SV entity is instantiated as a component because cocotb is
+    -- executing vcom before vlog. Hence the toplevel VHDL file is compiled
+    -- before the SV module. Therefore, an entity instantiation is not possible here.
+    component endian_swapper_sv
         generic (
             DATA_BYTES              : integer := 8);
         port (
@@ -69,7 +72,7 @@ architecture impl of endian_swapper_mixed is
             csr_waitrequest         : out   std_ulogic;
             csr_writedata           : in    std_ulogic_vector(31 downto 0)
         );
-  end component; 
+  end component;
 
 
     signal sv_to_vhdl_data:             std_ulogic_vector(DATA_BYTES*8-1 downto 0) ;

--- a/examples/mixed_language/hdl/toplevel.vhdl
+++ b/examples/mixed_language/hdl/toplevel.vhdl
@@ -38,9 +38,51 @@ entity endian_swapper_mixed is
     );
 end;
 
-architecture impl of endian_swapper_mixed is begin
+architecture impl of endian_swapper_mixed is 
 
-i_swapper_sv : entity work.endian_swapper_sv
+    component endian_swapper_sv 
+        generic (
+            DATA_BYTES              : integer := 8);
+        port (
+            clk                     : in    std_ulogic;
+            reset_n                 : in    std_ulogic;
+
+            stream_in_data          : in    std_ulogic_vector(DATA_BYTES*8-1 downto 0);
+            stream_in_empty         : in    std_ulogic_vector(2 downto 0);
+            stream_in_valid         : in    std_ulogic;
+            stream_in_startofpacket : in    std_ulogic;
+            stream_in_endofpacket   : in    std_ulogic;
+            stream_in_ready         : out   std_ulogic;
+
+            stream_out_data         : out   std_ulogic_vector(DATA_BYTES*8-1 downto 0);
+            stream_out_empty        : out   std_ulogic_vector(2 downto 0);
+            stream_out_valid        : out   std_ulogic;
+            stream_out_startofpacket: out   std_ulogic;
+            stream_out_endofpacket  : out   std_ulogic;
+            stream_out_ready        : in    std_ulogic;
+
+            csr_address             : in    std_ulogic_vector(1 downto 0);
+            csr_readdata            : out   std_ulogic_vector(31 downto 0);
+            csr_readdatavalid       : out   std_ulogic;
+            csr_read                : in    std_ulogic;
+            csr_write               : in    std_ulogic;
+            csr_waitrequest         : out   std_ulogic;
+            csr_writedata           : in    std_ulogic_vector(31 downto 0)
+        );
+  end component; 
+
+
+    signal sv_to_vhdl_data:             std_ulogic_vector(DATA_BYTES*8-1 downto 0) ;
+    signal sv_to_vhdl_empty:            std_ulogic_vector(2 downto 0);
+    signal sv_to_vhdl_valid:            std_ulogic;
+    signal sv_to_vhdl_startofpacket:    std_ulogic;
+    signal sv_to_vhdl_endofpacket:      std_ulogic;
+    signal sv_to_vhdl_ready:            std_ulogic;
+
+    signal csr_waitrequest_vhdl, csr_waitrequest_sv : std_ulogic;
+
+begin
+i_swapper_sv : endian_swapper_sv
     generic map (
         DATA_BYTES              =>      DATA_BYTES
     ) port map (
@@ -54,20 +96,54 @@ i_swapper_sv : entity work.endian_swapper_sv
         stream_in_valid         =>      stream_in_valid,
         stream_in_ready         =>      stream_in_ready,
 
-        stream_out_empty        =>      stream_out_empty,
-        stream_out_data         =>      stream_out_data,
-        stream_out_endofpacket  =>      stream_out_endofpacket,
-        stream_out_startofpacket=>      stream_out_startofpacket,
-        stream_out_valid        =>      stream_out_valid,
-        stream_out_ready        =>      stream_out_ready,
+        stream_out_empty        =>      sv_to_vhdl_empty,
+        stream_out_data         =>      sv_to_vhdl_data,
+        stream_out_endofpacket  =>      sv_to_vhdl_endofpacket,
+        stream_out_startofpacket=>      sv_to_vhdl_startofpacket,
+        stream_out_valid        =>      sv_to_vhdl_valid,
+        stream_out_ready        =>      sv_to_vhdl_ready,
 
         csr_address             =>      csr_address,
         csr_readdata            =>      csr_readdata,
         csr_readdatavalid       =>      csr_readdatavalid,
         csr_read                =>      csr_read,
         csr_write               =>      csr_write,
-        csr_waitrequest         =>      csr_waitrequest,
+        csr_waitrequest         =>      csr_waitrequest_sv,
         csr_writedata           =>      csr_writedata
     );
 
+
+
+i_swapper_vhdl : entity work.endian_swapper_vhdl
+generic map (
+    DATA_BYTES              =>      DATA_BYTES
+) port map (
+    clk                     =>      clk,
+    reset_n                 =>      reset_n,
+
+    stream_in_empty         =>      sv_to_vhdl_empty,
+    stream_in_data          =>      sv_to_vhdl_data,
+    stream_in_endofpacket   =>      sv_to_vhdl_endofpacket,
+    stream_in_startofpacket =>      sv_to_vhdl_startofpacket,
+    stream_in_valid         =>      sv_to_vhdl_valid,
+    stream_in_ready         =>      sv_to_vhdl_ready,
+
+    stream_out_empty        =>      stream_out_empty,
+    stream_out_data         =>      stream_out_data,
+    stream_out_endofpacket  =>      stream_out_endofpacket,
+    stream_out_startofpacket=>      stream_out_startofpacket,
+    stream_out_valid        =>      stream_out_valid,
+    stream_out_ready        =>      stream_out_ready,
+
+    csr_address             =>      csr_address,
+    csr_readdata            =>      open,
+    csr_readdatavalid       =>      open,
+    csr_read                =>      csr_read,
+    csr_write               =>      csr_write,
+    csr_waitrequest         =>      csr_waitrequest_vhdl,
+    csr_writedata           =>      csr_writedata
+);
+
+
+    csr_waitrequest <= csr_waitrequest_sv or csr_waitrequest_vhdl;
 end architecture;

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -33,7 +33,9 @@ ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
 
-SIM_ARGS += -t 1ps
+ifneq ($(filter $(SIM),questa modelsim),)
+    SIM_ARGS += -t 1ps
+endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim
 

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -9,10 +9,6 @@ else ifeq ($(shell echo $(SIM) | tr A-Z a-z),icarus)
 all:
 	@echo "Skipping example mixed_language since Icarus doesn't support this"
 clean::
-else ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),verilog)
-all:
-	@echo "Skipping example mixed_language since only Verilog toplevel implemented"
-clean::
 else
 
 TOPLEVEL = endian_swapper_mixed
@@ -25,7 +21,6 @@ VHDL_SOURCES    = $(PWD)/../hdl/endian_swapper.vhdl
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES += $(PWD)/../hdl/toplevel.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    $(error "VHDL toplevel not yet implemented")
     VHDL_SOURCES += $(PWD)/../hdl/toplevel.vhdl
 else
     $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
@@ -37,6 +32,8 @@ MODULE=test_mixed_language
 ifneq ($(filter $(SIM),ius xcelium),)
     SIM_ARGS += -v93
 endif
+
+SIM_ARGS += -t 1ps
 
 include $(shell cocotb-config --makefiles)/Makefile.sim
 

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -42,7 +42,7 @@ async def mixed_language_functional_test(dut):
     vhdl = dut.i_swapper_vhdl
     dut._log.info("Got: %s" % repr(vhdl._name))
 
-    # setup default valies
+    # setup default values
     dut.reset_n.value = 0
     dut.stream_out_ready.value = 1
 
@@ -67,18 +67,18 @@ async def mixed_language_functional_test(dut):
     await Timer(500, units="ns")
 
     previous_indata = 0
-    # transmit some packages
-    for pkg in range(1, 5):
+    # transmit some packets
+    for _ in range(1, 5):
 
         for i in range(1, 11):
             await RisingEdge(dut.clk)
             previous_indata = dut.stream_in_data.value
 
             # write stream in data
-            dut.stream_in_startofpacket.value = 1 == 1
-            # assert start of packet when i = 1
-            dut.stream_in_endofpacket.value = 1 == 10
-            # assert end of packet when i = 10
+            # set start of packet when i is 1
+            dut.stream_in_startofpacket.value = int(i == 1)
+            # set end of packet when i is 10
+            dut.stream_in_endofpacket.value = int(i == 10)
             dut.stream_in_data.value = i + 0x81FFFFFF2B00  # generate a magic number
             dut.stream_in_valid.value = 1
             await RisingEdge(dut.clk)
@@ -91,4 +91,4 @@ async def mixed_language_functional_test(dut):
             # compare in and out data
             assert int(previous_indata) == int(
                 dut.stream_out_data.value
-            ), "stream in data and stream out data were different"
+            ), f"stream in data and stream out data were different in round {i}"

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -17,7 +17,7 @@ async def mixed_language_accessing_test(dut):
 
     # discover all attributes of the SV component
     # This is a workaround since SV modules are not discovered automatically
-    # when using Modelsim/Questa and a VHLD toplevel file.
+    # when using Modelsim/Questa and a VHDL toplevel file.
     verilog._discover_all()
 
     vhdl = dut.i_swapper_vhdl

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -1,9 +1,11 @@
 import cocotb
 from cocotb.triggers import Timer
+from cocotb.triggers import RisingEdge
+from cocotb.clock import Clock
 
 
 @cocotb.test()
-async def mixed_language_test(dut):
+async def mixed_language_accessing_test(dut):
     """Try accessing handles and setting values in a mixed language environment."""
     await Timer(100, units="ns")
 
@@ -24,3 +26,64 @@ async def mixed_language_test(dut):
     # Try accessing an object other than a port...
     verilog.flush_pipe.value
     vhdl.flush_pipe.value
+    
+@cocotb.test()
+async def mixed_language_functional_test(dut):
+    """Try concurrent simulation of VHDL and Verilog and check the output."""
+    await Timer(100, units="ns")
+
+    verilog = dut.i_swapper_sv
+    dut._log.info("Got: %s" % repr(verilog._name))
+
+    vhdl = dut.i_swapper_vhdl
+    dut._log.info("Got: %s" % repr(vhdl._name))
+
+    # setup default valies
+    dut.reset_n.value = 0
+    dut.stream_out_ready.value = 1
+
+    dut.stream_in_startofpacket.value = 0     
+    dut.stream_in_endofpacket.value = 0    
+    dut.stream_in_data.value = 0
+    dut.stream_in_valid.value = 1
+    dut.stream_in_empty.value = 0
+
+    dut.csr_address.value = 0
+    dut.csr_read.value = 0
+    dut.csr_write.value = 0
+    dut.csr_writedata.value = 0
+
+    # reset cycle
+    await Timer(100, units="ns")
+    dut.reset_n.value = 1
+    await Timer(100, units="ns")
+
+    # start clock
+    cocotb.start_soon(Clock(dut.clk, 10, units='ns').start())
+    await Timer(500, units="ns")
+
+    # transmit some packages
+    previouse_indata = 0
+    for pkg in range(1,5):
+        print("pkg#" + str(pkg))
+        for i in range(1,10):  
+            await RisingEdge(dut.clk)
+            previouse_indata = dut.stream_in_data.value
+
+            ## write stream in data
+            dut.stream_in_startofpacket.value = 1 == 1;      
+            dut.stream_in_endofpacket.value = 1 == 20;      
+            dut.stream_in_data.value = i + 0x81FFFFFF2B00
+            dut.stream_in_valid.value = 1
+            await RisingEdge(dut.clk)
+            dut.stream_in_valid.value = 0
+
+            ## await stream out data 
+            await RisingEdge(dut.clk)
+            await RisingEdge(dut.clk)
+
+            ## compare in and out data    
+            assert int(previouse_indata) == int(dut.stream_out_data.value), "stream in data and stream out data were different"
+
+
+

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -15,6 +15,11 @@ async def mixed_language_accessing_test(dut):
     verilog = dut.i_swapper_sv
     dut._log.info("Got: %s" % repr(verilog._name))
 
+    # discover all attributes of the SV component
+    # This is a workaround since SV modules are not discovered automatically
+    # when using Modelsim/Questa and a VHLD toplevel file.
+    verilog._discover_all()
+
     vhdl = dut.i_swapper_vhdl
     dut._log.info("Got: %s" % repr(vhdl._name))
 

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -75,10 +75,6 @@ async def mixed_language_functional_test(dut):
             previous_indata = dut.stream_in_data.value
 
             # write stream in data
-            # set start of packet when i is 1
-            dut.stream_in_startofpacket.value = int(i == 1)
-            # set end of packet when i is 10
-            dut.stream_in_endofpacket.value = int(i == 10)
             dut.stream_in_data.value = i + 0x81FFFFFF2B00  # generate a magic number
             dut.stream_in_valid.value = 1
             await RisingEdge(dut.clk)

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -7,7 +7,13 @@ from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer
 
 
-@cocotb.test()
+# Riviera fails to find dut.i_swapper_sv (gh-2921)
+@cocotb.test(
+    expect_error=AttributeError
+    if cocotb.SIM_NAME.lower().startswith(("riviera", "aldec"))
+    and cocotb.LANGUAGE == "vhdl"
+    else ()
+)
 async def mixed_language_accessing_test(dut):
     """Try accessing handles and setting values in a mixed language environment."""
     await Timer(100, units="ns")
@@ -36,7 +42,13 @@ async def mixed_language_accessing_test(dut):
     vhdl.flush_pipe.value
 
 
-@cocotb.test()
+# Riviera fails to find dut.i_swapper_sv (gh-2921)
+@cocotb.test(
+    expect_error=AttributeError
+    if cocotb.SIM_NAME.lower().startswith(("riviera", "aldec"))
+    and cocotb.LANGUAGE == "vhdl"
+    else ()
+)
 async def mixed_language_functional_test(dut):
     """Try concurrent simulation of VHDL and Verilog and check the output."""
     await Timer(100, units="ns")


### PR DESCRIPTION
This pull request completes the incomplete example located at examples/mixed_language. 
- Implemented the VHDL top-level entity for examples/mixed_language 
- Added a test case where the input and the output of the swapper chain are compared 

Tested with Questa IntelFPGA Starters Edition. 

closes/referes to https://github.com/cocotb/cocotb/issues/778




<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
