### PR TITLE
CI: Explicitly setup Python to build wheels

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -26,7 +26,9 @@ jobs:
           - macos-11
     steps:
       - uses: actions/checkout@v3
-
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
       - name: Install nox
         run: python3 -m pip install nox
 


### PR DESCRIPTION
We currently use any system-installed Python version to invoke the wheel 
building process (which then happens inside a container). The exact Python
version does not matter, but it must be a working Python version
-- and that's currently not the case for the macos11 builds: Python and the
Python installation directory are not inside PATH, hence we install nox,
but it's not found in the next step.

https://github.com/actions/runner-images/pull/6518 fixes the problem, but
is not yet rolled out universally. It seems like using setup-python even
for this case is recommended
(https://github.com/actions/runner-images/issues/6507#issuecomment-1303096318), 
so let's do that.



<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->