### PR TITLE
Enable the use of the PyPi index for release tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -373,13 +373,24 @@ def release_test_sdist(session: nox.Session) -> None:
 def release_install(session: nox.Session) -> None:
     """Helper: Install cocotb from wheels and also install test dependencies."""
 
+    # We have to disable the use of the PyPi index when installing cocotb to
+    # guarantee that the wheels in dist are being used. But without an index
+    # pip cannot find the dependencies, which need to be installed from PyPi.
+    # Work around that by explicitly installing the dependencies first from
+    # PyPi, and then installing cocotb itself from the local dist directory.
+
+    session.log("Installing cocotb dependencies from PyPi")
+    session.run("pip", "install", "find_libpython")
+
     session.log(f"Installing cocotb from wheels in {dist_dir!r}")
     session.run(
         "pip",
         "install",
+        "--force-reinstall",
         "--only-binary",
         "cocotb",
         "--no-index",
+        "--no-dependencies",
         "--find-links",
         dist_dir,
         "cocotb",


### PR DESCRIPTION
cocotb installs binary wheels without using the package index to ensure
we test against the version of cocotb we just built.
Now that cocotb has an external dependency we need to get that from
PyPi, otherwise the installation fails.

pip seems to have no way unfortunately to indicate "install cocotb from
the local wheels (guaranteed!) and everything else from PyPi". To work
around that we first install the dependencies from PyPi explicitly, and
then install cocotb itself.

This setup isn't pretty and duplicates the dependencies into the
noxfile, but at least it's robust.