### PR TITLE
Remove outdated Questa warning in installation docs

### DIFF
--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -98,13 +98,6 @@ The **stable version** of cocotb can be installed by running
     Use ``pip -V`` to check.
     If this prints "(python 2.7)", use :command:`pip3` or ``python3 -m pip`` in place of :command:`pip` in the command shown.
 
-.. warning::
-
-        If you need to test VHDL in Questa, you must make sure that Questa is in your PATH before attempting to install cocotb.
-        Failure to do so will build cocotb without FLI support necessary to test VHDL in Questa.
-        If you end up in the situation where your cocotb doesn't have FLI support and you need it,
-        add the `--no-cache-dir` option to `pip install` to rebuild cocotb from scratch.
-
 If you want to install the **development version** of cocotb,
 `instructions are here <https://docs.cocotb.org/en/latest/install_devel.html>`_.
 


### PR DESCRIPTION
Questa (and ModelSim) don't have to be installed when building cocotb,
thanks to the integrated FLI headers. Remove the documentation that
suggests otherwise.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
