### PR TITLE
Questa/ModelSim and Riviera pre_cmd test argument

### DIFF
--- a/documentation/source/newsfragments/3344.feature.rst
+++ b/documentation/source/newsfragments/3344.feature.rst
@@ -1,0 +1,1 @@
+Add `pre_cmd` in :ref:`Python Test Runner <howto-python-runner>` for Questa simulator to run given commands before simulation start


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

This feature extremely useful at least for me :) A similiar variable exist in Makefile flow: `SCRIPT_FILE`. `pre_cmd` makes possible:

**1. Save coverage file.**

```
runner.test(
        ...
        pre_cmd=["coverage save -onexit covres.ucdb;"],
        ...
    )
```

Which is impossible (AFAIK) in the cocotb + Questa/Modelsim suite in batch mode at the moment.

**2. Set up waveforms if restart!**

```
runner.test(
        ...
        pre_cmd=["do wave.do;"],
        ...
    )
```

**3. For sure, we can mix the things**

```
runner.test(
        ...
        pre_cmd=["coverage save -onexit covres.ucdb; do wave.do;"],
        ...
    )
```

I also added this command to the Riviera flow, but I have no chance to test it.