### PR TITLE
Skipping Verilator on issue 330 test because it doesn't support accessing struct members

### DIFF
--- a/tests/test_cases/issue_330/issue_330.py
+++ b/tests/test_cases/issue_330/issue_330.py
@@ -9,8 +9,9 @@ SIM_NAME = cocotb.SIM_NAME.lower()
 
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
+# Verilator doesn't support struct member access via vpi (cocotb-1275, verilator-860)
 @cocotb.test(
-    expect_error=AttributeError if SIM_NAME.startswith(("icarus", "ghdl")) else ()
+    skip = cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl", "verilator"))
 )
 async def issue_330_direct(dut):
     """
@@ -28,8 +29,9 @@ async def issue_330_direct(dut):
 
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
+# Verilator doesn't support struct member vpi iteration (cocotb-1275, verilator-860)
 @cocotb.test(
-    expect_error=AttributeError if SIM_NAME.startswith(("icarus", "ghdl")) else ()
+    skip = cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl", "verilator"))
 )
 async def issue_330_iteration(dut):
     """


### PR DESCRIPTION
Verilator does support structs, but vpi and public access of structs outside the simulator itself isn't currently supported. Unfortunately, it doesn't seem likely to be supported soon, based on the status of https://github.com/verilator/verilator/issues/860. 

This change treats verilator like ghdl and icarus are for this test. 

Also, updated the tests to skip for these simulators, instead of pass if expected errors occur, i think it's confusing to mark a test that can't run because of missing simulator features as passed vs skipped. 

as far as I can tell, cocotb isn't trying to document these simulator limitations, but if i'm mistaken, I'll be happy to add some. I've separately been working some on verilator vpi documentation (like this https://github.com/verilator/verilator/pull/3925) 
