### PR TITLE
Catch exceptions derived from BaseException inside Tasks

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -391,7 +391,9 @@ class RegressionManager:
 
         try:
             outcome.get()
-        except Exception as e:
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException as e:
             result = remove_traceback_frames(e, ["_score_test", "get"])
         else:
             result = TestSuccess()
@@ -402,9 +404,6 @@ class RegressionManager:
             and not test.expect_error
         ):
             self._log_test_passed(test, None, None)
-
-        elif isinstance(result, AssertionError) and test.expect_fail:
-            self._log_test_passed(test, result, "failed as expected")
 
         elif isinstance(result, TestSuccess) and test.expect_error:
             self._log_test_failed(test, None, "passed but we expected an error")
@@ -429,6 +428,9 @@ class RegressionManager:
             else:
                 self._log_test_failed(test, result, "errored with unexpected type ")
                 result_pass = False
+
+        elif test.expect_fail:
+            self._log_test_passed(test, result, "failed as expected")
 
         else:
             self._log_test_failed(test, result, None)

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -581,7 +581,7 @@ class Scheduler:
                 coro.log.info("Test stopped by this forked coroutine")
                 e = remove_traceback_frames(e, ["_unschedule", "get"])
                 self._abort_test(e)
-            except Exception as e:
+            except BaseException as e:
                 coro.log.error("Exception raised by this forked coroutine")
                 e = remove_traceback_frames(e, ["_unschedule", "get"])
                 warnings.warn(

--- a/documentation/source/newsfragments/3196.bugfix.rst
+++ b/documentation/source/newsfragments/3196.bugfix.rst
@@ -1,0 +1,1 @@
+The :data:`Regression Manager <cocotb.regression_manager>` now correctly handles exceptions raised in tests when the exceptions inherit from `BaseException`.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,7 +27,7 @@
 
 # Do not fail on DeprecationWarning caused by virtualenv, which might come from
 # the site module.
-export PYTHONWARNINGS = error,ignore::DeprecationWarning:site
+export PYTHONWARNINGS = error,ignore::DeprecationWarning:site,always::FutureWarning:cocotb.scheduler
 
 REGRESSIONS :=  $(shell ls test_cases/)
 

--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -26,3 +26,7 @@ async def _check_traceback(running_coro, exc_type, pattern, *match_args):
 
 class MyException(Exception):
     ...
+
+
+class MyBaseException(BaseException):
+    ...

--- a/tests/test_cases/test_failure/Makefile
+++ b/tests/test_cases/test_failure/Makefile
@@ -9,6 +9,6 @@ MODULE := test_failure
 override_for_this_test:
 	-$(MAKE) all
 	$(call check_for_results_file)
-	test $$(../../../bin/combine_results.py | grep "Failure in testsuite" | wc -l) -eq 1 && rm -f results.xml
+	test $$(../../../bin/combine_results.py | grep "Failure in testsuite" | wc -l) -eq 4 && rm -f results.xml
 
 include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_failure/test_failure.py
+++ b/tests/test_cases/test_failure/test_failure.py
@@ -13,3 +13,18 @@ import cocotb
 @cocotb.test()
 async def test_fail(_):
     assert False
+
+
+@cocotb.test(expect_fail=True)
+async def test_pass_expect_fail(_):
+    assert True
+
+
+@cocotb.test(expect_error=Exception)
+async def test_pass_expect_error(_):
+    assert True
+
+
+@cocotb.test(expect_error=ValueError)
+async def test_wrong_error(_):
+    raise TypeError


### PR DESCRIPTION
Closes #3196.
Alternative to #3226.

Exceptions that are raised inside coroutines running in Tasks are captured inside an outcomes.Error object. Previously, when this object was unwrapped in the Scheduler or RegressionManager, the exception inside was not handled correctly if the exception was derived from BaseException and not Exception.

This was the case with pytest's Failed exception that is raised when the following checks fail in a Task:
* pytest.raises
* pytest.warns
* pytest.deprecated_call
