### PR TITLE
Add Logic/LogicArray to reference card

### DIFF
--- a/documentation/source/refcard.rst
+++ b/documentation/source/refcard.rst
@@ -25,7 +25,9 @@ Reference Card
 +------------------------+-----------------------------------------------------------------+
 | Assign immediately     | ``dut.mysignal.setimmediatevalue(0xFF00)``                      |
 +------------------------+-----------------------------------------------------------------+
-| Assign metavalue       | ``dut.mysignal.value = BinaryValue("X")``                       |
+| Assign metavalue       | | ``dut.mysignal.value = Logic("X")``                           |
+|                        | | ``dut.mysignal.value = LogicArray("01XZ")``                   |
+|                        | | ``dut.mysignal.value = BinaryValue("X")``  (deprecated)       |
 +------------------------+-----------------------------------------------------------------+
 | Read                   | | ``val = dut.mysignal.value``                                  |
 |                        | | (``mysig = dut.mysignal`` *creates an alias/reference*)       |


### PR DESCRIPTION
Mark BinaryValue as deprecated.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
