### PR TITLE
Remove an unused pytest mark

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ testpaths =
 # log_cli_level = DEBUG
 markers =
     simulator_required: mark tests as needing a simulator
+    compile: the compile step in runner-based tests
 
 [coverage:run]
 omit =


### PR DESCRIPTION
The 'compile' pytest mark is not registered, leading to warning emitted
by pytest. We don't actually seem to use this marker, so simply remove
it.

```
tests/pytest/test_parallel_cocotb.py:24
  /home/az_devops_agent/agent/_work/1/s/tests/pytest/test_parallel_cocotb.py:24: PytestUnknownMarkWarning: Unknown pytest.mark.compile - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.compile
```


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->