### PR TITLE
Update cocotb-config to produce unix-style paths

### DIFF
--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -51,9 +51,13 @@ import cocotb
 __all__ = ["share_dir", "makefiles_dir", "libs_dir"]
 
 
-share_dir = os.path.join(os.path.dirname(cocotb.__file__), "share").replace("\\", "/")
-makefiles_dir = os.path.join(os.path.dirname(cocotb.__file__), "share", "makefiles").replace("\\", "/")
-libs_dir = os.path.join(os.path.dirname(cocotb.__file__), "libs").replace("\\", "/")
+share_dir = os.path.join(os.path.dirname(cocotb.__file__), "share")
+makefiles_dir = os.path.join(os.path.dirname(cocotb.__file__), "share", "makefiles")
+libs_dir = os.path.join(os.path.dirname(cocotb.__file__), "libs")
+
+share_dir = share_dir.replace("\\", "/")
+makefiles_dir = makefiles_dir.replace("\\", "/")
+libs_dir = libs_dir.replace("\\", "/")
 
 
 def help_vars_text():
@@ -161,16 +165,16 @@ def lib_name_path(interface, simulator):
     """
     Return the absolute path of interface library for given interface (VPI/VHPI/FLI) and simulator
     """
-    library_name_path = os.path.join(libs_dir, lib_name(interface, simulator)).replace("\\", "/")
+    library_name_path = os.path.join(libs_dir, lib_name(interface, simulator))
 
-    return library_name_path
+    return library_name_path.replace("\\", "/")
 
 
 def _findlibpython():
-    libpython_path = find_libpython.find_libpython().replace("\\", "/")
+    libpython_path = find_libpython.find_libpython()
     if libpython_path is None:
         sys.exit(1)
-    return libpython_path
+    return libpython_path.replace("\\", "/")
 
 
 class PrintAction(argparse.Action):
@@ -197,9 +201,12 @@ class PrintFuncAction(argparse.Action):
 
 
 def get_parser():
-    prefix_dir = os.path.dirname(os.path.dirname(cocotb.__file__)).replace("\\", "/")
+    prefix_dir = os.path.dirname(os.path.dirname(cocotb.__file__))
     version = cocotb.__version__
-    python_bin = sys.executable.replace("\\", "/")
+    python_bin = sys.executable
+
+    prefix_dir = prefix_dir.replace("\\", "/")
+    python_bin = python_bin.replace("\\", "/")
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -51,13 +51,9 @@ import cocotb
 __all__ = ["share_dir", "makefiles_dir", "libs_dir"]
 
 
-share_dir = os.path.join(os.path.dirname(cocotb.__file__), "share")
-makefiles_dir = os.path.join(os.path.dirname(cocotb.__file__), "share", "makefiles")
-libs_dir = os.path.join(os.path.dirname(cocotb.__file__), "libs")
-
-# On Windows use mixed mode "c:/a/b/c" as this work in all cases
-if os.name == "nt":
-    libs_dir = libs_dir.replace("\\", "/")
+share_dir = os.path.join(os.path.dirname(cocotb.__file__), "share").replace("\\", "/")
+makefiles_dir = os.path.join(os.path.dirname(cocotb.__file__), "share", "makefiles").replace("\\", "/")
+libs_dir = os.path.join(os.path.dirname(cocotb.__file__), "libs").replace("\\", "/")
 
 
 def help_vars_text():
@@ -165,17 +161,13 @@ def lib_name_path(interface, simulator):
     """
     Return the absolute path of interface library for given interface (VPI/VHPI/FLI) and simulator
     """
-    library_name_path = os.path.join(libs_dir, lib_name(interface, simulator))
-
-    # On Windows use mixed mode "c:/a/b/c" as this work in all cases
-    if os.name == "nt":
-        return library_name_path.replace("\\", "/")
+    library_name_path = os.path.join(libs_dir, lib_name(interface, simulator)).replace("\\", "/")
 
     return library_name_path
 
 
 def _findlibpython():
-    libpython_path = find_libpython.find_libpython()
+    libpython_path = find_libpython.find_libpython().replace("\\", "/")
     if libpython_path is None:
         sys.exit(1)
     return libpython_path
@@ -205,9 +197,9 @@ class PrintFuncAction(argparse.Action):
 
 
 def get_parser():
-    prefix_dir = os.path.dirname(os.path.dirname(cocotb.__file__))
+    prefix_dir = os.path.dirname(os.path.dirname(cocotb.__file__)).replace("\\", "/")
     version = cocotb.__version__
-    python_bin = sys.executable
+    python_bin = sys.executable.replace("\\", "/")
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -198,7 +198,7 @@ class PrintFuncAction(argparse.Action):
 
 
 def get_parser():
-    prefix_dir = base_dir.joinpath("..").resolve().as_posix()
+    prefix_dir = base_dir.parent.resolve().as_posix()
     version = cocotb.__version__
     python_bin = Path(sys.executable).as_posix()
 

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -43,6 +43,7 @@ import argparse
 import os
 import sys
 import textwrap
+from pathlib import Path
 
 import find_libpython
 
@@ -50,14 +51,10 @@ import cocotb
 
 __all__ = ["share_dir", "makefiles_dir", "libs_dir"]
 
