### PR TITLE
Add bypass for user-defined coverage configuration

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -224,6 +224,7 @@ def _initialise_testbench(argv_):  # pragma: no cover
             global _library_coverage
             _library_coverage = coverage.coverage(
                 data_file=".coverage.cocotb",
+                config_file=False,
                 branch=True,
                 include=["{}/*".format(os.path.dirname(__file__))],
             )

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -125,7 +125,9 @@ class RegressionManager:
             if config_filepath is None:
                 # Exclude cocotb itself from coverage collection.
                 cocotb_package_dir = os.path.dirname(__file__)
-                self._cov = coverage.coverage(branch=True, omit=[f"{cocotb_package_dir}/*"])
+                self._cov = coverage.coverage(
+                    branch=True, omit=[f"{cocotb_package_dir}/*"]
+                )
             else:
                 # Allow the config file to handle all configuration
                 self._cov = coverage.coverage()

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -121,9 +121,14 @@ class RegressionManager:
 
         if coverage is not None:
             self.log.info("Enabling coverage collection of Python code")
-            # Exclude cocotb itself from coverage collection.
-            cocotb_package_dir = os.path.dirname(__file__)
-            self._cov = coverage.coverage(branch=True, omit=[f"{cocotb_package_dir}/*"])
+            config_filepath = os.getenv("COVERAGE_RCFILE")
+            if config_filepath is None:
+                # Exclude cocotb itself from coverage collection.
+                cocotb_package_dir = os.path.dirname(__file__)
+                self._cov = coverage.coverage(branch=True, omit=[f"{cocotb_package_dir}/*"])
+            else:
+                # Allow the config file to handle all configuration
+                self._cov = coverage.coverage()
             self._cov.start()
 
         # Test Discovery

--- a/documentation/source/newsfragments/3014.change.rst
+++ b/documentation/source/newsfragments/3014.change.rst
@@ -1,0 +1,1 @@
+When code coverage is enabled with :envvar:`COVERAGE` and a configuration file is specified with :envvar:`COVERAGE_RCFILE`, default coverage configuration is not applied to avoid overriding the user-defined configuration.


### PR DESCRIPTION
coverage.py allows user to configure code coverage via a config file, whose filepath is specified by `COVERAGE_RCFILE` env variable. However, arguments passed to coverage class take priority over settings in the config file.
This commit makes coverage class to be called without arguments if `COVERAGE_RCFILE` is defined so that cocotb doesn't override the user code coverage configuration.
cocotb library coverage is set to ignore the config file.

Closes #2993