### PR TITLE
Scheduler: Allow _unschedule() to cleanup unstarted Tasks to avoid "never awaited" warnings

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -1095,7 +1095,6 @@ class Scheduler:
             # Get first task but leave it in the list so that _unschedule() will correctly close the unstarted coroutine object.
             task = self._pending_coros[0]
             task.kill()
-        assert not self._pending_coros
 
         if self._main_thread is not threading.current_thread():
             raise Exception("Cleanup() called outside of the main thread")

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -1092,7 +1092,8 @@ class Scheduler:
         # We use a while loop because task.kill() calls _unschedule(), which will remove the task from _pending_coros.
         # If that happens a for loop will stop early and then the assert will fail.
         while self._pending_coros:
-            task = self._pending_coros.pop(0)
+            # Get first task but leave it in the list so that _unschedule() will correctly close the unstarted coroutine object.
+            task = self._pending_coros[0]
             task.kill()
         assert not self._pending_coros
 


### PR DESCRIPTION
Missed this in #3358.

For unstarted Tasks, `_unschedule()` calls `Task.close()` and removes it from `_pending_coros`. The `close()` call is necessary to avoid the warning for each coroutine object of the following form:

    RuntimeWarning: coroutine '<coroutine object>' was never awaited

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
