### PR TITLE
Testcase with Verilator's --timing option

### DIFF
--- a/tests/test_cases/test_3316/Makefile
+++ b/tests/test_cases/test_3316/Makefile
@@ -1,0 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+all:
+	@echo "Always skip this directory. Relevant tests are in test_3316_[a-d] directories."

--- a/tests/test_cases/test_3316/README.md
+++ b/tests/test_cases/test_3316/README.md
@@ -1,0 +1,31 @@
+## Motivation
+
+These test cases provided are meant to validate behavior of `cocotb` with `verilator` simulations, if timing statements are used in HDL code. Here, the term 'timing statements' refers to HDL statements which control the simulation time. The simplest example of such a statement is:
+
+    initial begin: proc_delay
+        #(10)
+            clk = ~clk;
+    end
+
+Starting with Verilator 5, if timing statements are present in code, [the simulator expects the user to specify their desired method of processing timing statements with additional flags](https://veripool.org/guide/latest/exe_verilator.html#cmdoption-no-timing). This is a result of changes made to [Verilator's Model Evaluation Loop](https://veripool.org/guide/latest/connecting.html#wrappers-and-model-evaluation-loop). The issue with Verilating was first reported in [#3254](https://github.com/cocotb/cocotb/issues/3254) and fixed by PR [#3316](https://github.com/cocotb/cocotb/pull/3316).
+
+## Test implementation
+In `test_3316_[a-d].py`, 2 cocotb tests are defined: `clk_in_coroutine` and `clk_in_hdl`. The first one provides a clock generator in the coroutine, but the other one expects that a clock generator is placed in the HDL code (c.f. `test_3316.sv`). Additionally, test behavior is controlled with 2 settings: verilator's `--timing` option and `TEST_CLK_EXTERNAL` macro. The `--timing` option determines how Verilator should process timing statements. The Verilog macro is used to control whether the clock generator is present in the Verilog code. A table below summarizes all used test configurations and the expected test behavior.
+
+### `clk_in_coroutine`
+
+| Case  |     Flag:external_clock     | timing_option |  Clock generator  |                  Description                  |
+| :---: | :-------------------------: | :-----------: | :---------------: | :-------------------------------------------: |
+|   A   |            None             |     None      | HDL AND Coroutine | Expected fail: Verilator needs timing options |
+|   B   | +define+TEST_CLK_EXTERNAL=1 |     None      |     Coroutine     |        Expected pass: regression case         |
+|   C   |            None             |   --timing    | HDL AND Coroutine |     Expected pass: since #3316 is merged      |
+|   D   | +define+TEST_CLK_EXTERNAL=1 |   --timing    |     Coroutine     |        Expected pass: regression case         |
+
+### `clk_in_hdl`
+
+| Case  |     Flag:external_clock     | timing_option | Clock generator |                  Description                   |
+| :---: | :-------------------------: | :-----------: | :-------------: | :--------------------------------------------: |
+|   A   |            None             |     None      |       HDL       | Expected fail: Verilator needs timing options  |
+|   B   | +define+TEST_CLK_EXTERNAL=1 |     None      |      None       | Expected fail: No events driving the simulator |
+|   C   |            None             |   --timing    |       HDL       |      Expected pass: since #3316 is merged      |
+|   D   | +define+TEST_CLK_EXTERNAL=1 |   --timing    |      None       | Expected fail: No events driving the simulator |

--- a/tests/test_cases/test_3316/test_3316.sv
+++ b/tests/test_cases/test_3316/test_3316.sv
@@ -1,0 +1,24 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+module test_3316 (
+`ifdef TEST_CLK_EXTERNAL
+    input  logic clk,
+`endif
+    input  logic d,
+    output logic q
+);
+
+`ifndef TEST_CLK_EXTERNAL
+  // Clocking
+  bit clk;
+  initial clk = 0;
+  always #5 clk = ~clk;
+`endif
+
+  always_ff @(posedge clk) begin : proc_dff
+    q <= d;
+  end
+
+endmodule : test_3316

--- a/tests/test_cases/test_3316_a/Makefile
+++ b/tests/test_cases/test_3316_a/Makefile
@@ -1,0 +1,21 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+TOPLEVEL_LANG ?= verilog
+SIM ?= verilator
+MODULE := test_3316_a
+VERILOG_SOURCES := ../test_3316/test_3316.sv
+TOPLEVEL := test_3316
+
+ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),verilog)
+all:
+	@echo "Skipping test since only Verilog is supported"
+else ifeq ($(filter verilator,$(shell echo $(SIM) | tr A-Z a-z)),)
+all:
+	@echo "Skipping test since only Verilator is supported"
+else ifeq ($(filter $(EXTRA_ARGS),--no-timing --timing),)
+all:
+	@echo "Skipping test since Verilator requires --timing or --no-timing option."
+else
+include $(shell cocotb-config --makefiles)/Makefile.sim
+endif

