### PR TITLE
Set level of gpi logger correctly

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -32,6 +32,7 @@ Everything related to logging
 import logging
 import os
 import sys
+import typing
 import warnings
 
 import cocotb.ANSI as ANSI
@@ -110,7 +111,7 @@ def default_config():
 
     # Notify GPI of log level, which it uses as an optimization to avoid
     # calling into Python.
-    simulator.log_level(log.getEffectiveLevel())
+    logging.getLogger("gpi").setLevel(level)
 
 
 class SimBaseLog(logging.getLoggerClass()):
@@ -136,10 +137,10 @@ class SimBaseLog(logging.getLoggerClass()):
         )
         return want_color_output()
 
-    def setLevel(self, level: int) -> None:
+    def setLevel(self, level: typing.Union[int, str]) -> None:
         super().setLevel(level)
         if self.name == "gpi":
-            simulator.log_level(level)
+            simulator.log_level(self.getEffectiveLevel())
 
 
 # this used to be a class, hence the unusual capitalization


### PR DESCRIPTION
The GPI logger was changed in #2875 from "cocotb.gpi" to "gpi",
but the Python "gpi" logger was not set to match `COCOTB_LOG_LEVEL`.
Set the level on startup.

Also fix setLevel for "gpi" logger to update C++ logging level.

`test_long_log_msg` was not displaying the `DEBUG` logs from GPI.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
