### PR TITLE
Add more deprecations for private interfaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,8 +192,9 @@ Deprecations serve the following purposes:
 * Remove potentially dangerous, broken, and misunderstood interfaces (usually accompanied with a superior alternative)
 
 Deprecations can be incorporated at any time.
-They are typically implemented by [issuing a `DeprecationWarning`](https://docs.python.org/3/library/warnings.html#warnings.warn) in Python code;
-or [issuing a LOG_WARN](https://docs.cocotb.org/en/stable/generated/file/gpi__logging_8h.html?highlight=LOG_WARN#c.LOG_WARN) with `DEPRECATED` in the message in C++ code.
+They are implemented in Python by [issuing a `DeprecationWarning`](https://docs.python.org/3/library/warnings.html#warnings.warn)
+or using the [`@deprecated`](cocotb/_deprecation.py) decorator.
+In C++ code, deprecations are implemented by [issuing a LOG_WARN](https://docs.cocotb.org/en/stable/generated/file/gpi__logging_8h.html?highlight=LOG_WARN#c.LOG_WARN) with `DEPRECATED` in the message.
 
 Removals only occur on major version bumps.
 One can create removal pull requests at any time, on the condition they will not be accepted until the next release is known to be a major version release.

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -41,6 +41,7 @@ from collections.abc import Coroutine
 from typing import Dict, List, Optional, Union
 
 import cocotb.handle
+from cocotb._deprecation import deprecated
 
 # Things we want in the cocotb namespace
 from cocotb.decorators import Task, coroutine, external, function, test  # noqa: F401
@@ -196,7 +197,7 @@ def fork(coro: Union[Task, Coroutine]) -> Task:
         DeprecationWarning,
         stacklevel=2,
     )
-    return scheduler.add(coro)
+    return scheduler._add(coro)
 
 
 def start_soon(coro: Union[Task, Coroutine]) -> Task:
@@ -321,7 +322,7 @@ def _initialise_testbench_(argv_):
 
     # Create the base handle type
 
-    process_plusargs()
+    _process_plusargs()
 
     # Seed the Python random number generator to make this repeatable
     global RANDOM_SEED
@@ -375,10 +376,10 @@ def _initialise_testbench_(argv_):
     regression_manager = RegressionManager.from_discovery(top)
 
     global scheduler
-    scheduler = Scheduler(handle_result=regression_manager.handle_result)
+    scheduler = Scheduler(handle_result=regression_manager._handle_result)
 
     # start Regression Manager
-    regression_manager.execute()
+    regression_manager._execute()
 
 
 def _sim_event(level, message):
@@ -403,7 +404,13 @@ def _sim_event(level, message):
         scheduler.log.error("Unsupported sim event")
 
 
-def process_plusargs():
+@deprecated("This function is now private")
+def process_plusargs() -> None:
+
+    _process_plusargs()
+
+
+def _process_plusargs() -> None:
 
     global plusargs
 

--- a/cocotb/_deprecation.py
+++ b/cocotb/_deprecation.py
@@ -1,0 +1,36 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import functools
+import warnings
+from typing import Any, Callable, Type, TypeVar
+
+AnyCallableT = TypeVar("AnyCallableT", bound=Callable[..., object])
+
+
+def deprecated(
+    msg: str, category: Type[Warning] = DeprecationWarning
+) -> Callable[[AnyCallableT], AnyCallableT]:
+    """Emits a DeprecationWarning when the decorated function is called.
+
+    This decorator works on normal functions, methods, and properties.
+    Usage on properties requires the ``@property`` decorator to appear outside the
+    ``@deprecated`` decorator.
+    Concrete classes can be deprecated by decorating their ``__init__`` or ``__new__``
+    method.
+
+    Args
+        msg: the deprecation message
+        category: the warning class to use
+    """
+
+    def decorator(f: AnyCallableT) -> AnyCallableT:
+        @functools.wraps(f)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(msg, category=category, stacklevel=2)
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/cocotb/_deprecation.py
+++ b/cocotb/_deprecation.py
@@ -20,7 +20,7 @@ def deprecated(
     Concrete classes can be deprecated by decorating their ``__init__`` or ``__new__``
     method.
 
-    Args
+    Args:
         msg: the deprecation message
         category: the warning class to use
     """

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -42,6 +42,7 @@ from typing import Any, Iterable, Optional, Tuple
 import cocotb
 import cocotb.ANSI as ANSI
 from cocotb import simulator
+from cocotb._deprecation import deprecated
 from cocotb.decorators import Task
 from cocotb.decorators import test as Test
 from cocotb.handle import SimHandle
@@ -225,7 +226,11 @@ class RegressionManager:
             )
             raise AttributeError("Test(s) %s doesn't exist in %s" % (tests, modules))
 
+    @deprecated("This method is now private.")
     def tear_down(self) -> None:
+        self._tear_down()
+
+    def _tear_down(self) -> None:
         # prevent re-entering the tear down procedure
         if not self._tearing_down:
             self._tearing_down = True
@@ -234,7 +239,7 @@ class RegressionManager:
 
         # fail remaining tests
         while True:
-            test = self.next_test()
+            test = self._next_test()
             if test is None:
                 break
             self._record_result(
@@ -259,14 +264,22 @@ class RegressionManager:
         # Setup simulator finalization
         simulator.stop_simulator()
 
+    @deprecated("This method is now private.")
     def next_test(self) -> Optional[Test]:
+        return self._next_test()
+
+    def _next_test(self) -> Optional[Test]:
         """Get the next test to run"""
         if not self._queue:
             return None
         self.count += 1
         return self._queue.pop(0)
 
+    @deprecated("This method is now private.")
     def handle_result(self, test: Task) -> None:
+        self._handle_result(test)
+
+    def _handle_result(self, test: Task) -> None:
         """Handle a test completing.
 
         Dump result to XML and schedule the next test (if any). Entered by the scheduler.
@@ -286,7 +299,7 @@ class RegressionManager:
             sim_time_ns=sim_time_ns,
         )
 
-        self.execute()
+        self._execute()
 
     def _init_test(self, test: Test) -> Optional[Task]:
         """Initialize a test.
@@ -468,14 +481,18 @@ class RegressionManager:
         )
 
         if sim_failed:
-            self.tear_down()
+            self._tear_down()
             return
 
+    @deprecated("This method is now private.")
     def execute(self) -> None:
+        self._execute()
+
+    def _execute(self) -> None:
         while True:
-            self._test = self.next_test()
+            self._test = self._next_test()
             if self._test is None:
-                return self.tear_down()
+                return self._tear_down()
 
             self._test_task = self._init_test(self._test)
             if self._test_task is not None:

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -46,6 +46,7 @@ from typing import Any, Callable, Union
 import cocotb
 import cocotb.decorators
 from cocotb import _py_compat, outcomes
+from cocotb._deprecation import deprecated
 from cocotb.decorators import Task
 from cocotb.log import SimLog
 from cocotb.result import TestComplete
@@ -598,7 +599,7 @@ class Scheduler:
         # TODO: we should be able to better keep track of when this needs to
         # be scheduled
         if self._write_coro_inst is None:
-            self._write_coro_inst = self.add(self._do_writes())
+            self._write_coro_inst = self._add(self._do_writes())
 
         if handle in self._write_calls:
             del self._write_calls[handle]
@@ -783,7 +784,11 @@ class Scheduler:
             )
         )
 
+    @deprecated("This method is now private.")
     def add(self, coroutine: Union[Task, Coroutine]) -> Task:
+        return self._add(coroutine)
+
+    def _add(self, coroutine: Union[Task, Coroutine]) -> Task:
         """Add a new coroutine.
 
         Just a wrapper around self.schedule which provides some debug and


### PR DESCRIPTION
Adds a `@deprecated` decorator which wraps functions. This deprecator
should work on functions, methods, properties (must be inner decorator),
and class `__init__` (to deprecate the class).

Uses this new decorator to deprecate several should-be-private interfaces.
