### PR TITLE
Cherry-pick content to 1.8 branch

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -61,15 +61,24 @@ ENVS = [
         "python-version": "3.11",
         "group": "ci",
     },
-    # A single test for the upcoming Python version.
     {
         "lang": "verilog",
         "sim": "icarus",
         "sim-version": "apt",
         "os": "ubuntu-20.04",
-        "python-version": "3.12.0-alpha - 3.12.0",
-        "group": "experimental",
+        "python-version": "3.12.0-rc - 3.12",
+        "group": "ci",
     },
+    # A single test for the upcoming Python version.
+    # TODO: Enable once Python 3.13 development starts.
+    # {
+    #    "lang": "verilog",
+    #    "sim": "icarus",
+    #    "sim-version": "apt",
+    #    "os": "ubuntu-20.04",
+    #    "python-version": "3.13.0-alpha - 3.13.0",
+    #    "group": "experimental",
+    # },
     # Test Icarus on Ubuntu
     {
         "lang": "verilog",

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,8 +1,8 @@
 # Python dependencies to build the documentation
 
-Sphinx ~= 6.0
+Sphinx ~= 7.0
 breathe
-sphinx-rtd-theme
+sphinx-rtd-theme >= 1.3.0
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinxcontrib-makedomain
 sphinxcontrib-spelling >= 5.3.0

--- a/documentation/source/platform_support.rst
+++ b/documentation/source/platform_support.rst
@@ -27,6 +27,7 @@ The following versions of Python (CPython), and all associated patch releases (e
 * Python 3.9
 * Python 3.10
 * Python 3.11
+* Python 3.12
 
 Supported Linux Distributions and Versions
 ==========================================

--- a/documentation/source/release_notes.rst
+++ b/documentation/source/release_notes.rst
@@ -10,6 +10,11 @@ All releases are available from the `GitHub Releases Page <https://github.com/co
 cocotb 1.8.1 (unreleased)
 =========================
 
+Features
+--------
+
+- Python 3.12 is now supported.
+
 Bugfixes
 --------
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -364,7 +364,7 @@ def release_build_bdist(session: nox.Session) -> None:
     """Build a binary distribution (wheels) on the current operating system."""
 
     # Pin a version to ensure reproducible builds.
-    session.run("pip", "install", "cibuildwheel==2.11.2")
+    session.run("pip", "install", "cibuildwheel==2.15.0")
 
     # cibuildwheel only auto-detects the platform if it runs on a CI server.
     # Do the auto-detect manually to enable local runs.


### PR DESCRIPTION
- Python 3.12 support
- Sphinx 7 (maint only, to keep the documentation build in line with the one in master)