### PR TITLE
Set timeunit to 1ns, same as timeprecision

### DIFF
--- a/examples/doc_examples/quickstart/my_design.sv
+++ b/examples/doc_examples/quickstart/my_design.sv
@@ -3,7 +3,7 @@
 
 module my_design(input logic clk);
 
-  timeunit 1s;
+  timeunit 1ns;
   timeprecision 1ns;
 
   logic my_signal_1;


### PR DESCRIPTION
Closes #2992.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
