### PR TITLE
String as define issue

### DIFF
--- a/tests/designs/runner/runner.sv
+++ b/tests/designs/runner/runner.sv
@@ -15,4 +15,10 @@ module runner #(
 
 basic_hierarchy_module  basic_hierarchy_module(.clk(1'b0), .reset(1'b0));
 
+initial begin
+    if (`DEFINE_STR != "path/to/some/(random quote)/file.wow'") begin
+        $error();
+    end
+end
+
 endmodule

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -10,7 +10,7 @@ import pytest
 
 import cocotb
 from cocotb.triggers import Timer
-from cocotb_tools.runner import _as_tcl_value, get_runner
+from cocotb_tools.runner import VHDL, _as_tcl_value, get_runner
 
 pytestmark = pytest.mark.simulator_required
 
@@ -31,6 +31,9 @@ def test_empty_string():
 
 def test_special_char():
     assert _as_tcl_value("Test \n end\ttest\r") == "Test\\ \\n\\ end\\\ttest\\\r"
+
+
+string_define_value = "path/to/some/(random quote)/file.wow'"
 
 
 @cocotb.test()
@@ -57,16 +60,14 @@ def test_runner(parameters, pre_cmd, clean_build):
     vhdl_gpi_interfaces = os.getenv("VHDL_GPI_INTERFACE", None)
 
     if hdl_toplevel_lang == "verilog":
-        sources = [os.path.join(tests_dir, "designs", "runner", "runner.v")]
+        sources = [os.path.join(tests_dir, "designs", "runner", "runner.sv")]
         gpi_interfaces = ["vpi"]
     else:
         sources = [os.path.join(tests_dir, "designs", "runner", "runner.vhdl")]
         gpi_interfaces = [vhdl_gpi_interfaces]
 
     runner = get_runner(sim)
-    compile_args = []
-    if sim == "xcelium":
-        compile_args = ["-v93"]
+    compile_args = [VHDL("-v93")] if sim == "xcelium" else []
 
     # Pre-make build directory and test file for clean build assertions
     build_dir = (
@@ -83,7 +84,7 @@ def test_runner(parameters, pre_cmd, clean_build):
         sources=sources,
         hdl_toplevel="runner",
         parameters=parameters,
-        defines={"DEFINE": 4},
+        defines={"DEFINE": 4, "DEFINE_STR": string_define_value},
         includes=[os.path.join(tests_dir, "designs", "basic_hierarchy_module")],
         build_args=compile_args,
         clean=clean_build,
@@ -116,7 +117,7 @@ def test_runner(parameters, pre_cmd, clean_build):
 def test_missing_libpython(monkeypatch):
     hdl_toplevel_lang = os.getenv("HDL_TOPLEVEL_LANG", "verilog")
     if hdl_toplevel_lang == "verilog":
-        hdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.v")]
+        hdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.sv")]
         gpi_interfaces = ["vpi"]
     else:
         hdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.vhdl")]
@@ -128,7 +129,7 @@ def test_missing_libpython(monkeypatch):
         WIDTH_IN="8",
         WIDTH_OUT="8",
     )
-    build_args = ["-v93"] if sim_tool == "xcelium" else []
+    build_args = [VHDL("-v93")] if sim_tool == "xcelium" else []
     build_dir = os.path.join(sim_build, "test_missing_libpython")
 
     os.makedirs(build_dir, exist_ok=True)
@@ -137,7 +138,7 @@ def test_missing_libpython(monkeypatch):
         sources=hdl_sources,
         hdl_toplevel="runner",
         parameters=sim_params,
-        defines={"DEFINE": 4},
+        defines={"DEFINE": 4, "DEFINE_STR": string_define_value},
         includes=[os.path.join(tests_dir, "designs", "basic_hierarchy_module")],
         build_args=build_args,
         build_dir=build_dir,


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

Closes #4153

String as define doesn't work. At least, for Questa and Icarus. I tried some tricks, but no luck. Is there a way to do it?

Thanks.