--- a/tests/test_cases/test_3316_a/test_3316_a.py
+++ b/tests/test_cases/test_3316_a/test_3316_a.py
@@ -1,0 +1,31 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge
+
+
+@cocotb.test()
+async def clk_in_coroutine(dut):
+    dut.d.value = 0
+    clock = Clock(dut.clk, 10, units="us")
+    cocotb.start_soon(clock.start(start_high=False))
+    await RisingEdge(dut.clk)
+    for _ in range(3):
+        val = random.randint(0, 1)
+        dut.d.value = val
+        await RisingEdge(dut.clk)
+
+
+@cocotb.test()
+async def clk_in_hdl(dut):
+    dut.d.value = 0
+    await RisingEdge(dut.clk)
+    for _ in range(3):
+        val = random.randint(0, 1)
+        dut.d.value = val
+        await RisingEdge(dut.clk)

--- a/tests/test_cases/test_3316_b/Makefile
+++ b/tests/test_cases/test_3316_b/Makefile
@@ -1,0 +1,20 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+TOPLEVEL_LANG ?= verilog
+SIM ?= verilator
+MODULE := test_3316_b
+VERILOG_SOURCES := ../test_3316/test_3316.sv
+TOPLEVEL := test_3316
+
+EXTRA_ARGS="+define+TEST_CLK_EXTERNAL=1"
+
+ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),verilog)
+all:
+	@echo "Skipping test since only Verilog is supported"
+else ifeq ($(filter verilator,$(shell echo $(SIM) | tr A-Z a-z)),)
+all:
+	@echo "Skipping test since only Verilator is supported"
+else
+include $(shell cocotb-config --makefiles)/Makefile.sim
+endif

--- a/tests/test_cases/test_3316_b/test_3316_b.py
+++ b/tests/test_cases/test_3316_b/test_3316_b.py
@@ -1,0 +1,37 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.result import SimFailure
+from cocotb.triggers import RisingEdge
+
+
+@cocotb.test()
+async def clk_in_coroutine(dut):
+    dut.d.value = 0
+    clock = Clock(dut.clk, 10, units="us")
+    cocotb.start_soon(clock.start(start_high=False))
+    await RisingEdge(dut.clk)
+    for _ in range(3):
+        val = random.randint(0, 1)
+        dut.d.value = val
+        await RisingEdge(dut.clk)
+
+
+@cocotb.test(expect_error=SimFailure)
+async def clk_in_hdl(dut):
+    try:
+        dut.d.value = 0
+        await RisingEdge(dut.clk)
+        for _ in range(3):
+            val = random.randint(0, 1)
+            dut.d.value = val
+            await RisingEdge(dut.clk)
+    except SimFailure:
+        pass
+    else:
+        assert False, "Exception did not occur"

--- a/tests/test_cases/test_3316_c/Makefile
+++ b/tests/test_cases/test_3316_c/Makefile
@@ -1,0 +1,23 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+TOPLEVEL_LANG ?= verilog
+SIM ?= verilator
+MODULE := test_3316_c
+VERILOG_SOURCES := ../test_3316/test_3316.sv
+TOPLEVEL := test_3316
+
+EXTRA_ARGS="--timing"
+
+ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),verilog)
+all:
+	@echo "Skipping test since only Verilog is supported"
+else ifeq ($(filter verilator,$(shell echo $(SIM) | tr A-Z a-z)),)
+all:
+	@echo "Skipping test since only Verilator is supported"
+else ifneq ($(shell ./check_version 2>/dev/null 1>&2; echo $$?),0)
+all:
+	@echo "Skipping test since it requires newer version of cocotb"
+else
+include $(shell cocotb-config --makefiles)/Makefile.sim
+endif

