### PR TITLE
Remove logo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://www.cocotb.org/assets/img/cocotb-logo-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://www.cocotb.org/assets/img/cocotb-logo.svg">
-  <img src="https://www.cocotb.org/assets/img/cocotb-logo.svg">
-</picture>
-
 **cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
 
 [![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=latest)](https://docs.cocotb.org/en/latest/)


### PR DESCRIPTION
The README gets rendered by a variety of Markdown renderers on GitHub,
on PyPi, and in various other aggregation sites. Finding a common syntax
for pictures, including one which switches between light and dark
themes, is (close to) impossible. Let's simplify things by not having a
logo in our README.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->