### PR TITLE
Do not force division to happen in `float`

### DIFF
--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -29,6 +29,9 @@
 
 import itertools
 import warnings
+from decimal import Decimal
+from numbers import Real
+from typing import Union
 
 from cocotb.log import SimLog
 from cocotb.triggers import Timer
@@ -114,7 +117,9 @@ class Clock(BaseClock):
         Using ``None`` as the *units* argument is deprecated, use ``'step'`` instead.
     """
 
-    def __init__(self, signal, period, units="step"):
+    def __init__(
+        self, signal, period: Union[float, Real, Decimal], units: str = "step"
+    ):
         BaseClock.__init__(self, signal)
         if units is None:
             warnings.warn(
@@ -124,8 +129,8 @@ class Clock(BaseClock):
             )
             units = "step"  # don't propagate deprecated value
         self.period = get_sim_steps(period, units)
-        self.half_period = get_sim_steps(period / 2.0, units)
-        self.frequency = 1.0 / get_time_from_sim_steps(self.period, units="us")
+        self.half_period = get_sim_steps(period / 2, units)
+        self.frequency = 1 / get_time_from_sim_steps(self.period, units="us")
         self.hdl = None
         self.signal = signal
         self.coro = None

--- a/documentation/source/newsfragments/3045.feature.rst
+++ b/documentation/source/newsfragments/3045.feature.rst
@@ -1,0 +1,1 @@
+Add support for :class:`fraction.Fraction` and :class:`decimal.Decimal` to the `` period`` argument of :class:`cocotb.clock.Clock`.

--- a/tests/test_cases/test_cocotb/test_clock.py
+++ b/tests/test_cases/test_cocotb/test_clock.py
@@ -4,7 +4,11 @@
 """
 Tests relating to cocotb.clock.Clock
 """
+import decimal
+import fractions
 from math import isclose
+
+import pytest
 
 import cocotb
 from cocotb.clock import Clock
@@ -58,3 +62,15 @@ async def test_clock_with_units(dut):
     assert isclose(edge_time_ns, start_time_ns + 4.0), "Expected a period of 4 ns"
 
     clk_gen.kill()
+
+
+@cocotb.test()
+async def test_clocks_with_other_number_types(dut):
+    clk1 = cocotb.start_soon(Clock(dut.clk, decimal.Decimal("1"), units="ns").start())
+    await Timer(10, "ns")
+    with pytest.warns(FutureWarning, match="cause a CancelledError to be thrown"):
+        clk1.cancel()
+    clk2 = cocotb.start_soon(Clock(dut.clk, fractions.Fraction(1), units="ns").start())
+    await Timer(10, "ns")
+    with pytest.warns(FutureWarning, match="cause a CancelledError to be thrown"):
+        clk2.cancel()


### PR DESCRIPTION
This should make it possible to use `Clock()` on `Decimal` types.

The `frequency` attribute will still be computed as a `float`, but this isn't used for anything anyway.

These `.0` suffixes were needed in Python 2, but have little place in Python 3 code.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
