### PR TITLE
Fail invalid BinaryValue assignment early

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -839,6 +839,7 @@ class ModifiableObject(NonConstantObject):
                 stacklevel=3,
             )
             value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
+
         elif isinstance(value, dict):
             warnings.warn(
                 "dict values are no longer accepted for value assignment. "
@@ -880,7 +881,13 @@ class ModifiableObject(NonConstantObject):
                 )
             value = BinaryValue(str(value))
 
-        elif not isinstance(value, BinaryValue):
+        elif isinstance(value, BinaryValue):
+            if len(value) != len(self):
+                raise ValueError(
+                    f"cannot assign value of length {len(value)} to handle of length {len(self)}"
+                )
+
+        else:
             raise TypeError(
                 "Unsupported type for value assignment: {} ({!r})".format(
                     type(value), value

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -10,6 +10,7 @@ import random
 import pytest
 
 import cocotb
+from cocotb.binary import BinaryValue
 from cocotb.handle import _Limits
 from cocotb.triggers import Timer
 from cocotb.types import Logic, LogicArray
@@ -416,3 +417,9 @@ async def test_assign_Logic(dut):
     assert dut.stream_in_ready.value.binstr.lower() == "x"
     with pytest.raises(ValueError):
         dut.stream_in_data.value = Logic("U")  # not the correct size
+
+
+@cocotb.test()
+async def test_assign_BinaryValue_too_big(dut):
+    with pytest.raises(ValueError):
+        dut.stream_in_data.value = BinaryValue(0, n_bits=1)


### PR DESCRIPTION
Assigning a BinaryValue of the incorrect size to a handle currently causes a GPI ERROR level message to be logged and the assignment doesn't go through. The user's test continues on none the wiser. This change performs the check in Python before the write is scheduled so an exception can be thrown immediately.