### PR TITLE
Explicitly declare signals in mixed language example

### DIFF
--- a/examples/mixed_language/hdl/toplevel.sv
+++ b/examples/mixed_language/hdl/toplevel.sv
@@ -38,6 +38,9 @@ logic                                       sv_to_vhdl_startofpacket;
 logic                                       sv_to_vhdl_endofpacket;
 logic                                       sv_to_vhdl_ready;
 
+logic                                       csr_waitrequest_sv;
+logic                                       csr_waitrequest_vhdl;
+
 
 endian_swapper_sv #(
     .DATA_BYTES                             (DATA_BYTES)


### PR DESCRIPTION
Fix an oversight in the Verilog code where two signals were not
explicitly declared.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->