### PR TITLE
Create a new ValueChange() trigger, deprecate the Edge() trigger

### DIFF
--- a/docs/source/triggers.rst
+++ b/docs/source/triggers.rst
@@ -22,13 +22,15 @@ Simulator Triggers
 Signals
 -------
 
-.. autoclass:: cocotb.triggers.Edge(signal)
-
 .. autoclass:: cocotb.triggers.RisingEdge(signal)
 
 .. autoclass:: cocotb.triggers.FallingEdge(signal)
 
+.. autoclass:: cocotb.triggers.ValueChange(signal)
+
 .. autoclass:: cocotb.triggers.ClockCycles
+
+.. autoclass:: cocotb.triggers.Edge(signal)
 
 
 Timing

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -418,8 +418,14 @@ class FallingEdge(_EdgeBase):
         return signal
 
 
-class Edge(_EdgeBase):
-    """Fires on any value change of *signal*."""
+class ValueChange(_EdgeBase):
+    """
+    Fires on any value change of *signal*.
+
+    *signal* may have any width.
+
+    .. versionadded:: 1.9.0
+    """
 
     __slots__ = ()
     _edge_type = 3
@@ -429,6 +435,43 @@ class Edge(_EdgeBase):
         if not isinstance(signal, ModifiableObject):
             raise TypeError("")
         return signal
+
+
+class Edge(ValueChange):
+    """Deprecated alias of :class:`cocotb.triggers.ValueChange`.
+
+    .. note::
+
+        ``Edge()`` in cocotb and ``edge`` in SystemVerilog do different things!
+
+        Cocotb's ``Edge()`` trigger considers changes to *all* bits the signal.
+        The SystemVerilog ``edge`` keyword only considers the least significant
+        bit, or in other words, ``edge`` in SystemVerilog is equivalent to
+        ()``posedge`` or ``negedge``).
+
+        Hence, the SystemVerilog statement ``@(edge my_multibit_signal)`` is
+        equivalent to
+        ``await First(RisingEdge(my_multibit_signal), FallingEdge(my_multibit_signal))``
+        in cocotb.
+
+    .. deprecated:: 2.0
+        Use ``ValueChange()`` instead of ``Edge()``, since the new name better
+        reflects what this trigger does.
+    """
+
+    def __init__(self, signal):
+        # The deprecation warning in here is best-effort: If the same signal
+        # was used previously with a different _EdgeBase subclass __init__()
+        # won't be called again and no deprecation warning is shown (triggers
+        # are singletons, and all _EdgeBase triggers share the same cache).
+        warnings.warn(
+            "Event() is a deprecated alias for ValueChange(). Please update "
+            "your code to use the new ValueChange() name.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        super().__init__(signal)
 
 
 class _Event(PythonTrigger):

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -385,7 +385,11 @@ class _EdgeBase(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
 
 
 class RisingEdge(_EdgeBase):
-    """Fires on the rising edge of *signal*, on a transition from ``0`` to ``1``."""
+    """Fires on the rising edge of *signal*, on a transition from ``0`` to ``1``.
+
+    *signal* may have any width, but only transitions from ``0`` to ``1`` are
+    considered a rising edge.
+    """
 
     __slots__ = ()
     _edge_type = 1
@@ -398,7 +402,11 @@ class RisingEdge(_EdgeBase):
 
 
 class FallingEdge(_EdgeBase):
-    """Fires on the falling edge of *signal*, on a transition from ``1`` to ``0``."""
+    """Fires on the falling edge of *signal*, on a transition from ``1`` to ``0``.
+
+    *signal* may have any width, but only transitions from ``1`` to ``0`` are
+    considered a falling edge.
+    """
 
     __slots__ = ()
     _edge_type = 2

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -274,9 +274,11 @@ async def test_edge_on_vector(dut):
                 await ReadOnly()  # not needed for other simulators
             edge_cnt = edge_cnt + 1
 
+    # Reset the design and let it settle.
     dut.stream_in_data.value = 0
     await RisingEdge(dut.clk)
     await RisingEdge(dut.clk)
+    assert dut.stream_out_data_registered.value.integer == 0
 
     cocotb.start_soon(wait_edge())
 
@@ -288,9 +290,11 @@ async def test_edge_on_vector(dut):
         dut.stream_in_data.value = 0
         await RisingEdge(dut.clk)
 
-    expected_count = 2 * ((2 ** len(dut.stream_in_data) - 1) - 1) - 1
+    # Ensure that the last transition has made it to the registered output.
+    await RisingEdge(dut.clk)
+    assert dut.stream_out_data_registered.value.integer == 0
 
-    assert edge_cnt == expected_count
+    assert edge_cnt == 2 * ((2 ** len(dut.stream_in_data) - 1) - 1)
 
 
 @cocotb.test()


### PR DESCRIPTION
Add a new trigger, `ValueChange()`, which behaves identically to the
existing `Edge()` trigger. However, `Edge()` is confusingly named when
considering multi-bit signals (vectors): the SystemVerilog keyword
`edge` only considers the LSB of a multi-bit signal, while cocotb
considers changes to all bits.
    
Introduce a new, better-named trigger, `ValueChange()`, and deprecate
the old one. Add a note to the documentation discussing the issue

- Better document RisingEdge() and FallingEdge() triggers
- Make test_edge_on_vector() more robust
- Add ValueChange() trigger, deprecate Edge() trigger
