### PR TITLE
Added message to xunit failure

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -505,7 +505,9 @@ class RegressionManager:
         else:
             test_pass, sim_failed = self._score_test(test, outcome)
             if not test_pass:
-                self.xunit.add_failure()
+                self.xunit.add_failure(
+                    message=f"Test failed with RANDOM_SEED={cocotb.RANDOM_SEED}"
+                )
                 self.failures += 1
             else:
                 self.passed += 1


### PR DESCRIPTION
Provides actionable information on JUNIT dashboard.

Check The annotation section in
https://github.com/learn-cocotb/interfaces-jahagirdar/actions/runs/3367627850 (Default cocotb) and 
https://github.com/learn-cocotb/interfaces-jahagirdar/actions/runs/3367654313 (version with this fix)

For an example of impact of this change.

In the patched version the dashboard prints the RANDOM_SEED value that can be used to locally replicate and debug the failure.

This helps avoid downloading and searching through regression logs running in GB's
