### PR TITLE
Use vendored fork of domaintools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,12 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-exclude: "^cocotb/_vendor"
+exclude: "^.*/_vendor/"
 repos:
 - repo: "https://github.com/psf/black"
   rev: "22.3.0"
   hooks:
   - id: "black"
-    args:
-    - "."
 
 - repo: "https://github.com/pycqa/isort"
   rev: "5.12.0"
@@ -17,7 +15,6 @@ repos:
   - id: "isort"
     args:
     - "--profile=black"
-    - "."
 
 - repo: "https://github.com/pycqa/flake8"
   rev: "3.9.2"

--- a/documentation/_vendor/README.md
+++ b/documentation/_vendor/README.md
@@ -1,0 +1,9 @@
+# Vendored libraries
+
+## sphinxcontrib-domaintools
+
+This was vendored in to fix warning that occur when building cocotb's documentation.
+It could not be fixed upstream because the project has been abandoned.
+
+Based on sphinx-contrib/domaintools@cc6a5dcb3204325f52d160a0da7e097f3a825c8c.
+Applied sphinx-contrib/domaintools#7 and sphinx-contrib-domaintools#13.

--- a/documentation/_vendor/domaintools/LICENSE.txt
+++ b/documentation/_vendor/domaintools/LICENSE.txt
@@ -1,0 +1,69 @@
+License for domaintools
+=======================
+
+Copyright (c) 2012, Kay-Uwe (Kiwi) Lorenz, ModuleWorks GmbH
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of the ModuleWorks GmbH nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL "Kay-Uwe (Kiwi) Lorenz" BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+License for incorporated Software
+=================================
+
+--------------------------------------------------------------------------
+The major part of code of domaintools is taken from `sphinx.domains.std`, 
+so here is incorporated the license for sphinx itself:
+--------------------------------------------------------------------------
+
+License for Sphinx
+------------------
+
+Copyright (c) 2007-2013 by the Sphinx team (see AUTHORS file).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/documentation/_vendor/domaintools/MANIFEST.in
+++ b/documentation/_vendor/domaintools/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.rst
+include LICENSE.txt

