### PR TITLE
fix: xcelium vpi and tmpdir flags

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -948,6 +948,7 @@ class Xcelium(Simulator):
             + verbosity_opts
             # + ["-vpicompat 1800v2005"]  # <1364v1995|1364v2001|1364v2005|1800v2005> Specify the IEEE VPI
             + ["-access +rwc"]
+            + ["-loadvpi"]
             # always start with VPI on Xcelium
             + [
                 cocotb.config.lib_name_path("vpi", "xcelium")
@@ -1001,7 +1002,7 @@ class Xcelium(Simulator):
             + ["-xmlibdirname"]
             + [f"{self.build_dir}/xrun_snapshot"]
             + ["-cds_implicit_tmpdir"]
-            + ["tmpdir"]
+            + [tmpdir]
             + ["-licqueue"]
             + verbosity_opts
             + ["-R"]


### PR DESCRIPTION
This commit fixes the breakage introduced in #3103, where the vpi argument and tmpdir got lost/mismatched.

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
