### PR TITLE
Ensure editable installs are always built with coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 13
+        after_n_builds: 9
 
 coverage:
     status:

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,8 +13,11 @@ nox.options.sessions = ["dev_test"]
 
 test_deps = ["pytest"]
 coverage_deps = ["coverage", "pytest-cov"]
-# gcovr 5.1 has an issue parsing some gcov files, so pin to 5.0. See https://github.com/gcovr/gcovr/issues/596
-# When using gcovr 5.0, deprecated jinja2.Markup was removed in 3.1, so an Exception is raised during html report generation. See https://github.com/gcovr/gcovr/pull/576
+# gcovr 5.1 has an issue parsing some gcov files, so pin to 5.0. See
+# https://github.com/gcovr/gcovr/issues/596
+# When using gcovr 5.0, deprecated jinja2.Markup was removed in 3.1, so an
+# Exception is raised during html report generation.
+# See https://github.com/gcovr/gcovr/pull/576
 # These issues are fixed on gcovr master branch, so next release should work.
 coverage_report_deps = ["coverage", "jinja2<3.1", "gcovr==5.0"]
 


### PR DESCRIPTION
Editable development installations are not rebuilt by nox for each session.
Since any development build (any editable install of development) could be
the "first" one, we need to ensure that they are all built in the same way.
We especially need to ensure that all editable installs are built with
coverage enabled.

This issue was found and explained by Marlon at 
https://github.com/cocotb/cocotb/pull/2924#issuecomment-1134972026. Thanks!


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->