### PR TITLE
Simplify includes in simulatormodule

### DIFF
--- a/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -39,7 +39,6 @@ static int releases = 0;
 
 #include <Python.h>
 #include <cocotb_utils.h>    // to_python to_simulator
-#include <gpi_logging.h>     // LOG_* macros
 #include <py_gpi_logging.h>  // py_gpi_logger_set_level
 
 #include <limits>


### PR DESCRIPTION
The LOG_* macros are used in code that lives in cocotb_utils.h, so we
don't need to import the header into simulatormodule.cpp.
