### PR TITLE
Fix scheduler bug

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -76,7 +76,7 @@ if _profiling:
 _debug = "COCOTB_SCHEDULER_DEBUG" in os.environ
 
 
-class InternalError(RuntimeError):
+class InternalError(BaseException):
     """An error internal to scheduler. If you see this, report a bug!"""
 
     pass

--- a/documentation/source/newsfragments/3267.bugfix.rst
+++ b/documentation/source/newsfragments/3267.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :class:`RecursionError` caused by certain corner cases in the scheduler.

--- a/documentation/source/newsfragments/3270.bugfix.rst
+++ b/documentation/source/newsfragments/3270.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed cleanup in scheduler which caused sporadic warning messages and bugs in some corner cases.

--- a/tests/test_cases/test_3270/Makefile
+++ b/tests/test_cases/test_3270/Makefile
@@ -1,0 +1,20 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+sim:
+	@echo Only Verilog is supported for this test, skipping...
+
+else
+
+MODULE := test_3270
+VERILOG_SOURCES := test_3270.v
+TOPLEVEL := trigger_counter
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+endif

--- a/tests/test_cases/test_3270/test_3270.py
+++ b/tests/test_cases/test_3270/test_3270.py
@@ -1,0 +1,108 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import First, RisingEdge, Timer
+
+
+class MonitorChange:
+    def __init__(self, signal, valid, expect_change=True) -> None:
+        self.monitor_process = None
+        self.signal = signal
+        self.valid = valid
+        self.expect_change = expect_change
+
+    def __enter__(self):
+        self.start_monitor()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.assert_change()
+            return True
+        else:
+            self.stop_monitor()
+            return False
+
+    async def _monitor_req_design_update(self):
+        update = False
+
+        while not update:
+            await First(RisingEdge(self.signal), RisingEdge(self.valid))
+            update = self.signal.value == 1 and self.valid.value == 1
+
+        assert self.expect_change, "Unexpected change happened"
+
+    def stop_monitor(self):
+        if self.monitor_process is not None:
+            self.monitor_process.kill()
+        self.monitor_process = None
+
+    def start_monitor(self):
+        self.stop_monitor()
+        self.monitor_process = cocotb.start_soon(self._monitor_req_design_update())
+
+    def assert_change(self):
+        is_ok = True
+        if not (self.monitor_process is None or self.monitor_process.done()):
+            is_ok = not self.expect_change
+        self.stop_monitor()
+        assert is_ok, "Change SHOULD have happened"
+
+
+async def init_dut(dut):
+    dut.i_rst_n.value = 1
+    dut.i_clk.value = 0
+    dut.i_trg.value = 0
+    dut.i_valid.value = 0
+    dut.i_cnt.value = 0
+    await Timer(1)
+    dut.i_rst_n.value = 0
+    await Timer(10, "ns")
+    dut.i_rst_n.value = 1
+    return cocotb.start_soon(Clock(dut.i_clk, 1, "ns").start())
+
+
+@cocotb.test()
+async def buggy(dut):
+    clk = await init_dut(dut)
+
+    async def stuff(dut):
+        with MonitorChange(dut.o_pulse, dut.o_valid, expect_change=False):
+            with MonitorChange(dut.i_trg, dut.o_valid, expect_change=False):
+                await Timer(10, "us")
+
+    coro = cocotb.start_soon(stuff(dut))
+
+    await Timer(5, "ns")
+    await RisingEdge(dut.i_clk)
+    dut.i_cnt.value = 5
+    dut.i_trg.value = 1
+    dut.i_valid.value = 0
+    await RisingEdge(dut.i_clk)
+    dut.i_trg.value = 0
+
+    await RisingEdge(dut.o_pulse)
+    clk.kill()
+    coro.kill()
+    await Timer(1, "us")
+
+
+@cocotb.test()
+async def basic_ok(dut):
+    clk = await init_dut(dut)
+
+    with MonitorChange(dut.o_pulse, dut.o_valid, expect_change=True):
+        await Timer(5, "ns")
+        await RisingEdge(dut.i_clk)
+        dut.i_cnt.value = 5
+        dut.i_trg.value = 1
+        dut.i_valid.value = 1
+        await RisingEdge(dut.i_clk)
+        dut.i_trg.value = 0
+
+        await RisingEdge(dut.o_pulse)
+        await Timer(10, "ns")
+
+    await Timer(10, "ns")
+    clk.kill()

--- a/tests/test_cases/test_3270/test_3270.v
+++ b/tests/test_cases/test_3270/test_3270.v
@@ -1,0 +1,35 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+module trigger_counter (
+    input logic i_clk,
+    input logic i_rst_n,
+    input logic i_trg,
+    input logic i_valid,
+    input logic [7:0] i_cnt,
+    output logic o_pulse,
+    output logic o_valid
+);
+
+
+  logic [7:0] cnt;
+
+  always @(posedge i_clk or negedge i_rst_n) begin : p_seq_
+    if (~i_rst_n) begin
+      cnt <= 0;
+      o_pulse <= 0;
+      o_valid <= 0;
+    end else begin
+      o_pulse <= 0;
+      o_valid <= i_valid;
+      if (i_trg) begin
+        cnt <= i_cnt;
+      end else if (cnt != 0) begin
+        cnt <= cnt - 1;
+        o_pulse <= (cnt == 1) ? 1'b1 : 1'b0;
+      end
+    end
+  end
+
+endmodule


### PR DESCRIPTION
Fixes #3267 and #3270. The shallow copy of `_triggers2coros` and the cleanup of triggers (in the `_event_loop` loop) after coros (in `_cleanup`) cause #3270. #3267 is dealt with by making `InternalError` a `BaseException` as was discussed in that issue.
