### PR TITLE
Update test expectations for Questa 2023.x FLI

### DIFF
--- a/cocotb/_sim_versions.py
+++ b/cocotb/_sim_versions.py
@@ -68,9 +68,24 @@ class QuestaVersion(LooseVersion):
         True
         >>> QuestaVersion("2020.1 2020.01") > QuestaVersion("10.7c 2018.08")
         True
+        >>> QuestaVersion("2020.1 2020.01") == QuestaVersion("2020.1")
+        True
+        >>> QuestaVersion("2023.1_2 2023.03") > QuestaVersion("2023.1_1")
+        True
     """
 
-    pass
+    def parse(self, vstring):
+        # A Questa version string, as returned by the simulator, consists of two
+        # space-separated parts. The first part is the actual version number,
+        # the second part seems to be the year and month of the initial release.
+        # We only need the first part, which is also used in public
+        # communication by Siemens.
+        try:
+            first_component = vstring.split(" ", 1)[0]
+        except IndexError:
+            first_component = vstring
+
+        super().parse(first_component)
 
 
 class RivieraVersion(LooseVersion):

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -27,6 +27,7 @@ import logging
 import os
 
 import cocotb
+from cocotb._sim_versions import QuestaVersion
 from cocotb.triggers import Combine, Timer
 
 
@@ -39,6 +40,19 @@ def total_object_count():
     # TODO: Why do we get massively different numbers for Questa/VHPI than for Questa/FLI or VPI?
     if SIM_NAME.startswith("modelsim") and os.environ["VHDL_GPI_INTERFACE"] == "vhpi":
         return 66959
+
+    # Questa 2023.1 onwards (FLI) do not discover the following objects, which
+    # are instantiated four times:
+    # - inst_generic_sp_ram.clk (<class 'cocotb.handle.ModifiableObject'>)
+    # - inst_generic_sp_ram.rst (<class 'cocotb.handle.ModifiableObject'>)
+    # - inst_generic_sp_ram.wen (<class 'cocotb.handle.ModifiableObject'>)
+    # - inst_generic_sp_ram.en (<class 'cocotb.handle.ModifiableObject'>)
+    if (
+        SIM_NAME.startswith("modelsim")
+        and QuestaVersion(SIM_VERSION) >= QuestaVersion("2023.1")
+        and os.environ["VHDL_GPI_INTERFACE"] == "fli"
+    ):
+        return 34569 - 4 * 4
 
     if SIM_NAME.startswith(
         (


### PR DESCRIPTION
Testing shows that Questa 2023.1 and 2023.2 (at this point) do not
discover four ports of an entity instantiated in a generate loop. Update
our test expectations to account for that behavior.

Also improve our QuestaVersion class to make it easier to do a version comparision.