### PR TITLE
feat: use shlex instead of manually implementing it

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -12,6 +12,7 @@
 import abc
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -50,25 +51,12 @@ def as_tcl_value(value: str) -> str:
     return value
 
 
-# Based on https://github.com/python/cpython/blob/main/Lib/shlex.py
-_shlex_find_unsafe = re.compile(r"[^\w@%+=:,./-]", re.ASCII).search
-
-
-def shlex_quote(s):
-    """Return a shell-escaped version of the string *s*."""
-    if not s:
-        return "''"
-    if _shlex_find_unsafe(s) is None:
-        return s
-
-    # use single quotes, and put single quotes into double quotes
-    # the string $'b is then quoted as '$'"'"'b'
-    return "'" + s.replace("'", "'\"'\"'") + "'"
-
-
 def shlex_join(split_command):
-    """Return a shell-escaped string from *split_command*."""
-    return " ".join(shlex_quote(arg) for arg in split_command)
+    """
+    Return a shell-escaped string from *split_command*
+    This is here more for compatibility purposes
+    """
+    return " ".join(shlex.quote(arg) for arg in split_command)
 
 
 class Simulator(abc.ABC):


### PR DESCRIPTION
To maintain backwards compatibility, we only implement a shim for shlex.join, which isn't available until python 3.8

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
