### PR TITLE
Add GUI_SCRIPT_FILE variable for Questa/Riviera

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -145,6 +145,9 @@ ifeq ($(WAVES),1)
 endif
 ifeq ($(GUI),1)
 	@echo "add log -r *" >> $@
+ifdef GUI_SCRIPT_FILE
+	@echo "do $(GUI_SCRIPT_FILE)" >> $@
+endif
 else
 	@echo "onbreak resume" >> $@
 	@echo "run -all" >> $@

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -135,6 +135,9 @@ ifeq ($(WAVES),1)
 endif
 ifeq ($(GUI),1)
 	@echo "wave -rec *" >> $@
+ifdef GUI_SCRIPT_FILE
+	@echo "do $(GUI_SCRIPT_FILE)" >> $@
+endif
 else
 	@echo "run -all" >> $@
 	@echo "endsim" >> $@

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -378,11 +378,18 @@ The following variables are makefile variables, not environment variables.
       Use to define a scratch directory for use by the simulator. The path is relative to the location where ``make`` was invoked.
       If not provided, the default scratch directory is :file:`sim_build`.
 
-.. envvar:: SCRIPT_FILE
+.. make:var:: SCRIPT_FILE
 
-    The name of a simulator script that is run as part of the simulation, e.g. for setting up wave traces.
+    The name of a simulator script that is run prior to loading the simulation.
+    This is currently supported for the Mentor Questa, Mentor ModelSim and Aldec Riviera simulators.
+
+.. make:var:: GUI_SCRIPT_FILE
+
+    The name of a simulator script that is run as part of the simulation for setting up wave traces.
     You can usually write out such a file from the simulator's GUI.
     This is currently supported for the Mentor Questa, Mentor ModelSim and Aldec Riviera simulators.
+
+    .. versionadded:: 1.9
 
 .. make:var:: TOPLEVEL_LIBRARY
 


### PR DESCRIPTION
Fixes #3029 

Also distinguishes the difference between the variables in the docs.

Although I personally have no use for the regular SCRIPT_FILE, I understand why we want to maintain backwards compatibility. If there is no specific application for the SCRIPT_FILE variable, maybe it should be deprecated at some point. I don't see what you would do with a script prior to loading the design (with `vsim` or `asim`).