### PR TITLE
modelsim: do SCRIPT_FILE after initializing sim

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -135,10 +135,10 @@ endif
 ifneq ($(VERILOG_SOURCES),)
 	@echo "vlog -work $(RTL_LIBRARY) +define+COCOTB_SIM -sv $(VLOG_ARGS) $(EXTRA_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
 endif
+	@echo "vsim $(VSIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS) $(SIM_BUILD)/$(TOPLEVEL)" >> $@
 ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@
 endif
-	@echo "vsim $(VSIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS) $(SIM_BUILD)/$(TOPLEVEL)" >> $@
 ifeq ($(WAVES),1)
 	@echo "log -recursive /*" >> $@
 endif


### PR DESCRIPTION
Fixes #3029

For Questa/Modelsim, the SCRIPT_FILE is currently run before the
simulation is initialized using the vsim command. In the common case
where SCRIPT_FILE=wave.do, a file that sets up traces in the GUI, these
traces fail to initialize since the underlying signals don't exist yet.

This commit runs the SCRIPT_FILE before the vsim command, allowing
traces to be set up properly.
