### PR TITLE
Correctly desensitize timer callbacks in FLI

### DIFF
--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -46,6 +46,10 @@ int FliProcessCbHdl::cleanup_callback() {
         case GPI_CALL:
             mti_Desensitize(m_proc_hdl);
             set_call_state(GPI_DELETE);
+            break;
+        case GPI_DELETE:
+        case GPI_FREE:
+            break;
     }
     return 0;
 }

--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -41,9 +41,11 @@
  *
  */
 int FliProcessCbHdl::cleanup_callback() {
-    if (get_call_state() == GPI_PRIMED) {
-        mti_Desensitize(m_proc_hdl);
-        set_call_state(GPI_DELETE);
+    switch (get_call_state()) {
+        case GPI_PRIMED:
+        case GPI_CALL:
+            mti_Desensitize(m_proc_hdl);
+            set_call_state(GPI_DELETE);
     }
     return 0;
 }


### PR DESCRIPTION
Small test shows 5x FLI performance. Closes #3229. The whole callback cleanup needs some love, but this is the minimal change to fix the performance regression.