### PR TITLE
CI: Enable MSVC test

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 15
+        after_n_builds: 10
 
 coverage:
     status:

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -163,12 +163,10 @@ ENVS = [
         "sim": "icarus",
         "sim-version": "b83daa3ae36891a372655652e53c9b4eefdfcafa",
         "os": "windows-latest",
-        "python-version": "3.8",
+        "python-version": "3.11",
         "toolchain": "msvc",
         "extra_name": "msvc | ",
-        # TODO: Moved from ci to experimental until
-        # https://github.com/cocotb/cocotb/issues/3326 is fixed.
-        "group": "experimental",
+        "group": "ci",
     },
     # Other
     # use clang instead of gcc

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -175,7 +175,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       id: windowstesting
       continue-on-error: ${{matrix.may_fail || false}}
-      timeout-minutes: 15
+      timeout-minutes: 20
       # Virtual environments don't work on Windows with cocotb. Avoid using them
       # in nox testing.
       run: |


### PR DESCRIPTION
Enable CI "windows + conda + msvc"
Change python to 3.11


There are errors `bash: C:Minicondapython.exe: command not found` that probably #3378 will solve.


Closes https://github.com/cocotb/cocotb/issues/3326