### PR TITLE
Add newsfragment for Riviera makefile fix

### DIFF
--- a/documentation/source/newsfragments/2912.bugfix.rst
+++ b/documentation/source/newsfragments/2912.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Riviera makefile error for mixed-language simulation when VHDL is the top-level. This bug prevented the VPI library from loading correctly, and was a regression in 1.5.0.


### PR DESCRIPTION
#2387 introduced an error in the Riviera makefile for mixed-language simulation where VHDL is the top level and Verilog is used inside the design.
The makefile error was fixed as part of #2912.

Add newsfragment for the regression fix.