### PR TITLE
Explicit eval_step in verilator

### DIFF
--- a/cocotb/share/lib/verilator/verilator.cpp
+++ b/cocotb/share/lib/verilator/verilator.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
         bool again = true;
         while (again) {
             // Evaluate design
-            top->eval();
+            top->eval_step();
 
             // Call Value Change callbacks triggered by eval()
             // These can modify signal values
@@ -101,6 +101,7 @@ int main(int argc, char** argv) {
             // These can modify signal values
             again |= settle_value_callbacks();
         }
+        top->eval_end_step();
 
         // Call ReadOnly callbacks
         VerilatedVpi::callCbs(cbReadOnlySynch);


### PR DESCRIPTION
This doesn't really follow the contribution guidelines, apologies for that, but since it's a small change, I hope it's OK, if not I can adjust as needed.

When running tests with verilator with dumpvar and dumpfile set as
```verilog
// This file is public domain, it can be freely copied without restrictions.
// SPDX-License-Identifier: CC0-1.0

module my_design(input logic clk);

  timeunit 1ns;
  timeprecision 1ns;

  logic my_signal_1;
  logic my_signal_2;

  assign my_signal_1 = 1'bx;
  assign my_signal_2 = 0;

  initial begin
    $dumpfile("filename.vcd");
    $dumpvars();
  end

endmodule
```
with the testbench
```python
# test_my_design.py (extended)

import cocotb
from cocotb.triggers import FallingEdge, Timer
from cocotb.clock import Clock


@cocotb.test()
async def my_second_test(dut):
    """Try accessing the design."""

    cocotb.start_soon(Clock(dut.clk, 1, units="ns").start())

    for _ in range(0, 10):
        await FallingEdge(dut.clk)  # wait for falling edge/"negedge"

    dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)
    # assert dut.my_signal_2.value[0] == 0, "my_signal_2[0]"
```
and Makefile
```Makefile
# Makefile

# defaults
SIM ?= verilator
TOPLEVEL_LANG ?= verilog

VERILOG_SOURCES += $(PWD)/test.sv
# use VHDL_SOURCES for VHDL files

# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
TOPLEVEL = my_design

# MODULE is the basename of the Python test file
MODULE = test

EXTRA_ARGS += --trace

# include cocotb's make rules to take care of the simulator setup
include $(shell cocotb-config --makefiles)/Makefile.sim
```
it currently prints
```
%Warning: previous dump at t=0, requesting t=0, dump call ignored
%Warning: previous dump at t=500, requesting t=500, dump call ignored
%Warning: previous dump at t=1000, requesting t=1000, dump call ignored
%Warning: previous dump at t=1500, requesting t=1500, dump call ignored
%Warning: previous dump at t=2000, requesting t=2000, dump call ignored
%Warning: previous dump at t=2500, requesting t=2500, dump call ignored
%Warning: previous dump at t=3000, requesting t=3000, dump call ignored
%Warning: previous dump at t=3500, requesting t=3500, dump call ignored
%Warning: previous dump at t=4000, requesting t=4000, dump call ignored
%Warning: previous dump at t=4500, requesting t=4500, dump call ignored
%Warning: previous dump at t=5000, requesting t=5000, dump call ignored
%Warning: previous dump at t=5500, requesting t=5500, dump call ignored
%Warning: previous dump at t=6000, requesting t=6000, dump call ignored
%Warning: previous dump at t=6500, requesting t=6500, dump call ignored
%Warning: previous dump at t=7000, requesting t=7000, dump call ignored
%Warning: previous dump at t=7500, requesting t=7500, dump call ignored
%Warning: previous dump at t=8000, requesting t=8000, dump call ignored
%Warning: previous dump at t=8500, requesting t=8500, dump call ignored
%Warning: previous dump at t=9000, requesting t=9000, dump call ignored
```

As far as I can tell [1, 2], when running verilator, one should only call `eval` once per time step, if wanting to re-evaluate things, `eval_step` and `eval_end_step` should be called

1: https://github.com/verilator/verilator/issues/2832
2: https://verilator.org/guide/latest/connecting.html#wrappers-and-model-evaluation-loop

Should I also add tests for this case, is it even possible to test for the stdout of the underlying simulator?