### PR TITLE
fix binstr returning 0 for value=0

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -214,7 +214,7 @@ class BinaryValue:
 
     def _convert_to_unsigned(self, x):
         if x == 0:
-            return self._adjust_unsigned("")
+            return self._adjust_unsigned("0")
         x = bin(x)
         if x[0] == "-":
             raise ValueError(
@@ -224,7 +224,7 @@ class BinaryValue:
 
     def _convert_to_signed_mag(self, x):
         if x == 0:
-            return self._adjust_unsigned("")
+            return self._adjust_unsigned("0")
         x = bin(x)
         if x[0] == "-":
             binstr = self._adjust_signed_mag("1" + x[3:])
@@ -239,7 +239,7 @@ class BinaryValue:
             binstr = bin(2 ** (_clog2(abs(x)) + 1) + x)[2:]
             binstr = self._adjust_twos_comp(binstr)
         elif x == 0:
-            binstr = self._adjust_twos_comp("")
+            binstr = self._adjust_twos_comp("0")
         else:
             binstr = self._adjust_twos_comp("0" + bin(x)[2:])
         if self.big_endian:


### PR DESCRIPTION
Hello,

I pull some minor changes:
I was using cocotb.binary to concatenate 2 vectors for a complex input on a single axistream bus. Each part (im/re) is on 8 bits and is concatenate on a 16 bits BinaryValue. In a more general case I use binaryValue to make the conversion to binstring since python only return signed magnitude of int.

If  you use the present version you will notice that for :

`Inbin=BinaryValue(n_bits=8,binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT,bigEndian=False)`
`Inbin.value=0`
`print(Inbin.binstr)`  will return None 
Since BinaryValue provide a way to handle and use binary representation it's an issue.
My very few modification force at least 1 zero in _str when the value is set to 0. If a n_bits is specified the size will be adapted by existing function.

Change made are minor, if it is really needed I can provide a test case as requested still at this moment it don't seem a necessity  
   


