### PR TITLE
Improve portability, helping with various BSDs

### DIFF
--- a/cocotb/share/include/exports.h
+++ b/cocotb/share/include/exports.h
@@ -9,12 +9,12 @@
 // Changing the default visibility to hidden has the advantage of significantly
 // reducing the code size and load times, as well as letting the optimizer
 // produce better code.
-#if defined(__linux__) || defined(__APPLE__)
-#define COCOTB_EXPORT __attribute__((visibility("default")))
-#define COCOTB_IMPORT
-#else
+#if _WIN32
 #define COCOTB_EXPORT __declspec(dllexport)
 #define COCOTB_IMPORT __declspec(dllimport)
+#else
+#define COCOTB_EXPORT __attribute__((visibility("default")))
+#define COCOTB_IMPORT
 #endif
 
 #endif

--- a/cocotb/share/lib/embed/embed.cpp
+++ b/cocotb/share/lib/embed/embed.cpp
@@ -7,7 +7,7 @@
 #include <gpi.h>  // gpi_event_t
 
 #include <cstdlib>  // getenv
-#if !defined(__linux__) && !defined(__APPLE__)
+#ifdef _WIN32
 #include <windows.h>  // Win32 API for loading the embed impl library
 
 #include <string>  // string
@@ -32,7 +32,7 @@ static void (*_embed_sim_event)(gpi_event_t level, const char *msg);
 
 static bool init_failed = false;
 
-#if !defined(__linux__) && !defined(__APPLE__)
+#ifdef _WIN32
 static ACTCTX act_ctx = {
     /* cbSize */ sizeof(ACTCTX),
     /* dwFlags */ ACTCTX_FLAG_HMODULE_VALID | ACTCTX_FLAG_RESOURCE_NAME_VALID,
@@ -68,7 +68,7 @@ extern "C" void embed_init_python(void) {
         // LCOV_EXCL_STOP
     }
 
-#if !defined(__linux__) && !defined(__APPLE__)
+#ifdef _WIN32
     if (!act_ctx.hModule) {
         // LCOV_EXCL_START
         init_failed = true;
@@ -130,7 +130,7 @@ extern "C" void embed_init_python(void) {
         // LCOV_EXCL_STOP
     }
 
-#if !defined(__linux__) && !defined(__APPLE__)
+#ifdef _WIN32
     if (!DeactivateActCtx(0, Cookie)) {
         // LCOV_EXCL_START
         init_failed = true;

--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -1012,7 +1012,7 @@ static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
                                        NULL,
                                        NULL};
 
-#if defined(__linux__) || defined(__APPLE__)
+#ifndef _WIN32
 // Only required for Python < 3.9, default for 3.9+ (bpo-11410)
 #pragma GCC visibility push(default)
 PyMODINIT_FUNC PyInit_simulator(void);

--- a/cocotb/share/lib/utils/cocotb_utils.cpp
+++ b/cocotb/share/lib/utils/cocotb_utils.cpp
@@ -31,10 +31,10 @@
 #include <gpi_logging.h>
 #include <stdlib.h>
 
-#if defined(__linux__) || defined(__APPLE__)
-#include <dlfcn.h>
-#else
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <dlfcn.h>
 #endif
 
 // Tracks if we are in the context of Python or Simulator
@@ -42,7 +42,7 @@ int is_python_context = 0;
 
 extern "C" void *utils_dyn_open(const char *lib_name) {
     void *ret = NULL;
-#if !defined(__linux__) && !defined(__APPLE__)
+#ifdef _WIN32
     SetErrorMode(0);
     ret = static_cast<void *>(LoadLibrary(lib_name));
     if (!ret) {
@@ -73,7 +73,7 @@ extern "C" void *utils_dyn_open(const char *lib_name) {
 
 extern "C" void *utils_dyn_sym(void *handle, const char *sym_name) {
     void *entry_point;
-#if !defined(__linux__) && !defined(__APPLE__)
+#ifdef _WIN32
     entry_point = reinterpret_cast<void *>(
         GetProcAddress(static_cast<HMODULE>(handle), sym_name));
     if (!entry_point) {

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -501,7 +501,7 @@ def _get_common_lib_ext(include_dirs, share_lib_dir):
     if os.name == "nt":
         libcocotbutils_sources += ["libcocotbutils.rc"]
     libcocotbutils_libraries = ["gpilog"]
-    if os.name != "nt":
+    if sys.platform.startswith(("linux", "darwin", "cygwin", "msys")):
         libcocotbutils_libraries.append("dl")  # dlopen, dlerror, dlsym
     libcocotbutils = Extension(
         os.path.join("cocotb", "libs", "libcocotbutils"),


### PR DESCRIPTION
This change permits cocotb to compile under OpenBSD and most likely other BSDs (such as FreeBSD and NetBSD).

No compiler warning or error is issued anymore while executing `python setup.py build`.

There are still issues to fix for getting cocotb to run, being worked on on my side, but these two commits were needed to at least compile it:

```
$ cocotb-config
Traceback (most recent call last):
  File "/usr/local/bin/cocotb-config", line 33, in <module>
    sys.exit(load_entry_point('cocotb==1.7.0.dev0', 'console_scripts', 'cocotb-config')())
  File "/usr/local/bin/cocotb-config", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/local/lib/python3.9/importlib/metadata.py", line 86, in load
    module = import_module(match.group('module'))
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/site-packages/cocotb-1.7.0.dev0-py3.9-openbsd-7.1-amd64.egg/cocotb/__init__.py", line 43, in <module>
    import cocotb.handle
  File "/usr/local/lib/python3.9/site-packages/cocotb-1.7.0.dev0-py3.9-openbsd-7.1-amd64.egg/cocotb/handle.py", line 39, in <module>
    from cocotb import simulator
ImportError: Cannot load specified object
```

Are you interested in these light changes upstream, preparing cocotb support for BSDs?