### PR TITLE
Update test expectations for Riviera-PRO 2022.04

### DIFF
--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -368,18 +368,8 @@ async def test_discover_all(dut):
     elif cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(
         "riviera"
     ):
-        # Numbers for versions before 2019.10 may be outdated
-        if cocotb.SIM_VERSION.startswith("2017.10.61"):
-            pass_total = 803
-        elif cocotb.SIM_VERSION.startswith(("2016.06", "2016.10", "2017.02")):
-            pass_total = 813
-        elif cocotb.SIM_VERSION.startswith("2016.02"):
-            pass_total = 947
-        elif cocotb.SIM_VERSION.startswith(("2019.10", "2020.", "2021.")):
-            # vpiVariables finds port_rec_out and sig_rec
-            pass_total = 1006
-        else:
-            pass_total = 1038
+        # Applies to Riviera-PRO 2019.10 and newer.
+        pass_total = 1006
     elif cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(
         "chronologic simulation vcs"
     ):

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -45,11 +45,8 @@ def total_object_count():
 
     # Riviera-PRO
     if SIM_NAME.startswith("riviera"):
-        if SIM_VERSION.startswith(("2019.10", "2020.", "2021.")):
-            return 27359
-        if SIM_VERSION.startswith("2016.02"):
-            return 32393
-        return 34569
+        # The expected result from Riviera-PRO 2019.10 on.
+        return 27359
 
     # Active-HDL
     if SIM_NAME.startswith("aldec"):
@@ -119,9 +116,8 @@ async def dual_iteration(dut):
 @cocotb.test(
     expect_fail=(
         cocotb.SIM_NAME.lower().startswith("riviera")
-        and cocotb.SIM_VERSION.startswith(("2019.10", "2020.", "2021."))
-    )
-    or cocotb.SIM_NAME.lower().startswith("aldec"),
+        or cocotb.SIM_NAME.lower().startswith("aldec")
+    ),
     expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else (),
 )
 async def test_n_dimension_array(dut):


### PR DESCRIPTION
In the discovery tests we have a long list of expectations for various
simulators. Riviera-PRO 2022.04 didn't change from the previous version,
but needs to be explicitly added to the list.

Instead of extending the list forever, I simply removed the expectations
for versions older than 2019.10, which were marked with "unsure if they
are actually correct" anyways. We test down to Riviera-PRO 2019.10 in
the extended CI checks, and I'm not overly worried about older versions
regressing.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->