### PR TITLE
Use 'X as default LogicArray value

### DIFF
--- a/cocotb/types/logic_array.py
+++ b/cocotb/types/logic_array.py
@@ -28,6 +28,8 @@ class LogicArray(Array[Logic]):
     used.
     Like :class:`Array`, if no *range* argument is given, it is deduced from the length
     of the iterable or bit string used to initialize the variable.
+    If a *range* argument is given, but no value,
+    the array is filled with the default value of Logic().
 
     .. code-block:: python3
 
@@ -37,11 +39,14 @@ class LogicArray(Array[Logic]):
         >>> LogicArray([0, True, "X"])
         LogicArray('01X', Range(2, 'downto', 0))
 
-        >>> LogicArray(0xA)                     # picks smallest range that can fit the value
+        >>> LogicArray(0xA)  # picks smallest range that can fit the value
         LogicArray('1010', Range(3, 'downto', 0))
 
-        >>> LogicArray(-4, Range(0, "to", 3))   # will sign-extend
+        >>> LogicArray(-4, Range(0, "to", 3))  # will sign-extend
         LogicArray('1100', Range(0, 'to', 3))
+
+        >>> LogicArray(range=Range(0, "to", 3))  # defaults values
+        LogicArray('XXXX', Range(0, 'to', 3))
 
     :class:`LogicArray`\ s support the same operations as :class:`Array`;
     however, it enforces the condition that all elements must be a :class:`Logic`.
@@ -115,20 +120,38 @@ class LogicArray(Array[Logic]):
 
     __slots__ = ()
 
+    @typing.overload
     def __init__(
         self,
-        value: typing.Optional[
-            typing.Union[int, typing.Iterable[LogicConstructibleT], BinaryValue]
+        value: typing.Union[int, typing.Iterable[LogicConstructibleT], BinaryValue],
+        range: typing.Optional[Range],
+    ):
+        ...
+
+    @typing.overload
+    def __init__(
+        self,
+        value: typing.Union[
+            int, typing.Iterable[LogicConstructibleT], BinaryValue, None
+        ],
+        range: Range,
+    ):
+        ...
+
+    def __init__(
+        self,
+        value: typing.Union[
+            int, typing.Iterable[LogicConstructibleT], BinaryValue, None
         ] = None,
         range: typing.Optional[Range] = None,
     ) -> None:
+        if value is None and range is None:
+            raise ValueError(
+                "at least one of the value and range input parameters must be given"
+            )
         if value is None:
-            if range is None:
-                raise ValueError(
-                    "at least one between value and range input parameters must not be None"
-                )
-            value = "X" * len(range)
-        if isinstance(value, int):
+            self._value = [Logic() for _ in range]
+        elif isinstance(value, int):
             if value < 0:
                 bitlen = int.bit_length(value + 1) + 1
             else:

--- a/cocotb/types/logic_array.py
+++ b/cocotb/types/logic_array.py
@@ -45,7 +45,7 @@ class LogicArray(Array[Logic]):
         >>> LogicArray(-4, Range(0, "to", 3))  # will sign-extend
         LogicArray('1100', Range(0, 'to', 3))
 
-        >>> LogicArray(range=Range(0, "to", 3))  # defaults values
+        >>> LogicArray(range=Range(0, "to", 3))  # default values
         LogicArray('XXXX', Range(0, 'to', 3))
 
     :class:`LogicArray`\ s support the same operations as :class:`Array`;

--- a/cocotb/types/logic_array.py
+++ b/cocotb/types/logic_array.py
@@ -117,9 +117,15 @@ class LogicArray(Array[Logic]):
 
     def __init__(
         self,
-        value: typing.Union[int, typing.Iterable[LogicConstructibleT], BinaryValue],
+        value: typing.Optional[typing.Union[int, typing.Iterable[LogicConstructibleT], BinaryValue]] = None,
         range: typing.Optional[Range] = None,
     ) -> None:
+        if value is None:
+            if range is None:
+                raise ValueError(
+                    "at least one between value and range input parameters must not be None"
+                )
+            value = 'X' * len(range)
         if isinstance(value, int):
             if value < 0:
                 bitlen = int.bit_length(value + 1) + 1

--- a/cocotb/types/logic_array.py
+++ b/cocotb/types/logic_array.py
@@ -117,7 +117,9 @@ class LogicArray(Array[Logic]):
 
     def __init__(
         self,
-        value: typing.Optional[typing.Union[int, typing.Iterable[LogicConstructibleT], BinaryValue]] = None,
+        value: typing.Optional[
+            typing.Union[int, typing.Iterable[LogicConstructibleT], BinaryValue]
+        ] = None,
         range: typing.Optional[Range] = None,
     ) -> None:
         if value is None:
@@ -125,7 +127,7 @@ class LogicArray(Array[Logic]):
                 raise ValueError(
                     "at least one between value and range input parameters must not be None"
                 )
-            value = 'X' * len(range)
+            value = "X" * len(range)
         if isinstance(value, int):
             if value < 0:
                 bitlen = int.bit_length(value + 1) + 1

--- a/documentation/source/newsfragments/3031.feature.rst
+++ b/documentation/source/newsfragments/3031.feature.rst
@@ -1,0 +1,1 @@
+:class:`cocotb.types.LogicArray` now supports a default value construction if a ``range`` is given.

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -14,6 +14,8 @@ def test_logic_array_constructor():
     with pytest.raises(ValueError):
         LogicArray([object()])
 
+    assert LogicArray(range=Range(0, "to", 3)) == LogicArray("XXXX")
+
     assert LogicArray(0) == LogicArray("0")
     assert LogicArray(0xA7) == LogicArray("10100111")
     assert LogicArray(-1) == LogicArray("1")
@@ -28,6 +30,9 @@ def test_logic_array_constructor():
 
     with pytest.raises(ValueError):
         LogicArray("101010", Range(0, "to", 0))
+
+    with pytest.raises(ValueError):
+        LogicArray()
 
 
 def test_logic_array_properties():


### PR DESCRIPTION
In System Verilog when a logic array is declared but not initialized, its value is X. This proposal aims to mimic such behavior.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
