### PR TITLE
Remove unnecessary objects from VPI discovery

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -141,15 +141,11 @@ static gpi_objtype_t to_gpi_objtype(int32_t vpitype) {
         case vpiUnionNet:
             return GPI_STRUCTURE;
 
-        case vpiModport:
         case vpiInterface:
         case vpiModule:
-        case vpiRefObj:
         case vpiPort:
-        case vpiAlways:
-        case vpiFunction:
-        case vpiInitial:
         case vpiGate:
+        case vpiSwitch:
         case vpiPrimTerm:
         case vpiGenScope:
             return GPI_MODULE;
@@ -254,13 +250,9 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
             break;
         case vpiModule:
         case vpiInterface:
-        case vpiModport:
-        case vpiRefObj:
         case vpiPort:
-        case vpiAlways:
-        case vpiFunction:
-        case vpiInitial:
         case vpiGate:
+        case vpiSwitch:
         case vpiPrimTerm:
         case vpiGenScope:
         case vpiGenScopeArray: {

--- a/src/cocotb/share/lib/vpi/VpiIterator.cpp
+++ b/src/cocotb/share/lib/vpi/VpiIterator.cpp
@@ -46,7 +46,6 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
     std::vector<int32_t> module_options = {
         // vpiModule,            // Aldec SEGV on mixed language
         // vpiModuleArray,       // Aldec SEGV on mixed language
-        // vpiIODecl,            // Don't care about these
         vpiMemory,
         vpiIntegerVar,
         vpiRealVar,
@@ -57,17 +56,8 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
         vpiNamedEvent,
         vpiNamedEventArray,
         vpiParameter,
-        // vpiSpecParam,         // Don't care
-        // vpiParamAssign,       // Aldec SEGV on mixed language
-        // vpiDefParam,          // Don't care
         vpiPrimitive,
         vpiPrimitiveArray,
-        // vpiContAssign,        // Don't care
-        vpiProcess,              // Don't care
-        vpiModPath,
-        vpiTchk,
-        vpiAttribute,
-        // vpiPort,              // Splits into high/lo signals; signals are still there under vpiReg/vpiNet
         vpiInternalScope,
         // vpiInterface,         // Aldec SEGV on mixed language
         // vpiInterfaceArray,    // Aldec SEGV on mixed language
@@ -83,8 +73,8 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
 #ifndef IUS
         vpiNetArray,
 #endif
-        vpiReg,       vpiRegArray,       vpiMemory,    vpiParameter,
-        vpiPrimitive, vpiPrimitiveArray, vpiAttribute, vpiMember,
+        vpiReg,       vpiRegArray,       vpiMemory, vpiParameter,
+        vpiPrimitive, vpiPrimitiveArray, vpiMember,
     };
 
     return decltype(VpiIterator::iterate_over){
@@ -97,14 +87,6 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
 
         {vpiNet,
          {
-             // vpiContAssign,        // Driver and load handled separately
-             // vpiPrimTerm,
-             // vpiPathTerm,
-             // vpiTchkTerm,
-             // vpiDriver,
-             // vpiLocalDriver,
-             // vpiLoad,
-             // vpiLocalLoad,
              vpiNetBit,
          }},
         {vpiNetArray,
@@ -118,12 +100,6 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
         {vpiMemory,
          {
              vpiMemoryWord,
-         }},
-        {vpiGate,
-         {
-             vpiPrimTerm,
-             vpiTableEntry,
-             vpiUdpDefn,
          }},
         {vpiPackage,
          {

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -255,13 +255,10 @@ async def test_discover_all(dut):
                      8 (asc_gen: signals)
                      8 (asc_gen: constant)
                      8 (asc_gen: variable)
-                     8 (asc_gen: process "always")                             (VPI - Aldec only)
                      9 (desc_gen[7:0])
                      8 (desc_gen: signals)
                      8 (desc_gen: constant)
                      8 (desc_gen: variable)
-                     8 (desc_gen: process "always")                            (VPI - Aldec only)
-          process:   1 ("always")                                              (VPI - Aldec only)
 
             TOTAL: 1032 (VHDL - Default)
                     818 (VHDL - Aldec)
@@ -272,17 +269,6 @@ async def test_discover_all(dut):
     tlog = logging.getLogger("cocotb.test")
 
     await Timer(10, "ns")
-
-    # Need to clear sub_handles so won't attempt to iterate over handles like sig_rec and sig_rec_array
-    #
-    # DO NOT REMOVE.  Aldec cannot iterate over the complex records due to bugs in the VPI interface.
-    if (
-        LANGUAGE in ["verilog"]
-        and cocotb.SIM_NAME.lower().startswith("riviera")
-        and cocotb.SIM_VERSION.startswith("2016.02")
-    ):
-        if len(dut._sub_handles) != 0:
-            dut._sub_handles = {}
 
     # Modelsim/Questa VPI will not find a vpiStructVar from vpiModule so we access them explicitly
     # to ensure the handle is in the dut "sub_handles" for iterating
@@ -305,7 +291,7 @@ async def test_discover_all(dut):
         pass_total = 308
     elif LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
         # Applies to Riviera-PRO 2019.10 and newer.
-        pass_total = 197
+        pass_total = 180
     elif LANGUAGE in ["vhdl"]:
         pass_total = 244
     else:

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -389,10 +389,8 @@ async def access_internal_register_array(dut):
     skip=LANGUAGE in ["vhdl"],
     expect_error=AttributeError if SIM_NAME.startswith(("icarus", "verilator")) else (),
 )
-async def access_gate(dut):
-    """
-    Test access to a gate Object
-    """
+async def access_gate(dut) -> None:
+    """Test access to a gate Object"""
     assert isinstance(dut.test_and_gate, HierarchyObject)
 
 

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -36,14 +36,7 @@ async def recursive_discovery(dut):
     """
     Recursively discover every single object in the design
     """
-    if SIM_NAME.startswith("verilator"):
-        pass_total = 26
-    elif SIM_NAME.startswith("riviera"):
-        # finds always and initial blocks
-        pass_total = 33
-    else:
-        # everyone seems to find the byteswap() function besides verilator
-        pass_total = 27
+    pass_total = 26
 
     # Icarus doesn't support array indexes like get_handle_by_name("some_path[x]")
     SKIP_HANDLE_ASSERT = cocotb.SIM_NAME.lower().startswith(("riviera", "icarus"))


### PR DESCRIPTION
Closes #3353.

Removed translation of syntactic elements like always, initial, and function blocks and modport defitions. `vpiRefObj` are aliases which require a `vpiActual` discovery to determine the underlying element. We will not translate those until we have that code in place.

Removed iteration over:
* `vpiProcess`
* `vpiModPath` (delay path)
* `vpiTchk`
* `vpiAttribute` (syntax)

Added translation of `vpiSwitch` which is a kind of primitive object like `vpiGate` and `vpiPrimTerm` for sake of completeness.