### PR TITLE
Various makefile cleanups, lite edition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ all: test
 
 .PHONY: clean
 clean:
-	-@find . -name "obj" | xargs rm -rf
-	-@find . -name "*.pyc" | xargs rm -rf
-	-@find . -name "*results.xml" | xargs rm -rf
+	-@find . -name "obj" -exec rm -rf {} +
+	-@find . -name "*.pyc" -delete
+	-@find . -name "*results.xml" -delete
 	$(MAKE) -C examples clean
 	$(MAKE) -C tests clean
 

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -36,7 +36,7 @@ COCOTB_MAKEFILE_INC_INCLUDED = 1
 # and RTL compilation phases are still evaluated by makefile dependencies)
 .PHONY: sim
 sim:
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 	$(MAKE) -f $(firstword $(MAKEFILE_LIST)) $(COCOTB_RESULTS_FILE)
 
 # Make sure to use bash for the pipefail option used in many simulator Makefiles

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -89,7 +89,7 @@ ifeq ($(MAKECMDGOALS),help)
     help_envvars := $(subst %,${newline},$(shell cocotb-config --help-vars | tr \\n %))
     $(info ${help_envvars})
     # is there a cleaner way to exit here?
-    $(error "Stopping after printing help")
+    $(error Stopping after printing help)
 endif
 
 # Default to Icarus if no simulator is defined
