### PR TITLE
Small improvements in preparation for a 1.8 release

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -50,7 +50,7 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "ghdl": ("https://ghdl.readthedocs.io/en/latest", None),
+    "ghdl": ("https://ghdl.github.io/ghdl", None),
     "scapy": ("https://scapy.readthedocs.io/en/latest", None),
     "pytest": ("https://docs.pytest.org/en/latest/", None),
 }

--- a/documentation/source/newsfragments/3045.feature.rst
+++ b/documentation/source/newsfragments/3045.feature.rst
@@ -1,1 +1,1 @@
-Add support for :class:`fraction.Fraction` and :class:`decimal.Decimal` to the `` period`` argument of :class:`cocotb.clock.Clock`.
+Add support for :class:`fraction.Fraction` and :class:`decimal.Decimal` to the ``period`` argument of :class:`cocotb.clock.Clock`.

--- a/documentation/source/newsfragments/3092.change.rst
+++ b/documentation/source/newsfragments/3092.change.rst
@@ -1,1 +1,0 @@
-Python 3.11 is now supported.

--- a/documentation/source/newsfragments/3103.feature.rst
+++ b/documentation/source/newsfragments/3103.feature.rst
@@ -1,0 +1,1 @@
+This release adds the :ref:`Python Test Runner <howto-python-runner>`, an experimental replacement for the traditional Makefile-based build and run flow.

--- a/documentation/source/newsfragments/3229.bugfix.rst
+++ b/documentation/source/newsfragments/3229.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a performance regression when using Questa with FLI introduced in cocotb 1.7.0.

--- a/documentation/source/newsfragments/3316.feature.rst
+++ b/documentation/source/newsfragments/3316.feature.rst
@@ -1,0 +1,1 @@
+Cocotb can now correctly drive Verilator when its new ``--timing`` flag is used.

--- a/documentation/source/newsfragments/3324.feature.rst
+++ b/documentation/source/newsfragments/3324.feature.rst
@@ -1,0 +1,1 @@
+Creating an FST waveform dump in Icarus Verilog can now be done by setting the :envvar:`WAVES` environment variable. Icarus-specific Verilog code is no longer required.

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -11,6 +11,20 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 
 .. towncrier release notes start
 
+cocotb 1.7.2 (2022-11-15)
+=========================
+
+Changes
+-------
+- Python 3.11 is now supported.
+- ``find_libpython``, a library to find (as the name indicates) libpython, is now a dependency of cocotb.
+  Its latest version resolves an issue for users on RedHat Enterprise Linux (RHEL) 8 and Python 3.8, where the correct Python library would not be detected. (:issue:`3097`)
+
+Bugfixes
+--------
+
+- Fixed a segmentation fault in Aldec Riviera-PRO that prevented mixed-language simulation from running. (:issue:`3078`)
+
 cocotb 1.7.1 (2022-09-17)
 =========================
 

--- a/documentation/source/runner.rst
+++ b/documentation/source/runner.rst
@@ -32,7 +32,7 @@ with the relevant part shown here:
 .. literalinclude:: ../../examples/simple_dff/test_dff.py
    :language: python3
    :start-at: def test_simple_dff_runner():
-   :end-at: runner.test(hdl_toplevel="dff", test_module="test_dff")
+   :end-at: runner.test(hdl_toplevel="dff", test_module="test_dff,")
 
 You run this file with pytest like
 


### PR DESCRIPTION
Small documentation improvements in preparation for the next release.

- Update intersphinx link to GHDL
- Import release notes for version 1.7.2
- Docs: Fix RST issue in runner docs
- Docs: Add more newsfragments for changes
