### PR TITLE
Pending Tasks cleanup backport

### DIFF
--- a/cocotb/_version.py
+++ b/cocotb/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = "1.8.0"
+__version__ = "1.8.1.dev0"

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -1088,8 +1088,11 @@ class Scheduler:
             trigger.unprime()
         assert not self._pending_triggers
 
-        # kill any queued coroutines
-        for task in self._pending_coros:
+        # Kill any queued coroutines.
+        # We use a while loop because task.kill() calls _unschedule(), which will remove the task from _pending_coros.
+        # If that happens a for loop will stop early and then the assert will fail.
+        while self._pending_coros:
+            task = self._pending_coros.pop(0)
             task.kill()
         assert not self._pending_coros
 

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -1092,9 +1092,9 @@ class Scheduler:
         # We use a while loop because task.kill() calls _unschedule(), which will remove the task from _pending_coros.
         # If that happens a for loop will stop early and then the assert will fail.
         while self._pending_coros:
-            task = self._pending_coros.pop(0)
+            # Get first task but leave it in the list so that _unschedule() will correctly close the unstarted coroutine object.
+            task = self._pending_coros[0]
             task.kill()
-        assert not self._pending_coros
 
         if self._main_thread is not threading.current_thread():
             raise Exception("Cleanup() called outside of the main thread")

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -7,7 +7,11 @@ Release Notes
 
 All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb/releases>`_.
 
-Cocotb 1.8.0 (2023-06-15)
+cocotb 1.8.1 (unreleased)
+=========================
+
+
+cocotb 1.8.0 (2023-06-15)
 =========================
 
 Features

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -10,6 +10,10 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 cocotb 1.8.1 (unreleased)
 =========================
 
+Bugfixes
+--------
+
+- Fix incorrect cleanup of pending Tasks (queued by :func:`cocotb.start_soon` but not started yet) when a test ends. (:issue:`3354`)
 
 cocotb 1.8.0 (2023-06-15)
 =========================

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -611,6 +611,18 @@ async def test_previous_start_soon_not_scheduled(_):
 
 
 @cocotb.test()
+async def test_test_end_with_multiple_pending_tasks(_):
+    """Test ending a test with multiple tasks queued by start_soon."""
+
+    async def coro():
+        return 0
+
+    # gh-3354
+    cocotb.start_soon(coro())
+    cocotb.start_soon(coro())
+
+
+@cocotb.test()
 async def test_start(_):
     async def coro():
         await Timer(1, "step")


### PR DESCRIPTION
Backport of #3358 and #3361 for 1.8.1

x-ref #3369
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
