### PR TITLE
Update test expectations for Xcelium 23.03

### DIFF
--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -159,11 +159,14 @@ async def test_read_write(dut):
     tlog.info("Checking writes:")
     _check_logic(tlog, dut.port_logic_out, 1)
     _check_logic(tlog, dut.port_logic_vec_out, 0xCC)
-    _check_value(tlog, dut.sig_t2, [0xCC, 0xDD, 0xEE, 0xFF])
-    _check_logic(tlog, dut.sig_t2[7], 0xCC)
-    _check_logic(tlog, dut.sig_t2[4], 0xFF)
-    _check_logic(tlog, dut.sig_t4[1][5], 0x66)
-    _check_logic(tlog, dut.sig_t4[3][7], 0xCC)
+    # Some writes to multi-dimensional arrays don't make it into the design.
+    # https://github.com/cocotb/cocotb/issues/3372
+    if not cocotb.SIM_NAME.startswith("xmsim"):
+        _check_value(tlog, dut.sig_t2, [0xCC, 0xDD, 0xEE, 0xFF])
+        _check_logic(tlog, dut.sig_t2[7], 0xCC)
+        _check_logic(tlog, dut.sig_t2[4], 0xFF)
+        _check_logic(tlog, dut.sig_t4[1][5], 0x66)
+        _check_logic(tlog, dut.sig_t4[3][7], 0xCC)
 
     if cocotb.LANGUAGE in ["vhdl"]:
         _check_int(tlog, dut.port_bool_out, 1)

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -68,7 +68,10 @@ async def test_loads(dut):
         tlog.info("Found %s" % repr(load))
 
 
-@cocotb.test()
+# Xcelium fails with "FATAL: We are calling up again".
+# TODO: Re-evaluate waiver once https://github.com/cocotb/cocotb/issues/1076 is
+# fixed.
+@cocotb.test(skip=cocotb.SIM_NAME.startswith("xmsim"))
 async def recursive_discovery(dut):
     """Recursively discover every single object in the design."""
     if cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):
@@ -93,7 +96,10 @@ async def recursive_discovery(dut):
     )
 
 
-@cocotb.test()
+# Xcelium fails with "FATAL: We are calling up again".
+# TODO: Re-evaluate waiver once https://github.com/cocotb/cocotb/issues/1076 is
+# fixed.
+@cocotb.test(skip=cocotb.SIM_NAME.startswith("xmsim"))
 async def recursive_discovery_boundary(dut):
     """Iteration through the boundary works but this just double checks."""
     if cocotb.SIM_NAME.lower().startswith(("ncsim", "xmsim")):


### PR DESCRIPTION
Update the test expectations for Xcelium 23.03 to make the TOPLEVEL_LANG=verilog tests pass. Issues are filed for the two new failures, both of which need upstream work most likely.

- Xcelium: Update test expectations for array access
- Xcelium: Skip mixed-language discovery tests
