### PR TITLE
CI: Update regression tests for Verilator

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -125,22 +125,23 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v4.106",
-        "os": "ubuntu-20.04",
+        "sim-version": "8ea814e4b4ce7416188130647c87dea41401a5b6",
+        # Needs 22.04 for newer GCC with C++ coroutine support used with --timing mode
+        "os": "ubuntu-22.04",
         "python-version": "3.8",
-        # Various cocotb tests are known to fail with Verilator 4.106.
-        # Newer versions of Verilator are not working at all.
-        # See also https://github.com/cocotb/cocotb/issues/2300
-        "group": "experimental",
+        # Various cocotb tests are known to fail with Verilator.
+        # See also https://github.com/cocotb/cocotb/issues/3194
+        "group": "ci",
     },
     {
         "lang": "verilog",
         "sim": "verilator",
         "sim-version": "master",
-        "os": "ubuntu-20.04",
+        # Needs 22.04 for newer GCC with C++ coroutine support used with --timing mode
+        "os": "ubuntu-22.04",
         "python-version": "3.8",
-        # Tests are currently not expected to work at all.
-        # See also https://github.com/cocotb/cocotb/issues/2300
+        # Various cocotb tests are known to fail with Verilator.
+        # See also https://github.com/cocotb/cocotb/issues/3194
         "group": "experimental",
     },
     # Test other OSes

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -171,7 +171,7 @@ jobs:
     - name: Set up Verilator (Ubunutu - source)
       if: startsWith(matrix.os, 'ubuntu') && matrix.sim == 'verilator'
       run: |
-        sudo apt-get install -y --no-install-recommends help2man make g++ perl python3 autoconf flex bison libfl2 libfl-dev zlibc zlib1g zlib1g-dev
+        sudo apt-get install -y --no-install-recommends help2man make g++ perl python3 autoconf flex bison libfl2 libfl-dev zlib1g zlib1g-dev
         git clone https://github.com/verilator/verilator.git
         cd verilator
         git reset --hard ${{matrix.sim-version}}

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -17,10 +17,16 @@ async def dff_simple_test(dut):
     """Test that d propagates to q"""
 
     # Assert initial output is unknown
+    # verilator does not support 4-state signals
+    # see https://veripool.org/guide/latest/languages.html#unknown-states
     initial = (
-        LogicArray("U")
-        if cocotb.LANGUAGE.lower().startswith("vhdl")
-        else LogicArray("X")
+        LogicArray(0)
+        if cocotb.SIM_NAME.lower().startswith("verilator")
+        else (
+            LogicArray("U")
+            if cocotb.LANGUAGE.lower().startswith("vhdl")
+            else LogicArray("X")
+        )
     )
     assert LogicArray(dut.q.value) == initial
     # Set initial input value to prevent it from floating

--- a/src/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/src/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -15,11 +15,17 @@ clean::
 
 else
 
-CMD := verilator
+CMD_BIN := verilator
 
