### PR TITLE
Xcelium Makefile: use filter instead of findstring to avoid false positives

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -73,7 +73,7 @@ else
 endif
 
 # Xcelium errors out if multiple timescales are specified on the command line.
-ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
+ifneq (,$(filter -timescale%,$(EXTRA_ARGS)))
     $(error Please use COCOTB_HDL_TIMEUNIT and COCOTB_HDL_TIMEPRECISION to specify timescale.)
 endif
 


### PR DESCRIPTION
findstring has false positives for inputs like `xyztimescale.v`
the change only matches timescale directive and not partial matches.. either " -timescale=..." or " -timescale ..."
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
