### PR TITLE
VHDL/GHDL move the make phase in build runner command

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -656,18 +656,19 @@ class Ghdl(Simulator):
             + [str(source_file) for source_file in self.vhdl_sources]
         ]
 
+        if self.hdl_toplevel is not None:
+            cmds += [
+                ["ghdl", "-m"]
+                + [f"--work={self.hdl_library}"]
+                + self.build_args
+                + [self.hdl_toplevel]
+            ]
+
         return cmds
 
     def _test_command(self) -> List[Command]:
 
         cmds = [
-            ["ghdl", "-m"]
-            + [f"--work={self.hdl_toplevel_library}"]
-            + self.test_args
-            + [self.sim_hdl_toplevel]
-        ]
-
-        cmds += [
             ["ghdl", "-r"]
             + [f"--work={self.hdl_toplevel_library}"]
             + self.test_args

--- a/tests/pytest/test_vhdl_libraries_multiple.py
+++ b/tests/pytest/test_vhdl_libraries_multiple.py
@@ -40,13 +40,24 @@ def test_toplevel_library():
     if sim == "xcelium":
         compile_args = ["-v93"]
 
-    for lib in ["e", "d", "c", "b", "a"]:
+    # Build additional libraries
+    for lib in ["e", "d", "c", "b"]:
         runner.build(
             hdl_library=f"{lib}lib",
             vhdl_sources=[src_path / f"{lib}.vhdl"],
             build_args=compile_args,
             build_dir=str(src_path / "sim_build" / "pytest"),
         )
+
+    # Build main hdl_library
+    lib = "a"
+    runner.build(
+        hdl_library=f"{lib}lib",
+        vhdl_sources=[src_path / f"{lib}.vhdl"],
+        hdl_toplevel="a",
+        build_args=compile_args,
+        build_dir=str(src_path / "sim_build" / "pytest"),
+    )
 
     runner.test(
         hdl_toplevel="a",


### PR DESCRIPTION
This PR give more separation to the build and test phase using cocotb runner with ghdl simulator.

Since there is no meaning in specifying the `hdl_toplevel` in VHDL additional libraries, when the runner `build()` method is called without the top entity to be analyzed only the `ghdl -i` command is invoked. Otherwise, when the `hdl_toplevel` is present, the `build()` method also add `ghdl -m` in commands.
It is now possible to invoke the `ghdl -m` and `ghdl -r` command using different arguments. 

This PR is related to the #3205