--- a/tests/test_cases/test_3316_c/check_version
+++ b/tests/test_cases/test_3316_c/check_version
@@ -1,0 +1,25 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#!/bin/bash
+
+VERSION=`cocotb-config --version`
+MIN_VERSION="1.8.0"
+echo "----------------------------------------"
+echo "cocotb-config       : $VERSION"
+echo "Minimum requirement : $MIN_VERSION"
+echo "----------------------------------------"
+
+# If set {MIN_VERSION, VERSION} is sorted in ascending order, then returns 0
+printf '%s\n' "$MIN_VERSION" "$VERSION" | sort --version-sort --check=silent
+RES=$?
+if [ $RES -eq 0 ]; then
+    echo "Minimum requirement is met"
+    echo "----------------------------------------"
+    exit 0
+else
+    echo "Minimum requirement not met"
+    echo "----------------------------------------"
+    exit 1
+fi

--- a/tests/test_cases/test_3316_c/test_3316_c.py
+++ b/tests/test_cases/test_3316_c/test_3316_c.py
@@ -1,0 +1,31 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge
+
+
+@cocotb.test()
+async def clk_in_coroutine(dut):
+    dut.d.value = 0
+    clock = Clock(dut.clk, 10, units="us")
+    cocotb.start_soon(clock.start(start_high=False))
+    await RisingEdge(dut.clk)
+    for _ in range(3):
+        val = random.randint(0, 1)
+        dut.d.value = val
+        await RisingEdge(dut.clk)
+
+
+@cocotb.test()
+async def clk_in_hdl(dut):
+    dut.d.value = 0
+    await RisingEdge(dut.clk)
+    for _ in range(3):
+        val = random.randint(0, 1)
+        dut.d.value = val
+        await RisingEdge(dut.clk)

--- a/tests/test_cases/test_3316_d/Makefile
+++ b/tests/test_cases/test_3316_d/Makefile
@@ -1,0 +1,20 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+TOPLEVEL_LANG ?= verilog
+SIM ?= verilator
+MODULE := test_3316_d
+VERILOG_SOURCES := ../test_3316/test_3316.sv
+TOPLEVEL := test_3316
+
+EXTRA_ARGS="+define+TEST_CLK_EXTERNAL=1 --timing"
+
+ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),verilog)
+all:
+	@echo "Skipping test since only Verilog is supported"
+else ifeq ($(filter verilator,$(shell echo $(SIM) | tr A-Z a-z)),)
+all:
+	@echo "Skipping test since only Verilator is supported"
+else
+include $(shell cocotb-config --makefiles)/Makefile.sim
+endif

--- a/tests/test_cases/test_3316_d/test_3316_d.py
+++ b/tests/test_cases/test_3316_d/test_3316_d.py
@@ -1,0 +1,37 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.result import SimFailure
+from cocotb.triggers import RisingEdge
+
+
+@cocotb.test()
+async def clk_in_coroutine(dut):
+    dut.d.value = 0
+    clock = Clock(dut.clk, 10, units="us")
+    cocotb.start_soon(clock.start(start_high=False))
+    await RisingEdge(dut.clk)
+    for _ in range(3):
+        val = random.randint(0, 1)
+        dut.d.value = val
+        await RisingEdge(dut.clk)
+
+
+@cocotb.test(expect_error=SimFailure)
+async def clk_in_hdl(dut):
+    try:
+        dut.d.value = 0
+        await RisingEdge(dut.clk)
+        for _ in range(3):
+            val = random.randint(0, 1)
+            dut.d.value = val
+            await RisingEdge(dut.clk)
+    except SimFailure:
+        pass
+    else:
+        assert False, "Exception did not occur"


### PR DESCRIPTION
#### Motivation

This PR adds test cases for Verilator's support of timing statements. If HDL code contains timing statements, then either `--timing` or `--no-timing` option must be used to select Verilator's behavior. Tests are related to functionality added in PR #3316.


#### Test description

Tests are split into 5 directories: 1 common `test_3316` and 4 for each test case `test_3316_[a-d]`. Details of execution are documented in `test_3316/README.md`. Each directory contains a Makefile so that tests are compatible with regression tests. Some tests are expected to fail and they are safe-guarded to prevent blocking next tests.
