### PR TITLE
Fix importing DLLs on wine

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -40,6 +40,10 @@ import warnings
 from collections.abc import Coroutine
 from typing import Dict, List, Optional, Union
 
+if os.name == "nt":
+    _libs_dir = os.path.join(os.path.dirname(__file__), "libs")
+    os.add_dll_directory(_libs_dir)
+
 import cocotb.handle
 from cocotb._deprecation import deprecated
 from cocotb.log import default_config


### PR DESCRIPTION
I encountered the following error in wine:

```
0034:err:module:import_dll Library cocotbutils.dll (which is needed by L"C:\\Program Files\\Python311\\Lib\\site-packages\\cocotb\\simulator.cp311-win_amd64.pyd") not found 0034:err:module:import_dll Library gpilog.dll (which is needed by L"C:\\Program Files\\Python311\\Lib\\site-packages\\cocotb\\simulator.cp311-win_amd64.pyd") not found 0034:err:module:import_dll Library gpi.dll (which is needed by L"C:\\Program Files\\Python311\\Lib\\site-packages\\cocotb\\simulator.cp311-win_amd64.pyd") not found 0034:err:module:import_dll Library pygpilog.dll (which is needed by L"C:\\Program Files\\Python311\\Lib\\site-packages\\cocotb\\simulator.cp311-win_amd64.pyd") not found Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Program Files\Python311\Scripts\cocotb-config.exe\__main__.py", line 4, in <module>
  File "C:\Program Files\Python311\Lib\site-packages\cocotb\__init__.py", line 43, in <module>
    import cocotb.handle
  File "C:\Program Files\Python311\Lib\site-packages\cocotb\handle.py", line 39, in <module>
    from cocotb import simulator
ImportError: DLL load failed while importing simulator: Module not found.
```

The fix is simple, but I'm surprised no one else has seen it.