### PR TITLE
Unbreak GHDL nightly CI

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -214,7 +214,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && matrix.sim == 'ghdl' && matrix.sim-version == 'nightly'
       uses: ghdl/setup-ghdl-ci@c4e457b6596ee2872274c3b7d2615ad8ddacd70c
       with:
-        backend: mcode
+        backend: llvm
 
       # Install Verilator
     - name: Set up Verilator (Ubuntu - apt)


### PR DESCRIPTION
GHDL nightly builds for Ubuntu 20.04 are not provided for mcode any
more, but only for llvm. Let's switch to that.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->