### PR TITLE
CI: Switch to GitHub $GITHUB_OUTPUT

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -188,6 +188,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--group")
     parser.add_argument("--output-format", choices=("gha", "json"), default="json")
+    parser.add_argument(
+        "--gha-output-file",
+        type=argparse.FileType("a", encoding="utf-8"),
+        help="The $GITHUB_OUTPUT file.",
+    )
 
     args = parser.parse_args()
 
@@ -198,13 +203,15 @@ def main() -> int:
         selected_envs = ENVS
 
     if args.output_format == "gha":
-        # Output for GitHub Actions (GHA). Sets the variable 'envs'.
+        # Output for GitHub Actions (GHA). Appends the configuration to
+        # the file named in the "--gha-output-file" argument.
+
+        assert args.gha_output_file is not None
 
         # The generated JSON output may not contain newlines to be parsed by GHA
-        print(f"::set-output name=envs::{json.dumps(selected_envs)}")
+        print(f"envs={json.dumps(selected_envs)}", file=args.gha_output_file)
 
-        # The set-output command is not visible in the GHA logs; print the
-        # the selected environments for easier debugging.
+        # Print the the selected environments for easier debugging.
         print("Generated the following test configurations:")
         print(json.dumps(selected_envs, indent=2))
     elif args.output_format == "json":

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -35,7 +35,7 @@ jobs:
     name: Generate a list of environments to run tests against
     steps:
     - uses: actions/checkout@v3
-    - run: ./.github/generate-envs.py --output-format=gha --group="${{inputs.group}}"
+    - run: ./.github/generate-envs.py --output-format=gha --gha-output-file="$GITHUB_OUTPUT" --group="${{inputs.group}}"
       id: run_generate_script
     outputs:
       envs: ${{ steps.run_generate_script.outputs.envs }}


### PR DESCRIPTION
set-output is deprecated and will be removed in June 2023. Prepare for that
by using the new method of doing things, which is, write the output to a
file $GITHUB_OUTPUT.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 
explains it all.



<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->