--- a/documentation/_vendor/domaintools/README.rst
+++ b/documentation/_vendor/domaintools/README.rst
@@ -1,0 +1,96 @@
+Domain Tools
+============
+
+This `Sphinx extension`_ provides a tool for easy `sphinx domain`_ creation.
+
+.. _Sphinx extension: http://sphinx-doc.org
+.. _sphinx domain: http://sphinx-doc.org/domains.html
+
+
+Installation
+------------
+
+::
+
+    pip install sphinxcontrib-domaintools
+
+
+Usage
+-----
+
+In this example there is created a simple domain for `GNU Make`_::
+
+    from sphinxcontrib.domaintools import custom_domain
+
+    def setup(app):
+        app.add_domain(custom_domain('GnuMakeDomain',
+            name  = 'make',
+            label = "GNU Make", 
+
+            elements = dict(
+                target = dict(
+                    objname      = "Make Target",
+                    indextemplate = "pair: %s; Make Target",
+                ),
+                var   = dict(
+                    objname = "Make Variable",
+                    indextemplate = "pair: %s; Make Variable"
+                ),
+            )))
+
+.. _GNU Make: http://www.gnu.org/software/make/
+
+Complete example you find in `sphinxcontrib.makedomain`_ package.
+
+A more complex example you can find in `sphinxcontrib-cmakedomain`_ package.
+
+.. _sphinxcontrib-cmakedomain: http://bitbucket.org/klorenz/sphinxcontrib-cmakedomain
+.. _sphinxcontrib-makedomain: http://bitbucket.org/klorenz/sphinxcontrib-makedomain
+
+
+Reference
+---------
+
+.. py:function:: custom_domain(class_name, name='', label='', elements = {}):
+
+    Create a custom domain.
+
+    For each given element there are created a directive and a role
+    for referencing and indexing.
+
+    :param class_name: ClassName of your new domain (e.g. `GnuMakeDomain`)
+    :param name      : short name of your domain (part of directives, e.g. `make`)
+    :param label     : Long name of your domain (e.g. `GNU Make`)
+    :param elements  :
+        dictionary of your domain directives/roles
+
+        An element value is a dictionary with following possible entries:
+
+        - `objname` - Long name of the entry, defaults to entry's key
+
+        - `role` - role name, defaults to entry's key
+
+        - `indextemplate` - e.g. ``pair: %s; Make Target``, where %s will be 
+          the matched part of your role.  You may leave this empty, defaults 
+          to ``pair: %s; <objname>``
+
+        - `parse_node` - a function with signature ``(env, sig, signode)``,
+          defaults to `None`.
+
+        - `fields` - A list of fields where parsed fields are mapped to. this
+          is passed to Domain as `doc_field_types` parameter.
+
+        - `ref_nodeclass` - class passed as XRefRole's innernodeclass,
+          defaults to `None`.
+
+
+License
+-------
+
+New BSD License.
+
+
+Author
+------
+
+`Kay-Uwe (Kiwi) Lorenz <kiwi@franka.dyndns.org>`_ (http://quelltexter.org)

--- a/documentation/_vendor/domaintools/README.rst
+++ b/documentation/_vendor/domaintools/README.rst
@@ -93,4 +93,4 @@ New BSD License.
 Author
 ------
 
-`Kay-Uwe (Kiwi) Lorenz <kiwi@franka.dyndns.org>`_ (http://quelltexter.org)
+`Kay-Uwe (Kiwi) Lorenz <tabkiwi@gmail.com>`_

--- a/documentation/_vendor/domaintools/setup.cfg
+++ b/documentation/_vendor/domaintools/setup.cfg
@@ -1,0 +1,6 @@
+[egg_info]
+;tag_build = dev
+;tag_date = true
+
+[aliases]
+release = egg_info -RDb ''

--- a/documentation/_vendor/domaintools/setup.py
+++ b/documentation/_vendor/domaintools/setup.py
@@ -1,0 +1,44 @@
+# from aptk.__version__ import release
+import sys, os
+
+from setuptools import setup, find_packages
+
+long_desc = '''
+This package contains tools for easy sphinx domain creation.
+'''
+
+# Package versioning solution originally found here:
+# http://stackoverflow.com/q/458550
+version_path = os.path.join('sphinxcontrib', 'domaintools', '_version.py')
+exec(open(version_path).read())
+
+requires = ['Sphinx>=1.0']
+
+setup(
+    name='sphinxcontrib-domaintools',
+    version=__version__,
+    url='http://bitbucket.org/klorenz/sphinxcontrib-domaintools',
+    download_url='http://pypi.python.org/pypi/sphinxcontrib-domaintools',
+    license='BSD',
+    author='Kay-Uwe (Kiwi) Lorenz',
+    author_email='kiwi@franka.dyndns.org',
+    description='Sphinx extension for easy domain creation.',
+    long_description=long_desc,
+    zip_safe=False,
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Documentation',
+        'Topic :: Utilities',
+    ],
+    platforms='any',
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=requires,
+    namespace_packages=['sphinxcontrib'],
+)

--- a/documentation/_vendor/domaintools/sphinxcontrib/__init__.py
+++ b/documentation/_vendor/domaintools/sphinxcontrib/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib
+    ~~~~~~~~~~~~~
+
+    This package is a namespace package that contains all extensions
+    distributed in the ``sphinx-contrib`` distribution.
+
+    :copyright: Copyright 2007-2009 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+__import__('pkg_resources').declare_namespace(__name__)
+

--- a/documentation/_vendor/domaintools/sphinxcontrib/domaintools/__init__.py
+++ b/documentation/_vendor/domaintools/sphinxcontrib/domaintools/__init__.py
@@ -75,7 +75,7 @@ class GenericObject(ObjectDescription):
                 indextype = 'single'
                 indexentry = self.indextemplate % (name,)
             self.indexnode['entries'].append((indextype, indexentry,
-                                              targetname, ''))
+                                              targetname, '', None))
         self.env.domaindata[self.domain]['objects'][self.objtype, name] = \
             self.env.docname, targetname
 

--- a/documentation/_vendor/domaintools/sphinxcontrib/domaintools/__init__.py
+++ b/documentation/_vendor/domaintools/sphinxcontrib/domaintools/__init__.py
@@ -106,7 +106,7 @@ class CustomDomain(Domain):
     def clear_doc(self, docname):
       if 'objects' in self.data:
        
-        for key, (fn, _) in self.data['objects'].items():
+        for key, (fn, _) in list(self.data['objects'].items()):
             if fn == docname:
                 del self.data['objects'][key]
 
@@ -125,7 +125,7 @@ class CustomDomain(Domain):
                             labelid, contnode)
 
     def get_objects(self):
-        for (type, name), info in self.data['objects'].items():
+        for (type, name), info in list(self.data['objects'].items()):
             yield (name, name, type, info[0], info[1],
                    self.object_types[type].attrs['searchprio'])
 

