### PR TITLE
Update Icarus Verilog build to support WAVES environment variable, 2023 version

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -69,9 +69,23 @@ ifdef VERILOG_INCLUDE_DIRS
 endif
 
 # Compilation phase
+
+ifeq ($(WAVES), 1)
+    VERILOG_SOURCES += $(SIM_BUILD)/iverilog_dump.v
+    COMPILE_ARGS += -s iverilog_dump
+endif
+
 $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	@echo "+timescale+$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)" > $(SIM_BUILD)/cmds.f
 	$(CMD) -o $(SIM_BUILD)/sim.vvp -D COCOTB_SIM=1 $(TOPMODULE_ARG) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+
+$(SIM_BUILD)/iverilog_dump.v: | $(SIM_BUILD)
+	@echo 'module iverilog_dump();' > $@
+	@echo 'initial begin' >> $@
+	@echo '    $$dumpfile("$(SIM_BUILD)/$(TOPLEVEL).vcd");' >> $@
+	@echo '    $$dumpvars(0, $(TOPLEVEL));' >> $@
+	@echo 'end' >> $@
+	@echo 'endmodule' >> $@
 
 # Execution phase
 

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -71,18 +71,19 @@ endif
 # Compilation phase
 
 ifeq ($(WAVES), 1)
-    VERILOG_SOURCES += $(SIM_BUILD)/iverilog_dump.v
-    COMPILE_ARGS += -s iverilog_dump
+    VERILOG_SOURCES += $(SIM_BUILD)/cocotb_iverilog_dump.v
+    COMPILE_ARGS += -s cocotb_iverilog_dump
+    PLUSARGS += -fst
 endif
 
 $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	@echo "+timescale+$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)" > $(SIM_BUILD)/cmds.f
 	$(CMD) -o $(SIM_BUILD)/sim.vvp -D COCOTB_SIM=1 $(TOPMODULE_ARG) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
-$(SIM_BUILD)/iverilog_dump.v: | $(SIM_BUILD)
-	@echo 'module iverilog_dump();' > $@
+$(SIM_BUILD)/cocotb_iverilog_dump.v: | $(SIM_BUILD)
+	@echo 'module cocotb_iverilog_dump();' > $@
 	@echo 'initial begin' >> $@
-	@echo '    $$dumpfile("$(SIM_BUILD)/$(TOPLEVEL).vcd");' >> $@
+	@echo '    $$dumpfile("$(SIM_BUILD)/$(TOPLEVEL).fst");' >> $@
 	@echo '    $$dumpvars(0, $(TOPLEVEL));' >> $@
 	@echo 'end' >> $@
 	@echo 'endmodule' >> $@

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -265,8 +265,8 @@ The following variables are makefile variables, not environment variables.
 
 .. make:var:: WAVES
 
-      Set this to 1 to enable wave traces dump for the Aldec Riviera-PRO and Mentor Graphics Questa simulators.
-      To get wave traces in Icarus Verilog see :ref:`sim-icarus-waveforms`.
+      Set this to 1 to enable wave traces dump for the Aldec Riviera-PRO, Mentor Graphics Questa, and Icarus Verilog simulators.
+      To get wave traces in Verilator see :ref:`sim-verilator-waveforms`.
 
 .. make:var:: TOPLEVEL_LANG
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -47,28 +47,15 @@ See also https://github.com/steveicarus/iverilog/issues/323.
 Waveforms
 ---------
 
-To get waveforms in VCD format some Verilog code must be added
-to the top component as shown in the example below:
+Icarus Verilog can produce waveform traces in the FST format, the native format of GTKWave.
+FST traces are much smaller and more efficient to write than VCD, but requires the use of GTKWave.
 
-.. code-block:: verilog
+To enable FST tracing, set :make:var:`WAVES` to ``1``. This can be set on the command line,
+as shown below, or as an environment variable with an ``EXPORT`` statement in your shell.
 
-    module button_deb(
-        input  clk,
-        input  rst,
-        input  button_in,
-        output button_valid);
+.. code-block:: bash
 
-    //... Verilog module code here
-
-    // the "macro" to dump signals
-    `ifdef COCOTB_SIM
-    initial begin
-      $dumpfile ("button_deb.vcd");
-      $dumpvars (0, button_deb);
-      #1;
-    end
-    `endif
-    endmodule
+    make SIM=icarus WAVES=1
 
 .. _sim-icarus-issues:
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -50,8 +50,7 @@ Waveforms
 Icarus Verilog can produce waveform traces in the FST format, the native format of GTKWave.
 FST traces are much smaller and more efficient to write than VCD, but requires the use of GTKWave.
 
-To enable FST tracing, set :make:var:`WAVES` to ``1``. This can be set on the command line,
-as shown below, or as an environment variable with an ``EXPORT`` statement in your shell.
+To enable FST tracing, set :make:var:`WAVES` to ``1``.
 
 .. code-block:: bash
 

--- a/examples/simple_dff/dff.sv
+++ b/examples/simple_dff/dff.sv
@@ -12,12 +12,4 @@ always @(posedge clk) begin
   q <= d;
 end
 
-// the "macro" to dump signals
-`ifdef COCOTB_SIM
-initial begin
-  $dumpfile ("dff.vcd");
-  $dumpvars (0, dff);
-  #1;
-end
-`endif
 endmodule


### PR DESCRIPTION
Details:
- Update Makefile.icarus to support WAVES by creating an iverilog_dump.v file that is automatically added to the build.
- Remove VCD support from examples/simple_dff/dff.sv

This is basically an updated version of PR #2239 against current top-of-tree. It generates a VCD instead of an FST. And it puts the waveform file in `sim_build/`.
