### PR TITLE
Pin version of nox used for CI

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -90,7 +90,7 @@ jobs:
       # Run tests that don't need a simulator.
     - name: Install Python testing dependencies
       run: |
-        pip install nox
+        pip install nox==2022.8.7
     - name: Run tests without simulators
       run: nox -s "${{ inputs.nox_session_test_nosim }}"
       continue-on-error: ${{matrix.may_fail || false}}


### PR DESCRIPTION
Attempt to fix broken Windows CI regression tests. [See here](https://github.com/cocotb/cocotb/actions/runs/3545251582/jobs/5953248024#step:7:123).