### PR TITLE
Pass VERILATOR_SIM_DEBUG through during compilation

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -36,7 +36,7 @@ else
 endif
 
 ifeq ($(VERILATOR_SIM_DEBUG), 1)
-  COMPILE_ARGS += --debug -CFLAGS "-DVL_DEBUG -g"
+  COMPILE_ARGS += --debug -CFLAGS "-DVL_DEBUG -DVERILATOR_SIM_DEBUG -g"
   PLUSARGS += +verilator+debug
   BUILD_ARGS += OPT_FAST=-Og OPT_SLOW=-Og OPT_GLOBAL=-Og
 endif


### PR DESCRIPTION
Pass VERILATOR_SIM_DEBUG through during compilation to trigger internalsDump() in verilator.cpp

The the preprocessor macro VERILATOR_SIM_DEBUG is used in verilator.cpp to enable a couple of debug options, but the makefile didn't define this when debugging was enabled.