### PR TITLE
Make dev tests through nox more reliable

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -145,7 +145,7 @@ def dev_test_sim(
         coverage_file.unlink()
 
     session.log(f"Running 'make test' against a simulator {config_str}")
-    session.run("make", "test", external=True, env=env)
+    session.run("make", "clean", "test", external=True, env=env)
 
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(
@@ -365,7 +365,7 @@ def release_test_sim(
     config_str = stringify_dict(env)
 
     session.log(f"Running tests against a simulator: {config_str}")
-    session.run("make", "test", external=True, env=env)
+    session.run("make", "clean", "test", external=True, env=env)
 
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(


### PR DESCRIPTION
Running multiple tests in development mode through nox failed due to
build artifacts being around after running `make test`. Fix that by
running `make clean` before the test.

(The real solution would be to not install cocotb in editable mode and
have test artifacts in the source directory, but that's a longer-term
project.)


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->