@@ -107,7 +107,7 @@ HAVE_SIMULATOR = $(shell if [ -f $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.$(S
 AVAILABLE_SIMULATORS = $(patsubst .%,%,$(suffix $(wildcard $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.*)))
 
 ifeq ($(HAVE_SIMULATOR),0)
-    $(error "Couldn't find makefile for simulator: "$(SIM_LOWERCASE)"! Available simulators: $(AVAILABLE_SIMULATORS)")
+    $(error Couldn't find makefile for simulator: "$(SIM_LOWERCASE)"! Available simulators: $(AVAILABLE_SIMULATORS))
 endif
 
 include $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.$(SIM_LOWERCASE)

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -41,7 +41,7 @@ ifneq ($(VERILOG_SOURCES),)
     GPI_EXTRA = $(shell cocotb-config --lib-name-path vpi activehdl):cocotbvpi_entry_point
 endif
 else
-   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+   $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 # Create a DO script (Tcl-like but not fully compatible) based on the list of $(VERILOG_SOURCES)

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -59,7 +59,7 @@ endif
 	@echo "endsim" >> $@
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(SIM_CMD_PREFIX) $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.do | tee $(SIM_BUILD)/sim.log
@@ -67,6 +67,6 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do $(CUSTOM_COMPILE_DEPS) $(CUSTOM_S
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -rf work
-	@rm -rf wave.asdb
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r work
+	$(RM) -r wave.asdb

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -90,5 +90,5 @@ endif
 
 
 clean::
-	-@rm -rf $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.cvc
+++ b/cocotb/share/makefiles/simulators/Makefile.cvc
@@ -46,7 +46,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     CVC_BIN_DIR := $(shell dirname $(CMD))
     export CVC_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -73,7 +73,7 @@ analyse: $(VHDL_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	$(CMD) -m $(GHDL_ARGS) $(COMPILE_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL)
 
 $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(SIM_CMD_PREFIX) $(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) --vpi=$(shell cocotb-config --lib-name-path vpi ghdl) $(SIM_ARGS) $(PLUSARGS)
@@ -81,5 +81,5 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	-@rm -rf $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -48,7 +48,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     GHDL_BIN_DIR := $(shell dirname $(CMD))
     export GHDL_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -72,7 +72,7 @@ $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 # Execution phase
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         $(SIM_CMD_PREFIX) $(ICARUS_BIN_DIR)/vvp -M $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(PLUSARGS)
@@ -80,7 +80,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) -r $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         $(SIM_CMD_PREFIX) gdb --args $(ICARUS_BIN_DIR)/vvp $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
@@ -88,5 +88,5 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	-@rm -rf $(SIM_BUILD)
+	$(RM) $(SIM_BUILD)
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -50,7 +50,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     ICARUS_BIN_DIR := $(shell dirname $(CMD))
     export ICARUS_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -41,7 +41,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     IUS_BIN_DIR := $(shell dirname $(CMD))
     export IUS_BIN_DIR
@@ -66,7 +66,7 @@ endif
 
 # IUS errors out if multiple timescales are specified on the command line.
 ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
-    $(error "Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.")
+    $(error Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.)
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
@@ -94,7 +94,7 @@ ifneq ($(VERILOG_SOURCES),)
     HDL_SOURCES += $(VERILOG_SOURCES)
 endif
 else
-   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+   $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.ius
+++ b/cocotb/share/makefiles/simulators/Makefile.ius
@@ -98,7 +98,7 @@ else
 endif
 
 $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
@@ -108,7 +108,7 @@ $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -rf irun.*
-	@rm -rf ncsim.*
-	@rm -rf gdb_cmd_ncsim
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r irun.*
+	$(RM) -r ncsim.*
+	$(RM) -r gdb_cmd_ncsim

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -39,7 +39,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 endif
 
 RTL_LIBRARY ?= work
@@ -84,7 +84,7 @@ GPI_EXTRA :=
 VHDL_GPI_INTERFACE ?= fli
 
 ifeq ($(filter vhpi fli,$(VHDL_GPI_INTERFACE)),)
-    $(error "A valid value (fli or vhpi) was not provided for VHDL_GPI_INTERFACE=$(VHDL_GPI_INTERFACE)")
+    $(error A valid value (fli or vhpi) was not provided for VHDL_GPI_INTERFACE=$(VHDL_GPI_INTERFACE))
 endif
 
 ifeq ($(TOPLEVEL_LANG),vhdl)
@@ -105,7 +105,7 @@ ifneq ($(VHDL_SOURCES),)
 endif
 
 else
-   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+   $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 define make_lib

--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -155,7 +155,7 @@ ifeq ($(PYTHON_ARCH),64bit)
 endif
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
 	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
@@ -164,4 +164,4 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.do
 	$(call check_for_results_file)
 
 clean::
-	-rm -rf $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -45,7 +45,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     ALDEC_BIN_DIR := $(shell dirname $(CMD))
     export ALDEC_BIN_DIR
@@ -98,7 +98,7 @@ ifneq ($(VERILOG_SOURCES),)
 endif
 
 else
-   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+   $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 # Create a TCL script based on the list of $(VERILOG_SOURCES)

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -143,7 +143,7 @@ endif
 # Note it's the redirection of the output rather than the 'do' command
 # that turns on batch mode (i.e. exit on completion/error)
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	set -o pipefail; GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(SIM_CMD_PREFIX) $(CMD) $(RUN_ARGS) -do $(SIM_BUILD)/runsim.tcl | tee $(SIM_BUILD)/sim.log
@@ -151,7 +151,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/runsim.tcl $(CUSTOM_COMPILE_DEPS) $(CUSTOM_
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -rf compile
-	@rm -rf library.cfg
-	@rm -rf dataset.asdb
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r compile
+	$(RM) -r library.cfg
+	$(RM) -r dataset.asdb

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -86,11 +86,9 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)
 
 	$(call check_for_results_file)
 
-.PHONY: clean
 clean::
 	$(RM) -r $(SIM_BUILD)
 	$(RM) -r simv.daidir
 	$(RM) -r cm.log
-	$(RM) -r $(COCOTB_RESULTS_FILE)
 	$(RM) -r ucli.key
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -79,7 +79,7 @@ $(SIM_BUILD)/simv: $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(CUSTOM_COMPILE_DEPS
 
 # Execution phase
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(SIM_CMD_PREFIX) $(SIM_BUILD)/simv +define+COCOTB_SIM=1 $(SIM_ARGS) $(EXTRA_ARGS)
@@ -88,9 +88,9 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)
 
 .PHONY: clean
 clean::
-	-@rm -rf $(SIM_BUILD)
-	-@rm -rf simv.daidir
-	-@rm -rf cm.log
-	-@rm -rf $(COCOTB_RESULTS_FILE)
-	-@rm -rf ucli.key
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r simv.daidir
+	$(RM) -r cm.log
+	$(RM) -r $(COCOTB_RESULTS_FILE)
+	$(RM) -r ucli.key
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.vcs
+++ b/cocotb/share/makefiles/simulators/Makefile.vcs
@@ -47,7 +47,7 @@ else
 endif
 
 ifeq (, $(CMD))
-     $(error "Unable to locate command >$(CMD_BIN)<")
+     $(error Unable to locate command >$(CMD_BIN)<)
 else
      VCS_BIN_DIR := $(shell dirname $(CMD))
      export VCS_BIN_DIR

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -57,7 +57,7 @@ $(SIM_BUILD)/Vtop: $(SIM_BUILD)/Vtop.mk
 	make -C $(SIM_BUILD) $(BUILD_ARGS) -f Vtop.mk
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/Vtop $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         $(SIM_CMD_PREFIX) $< $(PLUSARGS)
@@ -68,8 +68,8 @@ debug:
 	$(MAKE) VERILATOR_SIM_DEBUG=1 SIM_CMD_PREFIX="gdb --args" $(COCOTB_RESULTS_FILE)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -f dump.vcd
-	@rm -f dump.fst
+	$(RM) -r $(SIM_BUILD)
+	$(RM) dump.vcd
+	$(RM) dump.fst
 
 endif

--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -54,7 +54,7 @@ $(SIM_BUILD)/Vtop.mk: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_SHARE_D
 
 # Compilation phase
 $(SIM_BUILD)/Vtop: $(SIM_BUILD)/Vtop.mk
-	make -C $(SIM_BUILD) $(BUILD_ARGS) -f Vtop.mk
+	$(MAKE) -C $(SIM_BUILD) $(BUILD_ARGS) -f Vtop.mk
 
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/Vtop $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -107,7 +107,7 @@ endif
 LIBS := $(foreach LIB, $(VHDL_LIB_ORDER),-makelib $(LIB) $(VHDL_SOURCES_$(LIB)) -endlib)
 
 $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
 	# Make sure all libs in SOURCES_VHDL_* are mentioned in VHDL_LIB_ORDER and vice versa
 	$(foreach LIB, $(VHDL_LIB_ORDER), $(check_vhdl_sources))
@@ -121,7 +121,7 @@ $(COCOTB_RESULTS_FILE): $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	@rm -rf $(SIM_BUILD)
-	@rm -rf xrun.*
-	@rm -rf xmsim.*
-	@rm -rf gdb_cmd_xmsim
+	$(RM) -r $(SIM_BUILD)
+	$(RM) -r xrun.*
+	$(RM) -r xmsim.*
+	$(RM) -r gdb_cmd_xmsim

--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -41,7 +41,7 @@ else
 endif
 
 ifeq (, $(CMD))
-    $(error "Unable to locate command >$(CMD_BIN)<")
+    $(error Unable to locate command >$(CMD_BIN)<)
 else
     XCELIUM_BIN_DIR := $(shell dirname $(CMD))
     export XCELIUM_BIN_DIR
@@ -74,7 +74,7 @@ endif
 
 # Xcelium errors out if multiple timescales are specified on the command line.
 ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
-    $(error "Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.")
+    $(error Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.)
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
@@ -100,7 +100,7 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
         HDL_SOURCES += $(VERILOG_SOURCES)
     endif
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 # Builds a list of arguments to support VHDL libraries specified in VHDL_SOURCES_*:

--- a/examples/adder/tests/Makefile
+++ b/examples/adder/tests/Makefile
@@ -38,7 +38,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES = $(PWD)/../hdl/adder.vhdl
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 TOPLEVEL := adder

--- a/examples/matrix_multiplier/tests/Makefile
+++ b/examples/matrix_multiplier/tests/Makefile
@@ -49,7 +49,7 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
         COMPILE_ARGS += -2008
     endif
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 # Fix the seed to ensure deterministic tests

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -23,7 +23,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES += $(PWD)/../hdl/toplevel.vhdl
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 

--- a/examples/mixed_signal/tests/Makefile
+++ b/examples/mixed_signal/tests/Makefile
@@ -33,11 +33,11 @@ ifeq ($(SIM),$(filter $(SIM),ius xcelium))
         VERILOG_SOURCES += $(WPWD)/../hdl/tb_rescap.sv
         VERILOG_SOURCES += $(WPWD)/../hdl/tb_regulator.sv
     else ifeq ($(TOPLEVEL_LANG),vhdl)
-        $(error "VHDL toplevel not yet implemented")
+        $(error VHDL toplevel not yet implemented)
         VHDL_SOURCES += $(WPWD)/../hdl/rescap.vhdl
         VHDL_SOURCES += $(WPWD)/../hdl/regulator.vhdl
     else
-        $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+        $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
     endif
 else ifeq ($(SIM),vcs)
     VERILOG_SOURCES += $(WPWD)/../hdl/analog_probe_synopsys.sv
@@ -48,14 +48,14 @@ else ifeq ($(SIM),vcs)
         VERILOG_SOURCES += $(WPWD)/../hdl/tb_rescap.sv
         VERILOG_SOURCES += $(WPWD)/../hdl/tb_regulator.sv
     else ifeq ($(TOPLEVEL_LANG),vhdl)
-        $(error "VHDL toplevel not yet implemented")
+        $(error VHDL toplevel not yet implemented)
         VHDL_SOURCES += $(WPWD)/../hdl/rescap.vhdl
         VHDL_SOURCES += $(WPWD)/../hdl/regulator.vhdl
     else
-        $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+        $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
     endif
 else
-    $(error "This example does not have support for SIM=$(SIM)")
+    $(error This example does not have support for SIM=$(SIM))
 endif
 
 
@@ -82,7 +82,7 @@ else ifeq ($(SIM),vcs)
 #    COMPILE_ARGS += -ams_discipline <discipline_name>
     SIM_ARGS += $(EXTRA_SIM_ARGS)
 else
-    $(error "This example does not have support for SIM=$(SIM)")
+    $(error This example does not have support for SIM=$(SIM))
 endif
 
 

--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -47,7 +47,7 @@ else
     VHDL_SOURCES =  $(COCOTB)/tests/designs/array_module/array_module_pack.vhd $(COCOTB)/tests/designs/array_module/array_module.vhd
 endif
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -40,7 +40,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES =  $(COCOTB)/tests/designs/plusargs_module/tb_top.vhd
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 ifneq ($(filter $(SIM),ius xcelium),)

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -44,7 +44,7 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
         SIM_ARGS += -v93
     endif
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -26,7 +26,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/testbench.vhd
 else
-    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/configurations.vhd
 

--- a/tests/test_cases/issue_253/Makefile
+++ b/tests/test_cases/issue_253/Makefile
@@ -64,4 +64,6 @@ no_top_level: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 endif
 
 clean::
-	@rm -rf empty_top_level_result no_top_level_result notset_top_level_result
+	$(RM) -r empty_top_level_result
+	$(RM) -r no_top_level_result
+	$(RM) -r notset_top_level_result

--- a/tests/test_cases/test_seed/Makefile
+++ b/tests/test_cases/test_seed/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 run:
-	rm -f number
+	$(RM) number
 	$(MAKE) sim MODULE=test_other,test_seed RANDOM_SEED=1234
 	$(MAKE) sim MODULE=test_seed TESTCASE=test_reproducibility RANDOM_SEED=1234
 

--- a/tests/test_cases/test_skipped/Makefile
+++ b/tests/test_cases/test_skipped/Makefile
@@ -7,7 +7,7 @@ include ../../designs/sample_module/Makefile
 SKIPPED_TEST_FILE = ran_skipped_test~
 
 clean::
-	@rm -rf ${SKIPPED_TEST_FILE}
+	$(RM) -r ${SKIPPED_TEST_FILE}
 
 # Override the default target. We need to run clean (to remove the cached test file)
 # and then test to make sure it is recreated.


### PR DESCRIPTION
This pull request brings some of the Makefile cleanups from #1892:

* Improvements for Makefile.vcs (from @imphil)
* Fix a display bug with `$(error ...)` (from @imphil)
* `rm -f` being wrapped-up in an `$(RM)` macro (from @imphil)
* `make` being wraped-up in a `$(MAKE)` macro
* `find | xargs rm` being replaced in `find -exec rm {} +`, covering very rare corner-cases. I like piping though.

The `COCOTB_CONFIG_CMD` changes were not included, for which a dedicated branch can be made.