### PR TITLE
CI: Pass environment to pytest in release tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -465,6 +465,7 @@ def release_test_sim(
         "-v",
         "-k",
         "simulator_required",
+        env=env,
     )
 
     session.log(f"All tests passed with configuration {config_str}!")


### PR DESCRIPTION
Pass the same environment variables to pytest that we pass to make in our release tests.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