-
-share_dir = os.path.join(os.path.dirname(cocotb.__file__), "share")
-makefiles_dir = os.path.join(os.path.dirname(cocotb.__file__), "share", "makefiles")
-libs_dir = os.path.join(os.path.dirname(cocotb.__file__), "libs")
-
-share_dir = share_dir.replace("\\", "/")
-makefiles_dir = makefiles_dir.replace("\\", "/")
-libs_dir = libs_dir.replace("\\", "/")
+base_dir = Path(cocotb.__file__).joinpath("..").resolve()
+share_dir = base_dir.joinpath("share").as_posix()
+makefiles_dir = base_dir.joinpath("share").joinpath("makefiles").as_posix()
+libs_dir = base_dir.joinpath("libs").as_posix()
 
 
 def help_vars_text():
@@ -167,14 +164,14 @@ def lib_name_path(interface, simulator):
     """
     library_name_path = os.path.join(libs_dir, lib_name(interface, simulator))
 
-    return library_name_path.replace("\\", "/")
+    return Path(library_name_path).as_posix()
 
 
 def _findlibpython():
     libpython_path = find_libpython.find_libpython()
     if libpython_path is None:
         sys.exit(1)
-    return libpython_path.replace("\\", "/")
+    return Path(libpython_path).as_posix()
 
 
 class PrintAction(argparse.Action):
@@ -201,12 +198,9 @@ class PrintFuncAction(argparse.Action):
 
 
 def get_parser():
-    prefix_dir = os.path.dirname(os.path.dirname(cocotb.__file__))
+    prefix_dir = base_dir.joinpath("..").resolve().as_posix()
     version = cocotb.__version__
-    python_bin = sys.executable
-
-    prefix_dir = prefix_dir.replace("\\", "/")
-    python_bin = python_bin.replace("\\", "/")
+    python_bin = Path(sys.executable).as_posix()
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(

--- a/cocotb/config.py
+++ b/cocotb/config.py
@@ -51,7 +51,7 @@ import cocotb
 
 __all__ = ["share_dir", "makefiles_dir", "libs_dir"]
 
-base_dir = Path(cocotb.__file__).joinpath("..").resolve()
+base_dir = Path(cocotb.__file__).parent.resolve()
 share_dir = base_dir.joinpath("share").as_posix()
 makefiles_dir = base_dir.joinpath("share").joinpath("makefiles").as_posix()
 libs_dir = base_dir.joinpath("libs").as_posix()

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -37,7 +37,7 @@ COCOTB_MAKEFILE_INC_INCLUDED = 1
 .PHONY: sim
 sim:
 	$(RM) $(COCOTB_RESULTS_FILE)
-	$(MAKE) -f $(firstword $(MAKEFILE_LIST)) $(COCOTB_RESULTS_FILE)
+	"$(MAKE)" -f $(firstword $(MAKEFILE_LIST)) $(COCOTB_RESULTS_FILE)
 
 # Make sure to use bash for the pipefail option used in many simulator Makefiles
 SHELL := bash

--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -42,8 +42,8 @@ sim:
 # Make sure to use bash for the pipefail option used in many simulator Makefiles
 SHELL := bash
 
-# Directory containing the cocotb Python module (realpath for Windows compatibility)
-COCOTB_PY_DIR := $(realpath $(shell cocotb-config --prefix))
+# Directory containing the cocotb Python module
+COCOTB_PY_DIR := $(shell cocotb-config --prefix)
 
 # Directory containing all support files required to build cocotb-based
 # simulations: Makefile fragments, and the simulator libraries.
@@ -62,13 +62,7 @@ export OS
 IS_VENV=$(shell $(shell cocotb-config --python-bin) -c 'import sys; print(sys.prefix != sys.base_prefix)')
 
 # this ensures we use the same python as the one cocotb was installed into
-ifeq ($(IS_VENV),True)
-    # In a virtual environment, the Python binary may be a symlink, so it should not use realpath
-    PYTHON_BIN ?= $(shell cocotb-config --python-bin)
-else
-    # realpath to convert windows paths to unix paths, like cygpath -u
-    PYTHON_BIN ?= $(realpath $(shell cocotb-config --python-bin))
-endif
+PYTHON_BIN ?= $(shell cocotb-config --python-bin)
 
 include $(COCOTB_SHARE_DIR)/makefiles/Makefile.deprecations
 

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -98,8 +98,8 @@ SIM ?= icarus
 # Maintain backwards compatibility by supporting upper and lower case SIM variable
 SIM_LOWERCASE := $(shell echo $(SIM) | tr A-Z a-z)
 
-# Directory containing the cocotb Makfiles (realpath for Windows compatibility)
-COCOTB_MAKEFILES_DIR := $(realpath $(shell cocotb-config --makefiles))
+# Directory containing the cocotb Makfiles
+COCOTB_MAKEFILES_DIR := $(shell cocotb-config --makefiles)
 
 include $(COCOTB_MAKEFILES_DIR)/Makefile.deprecations
 

--- a/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -9,7 +9,7 @@ include $(shell cocotb-config --makefiles)/Makefile.inc
 CMD_BIN := vsimsa
 
 ifdef ACTIVEHDL_BIN_DIR
-    CMD := $(shell :; command -v $(realpath $(ACTIVEHDL_BIN_DIR))/$(CMD_BIN) 2>/dev/null)
+    CMD := $(shell :; command -v $(ACTIVEHDL_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
 else
     # auto-detect bin dir from system path
     CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)


### PR DESCRIPTION
These changes should allow anyone to use Cygwin or Git Bash (MINGW64) to run cocotb tests. I think this adds a lot of value, because setting up conda with msys is a hurdle many of my colleagues were uninterested in tackling.

Using `$(realpath` does not produce consistent behavior between these two platforms. Since the only paths used come from `cocotb-config`, we should be able to make sure that produces a path that anyone will be happy with.