### PR TITLE
Use new Github theme-dependent image syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-![cocotb logo](/../../../../cocotb/cocotb-web/blob/master/assets/img/cocotb-logo.svg#gh-light-mode-only)
-![cocotb logo](/../../../../cocotb/cocotb-web/blob/master/assets/img/cocotb-logo-dark.svg#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://www.cocotb.org/assets/img/cocotb-logo-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://www.cocotb.org/assets/img/cocotb-logo.svg">
+  <img src="https://www.cocotb.org/assets/img/cocotb-logo.svg">
+</picture>
 
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 


### PR DESCRIPTION
Closes #2915. Uses the new syntax described [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to). Check my fork to see it work. You might need to refresh the page a couple times to get the logo to change.