### PR TITLE
fix urls in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 * Read the [documentation](https://docs.cocotb.org)
 * Get involved:
   * [Raise a bug / request an enhancement](https://github.com/cocotb/cocotb/issues/new) (Requires a GitHub account)
-  * [Join the mailing list](https://lists.librecores.org/listinfo/cocotb)
   * [Join the Gitter chat room](https://gitter.im/cocotb/Lobby)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * Get involved:
   * [Raise a bug / request an enhancement](https://github.com/cocotb/cocotb/issues/new) (Requires a GitHub account)
   * [Join the mailing list](https://lists.librecores.org/listinfo/cocotb)
-  * [Join the Gitter chat room](https://gitter.im/cocotb)
+  * [Join the Gitter chat room](https://gitter.im/cocotb/Lobby)
 
 ## Installation
 


### PR DESCRIPTION
closes #3328 

Remove the mailing list url and add the right url for the gitter lobby