### PR TITLE
Fix code coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 14
+        after_n_builds: 13
 
 coverage:
     status:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -280,7 +280,8 @@ jobs:
       # - When changing how many builds are uploaded to codecov also update
       #   `codecov.notify.after_n_builds` in `.codecov.yml`.
       if: >
-        (steps.windowstesting.outcome == 'success'
+        ((steps.windowstesting.outcome == 'success'
+          && matrix.toolchain != 'mingw')
          || steps.unixtesting.outcome == 'success')
         && !startsWith(matrix.os, 'macos')
         && matrix.cxx != 'clang++'

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -135,6 +135,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
 
       # Install Python
     - name: Set up Python ${{matrix.python-version}}


### PR DESCRIPTION
The line numbers for Python coverage coming from the mingw CI job do not match the other environments, and appears to be messing up the coverage in certain files.

Here is an example: https://app.codecov.io/gh/cocotb/cocotb/blob/4e313310ff18eed7850b41f74765035eb2c92b57/cocotb/triggers.py

Test a PR without including the mingw coverage.