### PR TITLE
Statically link libstdc++ on Linux

### DIFF
--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -320,6 +320,15 @@ class build_ext(_build_ext):
                             "-Wl,-install_name,@rpath/%s.so" % install_name
                         ]
 
+                if sys.platform == "linux":
+                    # Avoid a runtime dependency on libstdc++. Some simulators
+                    # ship a version of libstdc++6.so which is older than the
+                    # one cocotb has been compiled with, which will then lead to
+                    # load-time errors like "libstdc++.so.6: version
+                    # `GLIBCXX_3.4.29' not found (required by
+                    # /path/to/libcocotbvhpi_modelsim.so)."
+                    ext.extra_link_args += ["-static-libstdc++"]
+
                 ext.extra_link_args += ["-Wl,-rpath,%s" % rpath for rpath in rpaths]
 
         # vpi_user.h and vhpi_user.h require that WIN32 is defined

--- a/documentation/source/newsfragments/3002.feature.rst
+++ b/documentation/source/newsfragments/3002.feature.rst
@@ -1,0 +1,1 @@
+cocotb binaries now statically link libstdc++ on Linux, which prevents library load errors even if the simulator ships its own libstdc++.


### PR DESCRIPTION
Some simulators, e.g. Questa, ship with their own copy of libstdc++.
When loading cocotb, which is linked against libstdc++, the version of
libstdc++ cocotb was compiled with must not be newer than the version of
libstdc++ shipped with the simulator. Since is this something we cannot
guarantee, it leads to user-visible problems where cocotb's VPI/VHPI/FLI
library fails to load.

For example, in Questa or Modelsim, the error looks like this when
running vcom on a system with libstdc++ 6.0.30 (GCC 12.1):

```
  # Loading /home/philipp/src/cocotb/cocotb/libs/libcocotbvhpi_modelsim.so
  # ** Error (suppressible): (vsim-3197) Load of "/home/philipp/src/cocotb/cocotb/libs/libcocotbvhpi_modelsim.so" failed: /path/to/questasim/gcc-7.4.0-linux_x86_64/lib64/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/philipp/src/cocotb/cocotb/libs/libcocotbvhpi_modelsim.so).
  # ** Warning: (vsim-FLI-3160) Failed to load FLI object file "/home/philipp/src/cocotb/cocotb/libs/libcocotbvhpi_modelsim.so".
```

To make cocotb resilient even if a simulator (or anything else in the
environment) provides an incompatible libstdc++, this patch statically
links libstdc++ into all cocotb libraries.

Before:
```
❯ ldd /home/philipp/src/cocotb/cocotb/libs/libcocotbvhpi_modelsim.so
        linux-vdso.so.1 (0x00007fff7c122000)
        libgpi.so => /home/philipp/src/cocotb/cocotb/libs/libgpi.so (0x00007fd7be8aa000)
        libgpilog.so => /home/philipp/src/cocotb/cocotb/libs/libgpilog.so (0x00007fd7be8a2000)
        libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fd7be600000)
        libm.so.6 => /lib64/libm.so.6 (0x00007fd7be51a000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fd7be860000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fd7be200000)
        libcocotbutils.so => /home/philipp/src/cocotb/cocotb/libs/libcocotbutils.so (0x00007fd7be858000)
        libembed.so => /home/philipp/src/cocotb/cocotb/libs/libembed.so (0x00007fd7be850000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fd7be8ec000)
```

After:

```
❯ ldd ./cocotb/libs/libcocotbvpi_modelsim.so
        linux-vdso.so.1 (0x00007fff8078d000)
        libgpi.so => /home/philipp/src/cocotb/./cocotb/libs/libgpi.so (0x00007f496f1a0000)
        libgpilog.so => /home/philipp/src/cocotb/./cocotb/libs/libgpilog.so (0x00007f496f162000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f496f05d000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f496f03a000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f496ee00000)
        libcocotbutils.so => /home/philipp/src/cocotb/./cocotb/libs/libcocotbutils.so (0x00007f496f032000)
        libembed.so => /home/philipp/src/cocotb/./cocotb/libs/libembed.so (0x00007f496edf8000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f496f1df000)
```


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->