### PR TITLE
A set of Xcelium/VHPI fixes to our test suite

### DIFF
--- a/examples/adder/tests/Makefile
+++ b/examples/adder/tests/Makefile
@@ -37,6 +37,9 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(PWD)/../hdl/adder.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES = $(PWD)/../hdl/adder.vhdl
+    ifneq ($(filter $(SIM),ius xcelium),)
+        COMPILE_ARGS += -v93
+    endif
 else
     $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif

--- a/examples/matrix_multiplier/hdl/matrix_multiplier.vhd
+++ b/examples/matrix_multiplier/hdl/matrix_multiplier.vhd
@@ -55,13 +55,13 @@ begin
   begin
 
     if (rising_edge(clk_i)) then
-      if (reset_i) then
+      if (reset_i = '1') then
         valid_o <= '0';
         c_o <= (others => (others => '0'));
       else
         valid_o <= valid_i;
 
-        if (valid_i) then
+        if (valid_i = '1') then
           c_o <= c_calc;
         else
           c_o <= (others => (others => 'X'));

--- a/examples/matrix_multiplier/tests/Makefile
+++ b/examples/matrix_multiplier/tests/Makefile
@@ -45,6 +45,8 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
     ifeq ($(SIM),ghdl)
         EXTRA_ARGS += --std=08
         SIM_ARGS += --wave=wave.ghw
+    else ifneq ($(filter $(SIM),ius xcelium),)
+        COMPILE_ARGS += -v200x
     else ifneq ($(filter $(SIM),questa modelsim riviera activehdl),)
         COMPILE_ARGS += -2008
     endif

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -30,7 +30,7 @@ endif
 MODULE=test_mixed_language
 
 ifneq ($(filter $(SIM),ius xcelium),)
-    SIM_ARGS += -v93
+    COMPILE_ARGS += -v93
 endif
 
 ifneq ($(filter $(SIM),questa modelsim),)

--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -39,7 +39,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/array_module/array_module.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     ifneq ($(filter $(SIM),ius xcelium),)
-        SIM_ARGS += -v93
+        COMPILE_ARGS += -v93
     endif
 ifeq ($(shell echo $(SIM) | tr A-Z a-z),aldec)
     VHDL_SOURCES =  $(COCOTB)/tests/designs/array_module/array_module_pack.vhd $(COCOTB)/tests/designs/array_module/array_module_aldec.vhd

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -44,7 +44,7 @@ else
 endif
 
 ifneq ($(filter $(SIM),ius xcelium),)
-    SIM_ARGS += -v93
+    COMPILE_ARGS += -v93
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -41,7 +41,7 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES =  $(COCOTB)/tests/designs/sample_module/sample_module_pack.vhdl $(COCOTB)/tests/designs/sample_module/sample_module_1.vhdl $(COCOTB)/tests/designs/sample_module/sample_module.vhdl
 
     ifneq ($(filter $(SIM),ius xcelium),)
-        SIM_ARGS += -v93
+        COMPILE_ARGS += -v93
     endif
 else
     $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))

--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -33,7 +33,7 @@ VERILOG_SOURCES += $(SRC_BASE)/top/verilog_toplevel.sv
 TOPLEVEL = verilog_toplevel
 
 ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-    SIM_ARGS += -v93
+    COMPILE_ARGS += -v93
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -31,7 +31,7 @@ endif
 VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/configurations.vhd
 
 ifneq ($(filter $(SIM),ius xcelium),)
-    SIM_ARGS += -v93
+    COMPILE_ARGS += -v93
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -62,7 +62,7 @@ VHDL_SOURCES = $(SRC_BASE)/packages/pkg_helper.vhd \
 	       $(SRC_BASE)/src/dec_viterbi.vhd
 
 ifneq ($(filter $(SIM),ius xcelium),)
-    SIM_ARGS += -v93
+    COMPILE_ARGS += -v93
 endif
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/test_fatal/Makefile
+++ b/tests/test_cases/test_fatal/Makefile
@@ -14,7 +14,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES := $(PWD)/fatal.vhd
     ifneq ($(filter $(SIM),ius xcelium),)
-        SIM_ARGS += -v93
+        COMPILE_ARGS += -v93
     endif
 endif
 

--- a/tests/test_cases/test_first_on_coincident_triggers/Makefile
+++ b/tests/test_cases/test_first_on_coincident_triggers/Makefile
@@ -13,7 +13,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES := $(PWD)/test.vhd
     ifneq ($(filter $(SIM),ius xcelium),)
-        SIM_ARGS += -v93
+        COMPILE_ARGS += -v93
     endif
 endif
 

--- a/tests/test_cases/test_vhdl_zerovector/Makefile
+++ b/tests/test_cases/test_vhdl_zerovector/Makefile
@@ -5,7 +5,7 @@
 ifeq ($(TOPLEVEL_LANG),vhdl)
 
 ifneq ($(filter $(SIM),ius xcelium),)
-    SIM_ARGS += -v93
+    COMPILE_ARGS += -v93
 endif
 
 TOPLEVEL := vhdl_zerovector


### PR DESCRIPTION
Various small updates to the cocotb test suite to better support Xcelium with VHDL toplevels.

Note that many tests still fail, but at least they now fail for reasons mostly out of our control.