### PR TITLE
Fix generating FST files on Windows when using Icarus

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -489,7 +489,7 @@ class Icarus(Simulator):
             f.write("+timescale+{}/{}\n".format(*self.timescale))
 
     def _create_iverilog_dump_file(self) -> None:
-        dumpfile_path = self.build_dir / f"{self.hdl_toplevel}.fst"
+        dumpfile_path = Path(self.build_dir, f"{self.hdl_toplevel}.fst").as_posix()
         with open(self.iverilog_dump_file, "w") as f:
             f.write("module cocotb_iverilog_dump();\n")
             f.write("initial begin\n")


### PR DESCRIPTION
Use posix-style path to generate FST waveform dumps from Icarus Verilog on both Windows and Unix-based OSes. Similar changes were introduced in https://github.com/cocotb/cocotb/pull/3378. This PR fixes a regression introduced in https://github.com/cocotb/cocotb/pull/3385

This PR requires testing in the CI on Windows runner.
@themperek 
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
