### PR TITLE
added plusargs support for ghdl

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -674,6 +674,7 @@ class Ghdl(Simulator):
             + self.test_args
             + [self.sim_hdl_toplevel]
             + ["--vpi=" + cocotb.config.lib_name_path("vpi", "ghdl")]
+            + self.plusargs
             + self._get_parameter_options(self.parameters)
         ]
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
When using ghdl -r some arguments (like vhdl version) must be passed after the top defnition while others must be passed after the vpi  arguments (like --wave).  
Now when using the plusargs optional arguments, this argument will be passed after the vpi  args , while  the test_args arguments will be passed after the top module declaration.

