### PR TITLE
Removed path from qualname to eliminate test reproducibility issues

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -376,7 +376,7 @@ class RegressionManager:
 
         # seed random number generator based on test module, name, and RANDOM_SEED
         hasher = hashlib.sha1()
-        hasher.update(test.__qualname__.encode())
+        hasher.update(os.path.basename(test.__qualname__.encode()))
         hasher.update(test.__module__.encode())
         seed = cocotb.RANDOM_SEED + int(hasher.hexdigest(), 16)
         random.seed(seed)


### PR DESCRIPTION
qualname contains the full path to the test folder

e.g.
`/home/vijayvithal/repos/switch/tests/env1/...` on my local machine
`home/runner/switch/tests/env1/...` on github Actions
`/var/lib/jenkins/workspace/switch_main/tests/env1/...` on jenkins

When the full qualname is used to generate the testseed it results in issues with reproducing testfailure found during regressions.

This PR uses only the basename of the qualname which will remain the same across all machines.