### PR TITLE
Patch support for --timing flag in verilator

### DIFF
--- a/cocotb/share/lib/verilator/verilator.cpp
+++ b/cocotb/share/lib/verilator/verilator.cpp
@@ -111,7 +111,10 @@ int main(int argc, char** argv) {
 #endif
         // cocotb controls the clock inputs using cbAfterDelay so
         // skip ahead to the next registered callback
-        vluint64_t next_time = VerilatedVpi::cbNextDeadline();
+        vluint64_t next_time_cocotb = VerilatedVpi::cbNextDeadline();
+        vluint64_t next_time_timing =
+            top->eventsPending() ? top->nextTimeSlot() : (vluint64_t)~0ULL;
+        vluint64_t next_time = std::min(next_time_cocotb, next_time_timing);
 
         // If there are no more cbAfterDelay callbacks,
         // the next deadline is max value, so end the simulation now

--- a/cocotb/share/lib/verilator/verilator.cpp
+++ b/cocotb/share/lib/verilator/verilator.cpp
@@ -111,14 +111,15 @@ int main(int argc, char** argv) {
 #endif
         // cocotb controls the clock inputs using cbAfterDelay so
         // skip ahead to the next registered callback
+        const vluint64_t NO_TOP_EVENTS_PENDING = static_cast<vluint64_t>(~0ULL);
         vluint64_t next_time_cocotb = VerilatedVpi::cbNextDeadline();
         vluint64_t next_time_timing =
-            top->eventsPending() ? top->nextTimeSlot() : (vluint64_t)~0ULL;
+            top->eventsPending() ? top->nextTimeSlot() : NO_TOP_EVENTS_PENDING;
         vluint64_t next_time = std::min(next_time_cocotb, next_time_timing);
 
         // If there are no more cbAfterDelay callbacks,
         // the next deadline is max value, so end the simulation now
-        if (next_time == static_cast<vluint64_t>(~0ULL)) {
+        if (next_time == NO_TOP_EVENTS_PENDING) {
             break;
         } else {
             main_time = next_time;


### PR DESCRIPTION
This PR adds a fix to error "Simulator shut down prematurely" when cocotb is used with Verilator and `--timing` parameter. The proposed fix is related to issue #3254

If the HDL code contains timing statements, e.g. `#10 clk = ~clk;`, then the Verilator should be called with a `--timing` flag. In current implementation Verilator shuts down prematurely, beacuse the call to `VerilatedVpi::cbNextDeadline()` returns uint64 max, meaning no more scheduled events (`cbNextDeadline()` is the deadline of the next registered VPI callback). If we want to support the Verilator's `--timing` flag, then a check must be performed to see if there are any events pending `top->eventsPending()` and then find the next time slot `top->nextTimeSlot()`. The next time step is then the smaller of time steps returned by `VerilatedVpi::cbNextDeadline()` and `top->nextTimeSlot()`

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
