### PR TITLE
Fix typo in ghdl/vcd example

### DIFF
--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -384,7 +384,7 @@ The option can be set on the command line, as shown in the following example.
 
 .. code-block:: bash
 
-    SIM_ARGS=--vcd=anyname.vhd make SIM=ghdl
+    SIM_ARGS=--vcd=anyname.vcd make SIM=ghdl
 
 A VCD file named :file:`anyname.vcd` will be generated in the current directory.
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
