### PR TITLE
Fixing testcase reproducibility issue.

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -505,7 +505,9 @@ class RegressionManager:
         else:
             test_pass, sim_failed = self._score_test(test, outcome)
             if not test_pass:
-                self.xunit.add_failure()
+                self.xunit.add_failure(
+                    message=f"Test failed with RANDOM_SEED={cocotb.RANDOM_SEED}"
+                )
                 self.failures += 1
             else:
                 self.passed += 1

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -376,7 +376,7 @@ class RegressionManager:
 
         # seed random number generator based on test module, name, and RANDOM_SEED
         hasher = hashlib.sha1()
-        hasher.update(test.__qualname__.encode())
+        hasher.update(os.path.basename(test.__qualname__.encode()))
         hasher.update(test.__module__.encode())
         seed = cocotb.RANDOM_SEED + int(hasher.hexdigest(), 16)
         random.seed(seed)


### PR DESCRIPTION
__qualname__ resolves to b'/home/vijayvithal/prj/switch/test/env1_test/cctb__run_hardware_test__fast___001', 

Where `'/home/vijayvithal/prj/` is the local folder where the design repo is checked out.
While running regressions on a remote server(github/jenkins/bitbucket etc.) the folder where the repo is checkout will be different.
This results in the same RANDOM_SEED computing to different test seed on different machines resulting in issues with reproducibility of test failures

This fix considers only the basename of __qualname__ which is same across machines e.g b'cctb__run_hardware_test__fast___001