### PR TITLE
Refactor development build steps in noxfile

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -291,7 +291,7 @@ jobs:
       continue-on-error: ${{matrix.may_fail || false}}
       timeout-minutes: 15
       run: |
-        nox -e tests
+        nox -s dev_test
 
     # codecov
     - name: Upload to codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 - repo: "https://github.com/psf/black"
-  rev: "22.1.0"
+  rev: "22.3.0"
   hooks:
   - id: "black"
     exclude: "^cocotb/_vendor"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,21 +260,40 @@ The regression does not end on the first failure, but continues until all tests 
 To run the tests locally with `nox`, issue the following command.
 
 ```command
-nox -e tests
+nox -s dev_test
 ```
 
 At the end of the regression, if there were any test failures, the tests that failed will be printed.
 If the tests succeed you will see the message `Session tests was successful` printed in green.
 
+By default the `dev_test` nox session runs all simulator-agnostic tests, as well as all tests which require a simulator and can be run against Icarus Verilog.
+Icarus Verilog must be installed.
+
+The simulator and the toplevel language can be changed by setting the environment variables [`SIM`](https://docs.cocotb.org/en/latest/building.html#var-SIM) and [`TOPLEVEL_LANG`](https://docs.cocotb.org/en/latest/building.html#var-TOPLEVEL_LANG).
+Alternatively, the simulator-specific nox sessions can be used, as described below.
+
 ### Selecting a Language and Simulator for Regression
 
-`nox` supports the usage of the environment variables [`SIM`](https://docs.cocotb.org/en/latest/building.html#var-SIM) and [`TOPLEVEL_LANG`](https://docs.cocotb.org/en/latest/building.html#var-TOPLEVEL_LANG) to select a simulator and language to run the regression.
-By default the tests will attempt to run with the Icarus Verilog simulator.
+cocotb can be used with multiple simulators, and can run tests against all of them.
+Nox provides a session for each valid simulator/language/GPI interface combination, from which one or multiple sessions can be selected.
 
-For example, if you wanted to run tests with GHDL on Linux with Python 3.8, you would issue the following command:
+The following examples are good starting points;
+refer to the [nox command-line usage documentation](https://nox.thea.codes/en/stable/usage.html) for more information.
 
 ```command
-SIM=ghdl TOPLEVEL_LANG=vhdl nox -e tests
+# List all available sessions.
+nox -l
+
+# Run all simulator-agnostic tests.
+nox -s dev_test_nosim
+
+# Run the simulator-specific tests against Xcelium, using a VHDL toplevel and
+# the VHPI interface.
+nox -s "dev_test_sim(sim='xcelium', toplevel_lang='vhdl', gpi_interface='vhpi')"
+
+# Run all simulator-specific tests against Icarus Verilog and GHDL.
+# Both simulators must be installed locally.
+nox -k "dev_test_sim and (icarus or ghdl)"
 ```
 
 ### Running Individual Tests Locally

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -5,10 +5,14 @@ import os
 import random
 from pathlib import Path
 
+import pytest
+
 import cocotb
 from cocotb.clock import Clock
 from cocotb.runner import get_runner
 from cocotb.triggers import FallingEdge
+
+pytestmark = pytest.mark.simulator_required
 
 
 @cocotb.test()

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,10 +2,17 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import glob
+from contextlib import suppress
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 import nox
 
-test_deps = ["coverage", "pytest", "pytest-cov"]
+# Sessions run by default if nox is called without further arguments.
+nox.options.sessions = ["dev_test"]
+
+test_deps = ["pytest"]
+coverage_deps = ["coverage", "pytest-cov"]
 
 dev_deps = [
     "black",
@@ -17,20 +24,207 @@ dev_deps = [
     "clang-format",
 ]
 
+#
+# Helpers for use within this file.
+#
+
+
+def simulator_support_matrix() -> List[Tuple[str, str, str]]:
+    """
+    Get a list of supported simulator/toplevel-language/GPI-interface tuples.
+    """
+
+    # Simulators with support for VHDL through VHPI, and Verilog through VPI.
+    standard = [
+        (sim, toplevel_lang, gpi_interface)
+        for sim in ("activehdl", "rivierapro", "xcelium")
+        for toplevel_lang in ("verilog", "vhdl")
+        for gpi_interface in ("vpi", "vhpi")
+        if (toplevel_lang, gpi_interface) in (("verilog", "vpi"), ("vhdl", "vhpi"))
+    ]
+
+    # Special-case simulators.
+    special = [
+        ("cvc", "verilog", "vpi"),
+        ("ghdl", "vhdl", "vpi"),
+        ("icarus", "verilog", "vpi"),
+        ("questa", "verilog", "vpi"),
+        ("questa", "vhdl", "fli"),
+        ("questa", "vhdl", "vhpi"),
+        ("verilator", "verilog", "vpi"),
+        ("vcs", "verilog", "vpi"),
+    ]
+
+    return standard + special
+
+
+def env_vars_for_test(
+    sim: Optional[str], toplevel_lang: Optional[str], gpi_interface: Optional[str]
+) -> Dict[str, str]:
+    """Prepare the environment variables controlling the test run."""
+    e = {}
+    if sim is not None:
+        e["SIM"] = sim
+    if toplevel_lang is not None:
+        e["TOPLEVEL_LANG"] = toplevel_lang
+    assert not (toplevel_lang == "verilog" and gpi_interface != "vpi")
+    if toplevel_lang == "vhdl" and gpi_interface is not None:
+        e["VHDL_GPI_INTERFACE"] = gpi_interface
+
+    return e
+
+
+def stringify_dict(d: Dict[str, str]) -> str:
+    return ", ".join(f"{k}={v}" for k, v in d.items())
+
+
+#
+# Development pipeline
+#
+# - Use nox to build an sdist; no separate build step is required.
+# - Run tests against the installed sdist.
+# - Collect coverage.
+#
+
 
 @nox.session
-def tests(session: nox.Session) -> None:
-    """run cocotb regression suite"""
+def dev_build(session: nox.Session) -> None:
+    session.warn("No building is necessary for development sessions.")
+
+
+@nox.session
+def dev_test(session: nox.Session) -> None:
+    """Run all development tests as configured through environment variables."""
+
+    dev_test_nosim(session)
+    dev_test_sim(session, sim=None, toplevel_lang=None, gpi_interface=None)
+
+
+@nox.session
+@nox.parametrize("sim,toplevel_lang,gpi_interface", simulator_support_matrix())
+def dev_test_sim(
+    session: nox.Session,
+    sim: Optional[str],
+    toplevel_lang: Optional[str],
+    gpi_interface: Optional[str],
+) -> None:
+    """Test a development version of cocotb against a simulator."""
+
     session.env["CFLAGS"] = "-Werror -Wno-deprecated-declarations -g --coverage"
     session.env["COCOTB_LIBRARY_COVERAGE"] = "1"
     session.env["CXXFLAGS"] = "-Werror"
     session.env["LDFLAGS"] = "--coverage"
-    session.install(*test_deps)
+
+    session.install(*test_deps, *coverage_deps)
     session.install("-e", ".")
-    session.run("pytest")
-    session.run("make", "test", external=True)
+
+    env = env_vars_for_test(sim, toplevel_lang, gpi_interface)
+    config_str = stringify_dict(env)
+
+    # Remove a potentially existing coverage file from a previous run for the
+    # same test configuration.
+    coverage_file = Path(f".coverage.test.sim-{sim}-{toplevel_lang}-{gpi_interface}")
+    with suppress(FileNotFoundError):
+        coverage_file.unlink()
+
+    session.log(f"Running 'make test' against a simulator {config_str}")
+    session.run("make", "test", external=True, env=env)
+
+    session.log(f"Running simulator-specific tests against a simulator {config_str}")
+    session.run(
+        "pytest",
+        "-v",
+        "--cov=cocotb",
+        "--cov-branch",
+        "-k",
+        "simulator_required",
+    )
+    Path(".coverage").rename(".coverage.pytest")
+
+    session.log(f"All tests passed with configuration {config_str}!")
+
+    # Combine coverage produced during the test runs, and place it in a file
+    # with a name specific to this invocation of dev_test_sim().
     coverage_files = glob.glob("**/.coverage.cocotb", recursive=True)
+    if not coverage_files:
+        session.error(
+            "No coverage files found. Something went wrong during the test execution."
+        )
+    coverage_files.append(".coverage.pytest")
     session.run("coverage", "combine", "--append", *coverage_files)
+    Path(".coverage").rename(coverage_file)
+
+    session.log(f"Stored Python coverage for this test run in {coverage_file}.")
+
+    # Combine coverage from all nox sessions as last step after all sessions
+    # have completed.
+    session.notify("dev_coverage_combine")
+
+
+@nox.session
+def dev_test_nosim(session: nox.Session) -> None:
+    """Run the simulator-agnostic tests against a cocotb development version."""
+    session.install(*test_deps, *coverage_deps)
+    session.install("-e", ".")
+
+    # Remove a potentially existing coverage file from a previous run for the
+    # same test configuration.
+    coverage_file = Path(".coverage.test.pytest")
+    with suppress(FileNotFoundError):
+        coverage_file.unlink()
+
+    # Run pytest with the default configuration in setup.cfg.
+    session.log("Running simulator-agnostic tests with pytest")
+    session.run(
+        "pytest",
+        "-v",
+        "--cov=cocotb",
+        "--cov-branch",
+        "-k",
+        "not simulator_required",
+    )
+
+    # Run pytest for files which can only be tested in the source tree, not in
+    # the installed binary (otherwise we get an "import file mismatch" error
+    # from pytest).
+    session.log("Running simulator-agnostic tests in the source tree with pytest")
+    pytest_sourcetree = [
+        "cocotb/utils.py",
+        "cocotb/binary.py",
+        "cocotb/types/",
+        "cocotb/_sim_versions.py",
+    ]
+    session.run(
+        "pytest",
+        "-v",
+        "--doctest-modules",
+        "--cov=cocotb",
+        "--cov-branch",
+        # Append to the .coverage file created in the previous pytest
+        # invocation in this session.
+        "--cov-append",
+        "-k",
+        "not simulator_required",
+        *pytest_sourcetree,
+    )
+
+    session.log("All tests passed!")
+
+    # Rename the .coverage file to make it unique for the
+    Path(".coverage").rename(coverage_file)
+
+    session.notify("dev_coverage_combine")
+
+
+@nox.session
+def dev_coverage_combine(session: nox.Session) -> None:
+    """Combine coverage from previous dev_* runs into a .coverage file."""
+    session.install(*coverage_deps)
+
+    coverage_files = glob.glob("**/.coverage.test.*", recursive=True)
+    session.run("coverage", "combine", *coverage_files)
+
+    session.log("Wrote combined coverage database for all tests to '.coverage'.")
 
 
 @nox.session

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ testpaths =
     cocotb/_sim_versions.py
 # log_cli = true
 # log_cli_level = DEBUG
+markers =
+    simulator_required: mark tests as needing a simulator
 
 [coverage:run]
 omit =

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,14 +17,11 @@ per-file-ignores =
     examples/doc_examples/quickstart/test_my_design.py: E402,F811
 
 [tool:pytest]
-addopts = -v --cov=cocotb --cov-branch --doctest-modules
+# Note: Do *not* add files within the cocotb/ tree here. Add them to the
+# noxfile instead.
 testpaths =
     tests/pytest
     examples/simple_dff
-    cocotb/utils.py
-    cocotb/binary.py
-    cocotb/types/
-    cocotb/_sim_versions.py
 # log_cli = true
 # log_cli_level = DEBUG
 markers =

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -4,7 +4,11 @@
 
 import os
 
+import pytest
+
 from cocotb.runner import get_runner
+
+pytestmark = pytest.mark.simulator_required
 
 tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sim_build = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sim_build")

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -18,6 +18,8 @@ from test_cocotb import (
 
 from cocotb.runner import get_runner
 
+pytestmark = pytest.mark.simulator_required
+
 
 @pytest.mark.compile
 def test_cocotb_parallel_compile():

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -10,6 +10,8 @@ import cocotb
 from cocotb.runner import get_runner
 from cocotb.triggers import Timer
 
+pytestmark = pytest.mark.simulator_required
+
 tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sim_build = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sim_build")
 


### PR DESCRIPTION
Split the development build steps in the noxfile in anticipation of the
release build steps.

- Split the tests run against a simulator from the pytests. The
  simulator tests need to be run once per simulator, the pytests only
  once overall (they are simulator-agnostic).
- Make nox more ergonomic to use by allowing the user to parametrize
  tests for different simulators directly from nox, without the need to
  set the cocotb-specific environment variables such as TOPLEVEL_LANG or
  SIM.
- Keep a single `dev_test` session (target) which has identical
  functionality to the existing "tests" target.
- Include "dev" in all step names to distinguish them from other types
  of builds (which will come at a later stage).
- Remove the pytest configuration which always runs the doctests as
  well; these tests cannot be run against an installed version of
  cocotb. Instead of using a config file to specify those files, pass the
  files to pytest directly when invoking it for an in-tree development
  build.
  To still use the config in `setup.cfg` we have to invoke pytest twice:
  once with the standard configuration in `setup.cfg`, and once with
  an explicit file list for tests in the source tree.

Usage examples:

Run all tests in development mode.
```
nox

 # or equivalently:
nox test_dev
```

Python coverage is now available at `.coverage`.

Run all development tests against Icarus and GHDL:

```
 # Show which sessions would be run
nox -l -k 'dev and (icarus or ghdl)'

 # Run them.
nox -k 'dev and (icarus or ghdl)'
```

Again, Python coverage is available at `.coverage`. This time it will be
combined coverage for Icarus and GHDL runs.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->