### PR TITLE
Avoid "here" links in documentation

### DIFF
--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -27,7 +27,7 @@ In order to use this simulator, set :make:var:`SIM` to ``icarus``:
 
 .. note::
     A working installation of `Icarus Verilog <http://iverilog.icarus.com/>`_ is required.
-    You can find installation instructions `here <https://iverilog.fandom.com/wiki/Installation_Guide>`_.
+    You can find installation instructions `in the Icarus Verilog Installation Guide <https://iverilog.fandom.com/wiki/Installation_Guide>`_.
 
 .. _sim-icarus-accessing-bits:
 
@@ -99,7 +99,7 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
 
 .. note::
     A working installation of `Verilator <https://www.veripool.org/verilator/>`_ is required.
-    You can find installation instructions `here <https://verilator.org/guide/latest/install.html>`_.
+    You can find installation instructions `in the Verilator documentation <https://verilator.org/guide/latest/install.html>`_.
 
 One major limitation compared to standard Verilog simulators is that it does not support delayed assignments when accessed from cocotb.
 
@@ -353,7 +353,7 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
 
 .. note::
     A working installation of `GHDL <https://ghdl.github.io/ghdl/about.html>`_ is required.
-    You can find installation instructions `here <https://ghdl.github.io/ghdl/getting.html>`_.
+    You can find installation instructions `in the GHDL documentation <https://ghdl.github.io/ghdl/getting.html>`_.
 
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.
 


### PR DESCRIPTION
Avoid repeated links labeled "here", which are both bad style and cause
a warning during the Sphinx build.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
