### PR TITLE
Remove unnecessary development dependencies

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -8,13 +8,8 @@ import nox
 test_deps = ["coverage", "pytest", "pytest-cov"]
 
 dev_deps = [
-    "black",
-    "isort",
     "mypy",
     "pre-commit",
-    "nox",
-    "flake8",
-    "clang-format",
 ]
 
 


### PR DESCRIPTION
The noxfile accumulated several development dependencies which are
installed in another way; installing them in the nox run isn't
necessary.

- nox itself must be installed by the time the noxfile is executed, so
  we can remove it.
- black, isort, flake8, and clang-format are installed (and versioned) through
  pre-commit, which installs those tools into a separate venv.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->