-ifeq ($(shell which $(CMD) 2>/dev/null),)
-# Verilator is not in PATH, lets start searching for it
-$(error Cannot find verilator.)
+ifdef VERILATOR_BIN_DIR
+  CMD := $(shell :; command -v $(VERILATOR_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+else
+  # auto-detect bin dir from system path
+  CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+endif
+
+ifeq (, $(CMD))
+  $(error Unable to locate command >$(CMD_BIN)<)
 endif
 
 VLT_MIN := 4.106

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -47,4 +47,8 @@ ifneq ($(filter $(SIM),ius xcelium),)
     COMPILE_ARGS += -v93
 endif
 
+ifeq ($(shell echo $(SIM) | tr A-Z a-z),verilator)
+    COMPILE_ARGS += --timing
+endif
+
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -99,7 +99,6 @@ var int stream_in_string_asciival_sum;
 `ifndef _VCP  // Aldec Riviera-PRO and Active-HDL
   // workaround for
   // # ELAB2: Fatal Error: ELAB2_0036 Unresolved hierarchical reference to "stream_in_string.len.len" from module "sample_module" (module not found).
-`ifndef VERILATOR
 always @(stream_in_string) begin
     $display("%m: stream_in_string has been updated, new value is '%s'", stream_in_string);
     stream_in_string_asciival_sum = 0;
@@ -111,7 +110,6 @@ always @(stream_in_string) begin
                  idx, stream_in_string_asciival, stream_in_string_asciival_sum);
     end
 end
-`endif //  `ifndef VERILATOR
 `endif //  `ifndef _VCP
 
 test_if struct_var;
@@ -126,7 +124,7 @@ initial begin
 end
 `endif
 
-parameter NUM_OF_MODULES = 4;
+parameter NUM_OF_MODULES /*verilator public_flat_rd*/ = 4;
 reg[NUM_OF_MODULES-1:0] temp;
 genvar idx;
 generate
@@ -180,16 +178,14 @@ initial begin
     mybits = '1;
 end
 
-`ifndef VERILATOR
-always @(*) begin
+always @(mybit) begin
     $display("%m: mybit has been updated, new value is %b", mybit);
 end
-always @(*) begin
+always @(mybits) begin
     $display("%m: mybits has been updated, new value is %b", mybits);
 end
-always @(*) begin
+always @(mybits_uninitialized) begin
     $display("%m: mybits_uninitialized has been updated, new value is %b", mybits_uninitialized);
 end
-`endif
 
 endmodule

--- a/tests/pytest/test_plusargs.py
+++ b/tests/pytest/test_plusargs.py
@@ -30,6 +30,8 @@ def test_toplevel_library():
     build_test_args = []
     if hdl_toplevel_lang == "vhdl" and sim == "xcelium":
         build_test_args = ["-v93"]
+    if sim == "verilator":
+        build_test_args = ["--timing"]
 
     verilog_sources = []
     vhdl_sources = []

--- a/tests/test_cases/issue_2255/test_issue2255.py
+++ b/tests/test_cases/issue_2255/test_issue2255.py
@@ -7,9 +7,14 @@ import logging
 import cocotb
 
 
-# GHDL doesn't discover the generate blocks
+# GHDL is unable to access signals in generate loops (gh-2594)
+# Verilator doesn't support vpiGenScope or vpiGenScopeArray (gh-1884)
 @cocotb.test(
-    expect_error=AssertionError if cocotb.SIM_NAME.lower().startswith("ghdl") else ()
+    expect_error=AssertionError
+    if cocotb.SIM_NAME.lower().startswith("ghdl")
+    else AttributeError
+    if cocotb.SIM_NAME.lower().startswith("verilator")
+    else ()
 )
 async def test_distinct_generates(dut):
     tlog = logging.getLogger("cocotb.test")

--- a/tests/test_cases/issue_330/issue_330.py
+++ b/tests/test_cases/issue_330/issue_330.py
@@ -10,10 +10,11 @@ SIM_NAME = cocotb.SIM_NAME.lower()
 
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
+# Verilator doesn't support structs (gh-1275)
 # Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
 @cocotb.test(
     expect_error=AttributeError
-    if SIM_NAME.startswith(("icarus", "ghdl"))
+    if SIM_NAME.startswith(("icarus", "ghdl", "verilator"))
     or (
         SIM_NAME.startswith("riviera")
         and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
@@ -37,8 +38,13 @@ async def issue_330_direct(dut):
 
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
+# Verilator doesn't support structs (gh-1275)
 @cocotb.test(
-    expect_error=AttributeError if SIM_NAME.startswith(("icarus", "ghdl")) else ()
+    expect_error=AttributeError
+    if SIM_NAME.startswith(("icarus", "ghdl"))
+    else AssertionError
+    if SIM_NAME.startswith("verilator")
+    else ()
 )
 async def issue_330_iteration(dut):
     """

--- a/tests/test_cases/test_array/Makefile
+++ b/tests/test_cases/test_array/Makefile
@@ -27,6 +27,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+# Icarus doesn't support structs (gh-2592)
+# Verilator doesn't support structs (gh-1275)
+
 ifeq ($(SIM),)
 all:
 	@echo "Skipping test_array since icarus doesn't support structs"
@@ -34,9 +37,9 @@ all:
 clean::
 # nothing to clean, just define target in this branch
 
-else ifeq ($(shell echo $(SIM) | tr A-Z a-z),icarus)
+else ifneq ($(filter $(shell echo $(SIM) | tr A-Z a-z),icarus verilator),)
 all:
-	@echo "Skipping test_array since icarus doesn't support structs"
+	@echo "Skipping test_array since $(SIM) doesn't support structs"
 
 clean::
 # nothing to clean, just define target in this branch

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -42,9 +42,12 @@ async def test_1dim_array_handles(dut):
 
 # GHDL unable to put values on nested array types (gh-2588)
 # iverilog flattens multi-dimensional unpacked arrays (gh-2595)
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 @cocotb.test(
     expect_error=Exception
     if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl"))
+    else AttributeError
+    if cocotb.SIM_NAME.lower().startswith("verilator")
     else ()
 )
 async def test_ndim_array_handles(dut):
@@ -106,9 +109,12 @@ async def test_1dim_array_indexes(dut):
 
 # GHDL unable to put values on nested array types (gh-2588)
 # iverilog flattens multi-dimensional unpacked arrays (gh-2595)
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 @cocotb.test(
     expect_error=Exception
     if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl"))
+    else AttributeError
+    if cocotb.SIM_NAME.lower().startswith("verilator")
     else ()
 )
 async def test_ndim_array_indexes(dut):

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -140,10 +140,11 @@ async def test_ndim_array_indexes(dut):
 
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
+# Verilator doesn't support structs (gh-1275)
 # Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
 @cocotb.test(
     expect_error=AttributeError
-    if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl"))
+    if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl", "verilator"))
     or (
         cocotb.SIM_NAME.lower().startswith("riviera")
         and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -274,10 +274,11 @@ async def test_edge_on_vector(dut):
                 await ReadOnly()  # not needed for other simulators
             edge_cnt = edge_cnt + 1
 
-    cocotb.start_soon(wait_edge())
-
     dut.stream_in_data.value = 0
     await RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)
+
+    cocotb.start_soon(wait_edge())
 
     for val in range(1, 2 ** len(dut.stream_in_data) - 1):
         # produce an edge by setting a value != 0:
@@ -287,7 +288,9 @@ async def test_edge_on_vector(dut):
         dut.stream_in_data.value = 0
         await RisingEdge(dut.clk)
 
-    assert edge_cnt == 2 * ((2 ** len(dut.stream_in_data) - 1) - 1)
+    expected_count = 2 * ((2 ** len(dut.stream_in_data) - 1) - 1) - 1
+
+    assert edge_cnt == expected_count
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -408,7 +408,9 @@ async def test_assign_LogicArray(dut):
         dut.stream_in_data.value = LogicArray("010")  # not the correct size
 
 
-@cocotb.test()
+# verilator does not support 4-state signals
+# see https://veripool.org/guide/latest/languages.html#unknown-states
+@cocotb.test(expect_error=AssertionError if SIM_NAME.startswith("verilator") else ())
 async def test_assign_Logic(dut):
     dut.stream_in_ready.value = Logic("X")
     await Timer(1, "ns")

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -282,6 +282,7 @@ async def test_integer(dut):
         cocotb.LANGUAGE in ["verilog"]
         and SIM_NAME.startswith("riviera")
         or SIM_NAME.startswith("ghdl")
+        or SIM_NAME.startswith("verilator")
     ):
         limits = (
             _Limits.VECTOR_NBIT
@@ -299,6 +300,7 @@ async def test_integer_overflow(dut):
         cocotb.LANGUAGE in ["verilog"]
         and SIM_NAME.startswith("riviera")
         or SIM_NAME.startswith("ghdl")
+        or SIM_NAME.startswith("verilator")
     ):
         limits = (
             _Limits.VECTOR_NBIT
@@ -380,7 +382,7 @@ async def test_real_assign_int(dut):
 
 
 # identifiers starting with `_` are illegal in VHDL
-@cocotb.test(skip=cocotb.LANGUAGE in ["vhdl"])
+@cocotb.test(skip=cocotb.LANGUAGE in ("vhdl"))
 async def test_access_underscore_name(dut):
     """Test accessing HDL name starting with an underscore"""
     # direct access does not work because we consider such names cocotb-internal

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -43,8 +43,13 @@ from cocotb.triggers import Timer
 
 
 # GHDL is unable to access signals in generate loops (gh-2594)
+# Verilator doesn't support vpiGenScope or vpiGenScopeArray (gh-1884)
 @cocotb.test(
-    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ()
+    expect_error=IndexError
+    if cocotb.SIM_NAME.lower().startswith("ghdl")
+    else AttributeError
+    if cocotb.SIM_NAME.lower().startswith("verilator")
+    else ()
 )
 async def pseudo_region_access(dut):
     """Test that pseudo-regions are accessible before iteration"""

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -41,14 +41,16 @@ from cocotb.handle import (
 )
 from cocotb.triggers import Timer
 
+SIM_NAME = cocotb.SIM_NAME.lower()
+
 
 # GHDL is unable to access signals in generate loops (gh-2594)
 # Verilator doesn't support vpiGenScope or vpiGenScopeArray (gh-1884)
 @cocotb.test(
     expect_error=IndexError
-    if cocotb.SIM_NAME.lower().startswith("ghdl")
+    if SIM_NAME.startswith("ghdl")
     else AttributeError
-    if cocotb.SIM_NAME.lower().startswith("verilator")
+    if SIM_NAME.startswith("verilator")
     else ()
 )
 async def pseudo_region_access(dut):
@@ -130,11 +132,11 @@ async def access_type_bit_verilog_metavalues(dut):
     dut.mybits.value = BinaryValue("XZ")
     await Timer(1, "ns")
     print(dut.mybits.value.binstr)
-    if cocotb.SIM_NAME.lower().startswith(("icarus", "ncsim", "xmsim")):
+    if SIM_NAME.startswith(("icarus", "ncsim", "xmsim")):
         assert (
             dut.mybits.value.binstr.lower() == "xz"
         ), "The assigned value was not as expected"
-    elif cocotb.SIM_NAME.lower().startswith(("riviera",)):
+    elif SIM_NAME.startswith(("riviera",)):
         assert (
             dut.mybits.value.binstr.lower() == "10"
         ), "The assigned value was not as expected"
@@ -146,11 +148,11 @@ async def access_type_bit_verilog_metavalues(dut):
     dut.mybits.value = BinaryValue("ZX")
     await Timer(1, "ns")
     print(dut.mybits.value.binstr)
-    if cocotb.SIM_NAME.lower().startswith(("icarus", "ncsim", "xmsim")):
+    if SIM_NAME.startswith(("icarus", "ncsim", "xmsim")):
         assert (
             dut.mybits.value.binstr.lower() == "zx"
         ), "The assigned value was not as expected"
-    elif cocotb.SIM_NAME.lower().startswith(("riviera",)):
+    elif SIM_NAME.startswith(("riviera",)):
         assert (
             dut.mybits.value.binstr.lower() == "01"
         ), "The assigned value was not as expected"
@@ -162,10 +164,14 @@ async def access_type_bit_verilog_metavalues(dut):
 
 @cocotb.test(
     # Icarus up to (and including) 10.3 doesn't support bit-selects, see https://github.com/steveicarus/iverilog/issues/323
+    # Verilator does not support net bits
     expect_error=IndexError
     if (
-        cocotb.SIM_NAME.lower().startswith("icarus")
-        and (IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"))
+        (
+            SIM_NAME.startswith("icarus")
+            and (IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"))
+        )
+        or SIM_NAME.startswith("verilator")
     )
     else (),
     skip=cocotb.LANGUAGE in ["vhdl"],
@@ -191,12 +197,12 @@ async def access_single_bit_erroneous(dut):
 # Icarus does not support integer signals (gh-2598)
 @cocotb.test(
     expect_error=AttributeError
-    if cocotb.SIM_NAME.lower().startswith(("icarus", "chronologic simulation vcs"))
+    if SIM_NAME.startswith(("icarus", "chronologic simulation vcs"))
     else (),
     expect_fail=(
-        cocotb.SIM_NAME.lower().startswith("riviera")
+        SIM_NAME.startswith("riviera")
         and cocotb.LANGUAGE in ["verilog"]
-        or cocotb.SIM_NAME.lower().startswith("ghdl")
+        or SIM_NAME.startswith(("ghdl", "verilator"))
     ),
 )
 async def access_integer(dut):
@@ -213,9 +219,7 @@ async def access_ulogic(dut):
 # GHDL discovers generics as vpiParameter (gh-2722)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=NotImplementedError
-    if cocotb.SIM_NAME.lower().startswith("ghdl")
-    else (),
+    expect_error=NotImplementedError if SIM_NAME.startswith("ghdl") else (),
 )
 async def access_constant_integer(dut):
     """
@@ -228,9 +232,7 @@ async def access_constant_integer(dut):
 # GHDL discovers generics as vpiParameter (gh-2722)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=NotImplementedError
-    if cocotb.SIM_NAME.lower().startswith("ghdl")
-    else (),
+    expect_error=NotImplementedError if SIM_NAME.startswith("ghdl") else (),
 )
 async def access_constant_string_vhdl(dut):
     """Access to a string, both constant and signal."""
@@ -242,7 +244,7 @@ async def access_constant_string_vhdl(dut):
 # GHDL discovers strings as vpiNetArray (gh-2584)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else (),
+    expect_error=TypeError if SIM_NAME.startswith("ghdl") else (),
 )
 async def test_writing_string_undersized(dut):
     test_string = b"cocotb"
@@ -255,7 +257,7 @@ async def test_writing_string_undersized(dut):
 # GHDL discovers strings as vpiNetArray (gh-2584)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else (),
+    expect_error=TypeError if SIM_NAME.startswith("ghdl") else (),
 )
 async def test_writing_string_oversized(dut):
     test_string = b"longer_than_the_array"
@@ -267,7 +269,7 @@ async def test_writing_string_oversized(dut):
 # GHDL discovers strings as vpiNetArray (gh-2584)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else (),
+    expect_error=TypeError if SIM_NAME.startswith("ghdl") else (),
 )
 async def test_read_single_character(dut):
     test_string = b"cocotb!!!"
@@ -281,7 +283,7 @@ async def test_read_single_character(dut):
 # GHDL discovers strings as vpiNetArray (gh-2584)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=TypeError if cocotb.SIM_NAME.lower().startswith("ghdl") else (),
+    expect_error=TypeError if SIM_NAME.startswith("ghdl") else (),
 )
 async def test_write_single_character(dut):
     # set initial value
@@ -305,8 +307,8 @@ async def test_write_single_character(dut):
 
 
 @cocotb.test(
-    skip=cocotb.LANGUAGE in ["vhdl"] or cocotb.SIM_NAME.lower().startswith("riviera"),
-    expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("icarus") else (),
+    skip=cocotb.LANGUAGE in ["vhdl"] or SIM_NAME.startswith("riviera"),
+    expect_error=AttributeError if SIM_NAME.startswith("icarus") else (),
 )
 async def access_const_string_verilog(dut):
     """Access to a const Verilog string."""
@@ -322,7 +324,7 @@ async def access_const_string_verilog(dut):
 
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["vhdl"],
-    expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("icarus") else (),
+    expect_error=AttributeError if SIM_NAME.startswith("icarus") else (),
 )
 async def access_var_string_verilog(dut):
     """Access to a var Verilog string."""
@@ -339,9 +341,7 @@ async def access_var_string_verilog(dut):
 # GHDL discovers generics as vpiParameter (gh-2722)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=NotImplementedError
-    if cocotb.SIM_NAME.lower().startswith("ghdl")
-    else (),
+    expect_error=NotImplementedError if SIM_NAME.startswith("ghdl") else (),
 )
 async def access_constant_boolean(dut):
     """Test access to a constant boolean"""
@@ -352,7 +352,7 @@ async def access_constant_boolean(dut):
 # GHDL discovers booleans as vpiNet (gh-2596)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_fail=cocotb.SIM_NAME.lower().startswith("ghdl"),
+    expect_fail=SIM_NAME.startswith("ghdl"),
 )
 @cocotb.test()
 async def access_boolean(dut):
@@ -371,7 +371,7 @@ async def access_internal_register_array(dut):
 
     # verilator does not support 4-state signals
     # see https://veripool.org/guide/latest/languages.html#unknown-states
-    if SIM_NAME.lower().startswith("verilator"):
+    if SIM_NAME.startswith("verilator"):
         expected_value = "00000000"
     else:
         expected_value = "xxxxxxxx"
@@ -389,7 +389,7 @@ async def access_internal_register_array(dut):
 
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["vhdl"],
-    expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("icarus") else (),
+    expect_error=AttributeError if SIM_NAME.startswith(("icarus", "verilator")) else (),
 )
 async def access_gate(dut):
     """
@@ -401,7 +401,7 @@ async def access_gate(dut):
 # GHDL is unable to access record types (gh-2591)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else (),
+    expect_error=AttributeError if SIM_NAME.startswith("ghdl") else (),
 )
 async def custom_type(dut):
     """
@@ -439,21 +439,29 @@ async def type_check_verilog(dut):
         (dut.stream_in_ready, "GPI_REGISTER"),
         (dut.register_array, "GPI_ARRAY"),
         (dut.temp, "GPI_REGISTER"),
-        (dut.and_output, "GPI_NET"),
-        (dut.stream_in_data, "GPI_NET"),
         (dut.logic_b, "GPI_REGISTER"),
         (dut.logic_c, "GPI_REGISTER"),
         (dut.INT_PARAM, "GPI_INTEGER"),
         (dut.REAL_PARAM, "GPI_REAL"),
-        (dut.STRING_PARAM, "GPI_STRING"),
     ]
 
-    if cocotb.SIM_NAME.lower().startswith("icarus"):
+    if SIM_NAME.startswith("icarus"):
         test_handles.append(
             (dut.logic_a, "GPI_NET")
         )  # https://github.com/steveicarus/iverilog/issues/312
     else:
         test_handles.append((dut.logic_a, "GPI_REGISTER"))
+
+    # Verilator returns vpiReg rather than vpiNet
+    # Verilator (correctly) treats parameters with implicit type, that are assigned a string literal value, as an unsigned integer. See IEEE 1800-2017 Section 5.9 and Section 6.20.2
+    if SIM_NAME.startswith("verilator"):
+        test_handles.append((dut.stream_in_data, "GPI_REGISTER"))
+        test_handles.append((dut.and_output, "GPI_REGISTER"))
+        test_handles.append((dut.STRING_PARAM, "GPI_INTEGER"))
+    else:
+        test_handles.append((dut.stream_in_data, "GPI_NET"))
+        test_handles.append((dut.and_output, "GPI_NET"))
+        test_handles.append((dut.STRING_PARAM, "GPI_STRING"))
 
     for handle in test_handles:
         assert handle[0]._type == handle[1]
@@ -462,7 +470,7 @@ async def type_check_verilog(dut):
 # GHDL cannot find signal in "block" statement, may be related to (gh-2594)
 @cocotb.test(
     skip=cocotb.LANGUAGE in ["verilog"],
-    expect_error=AttributeError if cocotb.SIM_NAME.lower().startswith("ghdl") else (),
+    expect_error=AttributeError if SIM_NAME.startswith("ghdl") else (),
 )
 async def access_block_vhdl(dut):
     """Access a VHDL block statement"""
@@ -486,7 +494,7 @@ async def discover_all_in_component_vhdl(dut):
     """Access a non local indexed name"""
 
     questa_vhpi = (
-        cocotb.SIM_NAME.lower().startswith("modelsim")
+        SIM_NAME.startswith("modelsim")
         and os.getenv("VHDL_GPI_INTERFACE", "fli") == "vhpi"
     )
 
@@ -505,7 +513,7 @@ async def discover_all_in_component_vhdl(dut):
 
     total_count = _discover(dut.isample_module1)
 
-    sim = cocotb.SIM_NAME.lower()
+    sim = SIM_NAME
 
     # ideally should be 32:
     #   1   EXAMPLE_STRING

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -364,8 +364,15 @@ async def access_boolean(dut):
 async def access_internal_register_array(dut):
     """Test access to an internal register array"""
 
+    # verilator does not support 4-state signals
+    # see https://veripool.org/guide/latest/languages.html#unknown-states
+    if SIM_NAME.lower().startswith("verilator"):
+        expected_value = "00000000"
+    else:
+        expected_value = "xxxxxxxx"
+
     assert (
-        dut.register_array[0].value.binstr == "xxxxxxxx"
+        dut.register_array[0].value.binstr == expected_value
     ), "Failed to access internal register array value"
 
     dut.register_array[1].setimmediatevalue(4)

--- a/tests/test_cases/test_fatal/Makefile
+++ b/tests/test_cases/test_fatal/Makefile
@@ -18,6 +18,10 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
     endif
 endif
 
+ifeq ($(shell echo $(SIM) | tr A-Z a-z),verilator)
+    COMPILE_ARGS += --timing
+endif
+
 # squash error code from simulator and ensure the cocotb test passed
 .PHONY: override_for_this_test
 override_for_this_test:

--- a/tests/test_cases/test_fatal/Makefile
+++ b/tests/test_cases/test_fatal/Makefile
@@ -20,13 +20,19 @@ endif
 
 ifeq ($(shell echo $(SIM) | tr A-Z a-z),verilator)
     COMPILE_ARGS += --timing
-endif
 
+# error if results file exists, because currently verilator cannot find root handle with an empty module containing $fatal (gh-2346)
+.PHONY: verilator_override_for_this_test
+verilator_override_for_this_test:
+	-$(MAKE) all
+	@test ! -f $(COCOTB_RESULTS_FILE) || (echo "ERROR: $(COCOTB_RESULTS_FILE) was written by Verilator but not expected to" >&2 && exit 1)
+else
 # squash error code from simulator and ensure the cocotb test passed
 .PHONY: override_for_this_test
 override_for_this_test:
 	-$(MAKE) all
 	$(call check_for_results_file)
 	../../../bin/combine_results.py &> /dev/null
+endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/test_first_on_coincident_triggers/Makefile
+++ b/tests/test_cases/test_first_on_coincident_triggers/Makefile
@@ -17,4 +17,8 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
     endif
 endif
 
+ifeq ($(shell echo $(SIM) | tr A-Z a-z),verilator)
+    COMPILE_ARGS += --timing
+endif
+
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/test_force_release/test_force_release.py
+++ b/tests/test_cases/test_force_release/test_force_release.py
@@ -5,7 +5,7 @@ from cocotb.handle import Force, Release
 from cocotb.triggers import Timer
 
 
-@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("ghdl"))
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith(("ghdl", "verilator")))
 async def test_force_release(dut):
     """
     Test force and release on simulation handles

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -26,15 +26,25 @@
 import logging
 
 import cocotb
+from cocotb._sim_versions import IcarusVersion
 from cocotb.triggers import First
 
+SIM_NAME = cocotb.SIM_NAME.lower()
 
-@cocotb.test(expect_fail=cocotb.SIM_NAME in ["Icarus Verilog"])
+
+@cocotb.test()
 async def recursive_discovery(dut):
     """
     Recursively discover every single object in the design
     """
-    if cocotb.SIM_NAME.lower().startswith(
+    if SIM_NAME.startswith("verilator"):
+        pass_total = 26
+    elif SIM_NAME.startswith("icarus"):
+        if IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"):
+            pass_total = 27
+        else:
+            pass_total = 259
+    elif SIM_NAME.startswith(
         ("modelsim", "ncsim", "xmsim", "chronologic simulation vcs")
     ):
         # vpiAlways does not show up

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -1,6 +1,8 @@
 import cocotb
 from cocotb.triggers import Timer
 
+SIM_NAME = cocotb.SIM_NAME.lower()
+
 
 @cocotb.test()
 async def test_in_vect_packed(dut):
@@ -10,7 +12,8 @@ async def test_in_vect_packed(dut):
     assert dut.out_vect_packed.value == test_value
 
 
-@cocotb.test()
+# Verilator combines 1-dimensional unpacked arrays into a single vector (gh-3611)
+@cocotb.test(expect_error=TypeError if SIM_NAME.startswith("verilator") else ())
 async def test_in_vect_unpacked(dut):
     test_value = [0x1, 0x0, 0x1]
     dut.in_vect_unpacked.value = test_value
@@ -42,7 +45,8 @@ async def test_in_2d_vect_packed_unpacked(dut):
     assert dut.out_2d_vect_packed_unpacked.value == test_value
 
 
-@cocotb.test()
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith("verilator") else ())
 async def test_in_2d_vect_unpacked_unpacked(dut):
     test_value = 3 * [[0x1, 0x0, 0x1]]
     dut.in_2d_vect_unpacked_unpacked.value = test_value
@@ -83,9 +87,12 @@ async def test_in_vect_packed_packed_packed(dut):
 
 
 # Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 @cocotb.test(
     expect_error=IndexError
-    if cocotb.LANGUAGE == "verilog" and cocotb.SIM_NAME.lower().startswith("modelsim")
+    if cocotb.LANGUAGE == "verilog" and SIM_NAME.startswith("modelsim")
+    else AttributeError
+    if SIM_NAME.startswith("verilator")
     else ()
 )
 async def test_in_vect_packed_packed_unpacked(dut):
@@ -95,7 +102,8 @@ async def test_in_vect_packed_packed_unpacked(dut):
     assert dut.out_vect_packed_packed_unpacked.value == test_value
 
 
-@cocotb.test()
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith("verilator") else ())
 async def test_in_vect_packed_unpacked_unpacked(dut):
     test_value = 3 * [3 * [5]]
     dut.in_vect_packed_unpacked_unpacked.value = test_value
@@ -103,7 +111,8 @@ async def test_in_vect_packed_unpacked_unpacked(dut):
     assert dut.out_vect_packed_unpacked_unpacked.value == test_value
 
 
-@cocotb.test()
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith("verilator") else ())
 async def test_in_vect_unpacked_unpacked_unpacked(dut):
     test_value = 3 * [3 * [[1, 0, 1]]]
     dut.in_vect_unpacked_unpacked_unpacked.value = test_value
@@ -120,9 +129,12 @@ async def test_in_arr_packed_packed(dut):
 
 
 # Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 @cocotb.test(
     expect_error=IndexError
-    if cocotb.LANGUAGE == "verilog" and cocotb.SIM_NAME.lower().startswith("modelsim")
+    if cocotb.LANGUAGE == "verilog" and SIM_NAME.startswith("modelsim")
+    else AttributeError
+    if SIM_NAME.startswith("verilator")
     else ()
 )
 async def test_in_arr_packed_unpacked(dut):
@@ -132,7 +144,8 @@ async def test_in_arr_packed_unpacked(dut):
     assert dut.out_arr_packed_unpacked.value == test_value
 
 
-@cocotb.test()
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
+@cocotb.test(expect_error=AttributeError if SIM_NAME.startswith("verilator") else ())
 async def test_in_arr_unpacked_unpacked(dut):
     test_value = 3 * [3 * [5]]
     dut.in_arr_unpacked_unpacked.value = test_value
@@ -149,9 +162,12 @@ async def test_in_2d_arr_packed(dut):
 
 
 # Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
+# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 @cocotb.test(
     expect_error=IndexError
-    if cocotb.LANGUAGE == "verilog" and cocotb.SIM_NAME.lower().startswith("modelsim")
+    if cocotb.LANGUAGE == "verilog" and SIM_NAME.startswith("modelsim")
+    else AttributeError
+    if SIM_NAME.startswith("verilator")
     else ()
 )
 async def test_in_2d_arr_unpacked(dut):


### PR DESCRIPTION
Update regression test suite for Verilator. Add expected test failures and skip some tests because of missing VPI support.

Part of #3194.

Includes alternative to #3235.

Needs #3196 fixed.