### PR TITLE
Fixing issue where startup callback caused mti_Desensitize to be called with a null parameter

### DIFF
--- a/cocotb/share/def/modelsim.def
+++ b/cocotb/share/def/modelsim.def
@@ -93,6 +93,8 @@ mti_Now
 mti_NowUpper
 mti_Quit
 mti_ReleaseSignal
+mti_RemoveLoadDoneCB
+mti_RemoveQuitCB
 mti_ScheduleWakeup
 mti_ScheduleWakeup64
 mti_Sensitize

--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -44,9 +44,7 @@ int FliProcessCbHdl::cleanup_callback() {
     switch (get_call_state()) {
         case GPI_PRIMED:
         case GPI_CALL:
-            if (m_proc_hdl != nullptr) {
-                mti_Desensitize(m_proc_hdl);
-            }
+            mti_Desensitize(m_proc_hdl);
             set_call_state(GPI_DELETE);
             break;
         case GPI_DELETE:
@@ -208,6 +206,12 @@ int FliStartupCbHdl::run_callback() {
     return 0;
 }
 
+int FliStartupCbHdl::cleanup_callback() {
+    mti_RemoveLoadDoneCB(handle_fli_callback, (void*)this);
+    set_call_state(GPI_DELETE);
+    return 0;
+}
+
 int FliShutdownCbHdl::arm_callback() {
     mti_AddQuitCB(handle_fli_callback, (void*)this);
     set_call_state(GPI_PRIMED);
@@ -218,5 +222,11 @@ int FliShutdownCbHdl::arm_callback() {
 int FliShutdownCbHdl::run_callback() {
     gpi_embed_end();
 
+    return 0;
+}
+
+int FliShutdownCbHdl::cleanup_callback() {
+    mti_RemoveQuitCB(handle_fli_callback, (void*)this);
+    set_call_state(GPI_DELETE);
     return 0;
 }

--- a/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -44,7 +44,9 @@ int FliProcessCbHdl::cleanup_callback() {
     switch (get_call_state()) {
         case GPI_PRIMED:
         case GPI_CALL:
-            mti_Desensitize(m_proc_hdl);
+            if (m_proc_hdl != nullptr) {
+                mti_Desensitize(m_proc_hdl);
+            }
             set_call_state(GPI_DELETE);
             break;
         case GPI_DELETE:

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -119,6 +119,7 @@ class FliStartupCbHdl : public FliProcessCbHdl {
 
     int arm_callback() override;
     int run_callback() override;
+    int cleanup_callback() override;
 };
 
 class FliShutdownCbHdl : public FliProcessCbHdl {
@@ -128,6 +129,7 @@ class FliShutdownCbHdl : public FliProcessCbHdl {
 
     int arm_callback() override;
     int run_callback() override;
+    int cleanup_callback() override;
 };
 
 class FliTimedCbHdl : public FliProcessCbHdl, public GpiCommonCbHdl {


### PR DESCRIPTION
A recent change to `FliCbHdl` causes Modelsim DE 2022.4 to emit this suppressible error:

```
# ** Error (suppressible): (vsim-FLI-3132) mti_Desensitize(): NULL process ID parameter.
```

This fix performs a null check before calling `mti_Desensitize` to avoid this error being emitted. While not a functional problem it is annoying for log parsing to have errors like this contaminating the log.