### PR TITLE
CI: Use a version of the GHDL action that works

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -212,7 +212,7 @@ jobs:
         sudo apt install -y --no-install-recommends ghdl-mcode ghdl
     - name : Set up GHDL (Ubunutu - nightly)
       if: startsWith(matrix.os, 'ubuntu') && matrix.sim == 'ghdl' && matrix.sim-version == 'nightly'
-      uses: ghdl/setup-ghdl-ci@nightly
+      uses: ghdl/setup-ghdl-ci@c4e457b6596ee2872274c3b7d2615ad8ddacd70c
       with:
         backend: mcode
 


### PR DESCRIPTION
The "nightly" version has been broken for multiple weeks now. A fix has
been committed
(https://github.com/ghdl/setup-ghdl-ci/commit/d1153380e62073d4d426b0627fea21fe9bf8d784)
but hasn't made it into a release yet. Use a known-good Git commit hash
to have a stable version that works.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->