### PR TITLE
`clean` argument for runner

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -151,6 +151,7 @@ class Simulator(abc.ABC):
         hdl_toplevel: Optional[str] = None,
         always: bool = False,
         build_dir: PathLike = "sim_build",
+        clean: bool = False,
         verbose: bool = False,
     ) -> None:
         """Build the HDL sources.
@@ -166,10 +167,14 @@ class Simulator(abc.ABC):
             hdl_toplevel: The name of the HDL toplevel module.
             always: Always run the build step.
             build_dir: Directory to run the build step in.
+            clean: Delete build_dir before building
             verbose: Enable verbose messages.
         """
 
+        self.clean: bool = clean
         self.build_dir = get_abs_path(build_dir)
+        if self.clean:
+            self.rm_build_folder(self.build_dir)
         os.makedirs(self.build_dir, exist_ok=True)
 
         # note: to avoid mutating argument defaults, we ensure that no value
@@ -362,6 +367,11 @@ class Simulator(abc.ABC):
                 raise SystemExit(
                     f"Process {process.args[0]!r} terminated with error {process.returncode}"
                 )
+
+    def rm_build_folder(self, build_dir: Path):
+        if os.path.isdir(build_dir):
+            print("Removing:", build_dir)
+            shutil.rmtree(build_dir, ignore_errors=True)
 
 
 def get_results(results_xml_file: Path) -> Tuple[int, int]:

--- a/documentation/source/newsfragments/3351.feature.rst
+++ b/documentation/source/newsfragments/3351.feature.rst
@@ -1,0 +1,1 @@
+Add `clean` argument to :ref:`Python Test Runner <howto-python-runner>` to remove build_dir completely during runner.build() stage


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

The argument might be used for 100% pure rebuild the testbench and delete any previous results such as build artifacts, simulator libraries and so on.

Actually, simple copy-paste of [cocotb-test](https://github.com/themperek/cocotb-test/blob/32b19b0813ae40cefc2b6d5bf1a1a715682fb18c/cocotb_test/simulator.py#L1219) with minor editing, because cocotb runner knows exact path to the building directory thanks to build_dir argument.

Not sure about tests, it could be something like:

1. create `build_dir` before `runner.build()` call
2. put some file into folder
3. run `runner.build()`
4. assert file in the folder. Must be `false` for `clean` build, `true` for `non-clean` build.

Looks a bit poor, but still... Feedback is welcome :)