### PR TITLE
GPI: Mark various string references as const

### DIFF
--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -113,8 +113,9 @@ bool FliImpl::isTypeSignal(int type, int full_type) {
     return (type == accSignal || full_type == accAliasSignal);
 }
 
-GpiObjHdl *FliImpl::create_gpi_obj_from_handle(void *hdl, std::string &name,
-                                               std::string &fq_name,
+GpiObjHdl *FliImpl::create_gpi_obj_from_handle(void *hdl,
+                                               const std::string &name,
+                                               const std::string &fq_name,
                                                int accType, int accFullType) {
     GpiObjHdl *new_obj = NULL;
 

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -271,7 +271,8 @@ GpiObjHdl *FliImpl::native_check_create(void *raw_hdl, GpiObjHdl *) {
  * @brief   Determine whether a simulation object is native to FLI and create
  *          a handle if it is
  */
-GpiObjHdl *FliImpl::native_check_create(std::string &name, GpiObjHdl *parent) {
+GpiObjHdl *FliImpl::native_check_create(const std::string &name,
+                                        GpiObjHdl *parent) {
     bool search_rgn = false;
     bool search_sig = false;
     bool search_var = false;

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -162,7 +162,8 @@ class FliObjHdl : public GpiObjHdl, public FliObj {
         : GpiObjHdl(impl, hdl, objtype, is_const),
           FliObj(acc_type, acc_full_type) {}
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 };
 
 class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
@@ -177,7 +178,8 @@ class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
           m_either_cb(impl, this, GPI_FALLING | GPI_RISING) {}
 
     GpiCbHdl *value_change_cb(int edge) override;
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 
     bool is_var() { return m_is_var; }
 
@@ -217,7 +219,8 @@ class FliValueObjHdl : public FliSignalObjHdl {
 
     void *get_sub_hdl(int index);
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 
     mtiTypeKindT get_fli_typekind() { return m_fli_type; }
     mtiTypeIdT get_fli_typeid() { return m_val_type; }
@@ -243,7 +246,8 @@ class FliEnumObjHdl : public FliValueObjHdl {
     using FliValueObjHdl::set_signal_value;
     int set_signal_value(int32_t value, gpi_set_action_t action) override;
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 
   private:
     char **m_value_enum = nullptr;  // Do Not Free
@@ -269,7 +273,8 @@ class FliLogicObjHdl : public FliValueObjHdl {
     int set_signal_value_binstr(std::string &value,
                                 gpi_set_action_t action) override;
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 
   private:
     char *m_mti_buff = nullptr;
@@ -292,7 +297,8 @@ class FliIntObjHdl : public FliValueObjHdl {
     using FliValueObjHdl::set_signal_value;
     int set_signal_value(int32_t value, gpi_set_action_t action) override;
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 };
 
 class FliRealObjHdl : public FliValueObjHdl {
@@ -312,7 +318,8 @@ class FliRealObjHdl : public FliValueObjHdl {
     using FliValueObjHdl::set_signal_value;
     int set_signal_value(double value, gpi_set_action_t action) override;
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 
   private:
     double *m_mti_buff = nullptr;
@@ -336,7 +343,8 @@ class FliStringObjHdl : public FliValueObjHdl {
     int set_signal_value_str(std::string &value,
                              gpi_set_action_t action) override;
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 
   private:
     char *m_mti_buff = nullptr;

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -434,9 +434,9 @@ class FliImpl : public GpiImplInterface {
     const char *reason_to_string(int reason) override;
 
     /* Method to provide strings from operation types */
-    GpiObjHdl *create_gpi_obj_from_handle(void *hdl, std::string &name,
-                                          std::string &fq_name, int accType,
-                                          int accFullType);
+    GpiObjHdl *create_gpi_obj_from_handle(void *hdl, const std::string &name,
+                                          const std::string &fq_name,
+                                          int accType, int accFullType);
 
   private:
     bool isValueConst(int kind);

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -415,7 +415,7 @@ class FliImpl : public GpiImplInterface {
     const char *get_simulator_version() override;
 
     /* Hierachy related */
-    GpiObjHdl *native_check_create(std::string &name,
+    GpiObjHdl *native_check_create(const std::string &name,
                                    GpiObjHdl *parent) override;
     GpiObjHdl *native_check_create(int32_t index, GpiObjHdl *parent) override;
     GpiObjHdl *native_check_create(void *raw_hdl, GpiObjHdl *paret) override;

--- a/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -64,7 +64,7 @@ GpiCbHdl *FliSignalObjHdl::value_change_cb(int edge) {
     return (GpiCbHdl *)cb;
 }
 
-int FliObjHdl::initialise(std::string &name, std::string &fq_name) {
+int FliObjHdl::initialise(const std::string &name, const std::string &fq_name) {
     bool is_signal =
         (get_acc_type() == accSignal || get_acc_full_type() == accAliasSignal);
     mtiTypeIdT typeId;
@@ -101,11 +101,13 @@ int FliObjHdl::initialise(std::string &name, std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
-int FliSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
+int FliSignalObjHdl::initialise(const std::string &name,
+                                const std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
-int FliValueObjHdl::initialise(std::string &name, std::string &fq_name) {
+int FliValueObjHdl::initialise(const std::string &name,
+                               const std::string &fq_name) {
     if (get_type() == GPI_ARRAY) {
         m_range_left = mti_TickLeft(m_val_type);
         m_range_right = mti_TickRight(m_val_type);
@@ -205,7 +207,8 @@ void *FliValueObjHdl::get_sub_hdl(int index) {
         return m_sub_hdls[idx];
 }
 
-int FliEnumObjHdl::initialise(std::string &name, std::string &fq_name) {
+int FliEnumObjHdl::initialise(const std::string &name,
+                              const std::string &fq_name) {
     m_num_elems = 1;
     m_value_enum = mti_GetEnumValues(m_val_type);
     m_num_enum = mti_TickLength(m_val_type);
@@ -277,7 +280,8 @@ int FliEnumObjHdl::set_signal_value(const int32_t value,
     }
 }
 
-int FliLogicObjHdl::initialise(std::string &name, std::string &fq_name) {
+int FliLogicObjHdl::initialise(const std::string &name,
+                               const std::string &fq_name) {
     switch (m_fli_type) {
         case MTI_TYPE_ENUM:
             m_num_elems = 1;
@@ -550,7 +554,8 @@ int FliLogicObjHdl::set_signal_value_binstr(std::string &value,
     }
 }
 
-int FliIntObjHdl::initialise(std::string &name, std::string &fq_name) {
+int FliIntObjHdl::initialise(const std::string &name,
+                             const std::string &fq_name) {
     m_num_elems = 1;
 
     m_val_buff = new char[33];  // Integers are always 32-bits
@@ -635,7 +640,8 @@ int FliIntObjHdl::set_signal_value(const int32_t value,
     }
 }
 
-int FliRealObjHdl::initialise(std::string &name, std::string &fq_name) {
+int FliRealObjHdl::initialise(const std::string &name,
+                              const std::string &fq_name) {
     m_num_elems = 1;
 
     m_mti_buff = new double;
@@ -697,7 +703,8 @@ int FliRealObjHdl::set_signal_value(const double value,
     }
 }
 
-int FliStringObjHdl::initialise(std::string &name, std::string &fq_name) {
+int FliStringObjHdl::initialise(const std::string &name,
+                                const std::string &fq_name) {
     m_range_left = mti_TickLeft(m_val_type);
     m_range_right = mti_TickRight(m_val_type);
     m_num_elems = mti_TickLength(m_val_type);

--- a/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -70,7 +70,7 @@ bool GpiHdl::is_this_impl(GpiImplInterface *impl) {
     return impl == this->m_impl;
 }
 
-int GpiObjHdl::initialise(std::string &name, std::string &fq_name) {
+int GpiObjHdl::initialise(const std::string &name, const std::string &fq_name) {
     m_name = name;
     m_fullname = fq_name;
     return 0;

--- a/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -257,7 +257,8 @@ gpi_sim_hdl gpi_get_root_handle(const char *name) {
     }
 }
 
-static GpiObjHdl *gpi_get_handle_by_name_(GpiObjHdl *parent, std::string name,
+static GpiObjHdl *gpi_get_handle_by_name_(GpiObjHdl *parent,
+                                          const std::string &name,
                                           GpiImplInterface *skip_impl) {
     LOG_DEBUG("Searching for %s", name.c_str());
 

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -118,7 +118,7 @@ class GPI_EXPORT GpiObjHdl : public GpiHdl {
     };
 
     bool is_native_impl(GpiImplInterface *impl);
-    virtual int initialise(std::string &name, std::string &full_name);
+    virtual int initialise(const std::string &name, const std::string &full_name);
 
   protected:
     int m_num_elems = 0;

--- a/cocotb/share/lib/gpi/gpi_priv.h
+++ b/cocotb/share/lib/gpi/gpi_priv.h
@@ -118,7 +118,8 @@ class GPI_EXPORT GpiObjHdl : public GpiHdl {
     };
 
     bool is_native_impl(GpiImplInterface *impl);
-    virtual int initialise(const std::string &name, const std::string &full_name);
+    virtual int initialise(const std::string &name,
+                           const std::string &full_name);
 
   protected:
     int m_num_elems = 0;
@@ -248,7 +249,7 @@ class GPI_EXPORT GpiImplInterface {
     virtual const char *get_simulator_version() = 0;
 
     /* Hierarchy related */
-    virtual GpiObjHdl *native_check_create(std::string &name,
+    virtual GpiObjHdl *native_check_create(const std::string &name,
                                            GpiObjHdl *parent) = 0;
     virtual GpiObjHdl *native_check_create(int32_t index,
                                            GpiObjHdl *parent) = 0;

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -174,7 +174,8 @@ vhpiPutValueModeT map_put_value_mode(gpi_set_action_t action) {
     return put_value_mode;
 }
 
-int VhpiArrayObjHdl::initialise(std::string &name, std::string &fq_name) {
+int VhpiArrayObjHdl::initialise(const std::string &name,
+                                const std::string &fq_name) {
     vhpiHandleT handle = GpiObjHdl::get_handle<vhpiHandleT>();
 
     m_indexable = true;
@@ -236,7 +237,8 @@ int VhpiArrayObjHdl::initialise(std::string &name, std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
-int VhpiObjHdl::initialise(std::string &name, std::string &fq_name) {
+int VhpiObjHdl::initialise(const std::string &name,
+                           const std::string &fq_name) {
     vhpiHandleT handle = GpiObjHdl::get_handle<vhpiHandleT>();
     if (handle != NULL) {
         vhpiHandleT du_handle = vhpi_handle(vhpiDesignUnit, handle);
@@ -256,7 +258,8 @@ int VhpiObjHdl::initialise(std::string &name, std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
-int VhpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
+int VhpiSignalObjHdl::initialise(const std::string &name,
+                                 const std::string &fq_name) {
     // Determine the type of object, either scalar or vector
     m_value.format = vhpiObjTypeVal;
     m_value.bufSize = 0;
@@ -330,7 +333,8 @@ int VhpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
-int VhpiLogicSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
+int VhpiLogicSignalObjHdl::initialise(const std::string &name,
+                                      const std::string &fq_name) {
     // Determine the type of object, either scalar or vector
     m_value.format = vhpiLogicVal;
     m_value.bufSize = 0;

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -266,8 +266,8 @@ bool is_enum_boolean(vhpiHandleT hdl) {
 }
 
 GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl,
-                                                std::string &name,
-                                                std::string &fq_name) {
+                                                const std::string &name,
+                                                const std::string &fq_name) {
     vhpiIntT type;
     gpi_objtype_t gpi_type;
     GpiObjHdl *new_obj = NULL;

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -500,7 +500,8 @@ GpiObjHdl *VhpiImpl::native_check_create(void *raw_hdl, GpiObjHdl *parent) {
     return new_obj;
 }
 
-GpiObjHdl *VhpiImpl::native_check_create(std::string &name, GpiObjHdl *parent) {
+GpiObjHdl *VhpiImpl::native_check_create(const std::string &name,
+                                         GpiObjHdl *parent) {
     vhpiHandleT vhpi_hdl = parent->get_handle<vhpiHandleT>();
 
     vhpiHandleT new_hdl;

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -289,8 +289,8 @@ class VhpiImpl : public GpiImplInterface {
     const char *format_to_string(int format);
 
     GpiObjHdl *create_gpi_obj_from_handle(vhpiHandleT new_hdl,
-                                          std::string &name,
-                                          std::string &fq_name);
+                                          const std::string &name,
+                                          const std::string &fq_name);
 
   private:
     VhpiReadwriteCbHdl m_read_write;

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -280,7 +280,7 @@ class VhpiImpl : public GpiImplInterface {
     GpiCbHdl *register_nexttime_callback() override;
     GpiCbHdl *register_readwrite_callback() override;
     int deregister_callback(GpiCbHdl *obj_hdl) override;
-    GpiObjHdl *native_check_create(std::string &name,
+    GpiObjHdl *native_check_create(const std::string &name,
                                    GpiObjHdl *parent) override;
     GpiObjHdl *native_check_create(int32_t index, GpiObjHdl *parent) override;
     GpiObjHdl *native_check_create(void *raw_hdl, GpiObjHdl *parent) override;

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -170,7 +170,8 @@ class VhpiArrayObjHdl : public GpiObjHdl {
         : GpiObjHdl(impl, hdl, objtype) {}
     ~VhpiArrayObjHdl() override;
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 };
 
 class VhpiObjHdl : public GpiObjHdl {
@@ -179,7 +180,8 @@ class VhpiObjHdl : public GpiObjHdl {
         : GpiObjHdl(impl, hdl, objtype) {}
     ~VhpiObjHdl() override;
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 };
 
 class VhpiSignalObjHdl : public GpiSignalObjHdl {
@@ -207,7 +209,8 @@ class VhpiSignalObjHdl : public GpiSignalObjHdl {
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(int edge) override;
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 
   protected:
     vhpiEnumT chr2vhpi(char value);
@@ -229,7 +232,8 @@ class VhpiLogicSignalObjHdl : public VhpiSignalObjHdl {
     int set_signal_value_binstr(std::string &value,
                                 gpi_set_action_t action) override;
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 };
 
 class VhpiIterator : public GpiIterator {

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -119,7 +119,8 @@ int VpiCbHdl::cleanup_callback() {
     return 0;
 }
 
-int VpiArrayObjHdl::initialise(std::string &name, std::string &fq_name) {
+int VpiArrayObjHdl::initialise(const std::string &name,
+                               const std::string &fq_name) {
     vpiHandle hdl = GpiObjHdl::get_handle<vpiHandle>();
 
     m_indexable = true;
@@ -207,7 +208,7 @@ int VpiArrayObjHdl::initialise(std::string &name, std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
-int VpiObjHdl::initialise(std::string &name, std::string &fq_name) {
+int VpiObjHdl::initialise(const std::string &name, const std::string &fq_name) {
     char *str;
     vpiHandle hdl = GpiObjHdl::get_handle<vpiHandle>();
     str = vpi_get_str(vpiDefName, hdl);
@@ -218,7 +219,8 @@ int VpiObjHdl::initialise(std::string &name, std::string &fq_name) {
     return GpiObjHdl::initialise(name, fq_name);
 }
 
-int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
+int VpiSignalObjHdl::initialise(const std::string &name,
+                                const std::string &fq_name) {
     int32_t type = vpi_get(vpiType, GpiObjHdl::get_handle<vpiHandle>());
     if ((vpiIntVar == type) || (vpiIntegerVar == type) ||
         (vpiIntegerNet == type) || (vpiRealNet == type)) {

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -172,8 +172,8 @@ static gpi_objtype_t const_type_to_gpi_objtype(int32_t const_type) {
 }
 
 GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
-                                               std::string &name,
-                                               std::string &fq_name) {
+                                               const std::string &name,
+                                               const std::string &fq_name) {
     int32_t type;
     GpiObjHdl *new_obj = NULL;
     if (vpiUnknown == (type = vpi_get(vpiType, new_hdl))) {

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -292,7 +292,8 @@ GpiObjHdl *VpiImpl::native_check_create(void *raw_hdl, GpiObjHdl *parent) {
     return new_obj;
 }
 
-GpiObjHdl *VpiImpl::native_check_create(std::string &name, GpiObjHdl *parent) {
+GpiObjHdl *VpiImpl::native_check_create(const std::string &name,
+                                        GpiObjHdl *parent) {
     vpiHandle new_hdl;
     const vpiHandle parent_hdl = parent->get_handle<vpiHandle>();
     std::string fq_name = parent->get_fullname() + "." + name;

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -272,7 +272,7 @@ class VpiImpl : public GpiImplInterface {
     GpiCbHdl *register_nexttime_callback() override;
     GpiCbHdl *register_readwrite_callback() override;
     int deregister_callback(GpiCbHdl *obj_hdl) override;
-    GpiObjHdl *native_check_create(std::string &name,
+    GpiObjHdl *native_check_create(const std::string &name,
                                    GpiObjHdl *parent) override;
     GpiObjHdl *native_check_create(int32_t index, GpiObjHdl *parent) override;
     GpiObjHdl *native_check_create(void *raw_hdl, GpiObjHdl *parent) override;

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -277,8 +277,9 @@ class VpiImpl : public GpiImplInterface {
     GpiObjHdl *native_check_create(int32_t index, GpiObjHdl *parent) override;
     GpiObjHdl *native_check_create(void *raw_hdl, GpiObjHdl *parent) override;
     const char *reason_to_string(int reason) override;
-    GpiObjHdl *create_gpi_obj_from_handle(vpiHandle new_hdl, std::string &name,
-                                          std::string &fq_name);
+    GpiObjHdl *create_gpi_obj_from_handle(vpiHandle new_hdl,
+                                          const std::string &name,
+                                          const std::string &fq_name);
 
   private:
     /* Singleton callbacks */

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -157,7 +157,8 @@ class VpiArrayObjHdl : public GpiObjHdl {
     VpiArrayObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype)
         : GpiObjHdl(impl, hdl, objtype) {}
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 };
 
 class VpiObjHdl : public GpiObjHdl {
@@ -165,7 +166,8 @@ class VpiObjHdl : public GpiObjHdl {
     VpiObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype)
         : GpiObjHdl(impl, hdl, objtype) {}
 
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 };
 
 class VpiSignalObjHdl : public GpiSignalObjHdl {
@@ -191,7 +193,8 @@ class VpiSignalObjHdl : public GpiSignalObjHdl {
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(int edge) override;
-    int initialise(std::string &name, std::string &fq_name) override;
+    int initialise(const std::string &name,
+                   const std::string &fq_name) override;
 
   private:
     int set_signal_value(s_vpi_value value, gpi_set_action_t action);


### PR DESCRIPTION
Looks like we didn't apply const too generously to std::string references. Let's do that to increase performance (a bit) and make it clearer who's modifying what.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->