### PR TITLE
Scheduler: Fix _pending_coros cleanup

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -1088,8 +1088,11 @@ class Scheduler:
             trigger.unprime()
         assert not self._pending_triggers
 
-        # kill any queued coroutines
-        for task in self._pending_coros:
+        # Kill any queued coroutines.
+        # We use a while loop because task.kill() calls _unschedule(), which will remove the task from _pending_coros.
+        # If that happens a for loop will stop early and then the assert will fail.
+        while self._pending_coros:
+            task = self._pending_coros.pop(0)
             task.kill()
         assert not self._pending_coros
 

--- a/documentation/source/newsfragments/3354.bugfix.rst
+++ b/documentation/source/newsfragments/3354.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect cleanup of pending Tasks (queued by :func:`cocotb.start_soon` but not started yet) when a test ends.

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -611,6 +611,18 @@ async def test_previous_start_soon_not_scheduled(_):
 
 
 @cocotb.test()
+async def test_test_end_with_multiple_pending_tasks(_):
+    """Test ending a test with multiple tasks queued by start_soon."""
+
+    async def coro():
+        return 0
+
+    # gh-3354
+    cocotb.start_soon(coro())
+    cocotb.start_soon(coro())
+
+
+@cocotb.test()
 async def test_start(_):
     async def coro():
         await Timer(1, "step")


### PR DESCRIPTION
Closes #3354.

Previously, `_cleanup()` would iterate over `_pending_coros` in a for loop.
Because `Task.kill()` calls `_unschedule()`, the Task was removed from `_pending_coros` while iterating over it.
Use a while loop to ensure all of the Tasks are killed and removed.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
