### PR TITLE
Support not using parenthesis on cocotb.test

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -140,7 +140,8 @@ class external:
 class _decorator_helper(type):
     """
     Metaclass that allows a type to be constructed using decorator syntax,
-    passing the decorated function as the first argument.
+    passing the decorated function as the first argument. Supports
+    construction with or without having the type called.
 
     So:
 
@@ -154,6 +155,11 @@ class _decorator_helper(type):
     """
 
     def __call__(cls, *args, **kwargs):
+        if len(args) == 1 and callable(args[0]):  # case without parenthesis
+            f = args[0]
+            return type.__call__(cls, f, **kwargs)
+
+        # case with parenthesis
         def decorator(f):
             # fall back to the normal way of constructing an object, now that
             # we have all the arguments

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -40,6 +40,8 @@ The exceptions in this module can be raised at any point by any code and will te
     :synopsis: Exceptions and functions for simulation result handling.
 
 
+.. _writing-tests:
+
 Writing and Generating tests
 ============================
 

--- a/documentation/source/newsfragments/2731.feature.rst
+++ b/documentation/source/newsfragments/2731.feature.rst
@@ -1,0 +1,1 @@
+Support not using parenthesis on ``@cocotb.test`` decorator

--- a/documentation/source/writing_testbenches.rst
+++ b/documentation/source/writing_testbenches.rst
@@ -156,6 +156,29 @@ We can also cast the signal handle directly to an integer:
     42
 
 
+.. _writing_tbs_identifying_tests:
+
+Identifying tests
+=================
+
+Cocotb tests are identified using the :class:`~cocotb.test` decorator.
+Using this decorator will tell cocotb that this function is a special type of coroutine that is meant
+to either pass or fail.
+The :class:`~cocotb.test` decorator supports several keyword arguments (see section :ref:`writing-tests`).
+In most cases no arguments are passed to the decorator so cocotb tests can be written as:
+
+.. code-block:: python3
+
+    # A valid cocotb test
+    @cocotb.test
+    async def test(dut):
+        pass
+
+    # Also a valid cocotb test
+    @cocotb.test()
+    async def test(dut):
+        pass
+
 .. _writing_tbs_concurrent_sequential:
 
 Concurrent and sequential execution

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -206,3 +206,8 @@ async def test_base_exception_in_task_expect_fail(dut):
 
     cocotb.start_soon(test_func())
     await NullTrigger()
+
+
+@cocotb.test
+async def test_without_parenthesis(dut):
+    pass


### PR DESCRIPTION
Added a test case under tests/test_cases/issue_2731.

Fixes #2731
