### PR TITLE
Doc: Fix warning about the spelling module

### DIFF
--- a/documentation/source/contributors.rst
+++ b/documentation/source/contributors.rst
@@ -2,7 +2,7 @@
 Contributors
 ************
 
-.. spelling::
+.. spelling:word-list::
    McGregor
    Grimwood
    FOSSi

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -1,7 +1,7 @@
 .. _coroutines:
 .. _async_functions:
 
-.. spelling::
+.. spelling:word-list::
    Async
 
 

--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -75,7 +75,7 @@ The cocotb testbench pulls the reset on both instances and checks that they beha
 
    This example is not complete.
 
-.. spelling::
+.. spelling:word-list::
    Todo
 
 

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -2,7 +2,7 @@
 Library Reference
 *****************
 
-.. spelling::
+.. spelling:word-list::
    AXIProtocolError
    BusDriver
    De

--- a/documentation/source/refcard.rst
+++ b/documentation/source/refcard.rst
@@ -10,7 +10,7 @@ Reference Card
    The "| " syntax is a "Line Block", see
       https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#line-blocks
 
-.. spelling::
+.. spelling:word-list::
    coro
    coros
    func

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -2,7 +2,7 @@
 Release Notes
 *************
 
-.. spelling::
+.. spelling:word-list::
    dev
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.


### PR DESCRIPTION
Switch to a new syntax, as indicated by a warning from the spelling
Sphinx extension: 'direct use of the spelling directive is
deprecated, replace ".. spelling::" with ".. spelling:word-list::"'


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->