### PR TITLE
Build and smoke-test the sdist in CI

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -43,6 +43,24 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
 
+  test_sdist:
+    name: Test the source distribution (sdist)
+    needs: build_release
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - uses: actions/download-artifact@v3
+      with:
+        name: cocotb-dist
+        path: dist
+    - name: Install nox
+      run: python3 -m pip install nox
+    - name: Smoke-test the sdist
+      run: nox -s release_test_sdist
+
   test_release:
     name: Regression Tests
     needs: build_release
@@ -55,7 +73,9 @@ jobs:
 
   deploy_pypi:
     name: Deploy to pypi.org
-    needs: test_release
+    needs:
+    - test_release
+    - test_sdist
     runs-on: ubuntu-20.04
     # Only upload tagged releases.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/noxfile.py
+++ b/noxfile.py
@@ -340,6 +340,36 @@ def release_build_sdist(session: nox.Session) -> None:
     session.log(f"Source distribution in release mode built into {dist_dir!r}")
 
 
+@nox.session
+def release_test_sdist(session: nox.Session) -> None:
+    """Build and install the sdist."""
+
+    # Find the sdist to install.
+    sdists = list(Path(dist_dir).glob("cocotb-*.tar.gz"))
+    if len(sdists) == 0:
+        session.error(
+            f"No *.tar.gz sdist file found in {dist_dir!r} "
+            f"Run the 'release_build' session first."
+        )
+    if len(sdists) > 1:
+        session.error(
+            f"More than one potential sdist found in the {dist_dir!r} "
+            f"directory. Run the 'release_clean' session first!"
+        )
+    sdist_path = sdists[0]
+    assert sdist_path.is_file()
+
+    session.log("Installing cocotb from sdist, which includes the build step")
+    session.run(
+        "pip",
+        "install",
+        str(sdist_path),
+    )
+
+    session.log("Running cocotb-config as basic installation smoke test")
+    session.run("cocotb-config", "--version")
+
+
 def release_install(session: nox.Session) -> None:
     """Helper: Install cocotb from wheels and also install test dependencies."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import glob
+import shutil
 import sys
 from contextlib import suppress
 from pathlib import Path
@@ -270,6 +271,7 @@ def dev_coverage_report(session: nox.Session) -> None:
 #
 # Release pipeline.
 #
+# - Clean out the dist directory.
 # - Build wheels (release builds).
 # - Install cocotb from wheel.
 # - Run tests against cocotb installed from the wheel.
@@ -279,6 +281,12 @@ def dev_coverage_report(session: nox.Session) -> None:
 
 # Directory containing the distribution artifacts (sdist and bdist).
 dist_dir = "dist"
+
+
+@nox.session
+def release_clean(session: nox.Session) -> None:
+    """Remove all build artifacts from the dist directory."""
+    shutil.rmtree(dist_dir, ignore_errors=True)
 
 
 @nox.session


### PR DESCRIPTION
Prevent packaging errors from slipping through which make the sdist unusable. No full testing is done on the sdist, we continue to do that on the wheels (otherwise we'd have the same CI pipeline twice, with very limited benefit).

Fixes #3084


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->