### PR TITLE
Rename "General Procedural Interface" to "Generic Procedural Interface"

### DIFF
--- a/documentation/source/glossary.rst
+++ b/documentation/source/glossary.rst
@@ -30,7 +30,7 @@ Glossary
       Foreign Language Interface. Mentor Graphics' equivalent to :term:`VHPI`
 
    GPI
-      General Procedural Interface, cocotb's abstraction over :term:`VPI`, :term:`VHPI`, and :term:`FLI`.
+      Generic Procedural Interface, cocotb's abstraction over :term:`VPI`, :term:`VHPI`, and :term:`FLI`.
 
    HAL
       Hardware Abstraction Layer


### PR DESCRIPTION
As per #3016 rename "General Procedural Interface" to "Generic Procedural Interface" as first named in #41.

After this is merged I will update the Wiki accordingly.
