### PR TITLE
cocotb-clean CLI command

### DIFF
--- a/cocotb/clean.py
+++ b/cocotb/clean.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Clean cocotb build directories with CLI"""
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        default=False,
+        help="recursive delete build folders",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-d",
+        "--dirname",
+        default="sim_build",
+        type=str,
+        help="build folder name (default: %(default)s)",
+    )
+
+    return parser
+
+
+def rm_build_folder(build_dir: Path):
+    if os.path.isdir(build_dir):
+        print("Removing:", build_dir)
+        shutil.rmtree(build_dir, ignore_errors=True)
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    dir = os.getcwd()
+    rm_build_folder(os.path.join(dir, args.dirname))
+
+    if args.recursive:
+        dir = os.getcwd()
+        for dir, _, _ in os.walk(dir):
+            rm_build_folder(os.path.join(dir, args.dirname))
+
+
+if __name__ == "__main__":
+    main()

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -25,6 +25,7 @@ from xml.etree import cElementTree as ET
 
 import find_libpython
 
+import cocotb.clean
 import cocotb.config
 
 PathLike = Union["os.PathLike[str]", str]
@@ -174,7 +175,7 @@ class Simulator(abc.ABC):
         self.clean: bool = clean
         self.build_dir = get_abs_path(build_dir)
         if self.clean:
-            self.rm_build_folder(self.build_dir)
+            cocotb.clean.rm_build_folder(self.build_dir)
         os.makedirs(self.build_dir, exist_ok=True)
 
         # note: to avoid mutating argument defaults, we ensure that no value
@@ -367,11 +368,6 @@ class Simulator(abc.ABC):
                 raise SystemExit(
                     f"Process {process.args[0]!r} terminated with error {process.returncode}"
                 )
-
-    def rm_build_folder(self, build_dir: Path):
-        if os.path.isdir(build_dir):
-            print("Removing:", build_dir)
-            shutil.rmtree(build_dir, ignore_errors=True)
 
 
 def get_results(results_xml_file: Path) -> Tuple[int, int]:

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
     entry_points={
         "console_scripts": [
             "cocotb-config=cocotb.config:main",
+            "cocotb-clean=cocotb.clean:main",
         ]
     },
     platforms="any",

--- a/tests/pytest/test_cocotb_clean.py
+++ b/tests/pytest/test_cocotb_clean.py
@@ -1,0 +1,35 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import subprocess
+from pathlib import Path
+
+tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_cocotb_clean():
+    path_default = Path(os.path.join("sim_build"))
+    path_single = Path(os.path.join("single_dir"))
+    path_multi = Path(os.path.join("first_dir/second_dir/third_dir"))
+
+    path_default.mkdir(exist_ok=True)
+    path_single.mkdir(exist_ok=True)
+    path_multi.mkdir(exist_ok=True, parents=True)
+
+    # Let's remove them one by one and assert the rest
+    subprocess.check_output(["cocotb-clean"])
+    assert not os.path.isdir(path_default)
+    assert os.path.isdir(path_single)
+    assert os.path.isdir(path_multi)
+
+    subprocess.check_output(["cocotb-clean", "-d", "single_dir"])
+    assert not os.path.isdir(path_single)
+
+    subprocess.check_output(["cocotb-clean", "-rd", "third_dir"])
+    assert not os.path.isdir(path_multi)
+
+
+if __name__ == "__main__":
+    test_cocotb_clean()


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

As mentioned [here](https://github.com/cocotb/cocotb/pull/3351#issuecomment-1604511354), I've added `cocotb-clean` CLI command. `cocotb-clean` makes possible removing build folder even recursively. There is also simple test with `subprocess` lib.

Partially taken from @themperek [cocotb-test](https://github.com/themperek/cocotb-test). So, is it enough to have default cocotb license header here?

~~PS. I'll proceed after #3351. Now, I'm just wanna run CI to check possible issues.~~