### PR TITLE
Enable Python 3.12 builds

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -61,15 +61,24 @@ ENVS = [
         "python-version": "3.11",
         "group": "ci",
     },
-    # A single test for the upcoming Python version.
     {
         "lang": "verilog",
         "sim": "icarus",
         "sim-version": "apt",
         "os": "ubuntu-20.04",
-        "python-version": "3.12.0-alpha - 3.12.0",
-        "group": "experimental",
+        "python-version": "3.12.0-rc - 3.12",
+        "group": "ci",
     },
+    # A single test for the upcoming Python version.
+    # TODO: Enable once Python 3.13 development starts.
+    # {
+    #    "lang": "verilog",
+    #    "sim": "icarus",
+    #    "sim-version": "apt",
+    #    "os": "ubuntu-20.04",
+    #    "python-version": "3.13.0-alpha - 3.13.0",
+    #    "group": "experimental",
+    # },
     # Test Icarus on Ubuntu
     {
         "lang": "verilog",

--- a/documentation/source/newsfragments/3409.feature.rst
+++ b/documentation/source/newsfragments/3409.feature.rst
@@ -1,0 +1,1 @@
+Python 3.12 is now supported.

--- a/documentation/source/platform_support.rst
+++ b/documentation/source/platform_support.rst
@@ -27,6 +27,7 @@ The following versions of Python (CPython), and all associated patch releases (e
 * Python 3.9
 * Python 3.10
 * Python 3.11
+* Python 3.12
 
 Supported Linux Distributions and Versions
 ==========================================

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ dev_deps = [
 ]
 
 # Version of the cibuildwheel package used to build wheels.
-cibuildwheel_version = "2.13.1"
+cibuildwheel_version = "2.15.0"
 
 #
 # Helpers for use within this file.


### PR DESCRIPTION
Update cibuildwheel to build wheels for Python 3.12, which is now in rc2
mode and will not see any backwards-incompatible changes to its API.
Also update the CI configuration to build Python 3.12 by default for all
builds, not only the experimental ones.
