### PR TITLE
Improve debugging documentation

### DIFF
--- a/documentation/source/troubleshooting.rst
+++ b/documentation/source/troubleshooting.rst
@@ -22,6 +22,26 @@ If things fail from within Python, or coroutines aren't being called when you ex
 :envvar:`COCOTB_SCHEDULER_DEBUG` variable can be used to (greatly) increase the verbosity of the scheduler.
 
 
+Building cocotb In Development Mode
+===================================
+
+By default cocotb binaries installed from PyPi are stripped, i.e. they do not contain debug symbols.
+Rebuilding cocotb from source can add this information back, making it significantly easier to debug cocotb code.
+In the following, we'll assume the use of a Linux machine for debugging cocotb, which simplifies the process significantly.
+
+First, install all build requirements as listed at :ref:`install-devel`.
+
+Then execute the following commands to download a development version of cocotb and prepare a shell environment with this a development build of cocotb available:
+
+.. code-block:: shell-session
+
+  $ # Obtain the latest development version of cocotb through git
+  $ git clone https://github.com/cocotb/cocotb.git
+  $ # Build cocotb in debug mode, and enter a bash shell
+  $ cd cocotb
+  $ nox -s dev -- /bin/bash
+
+
 .. _troubleshooting-attaching-debugger:
 
 Attaching a Debugger

--- a/documentation/source/troubleshooting.rst
+++ b/documentation/source/troubleshooting.rst
@@ -52,12 +52,38 @@ Attaching a Debugger
 C and C++
 ---------
 
-In order to give yourself time to attach a debugger to the simulator process before it starts to run,
-you can set the environment variable :envvar:`COCOTB_ATTACH` to a pause time value in seconds.
-If set, cocotb will print the process ID (PID) to attach to and wait the specified time before
-actually letting the simulator run.
+The most convenient way to debug the cocotb C code and the interaction between cocotb and the simulator is using GDB.
+This is a two-step process:
 
-For the GNU debugger GDB, the command is ``attach <process-id>``.
+1. Run the simulation with :envvar:`COCOTB_ATTACH` set.
+2. Use ``gdb -p`` to attach to the simulator process.
+
+Have a look at :ref:`building` for various useful variables related to debugging.
+
+Example:
+Debug the test ``test_array_simple`` with Questa, using the VHDL toplevel and the VHPI.
+
+1. Run the simulation and take note of the process identifier (PID) displayed after the simulator starts up.
+
+  .. code-block:: shell-session
+
+    $ make -C tests/test_cases/test_array_simple SIM=questa TOPLEVEL_LANG=vhdl VHDL_GPI_INTERFACE=vhpi COCOTB_ATTACH=300 COCOTB_LOG_LEVEL=trace
+    ...
+    #      -.--ns ERROR    gpi                                ..mbed/gpi_embed.cpp:154  in _embed_init_python              Waiting for 300 seconds - attach to PID 9583 with your debugger
+
+
+2. Open a new terminal window or tab, and attach GDB to the running process.
+
+  .. code-block:: shell-session
+
+    $ gdb -p 9583
+    ...
+    48        r = INTERNAL_SYSCALL_CANCEL (clock_nanosleep_time64, clock_id, flags, req,
+    (gdb) # Set breakpoints or do anything else you'd like to do. Finally, let the simulation run:
+    (gdb) continue
+    Continuing.
+    [Inferior 1 (process 9583) exited normally]
+    (gdb) quit
 
 .. _troubleshooting-attaching-debugger-python:
 


### PR DESCRIPTION
Document better how to build a debug version of cocotb, and then use GDB to find problems in the interaction with the simulator.

- Document how to build cocotb in development mode
- Document in more detail how to use GDB

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
