### PR TITLE
Document minimal Verilator version

### DIFF
--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -89,7 +89,7 @@ Verilator
     Therefore, Verilator support in cocotb is currently experimental.
     Some features of cocotb may not work correctly or at all.
 
-    ** cocotb only supports Verilator 5.006 and later.**
+    **cocotb only supports Verilator 5.006 and later.**
 
 In order to use this simulator, set :make:var:`SIM` to ``verilator``:
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -89,8 +89,7 @@ Verilator
     Therefore, Verilator support in cocotb is currently experimental.
     Some features of cocotb may not work correctly or at all.
 
-    **Currently cocotb only supports Verilator 4.106 (no earlier or later version).**
-    See also the corresponding cocotb issue :issue:`2300` and `upstream issue <https://github.com/verilator/verilator/issues/2778>`_.
+    ** cocotb only supports Verilator 5.006 and later.**
 
 In order to use this simulator, set :make:var:`SIM` to ``verilator``:
 


### PR DESCRIPTION
Document 5.006 as minimal version where #2300 was solved.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
