### PR TITLE
Fix warning about SQLite and Threads in ipython support on Windows

### DIFF
--- a/cocotb/ipython_support.py
+++ b/cocotb/ipython_support.py
@@ -61,7 +61,7 @@ async def embed(user_ns: dict = {}):
     c = load_default_config()
     c.TerminalInteractiveShell.loop_runner = lambda x: _runner(shell, x)
     c.TerminalInteractiveShell.autoawait = True
-    c.HistoryAccessor.connection_options = {'check_same_thread' : False }
+    c.HistoryAccessor.connection_options = {"check_same_thread": False}
     # create a shell with access to the dut, and cocotb pre-imported
     shell = IPython.terminal.embed.InteractiveShellEmbed(
         user_ns=default_ns,

--- a/cocotb/ipython_support.py
+++ b/cocotb/ipython_support.py
@@ -61,6 +61,8 @@ async def embed(user_ns: dict = {}):
     c = load_default_config()
     c.TerminalInteractiveShell.loop_runner = lambda x: _runner(shell, x)
     c.TerminalInteractiveShell.autoawait = True
+    # Python3 checks SQLite DB accesses to ensure process ID matches the one that opened the DB and is not propogated
+    # because we launch IPython in a different process, this will cause unnecessary warnings, so disable the PID check
     c.HistoryAccessor.connection_options = {"check_same_thread": False}
     # create a shell with access to the dut, and cocotb pre-imported
     shell = IPython.terminal.embed.InteractiveShellEmbed(

--- a/cocotb/ipython_support.py
+++ b/cocotb/ipython_support.py
@@ -61,7 +61,7 @@ async def embed(user_ns: dict = {}):
     c = load_default_config()
     c.TerminalInteractiveShell.loop_runner = lambda x: _runner(shell, x)
     c.TerminalInteractiveShell.autoawait = True
-
+    c.HistoryAccessor.connection_options = {'check_same_thread' : False }
     # create a shell with access to the dut, and cocotb pre-imported
     shell = IPython.terminal.embed.InteractiveShellEmbed(
         user_ns=default_ns,


### PR DESCRIPTION
The following error occurs on a windows machine due to PID of the thread changing. `File "C:\Users\mcheah\git\cocotb\env\lib\site-packages\IPython\core\history.py", line 812, in _writeout_input_cache
                                                            with conn:
                                                        sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 10276 and this is thread id 8364.`

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
