### PR TITLE
Support Python 3.11

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 9
+        after_n_builds: 10
 
 coverage:
     status:

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -53,13 +53,21 @@ ENVS = [
         "python-version": "3.10",
         "group": "ci",
     },
+    {
+        "lang": "verilog",
+        "sim": "icarus",
+        "sim-version": "apt",
+        "os": "ubuntu-20.04",
+        "python-version": "3.11.0-rc - 3.11",
+        "group": "ci",
+    },
     # A single test for the upcoming Python version.
     {
         "lang": "verilog",
         "sim": "icarus",
         "sim-version": "apt",
         "os": "ubuntu-20.04",
-        "python-version": "3.11.0-alpha - 3.11.0",
+        "python-version": "3.12.0-alpha - 3.12.0",
         "group": "experimental",
     },
     # Test Icarus on Ubuntu

--- a/documentation/source/newsfragments/3092.change.rst
+++ b/documentation/source/newsfragments/3092.change.rst
@@ -1,0 +1,1 @@
+Python 3.11 is now supported.

--- a/documentation/source/platform_support.rst
+++ b/documentation/source/platform_support.rst
@@ -26,6 +26,7 @@ The following versions of Python (CPython), and all associated patch releases (e
 * Python 3.8
 * Python 3.9
 * Python 3.10
+* Python 3.11
 
 Supported Linux Distributions and Versions
 ==========================================

--- a/noxfile.py
+++ b/noxfile.py
@@ -293,7 +293,7 @@ def release_build_bdist(session: nox.Session) -> None:
     """Build a binary distribution (wheels) on the current operating system."""
 
     # Pin a version to ensure reproducible builds.
-    session.run("pip", "install", "cibuildwheel==2.5.0")
+    session.run("pip", "install", "cibuildwheel==2.10.1")
 
     # cibuildwheel only auto-detects the platform if it runs on a CI server.
     # Do the auto-detect manually to enable local runs.

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: BSD License",
         "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
         "Framework :: cocotb",


### PR DESCRIPTION
Python 3.11 is in its release candidate stage, start supporting it -- they promise not to break backwards-compat any more, even for wheels. 


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->