### PR TITLE
CI: Remove sxstrace test from CI

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -231,9 +231,6 @@ jobs:
     - name: Install cocotb runtime dependencies (Windows, msvc)
       if: startsWith(matrix.os, 'windows') && matrix.toolchain == 'msvc'
       run: conda install --yes -c msys2 m2-base m2-make
-    - name: SxS trace test (Windows)
-      if: startsWith(matrix.os, 'windows')
-      run: .\tests\sxs.ps1
     - name: Test (Windows)
       if: startsWith(matrix.os, 'windows')
       id: windowstesting

--- a/tests/sxs.ps1
+++ b/tests/sxs.ps1
@@ -1,3 +1,10 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Run this script with:
+# powershell -executionpolicy bypass -File tests\sxs.ps1
+
 $j = Start-Job -ScriptBlock { SxsTrace Trace -logfile:SxsTrace.etl }
 Start-Sleep -s 5
 python -c "import cocotb.simulator"


### PR DESCRIPTION
Make it possible to run the sxstest through nox.

Remove it from CI, since it doesn't seem to provide enough value to run
repeatedly.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->