### PR TITLE
Fix experimental tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -15,7 +15,7 @@ on:
         type: string
         default: dev_test_nosim
       collect_coverage:
-        required: true
+        required: false
         type: boolean
         default: false
       download_artifacts:


### PR DESCRIPTION
The new `collect_coverage` GitHub Actions parameter is optional and has
a default value. Mark it as such to avoid an error when calling the
experimental test suite:

> The workflow is not valid. .github/workflows/experimental.yml (Line: 21,
> Col: 11): Input collect_coverage is required, but not provided while
> calling.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->