### PR TITLE
update verilator coverage to work if vl_finish ends the testrun

### DIFF
--- a/cocotb/share/lib/verilator/verilator.cpp
+++ b/cocotb/share/lib/verilator/verilator.cpp
@@ -115,7 +115,6 @@ int main(int argc, char** argv) {
         // If there are no more cbAfterDelay callbacks,
         // the next deadline is max value, so end the simulation now
         if (next_time == static_cast<vluint64_t>(~0ULL)) {
-            vl_finish(__FILE__, __LINE__, "");
             break;
         } else {
             main_time = next_time;

--- a/documentation/source/newsfragments/1478.bugfix.rst
+++ b/documentation/source/newsfragments/1478.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed Verilator not writing coverage files in some cases
+Fixed Verilator not writing coverage files in some cases.

--- a/documentation/source/newsfragments/1478.bugfix.rst
+++ b/documentation/source/newsfragments/1478.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Verilator not writing coverage files in some cases


### PR DESCRIPTION
update inspired by https://github.com/cocotb/cocotb/issues/1478#issuecomment-903345076 However, through trial and error I discovered that sometimes tests end with vl_finish, and other times not, so both write("coverage.dat") lines are needed in verilator.cpp. 

