### PR TITLE
Add support for `vpiPackedArrayNet` type

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -109,6 +109,7 @@ static gpi_objtype_t to_gpi_objtype(int32_t vpitype) {
 
         case vpiInterfaceArray:
         case vpiPackedArrayVar:
+        case vpiPackedArrayNet:
         case vpiRegArray:
         case vpiNetArray:
         case vpiGenScopeArray:
@@ -223,6 +224,7 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiNetArray:
         case vpiInterfaceArray:
         case vpiPackedArrayVar:
+        case vpiPackedArrayNet:
         case vpiMemory:
         case vpiInterconnectArray:
             new_obj = new VpiArrayObjHdl(this, new_hdl, to_gpi_objtype(type));


### PR DESCRIPTION
Update VpiImpl.cpp for partial fix of git issue #2982 to correctly identify vpiPackedArrayNet as a valid type. A runnable example is shown in the git issue [test_questa_vpi_cocotb.zip](https://github.com/cocotb/cocotb/files/8734580/test_questa_vpi_cocotb.zip)

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
