### PR TITLE
Doc: Remove leftover line

### DIFF
--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -124,8 +124,6 @@ classes used within ``cocotb``.
 Testbench Structure
 ===================
 
-These are provided by the `cocotb-bus <https://github.com/cocotb/cocotb-bus>`_ package.
-
 Clock
 -----
 


### PR DESCRIPTION
Remove a line which was left over from
2d890b88094d756d3ffbb31e0b62bab473b133bf and which does not make sense
any more as-is.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
