### PR TITLE
Support Questa with the VHPI interface

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -394,8 +394,9 @@ class HierarchyArrayObject(RegionObject):
     def _sub_handle_key(self, name):
         """Translate the handle name to a key to use in :any:`_sub_handles` dictionary."""
         # This is slightly hacky, but we need to extract the index from the name
+        # See also GEN_IDX_SEP_* in VhpiImpl.h for the VHPI separators.
         #
-        # FLI and VHPI(IUS):  _name(X) where X is the index
+        # FLI and VHPI:       _name(X) where X is the index
         # VHPI(ALDEC):        _name__X where X is the index
         # VPI:                _name[X] where X is the index
         import re

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -44,12 +44,14 @@
 #include "_vendor/vhpi/vhpi_user.h"
 
 // Define Index separator
-#ifdef IUS
-#define GEN_IDX_SEP_LHS "("
-#define GEN_IDX_SEP_RHS ")"
-#else
+#ifdef ALDEC
+// Aldec
 #define GEN_IDX_SEP_LHS "__"
 #define GEN_IDX_SEP_RHS ""
+#else
+// IUS/Xcelium and Questa
+#define GEN_IDX_SEP_LHS "("
+#define GEN_IDX_SEP_RHS ")"
 #endif
 
 // Should be run after every VHPI call to check error status

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -139,7 +139,7 @@ async def test_read_write(dut):
         dut.sig_int.value = 5000
         dut.sig_real.value = 22.54
         dut.sig_char.value = ord("Z")
-        dut.sig_str.value = "Testing"
+        dut.sig_str.value = b"Testing"
         dut.sig_rec.a.value = 1
         dut.sig_rec.b[0].value = 0x01
         dut.sig_rec.b[1].value = 0x23

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -3,6 +3,7 @@ A set of tests that demonstrate Array structure support
 """
 
 import logging
+import os
 
 import cocotb
 from cocotb.clock import Clock
@@ -363,6 +364,12 @@ async def test_discover_all(dut):
         pass_total = 571
     elif cocotb.SIM_NAME.lower().startswith("ghdl"):
         pass_total = 56
+    elif (
+        cocotb.LANGUAGE in ["vhdl"]
+        and cocotb.SIM_NAME.lower().startswith("modelsim")
+        and os.environ["VHDL_GPI_INTERFACE"] == "vhpi"
+    ):
+        pass_total = 920
     elif cocotb.LANGUAGE in ["vhdl"]:
         pass_total = 856
     elif cocotb.LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith(

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -39,9 +39,9 @@ def _check_logic(tlog, hdl, expected):
 
 def _check_str(tlog, hdl, expected):
     assert hdl.value == expected, "{2!r}: Expected >{0}< but got >{1}<".format(
-        expected, str(hdl), hdl
+        expected, hdl.value, hdl
     )
-    tlog.info("   Found {!r} ({}) with value={}".format(hdl, hdl._type, str(hdl)))
+    tlog.info("   Found {!r} ({}) with value={}".format(hdl, hdl._type, hdl.value))
 
 
 def _check_real(tlog, hdl, expected):

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -273,7 +273,7 @@ async def test_write_single_character(dut):
 
     # iterate over each character handle and uppercase it
     for c in dut.stream_in_string:
-        lowercase = chr(c)
+        lowercase = chr(c.value)
         uppercase = lowercase.upper()
         uppercase_as_int = ord(uppercase)
         c.setimmediatevalue(uppercase_as_int)

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -24,6 +24,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import os
 
 import cocotb
 from cocotb.triggers import Combine, Timer
@@ -33,6 +34,11 @@ def total_object_count():
     """Return the total object count based on simulator."""
     SIM_NAME = cocotb.SIM_NAME.lower()
     SIM_VERSION = cocotb.SIM_VERSION.lower()
+
+    # Questa with VHPI
+    # TODO: Why do we get massively different numbers for Questa/VHPI than for Questa/FLI or VPI?
+    if SIM_NAME.startswith("modelsim") and os.environ["VHDL_GPI_INTERFACE"] == "vhpi":
+        return 66959
 
     if SIM_NAME.startswith(
         (

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -24,6 +24,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import warnings
 
 import cocotb
 from cocotb.handle import (
@@ -97,7 +98,13 @@ async def check_objects(dut):
         pass
 
     try:
-        dut.inst_axi4s_buffer.DATA_WIDTH <= 42
+        with warnings.catch_warnings():
+            # The <= syntax is deprecated and raises a DeprecationWarning, which
+            # we need to ignore to get to the condition we actually want to
+            # test.
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+            dut.inst_axi4s_buffer.DATA_WIDTH <= 42
         tlog.error(
             "Shouldn't be allowed to set a value on constant object using __le__"
         )

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -91,7 +91,7 @@ async def check_objects(dut):
         fails += 1
 
     try:
-        dut.inst_axi4s_buffer.DATA_WIDTH = 42
+        dut.inst_axi4s_buffer.DATA_WIDTH.value = 42
         tlog.error("Shouldn't be allowed to set a value on constant object")
         fails += 1
     except TypeError:

--- a/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
+++ b/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
@@ -2,10 +2,17 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
+
 import pytest
 
 import cocotb
 from cocotb.triggers import Timer
+
+is_questa_vhpi = (
+    cocotb.SIM_NAME.lower().startswith("modelsim")
+    and os.environ["VHDL_GPI_INTERFACE"] == "vhpi"
+)
 
 
 @cocotb.test()
@@ -21,6 +28,7 @@ async def test_long_signal(dut):
     if cocotb.SIM_NAME.lower().startswith(
         ("ghdl", "xmsim", "ncsim", "riviera", "aldec")
     )
+    or is_questa_vhpi
     else ()
 )
 async def test_read_zero_signal(dut):
@@ -33,6 +41,7 @@ async def test_read_zero_signal(dut):
     if cocotb.SIM_NAME.lower().startswith(
         ("ghdl", "xmsim", "ncsim", "riviera", "aldec")
     )
+    or is_questa_vhpi
     else ()
 )
 async def test_write_zero_signal_with_0(dut):
@@ -47,6 +56,7 @@ async def test_write_zero_signal_with_0(dut):
     if cocotb.SIM_NAME.lower().startswith(
         ("ghdl", "xmsim", "ncsim", "riviera", "aldec")
     )
+    or is_questa_vhpi
     else ()
 )
 async def test_write_zero_signal_with_1(dut):


### PR DESCRIPTION
Fix all remaining issues to make the cocotb test suite pass with Questa/VHPI. Tested on a pre-release version of an upcoming Questa release (2022_weekly_220527).

This PR contains a mix of fixes to our test suite, which somehow got unnoticed so far, and adjustments in our test expectations to support Questa VHPI.

I'm not quite sure yet why we didn't catch the various deprecation and future warnings before with Aldec VHPI that I now fixed.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->