### PR TITLE
Improve typing of `cocotb.test`

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -43,7 +43,7 @@ import cocotb
 import cocotb.ANSI as ANSI
 from cocotb import simulator
 from cocotb._deprecation import deprecated
-from cocotb.decorators import test as Test
+from cocotb.decorators import Test
 from cocotb.handle import SimHandle
 from cocotb.log import SimLog
 from cocotb.outcomes import Error, Outcome

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -24,14 +24,6 @@ async def test_error(dut):
     fail  # noqa
 
 
-@cocotb.test()
-async def test_tests_are_tests(dut):
-    """
-    Test that things annotated with cocotb.test are tests
-    """
-    assert isinstance(test_tests_are_tests, cocotb.test)
-
-
 # just to be sure...
 @cocotb.test(expect_fail=True)
 async def test_async_test_can_fail(dut):


### PR DESCRIPTION
This is accomplished by changing the impl of the decorator to use "normal" decorators instead of metaclasses, which often confuse type checkers.