--- a/documentation/_vendor/domaintools/sphinxcontrib/domaintools/__init__.py
+++ b/documentation/_vendor/domaintools/sphinxcontrib/domaintools/__init__.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib.domaintools
+    =========================
+
+    Code is taken from `sphinx.domains.std`_ and is 
+    parameterized for easy domain creation.
+
+    :copyright: Kay-Uwe (Kiwi) Lorenz, ModuleWorks GmbH
+    :license: BSD, see LICENSE.txt for details
+
+
+    sphinx.domains.std
+    ~~~~~~~~~~~~~~~~~~
+
+    The standard domain.
+
+    :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+import unicodedata
+
+from docutils import nodes
+
+from sphinx import addnodes
+from sphinx.roles import XRefRole
+from sphinx.domains import Domain, ObjType
+from sphinx.directives import ObjectDescription
+from sphinx.util import ws_re
+from sphinx.util.nodes import clean_astext, make_refnode
+
+from ._version import __version__
+
+
+class GenericObject(ObjectDescription):
+    """
+    #  A generic x-ref directive registered with Sphinx.add_object_type().
+
+    Usage:
+        DomainObject = type('DomainObject', (GenericObject, object), dict(
+            domain = 'my-domain-name'))
+
+        DomainObject = type('DomainObject', (GenericObject, object), dict(
+            domain = 'my-domain-name', indextemplate=(
+
+        class MyDescriptionObject(GenericObject):
+    
+    """
+    indextemplate = ''
+    parse_node = None
+    domain = 'std'
+
+    def handle_signature(self, sig, signode):
+        if self.parse_node:
+            name = self.parse_node(self.env, sig, signode)
+        else:
+            signode.clear()
+            signode += addnodes.desc_name(sig, sig)
+            # normalize whitespace like XRefRole does
+            name = ws_re.sub('', sig)
+        return name
+
+    def add_target_and_index(self, name, sig, signode):
+        targetname = '%s-%s' % (self.objtype, name)
+        signode['ids'].append(targetname)
+        self.state.document.note_explicit_target(signode)
+        if self.indextemplate:
+            colon = self.indextemplate.find(':')
+            if colon != -1:
+                indextype = self.indextemplate[:colon].strip()
+                indexentry = self.indextemplate[colon+1:].strip() % (name,)
+            else:
+                indextype = 'single'
+                indexentry = self.indextemplate % (name,)
+            self.indexnode['entries'].append((indextype, indexentry,
+                                              targetname, ''))
+        self.env.domaindata[self.domain]['objects'][self.objtype, name] = \
+            self.env.docname, targetname
+
+class CustomDomain(Domain):
+    """
+    Domain for all objects that don't fit into another domain or are added
+    via the application interface.
+    """
+
+    name = 'std'
+    label = 'Default'
+
+    object_types = {
+    }
+
+    directives = {
+    }
+    roles = {
+    }
+
+    initial_data = {
+        'objects': {},      # (type, name) -> docname, labelid
+    }
+
+    dangling_warnings = {
+    }
+
+    def clear_doc(self, docname):
+      if 'objects' in self.data:
+       
+        for key, (fn, _) in self.data['objects'].items():
+            if fn == docname:
+                del self.data['objects'][key]
+
+    def resolve_xref(self, env, fromdocname, builder,
+                     typ, target, node, contnode):
+        objtypes = self.objtypes_for_role(typ) or []
+        for objtype in objtypes:
+            if (objtype, target) in self.data['objects']:
+                docname, labelid = self.data['objects'][objtype, target]
+                break
+        else:
+            docname, labelid = '', ''
+        if not docname:
+            return None
+        return make_refnode(builder, fromdocname, docname,
+                            labelid, contnode)
+
+    def get_objects(self):
+        for (type, name), info in self.data['objects'].items():
+            yield (name, name, type, info[0], info[1],
+                   self.object_types[type].attrs['searchprio'])
+
+    def get_type_name(self, type, primary=False):
+        # never prepend "Default"
+        return type.lname
+
+
+def custom_domain(class_name, name='', label='', elements = {}):
+    '''create a custom domain
+
+    For each given element there are created a directive and a role
+    for referencing and indexing.
+
+    :param class_name: ClassName of your new domain (e.g. `GnuMakeDomain`)
+    :param name      : short name of your domain (part of directives, e.g. `make`)
+    :param label     : Long name of your domain (e.g. `GNU Make`)
+    :param elements  :
+        dictionary of your domain directives/roles
+
+        An element value is a dictionary with following possible entries:
+
+        - `objname` - Long name of the entry, defaults to entry's key
+
+        - `role` - role name, defaults to entry's key
+
+        - `indextemplate` - e.g. ``pair: %s; Make Target``, where %s will be 
+          the matched part of your role.  You may leave this empty, defaults 
+          to ``pair: %s; <objname>``
+
+        - `parse_node` - a function with signature ``(env, sig, signode)``,
+          defaults to `None`.
+
+        - `fields` - A list of fields where parsed fields are mapped to. this
+          is passed to Domain as `doc_field_types` parameter.
+
+        - `ref_nodeclass` - class passed as XRefRole's innernodeclass,
+          defaults to `None`.
+
+    '''
+    domain_class = type(class_name, (CustomDomain, object), dict(
+        name  = name,
+        label = label,
+    ))
+
+    domain_object_class = \
+        type("%s_Object"%name, (GenericObject, object), dict(domain=name))
+
+    for n,e in elements.items():
+        obj_name = e.get('objname', n)
+        domain_class.object_types[n] = ObjType(
+            obj_name, e.get('role', n) )
+
+        domain_class.directives[n] = type(n, (domain_object_class, object), dict(
+            indextemplate   = e.get('indextemplate', 'pair: %%s; %s' % obj_name),
+            parse_node      = staticmethod(e.get('parse', None)),
+            doc_field_types = e.get('fields', []),
+            ))
+
+        domain_class.roles[e.get('role', n)] = XRefRole(innernodeclass=
+            e.get('ref_nodeclass', None))
+
+    return domain_class
+

