### PR TITLE
Fix incorrect string splitting for Xcelium

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -844,9 +844,11 @@ class Xcelium(Simulator):
         self.env["CDS_AUTO_64BIT"] = "all"
         cmd = [
             ["xrun"]
-            + ["-logfile xrun_build.log"]
+            + ["-logfile"]
+            + ["xrun_build.log"]
             + ["-elaborate"]
-            + [f"-xmlibdirname {self.build_dir}/xrun_snapshot"]
+            + ["-xmlibdirname"]
+            + [f"{self.build_dir}/xrun_snapshot"]
             + ["-licqueue"]
             # TODO: way to switch to these verbose messages?:
             + ["-messages"]
@@ -857,11 +859,8 @@ class Xcelium(Simulator):
             # + ["-plierr_verbose"]  # Expand handle info in PLI/VPI/VHPI messages
             # + ["-vpicompat 1800v2005"]  # <1364v1995|1364v2001|1364v2005|1800v2005> Specify the IEEE VPI
             + ["-access +rwc"]
-            + [
-                "-loadvpi "
-                + cocotb.config.lib_name_path("vpi", "xcelium")
-                + ":vlog_startup_routines_bootstrap"
-            ]
+            + ["-loadvpi"]
+            + [cocotb.config.lib_name_path("vpi", "xcelium") + ":vlog_startup_routines_bootstrap"]
             + [f"-work {self.library_name}"]
             + self.compile_args
             + ["-define COCOTB_SIM"]
@@ -883,10 +882,12 @@ class Xcelium(Simulator):
 
         cmd += [
             ["xrun"]
-            + [f"-logfile xrun_{self.current_test_name}.log"]
-            + [
-                f"-xmlibdirname {self.build_dir}/xrun_snapshot -cds_implicit_tmpdir {tmpdir}"
-            ]
+            + ["-logfile"]
+            + [f"xrun_{self.current_test_name}.log"]
+            + ["-xmlibdirname"]
+            + [f"{self.build_dir}/xrun_snapshot"]
+            + ["-cds_implicit_tmpdir"]
+            + [f"{tmpdir}"]
             + ["-licqueue"]
             # TODO: way to switch to these verbose messages?:
             + ["-messages"]

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -887,7 +887,7 @@ class Xcelium(Simulator):
             + ["-xmlibdirname"]
             + [f"{self.build_dir}/xrun_snapshot"]
             + ["-cds_implicit_tmpdir"]
-            + [f"{tmpdir}"]
+            + ["tmpdir"]
             + ["-licqueue"]
             # TODO: way to switch to these verbose messages?:
             + ["-messages"]
@@ -900,10 +900,11 @@ class Xcelium(Simulator):
             + self.sim_args
             + self.plus_args
             + ["-gui" if self.gui else ""]
+            + ["-input"]
             + [
-                '-input "@probe -create {self.sim_toplevel} -all -depth all"'
+                f'@database -open waves -shm; probe -create {self.sim_toplevel} -all -depth all; run; exit;'
                 if self.waves
-                else ""
+                else "@run; exit;"
             ]
         ]
         self.env["GPI_EXTRA"] = (

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -858,12 +858,17 @@ class Xcelium(Simulator):
             # + ["-plidebug"]  # Enhance the profile output with PLI info
             # + ["-plierr_verbose"]  # Expand handle info in PLI/VPI/VHPI messages
             # + ["-vpicompat 1800v2005"]  # <1364v1995|1364v2001|1364v2005|1800v2005> Specify the IEEE VPI
-            + ["-access +rwc"]
+            + ["-access"]
+            + ["+rwc"]
             + ["-loadvpi"]
-            + [cocotb.config.lib_name_path("vpi", "xcelium") + ":vlog_startup_routines_bootstrap"]
+            + [
+                cocotb.config.lib_name_path("vpi", "xcelium")
+                + ":vlog_startup_routines_bootstrap"
+            ]
             + [f"-work {self.library_name}"]
             + self.compile_args
-            + ["-define COCOTB_SIM"]
+            + ["-define"]
+            + ["COCOTB_SIM"]
             + self.get_define_options(self.defines)
             + self.get_include_options(self.includes)
             + self.get_parameter_options(self.parameters)
@@ -902,7 +907,7 @@ class Xcelium(Simulator):
             + ["-gui" if self.gui else ""]
             + ["-input"]
             + [
-                f'@database -open waves -shm; probe -create {self.sim_toplevel} -all -depth all; run; exit;'
+                f"@database -open waves -shm; probe -create {self.sim_toplevel} -all -depth all; run; exit;"
                 if self.waves
                 else "@run; exit;"
             ]


### PR DESCRIPTION
Currently, the way the cmd list is passed into the execute could make shell wrongly quote parts of the command, triggering E,BDOPTQ error message for Xcelium

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
