### PR TITLE
add a workaround for test_sv_interface with SIM=verilator

### DIFF
--- a/documentation/source/newsfragments/3191.bugfix.rst
+++ b/documentation/source/newsfragments/3191.bugfix.rst
@@ -1,0 +1,1 @@
+Updated test_sv_interface with a workaround for Verilator so the test now passes with that simulator

--- a/tests/test_cases/test_sv_interface/top.sv
+++ b/tests/test_cases/test_sv_interface/top.sv
@@ -13,5 +13,7 @@ endinterface
 module top ();
 
 sv_if sv_if_i();
-
+`ifdef VERILATOR
+   logic d; // without this workaround for Verilator, cocotb gets a gpi error 'no root handle found'
+`endif
 endmodule


### PR DESCRIPTION
This simple workaround gets the test_sv_interface test to pass with Verilator. 

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
