### PR TITLE
Configure actions/stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,6 +21,13 @@ jobs:
           If it has not been resolved, you may need to provide more information.
           If no more activity on this issue occurs in 7 days, it will be closed.
         stale-issue-label: "status:stale"
+        stale-pr-message: >
+          Are you still actively working on this PR?
+          You may have requested changes that need to be addressed.
+          If the maintainers aren't being timely with a review, we apologize.
+          Please bump this PR to keep it alive.
+          If no more activity on this PR occurs in 7 days, it will be closed.
+        stale-pr-label: "status:stale"
         any-of-labels: "type:question,status:close?"
         exempt-issue-labels: "type:bug,type:feature"
         operations-per-run: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,11 +22,11 @@ jobs:
           If no more activity on this issue occurs in 7 days, it will be closed.
         stale-issue-label: "status:stale"
         stale-pr-message: >
-          Are you still actively working on this PR?
+          Are you still actively working on this pull request?
           You may have requested changes that need to be addressed.
           If the maintainers aren't being timely with a review, we apologize.
-          Please bump this PR to keep it alive.
-          If no more activity on this PR occurs in 7 days, it will be closed.
+          Please bump this pull request to keep it alive.
+          If no more activity on this pull request occurs in 7 days, it will be closed.
         stale-pr-label: "status:stale"
         any-of-labels: "type:question,status:close?"
         operations-per-run: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,5 +29,4 @@ jobs:
           If no more activity on this PR occurs in 7 days, it will be closed.
         stale-pr-label: "status:stale"
         any-of-labels: "type:question,status:close?"
-        exempt-issue-labels: "type:bug,type:feature"
         operations-per-run: 30


### PR DESCRIPTION
Adds a stale PR message and corrects the tagged label. Removes the exempted labels for closure. If an issue should not be closed, it should have the `question` or `close?` label removed. 