### PR TITLE
Questa prevent removing library without sources

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.questa
+++ b/cocotb/share/makefiles/simulators/Makefile.questa
@@ -127,7 +127,9 @@ $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEP
 	@echo "}" >> $@
 	@echo "vmap -c" >> $@
 	$(foreach LIB, $(VHDL_LIB_ORDER), $(make_lib))
+ifneq ($(VHDL_SOURCES),)
 	@echo "if [file exists $(SIM_BUILD)/$(RTL_LIBRARY)] {vdel -lib $(SIM_BUILD)/$(RTL_LIBRARY) -all}" >> $@
+endif
 	@echo "vlib $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
 	@echo "vmap $(RTL_LIBRARY) $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)


### PR DESCRIPTION
If Questa is not rebuilding RTL_LIBRARY (in my case, it is being built in another make target which is part of COMPILE_DEPS) there is no reason to delete it.