### PR TITLE
Logger name cleanup

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -101,8 +101,7 @@ class Task(typing.Coroutine[typing.Any, typing.Any, T]):
             )
         else:
             raise TypeError(
-                "%s isn't a valid coroutine! Did you forget to use the yield keyword?"
-                % inst
+                f"{inst} isn't a valid coroutine! Did you forget to use the yield keyword?"
             )
         self._coro = inst
         self._started = False
@@ -119,7 +118,7 @@ class Task(typing.Coroutine[typing.Any, typing.Any, T]):
     def log(self) -> SimLog:
         # Creating a logger is expensive, only do it if we actually plan to
         # log anything
-        return SimLog("cocotb.coroutine.%s" % self.__qualname__, id(self))
+        return SimLog(f"cocotb.{self.__qualname__}.{self._coro.__qualname__}")
 
     @property
     def retval(self) -> T:
@@ -360,6 +359,11 @@ class RunningTest(RunningCoroutine[T]):
 
     _name: str = "Test"
 
+    def __init__(self, inst, parent):
+        super().__init__(inst, parent)
+        self.__name__ = f"{type(self)._name} {self.funcname}"
+        self.__qualname__ = self.__name__
+
 
 class coroutine:
     """Decorator class that allows us to provide common coroutine mechanisms:
@@ -377,7 +381,7 @@ class coroutine:
 
     @lazy_property
     def log(self):
-        return SimLog("cocotb.coroutine.%s" % self._func.__qualname__, id(self))
+        return SimLog(f"cocotb.coroutine.{self._func.__qualname__}.{id(self)}")
 
     def __call__(self, *args, **kwargs):
         return RunningCoroutine(self._func(*args, **kwargs), self)
@@ -409,7 +413,7 @@ class function:
 
     @lazy_property
     def log(self):
-        return SimLog("cocotb.function.%s" % self._coro.__qualname__, id(self))
+        return SimLog(f"cocotb.function.{self._coro.__qualname__}.{id(self)}")
 
     def __call__(self, *args, **kwargs):
         return cocotb.scheduler._queue_function(self._coro(*args, **kwargs))
@@ -432,7 +436,7 @@ class external:
 
     def __init__(self, func):
         self._func = func
-        self._log = SimLog("cocotb.external.%s" % self._func.__qualname__, id(self))
+        self._log = SimLog(f"cocotb.external.{self._func.__qualname__}.{id(self)}")
 
     def __call__(self, *args, **kwargs):
         return cocotb.scheduler._run_in_executor(self._func, *args, **kwargs)

--- a/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
+++ b/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
@@ -22,7 +22,7 @@ static void fallback_handler(const char *name, int level, const char *pathname,
                              const char *msg) {
     // Note: don't call the LOG_ERROR macro because that might recurse
     gpi_native_logger_log(name, level, pathname, funcname, lineno, msg);
-    gpi_native_logger_log("cocotb.gpi", GPIError, __FILE__, __func__, __LINE__,
+    gpi_native_logger_log("gpi", GPIError, __FILE__, __func__, __LINE__,
                           "Error calling Python logging function from C++ "
                           "while logging the above");
 }

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -82,7 +82,7 @@ static inline int __check_vhpi_error(const char *file, const char *func,
             break;
     }
 
-    gpi_log("cocotb.gpi", loglevel, file, func, line,
+    gpi_log("gpi", loglevel, file, func, line,
             "VHPI Error level %d: %s\nFILE %s:%d", info.severity, info.message,
             info.file, info.line);
 

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -72,9 +72,8 @@ static inline int __check_vpi_error(const char *file, const char *func,
             loglevel = GPIWarning;
     }
 
-    gpi_log("cocotb.gpi", loglevel, file, func, line, "VPI error");
-    gpi_log("cocotb.gpi", loglevel, info.file, info.product, info.line,
-            info.message);
+    gpi_log("gpi", loglevel, file, func, line, "VPI error");
+    gpi_log("gpi", loglevel, info.file, info.product, info.line, info.message);
 
 #endif
     return level;

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -478,6 +478,24 @@ async def test_task_repr(dut):
     log.info(repr(coro_task))
     assert re.match(r"<Task \d+ created coro=coroutine_outer\(\)>", repr(coro_task))
 
+    log.info(str(coro_task))
+    assert re.match(r"<Task \d+>", str(coro_task))
+
+
+@cocotb.test()
+async def test_test_repr(_):
+    """Test RunningTest.__repr__"""
+    log = logging.getLogger("cocotb.test")
+
+    current_test = cocotb.scheduler._test
+    log.info(repr(current_test))
+    assert re.match(
+        r"<Test test_test_repr running coro=test_test_repr\(\)>", repr(current_test)
+    )
+
+    log.info(str(current_test))
+    assert re.match(r"<Test test_test_repr>", str(current_test))
+
 
 @cocotb.test()
 async def test_start_soon_async(_):


### PR DESCRIPTION
Closes #2960.

Also fixes an issue introduced by #2670 where `RunningTest.__repr__` was of the form `<Test 123>` with the `Task` id rather than the test name.