--- a/documentation/_vendor/domaintools/sphinxcontrib/domaintools/_version.py
+++ b/documentation/_vendor/domaintools/sphinxcontrib/domaintools/_version.py
@@ -1,0 +1,8 @@
+# Package versioning solution originally found here:
+# http://stackoverflow.com/q/458550
+
+# Store the version here so:
+# 1) we don't load dependencies by storing it in __init__.py
+# 2) we can import it in setup.py for the same reason
+# 3) we can import it into your module
+__version__ = '0.4'

--- a/documentation/_vendor/domaintools/sphinxcontrib/domaintools/_version.py
+++ b/documentation/_vendor/domaintools/sphinxcontrib/domaintools/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '0.4'
+__version__ = "1000.0"

--- a/documentation/conda.yml
+++ b/documentation/conda.yml
@@ -6,4 +6,5 @@ dependencies:
   - pip
   # Packages installed from PyPI
   - pip:
+      - ./_vendor/domaintools
       - -r requirements.txt

--- a/noxfile.py
+++ b/noxfile.py
@@ -513,11 +513,18 @@ def release_test_nosim(session: nox.Session) -> None:
     session.log("All tests passed!")
 
 
+def create_env_for_docs_build(session: nox.Session) -> None:
+    session.run(
+        "pip", "install", "documentation/_vendor/domaintools"
+    )  # not done in requirements.txt due to the way relative paths are handled in that file (gh-pypa/pip#8765)
+    session.run("pip", "install", "-r", "documentation/requirements.txt")
+    session.run("pip", "install", "-e", ".")
+
+
 @nox.session
 def docs(session: nox.Session) -> None:
     """invoke sphinx-build to build the HTML docs"""
-    session.run("pip", "install", "-r", "documentation/requirements.txt")
-    session.run("pip", "install", "-e", ".")
+    create_env_for_docs_build(session)
     outdir = session.cache_dir / "docs_out"
     session.run(
         "sphinx-build", "./documentation/source", str(outdir), "--color", "-b", "html"
@@ -529,8 +536,7 @@ def docs(session: nox.Session) -> None:
 @nox.session
 def docs_linkcheck(session: nox.Session) -> None:
     """invoke sphinx-build to linkcheck the docs"""
-    session.run("pip", "install", "-r", "documentation/requirements.txt")
-    session.run("pip", "install", "-e", ".")
+    create_env_for_docs_build(session)
     outdir = session.cache_dir / "docs_out"
     session.run(
         "sphinx-build",
@@ -545,8 +551,7 @@ def docs_linkcheck(session: nox.Session) -> None:
 @nox.session
 def docs_spelling(session: nox.Session) -> None:
     """invoke sphinx-build to spellcheck the docs"""
-    session.run("pip", "install", "-r", "documentation/requirements.txt")
-    session.run("pip", "install", "-e", ".")
+    create_env_for_docs_build(session)
     outdir = session.cache_dir / "docs_out"
     session.run(
         "sphinx-build",
@@ -563,6 +568,7 @@ def dev(session: nox.Session) -> None:
     """Build a development environment and optionally run a command given as extra args"""
 
     configure_env_for_dev_build(session)
+    create_env_for_docs_build(session)
 
     session.run(
         "pip", "install", *test_deps, *dev_deps, *coverage_deps, *coverage_report_deps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ build-backend = "setuptools.build_meta"
 [tool.isort]
 profile = "black"
 extend_skip_glob = [
-    "cocotb/_vendor/*"
+    "*/_vendor/*"
 ]
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ source =
 [coverage:report]
 omit =
     */cocotb/config.py
-    */cocotb/_vendor/*
+    */_vendor/*
 exclude_lines =
     pragma: no cover
     # for excluding typing stubs


### PR DESCRIPTION
Closes #3314. Vendors in the [sphinxcontrib-domaintools](https://github.com/sphinx-contrib/domaintools) repo with the patches mentioned in https://github.com/cocotb/cocotb/issues/3314#issue-1719488035 applied. Unfortunately I had to add the dependency to the noxfile instead of the requirements file since relative paths in requirements.txt aren't handled very well (https://github.com/pypa/pip/issues/8765).