### PR TITLE
Icarus Verilog: Recursively remove output directory

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -88,5 +88,5 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	$(call check_for_results_file)
 
 clean::
-	$(RM) $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)
 endif


### PR DESCRIPTION
`make clean` with SIM=icarus fails because `sim_build` is a directory.
All other simulators use "rm -r" correctly.

Regression from eb970cd53b778c893a96c77d2c4fad463196c3d7.

```
/usr/bin/make -C adder/tests clean;  /usr/bin/make -C simple_dff clean;  /usr/bin/make -C matrix_multiplier/tests clean;  /usr/bin/make -C mixed_language/tests clean;  /usr/bin/make -C doc_examples/quickstart clean;
make[2]: Verzeichnis „/home/philipp/src/cocotb/examples/adder/tests“ wird betreten
rm -f sim_build
rm: das Entfernen von 'sim_build' ist nicht möglich: Ist ein Verzeichnis
make[2]: *** [/home/philipp/src/cocotb/cocotb/share/makefiles/simulators/Makefile.icarus:91: clean] Fehler 1
```


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->