### PR TITLE
partial GPI cleanup

### DIFF
--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -119,9 +119,6 @@ GPI_EXPORT bool gpi_has_registered_impl(void);
 // Stop the simulator
 GPI_EXPORT void gpi_sim_end(void);
 
-// Cleanup GPI resources during sim shutdown
-GPI_EXPORT void gpi_cleanup(void);
-
 // Returns simulation time as two uints. Units are default sim units
 GPI_EXPORT void gpi_get_sim_time(uint32_t *high, uint32_t *low);
 GPI_EXPORT void gpi_get_sim_precision(int32_t *precision);

--- a/cocotb/share/include/gpi.h
+++ b/cocotb/share/include/gpi.h
@@ -266,10 +266,6 @@ GPI_EXPORT void gpi_deregister_callback(gpi_cb_hdl gpi_hdl);
 // callback data
 GPI_EXPORT void *gpi_get_callback_data(gpi_cb_hdl gpi_hdl);
 
-// Print out what implementations are registered. Python needs to be loaded for
-// this, Returns the number of libs
-GPI_EXPORT size_t gpi_print_registered_impl(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -1114,7 +1114,7 @@ static void register_embed() {
 void cocotb_init() {
     LOG_INFO("cocotb_init called");
     register_embed();
-    gpi_load_extra_libs();
+    gpi_entry_point();
     register_initial_callback();
     register_final_callback();
 }

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -1065,6 +1065,8 @@ extern "C" {
 
 // Main re-entry point for callbacks from simulator
 void handle_fli_callback(void *data) {
+    gpi_to_user();
+
     fflush(stderr);
 
     FliProcessCbHdl *cb_hdl = (FliProcessCbHdl *)data;
@@ -1090,6 +1092,8 @@ void handle_fli_callback(void *data) {
         /* Issue #188 seems to appear via FLI as well */
         cb_hdl->cleanup_callback();
     }
+
+    gpi_to_simulator();
 };
 
 static void register_initial_callback() {

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -1106,14 +1106,14 @@ static void register_final_callback() {
     sim_finish_cb->arm_callback();
 }
 
-static void register_embed() {
+static void register_impl() {
     fli_table = new FliImpl("FLI");
     gpi_register_impl(fli_table);
 }
 
 void cocotb_init() {
     LOG_INFO("cocotb_init called");
-    register_embed();
+    register_impl();
     gpi_entry_point();
     register_initial_callback();
     register_final_callback();
@@ -1121,4 +1121,4 @@ void cocotb_init() {
 
 }  // extern "C"
 
-GPI_ENTRY_POINT(cocotbfli, register_embed);
+GPI_ENTRY_POINT(cocotbfli, register_impl);

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -137,10 +137,6 @@ void gpi_cleanup(void) {
     embed_sim_cleanup();
 }
 
-void gpi_embed_event(gpi_event_t level, const char *msg) {
-    embed_sim_event(level, msg);
-}
-
 static void gpi_load_libs(std::vector<std::string> to_load) {
     std::vector<std::string>::iterator iter;
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -92,7 +92,7 @@ static GpiHandleStore unique_handles;
 
 #endif
 
-size_t gpi_print_registered_impl() {
+static size_t gpi_print_registered_impl() {
     vector<GpiImplInterface *>::iterator iter;
     for (iter = registered_impls.begin(); iter != registered_impls.end();
          iter++) {

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -178,7 +178,7 @@ static void gpi_load_libs(std::vector<std::string> to_load) {
     }
 }
 
-void gpi_load_extra_libs() {
+void gpi_entry_point() {
     /* Lets look at what other libs we were asked to load too */
     char *lib_env = getenv("GPI_EXTRA");
 

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -81,6 +81,7 @@ class GpiHandleStore {
 };
 
 static GpiHandleStore unique_handles;
+static bool sim_ending = false;
 
 #define CHECK_AND_STORE(_x) unique_handles.check_and_store(_x)
 #define CLEAR_STORE() unique_handles.clear()
@@ -123,10 +124,13 @@ void gpi_embed_init(int argc, char const *const *argv) {
 
 void gpi_embed_end() {
     embed_sim_event(SIM_FAIL, "Simulator shutdown prematurely");
-    gpi_cleanup();
+    sim_ending = true;
 }
 
-void gpi_sim_end() { registered_impls[0]->sim_end(); }
+void gpi_sim_end() {
+    registered_impls[0]->sim_end();
+    sim_ending = true;
+}
 
 void gpi_cleanup(void) {
     CLEAR_STORE();
@@ -590,3 +594,12 @@ void gpi_deregister_callback(gpi_cb_hdl cb_hdl) {
 const char *GpiImplInterface::get_name_c() { return m_name.c_str(); }
 
 const string &GpiImplInterface::get_name_s() { return m_name; }
+
+void gpi_to_user() { LOG_TRACE("Passing control to GPI user"); }
+
+void gpi_to_simulator() {
+    if (sim_ending) {
+        gpi_cleanup();
+    }
+    LOG_TRACE("Returning control to simulator");
+}

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -284,10 +284,11 @@ class GPI_EXPORT GpiImplInterface {
 GPI_EXPORT int gpi_register_impl(GpiImplInterface *func_tbl);
 
 GPI_EXPORT void gpi_embed_init(int argc, char const *const *argv);
-GPI_EXPORT void gpi_cleanup();
 GPI_EXPORT void gpi_embed_end();
 GPI_EXPORT void gpi_embed_event(gpi_event_t level, const char *msg);
 GPI_EXPORT void gpi_load_extra_libs();
+GPI_EXPORT void gpi_to_user();
+GPI_EXPORT void gpi_to_simulator();
 
 typedef void (*layer_entry_func)();
 

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -285,7 +285,6 @@ GPI_EXPORT int gpi_register_impl(GpiImplInterface *func_tbl);
 
 GPI_EXPORT void gpi_embed_init(int argc, char const *const *argv);
 GPI_EXPORT void gpi_embed_end();
-GPI_EXPORT void gpi_embed_event(gpi_event_t level, const char *msg);
 GPI_EXPORT void gpi_load_extra_libs();
 GPI_EXPORT void gpi_to_user();
 GPI_EXPORT void gpi_to_simulator();

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -285,7 +285,7 @@ GPI_EXPORT int gpi_register_impl(GpiImplInterface *func_tbl);
 
 GPI_EXPORT void gpi_embed_init(int argc, char const *const *argv);
 GPI_EXPORT void gpi_embed_end();
-GPI_EXPORT void gpi_load_extra_libs();
+GPI_EXPORT void gpi_entry_point();
 GPI_EXPORT void gpi_to_user();
 GPI_EXPORT void gpi_to_simulator();
 

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -37,8 +37,6 @@
 static int takes = 0;
 static int releases = 0;
 
-static int sim_ending = 0;
-
 #include <Python.h>
 #include <cocotb_utils.h>    // COCOTB_UNUSED
 #include <gpi_logging.h>     // LOG_* macros
@@ -238,7 +236,6 @@ int handle_gpi_callback(void *user_data) {
             PyErr_Print();
 
             gpi_sim_end();
-            sim_ending = 1;
             ret = 0;
             goto out;
         }
@@ -261,13 +258,6 @@ out:
 
 err:
     to_simulator();
-
-    if (sim_ending) {
-        // This is the last callback of a successful run,
-        // so call the cleanup function as we'll never return
-        // to Python
-        gpi_cleanup();
-    }
     return ret;
 }
 
@@ -884,7 +874,6 @@ static PyObject *stop_simulator(PyObject *self, PyObject *args) {
     }
 
     gpi_sim_end();
-    sim_ending = 1;
     Py_RETURN_NONE;
 }
 

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -1020,7 +1020,7 @@ static void register_embed() {
 
 // pre-defined VHPI registration table
 COCOTBVHPI_EXPORT void (*vhpi_startup_routines[])() = {
-    register_embed, gpi_load_extra_libs, register_initial_callback,
+    register_embed, gpi_entry_point, register_initial_callback,
     register_final_callback, nullptr};
 
 // For non-VHPI compliant applications that cannot find vhpi_startup_routines

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -975,6 +975,8 @@ extern "C" {
 
 // Main entry point for callbacks from simulator
 void handle_vhpi_callback(const vhpiCbDataT *cb_data) {
+    gpi_to_user();
+
     VhpiCbHdl *cb_hdl = (VhpiCbHdl *)cb_data->user_data;
 
     if (!cb_hdl) {
@@ -998,7 +1000,7 @@ void handle_vhpi_callback(const vhpiCbDataT *cb_data) {
             }
     }
 
-    return;
+    gpi_to_simulator();
 };
 
 static void register_initial_callback() {

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -1013,14 +1013,14 @@ static void register_final_callback() {
     sim_finish_cb->arm_callback();
 }
 
-static void register_embed() {
+static void register_impl() {
     vhpi_table = new VhpiImpl("VHPI");
     gpi_register_impl(vhpi_table);
 }
 
 // pre-defined VHPI registration table
 COCOTBVHPI_EXPORT void (*vhpi_startup_routines[])() = {
-    register_embed, gpi_entry_point, register_initial_callback,
+    register_impl, gpi_entry_point, register_initial_callback,
     register_final_callback, nullptr};
 
 // For non-VHPI compliant applications that cannot find vhpi_startup_routines
@@ -1035,4 +1035,4 @@ COCOTBVHPI_EXPORT void vhpi_startup_routines_bootstrap() {
 }
 }
 
-GPI_ENTRY_POINT(cocotbvhpi, register_embed)
+GPI_ENTRY_POINT(cocotbvhpi, register_impl)

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -667,7 +667,7 @@ int32_t handle_vpi_callback(p_cb_data cb_data) {
     return rv;
 }
 
-static void register_embed() {
+static void register_impl() {
     vpi_table = new VpiImpl("VPI");
     gpi_register_impl(vpi_table);
 }
@@ -683,7 +683,7 @@ static void register_final_callback() {
 }
 
 COCOTBVPI_EXPORT void (*vlog_startup_routines[])() = {
-    register_embed, gpi_entry_point, register_initial_callback,
+    register_impl, gpi_entry_point, register_initial_callback,
     register_final_callback, nullptr};
 
 // For non-VPI compliant applications that cannot find vlog_startup_routines
@@ -697,4 +697,4 @@ COCOTBVPI_EXPORT void vlog_startup_routines_bootstrap() {
 }
 }
 
-GPI_ENTRY_POINT(cocotbvpi, register_embed)
+GPI_ENTRY_POINT(cocotbvpi, register_impl)

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -629,6 +629,8 @@ extern "C" {
 
 // Main re-entry point for callbacks from simulator
 int32_t handle_vpi_callback(p_cb_data cb_data) {
+    gpi_to_user();
+
     int rv = 0;
 
     VpiCbHdl *cb_hdl = (VpiCbHdl *)cb_data->user_data;
@@ -659,6 +661,8 @@ int32_t handle_vpi_callback(p_cb_data cb_data) {
             delete cb_hdl;
         }
     }
+
+    gpi_to_simulator();
 
     return rv;
 }

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -683,7 +683,7 @@ static void register_final_callback() {
 }
 
 COCOTBVPI_EXPORT void (*vlog_startup_routines[])() = {
-    register_embed, gpi_load_extra_libs, register_initial_callback,
+    register_embed, gpi_entry_point, register_initial_callback,
     register_final_callback, nullptr};
 
 // For non-VPI compliant applications that cannot find vlog_startup_routines


### PR DESCRIPTION
Several cleanups on the GPI code. Mostly aesthetic, like renaming and making things private that don't need to be public. Moved `sim_ending` flag to GPI.