### PR TITLE
CI: Remove Python 3.11rc versions from CI config

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -58,7 +58,7 @@ ENVS = [
         "sim": "icarus",
         "sim-version": "apt",
         "os": "ubuntu-20.04",
-        "python-version": "3.11.0-rc - 3.11",
+        "python-version": "3.11",
         "group": "ci",
     },
     # A single test for the upcoming Python version.


### PR DESCRIPTION
The release version was used anyway as soon as it became available, but
let's make that explicit and in line with the other job descriptions.


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->