### PR TITLE
Document the need for libstdc++-static on some distributions

### DIFF
--- a/documentation/source/install_devel.rst
+++ b/documentation/source/install_devel.rst
@@ -21,6 +21,9 @@ Namely, it requires the Python development headers and a C/C++ compiler.
 * Python 3.6+
 * Python development packages
 * GCC 4.8.1+, Clang 3.3+ or Microsoft Visual C++ 14.21+ and associated development packages
+* On Linux: A static build of the C++ standard library ``libstdc++``.
+  Some distributions include the static library in their default packages (e.g. Debian/Ubuntu),
+  others (e.g. Red Hat) require the installation of a package typically named ``libstdc++-static``.
 * GNU Make
 * A Verilog or VHDL simulator, depending on your :term:`RTL` source code
 
@@ -48,7 +51,7 @@ The installation instructions vary depending on your operating system:
 
       .. code-block:: bash
 
-          sudo yum install make gcc gcc-c++ libstdc++-devel python3 python3-devel python3-pip
+          sudo yum install make gcc gcc-c++ libstdc++-devel libstdc++-static python3 python3-devel python3-pip
 
    .. group-tab:: macOS
 

--- a/documentation/source/install_devel.rst
+++ b/documentation/source/install_devel.rst
@@ -37,7 +37,7 @@ The installation instructions vary depending on your operating system:
 
          conda install -c msys2 m2-base m2-make
 
-   .. group-tab:: Linux - Debian
+   .. group-tab:: Linux - Debian/Ubuntu
 
       In a terminal, run
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->