### PR TITLE
CI: Add Cadence Xcelium (VPI)

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -237,6 +237,26 @@ ENVS = [
         "python-version": "3.8",
         "group": "ci",
     },
+    # Test Cadence Xcelium on Ubuntu
+    {
+        "lang": "verilog",
+        "sim": "xcelium",
+        "sim-version": "cadence/xcelium/2303",
+        "os": "ubuntu-20.04",
+        "self-hosted": True,
+        "python-version": "3.8",
+        "group": "ci",
+    },
+    # Xcelium VHDL (VHPI) is not yet supported.
+    # {
+    #     "lang": "vhdl",
+    #     "sim": "xcelium",
+    #     "sim-version": "cadence/xcelium/2303",
+    #     "os": "ubuntu-20.04",
+    #     "self-hosted": True,
+    #     "python-version": "3.8",
+    #     "group": "ci",
+    # },
 ]
 
 

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -142,9 +142,10 @@ def test_mixed_language_runner():
             f"A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG={hdl_toplevel_lang}"
         )
 
+    build_args = []
     test_args = []
     if sim == "xcelium":
-        test_args = ["-v93"]
+        build_args = ["-v93"]
     elif sim == "questa":
         test_args = ["-t", "1ps"]
 
@@ -154,9 +155,11 @@ def test_mixed_language_runner():
     runner = get_runner(sim)
 
     runner.build(
+        hdl_toplevel="endian_swapper_mixed",
         verilog_sources=verilog_sources,
         vhdl_sources=vhdl_sources,
         always=True,
+        build_args=build_args,
     )
 
     runner.test(

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -123,14 +123,23 @@ async def do_test_afterdelay_in_readonly(dut, delay):
     exited = True
 
 
-# Riviera and Questa (in Verilog) correctly fail to register ReadWrite after ReadOnly
-# Riviera and Questa (in VHDL) incorrectly allow registering ReadWrite after ReadOnly
+# A TriggerException is expected to happen in this test, which indicates that
+# ReadWrite after ReadOnly fails to register.
+# - Riviera and Questa (in Verilog) and Xcelium pass.
+# - Riviera and Questa (in VHDL) incorrectly allow registering ReadWrite
+#   after ReadOnly.
+# - Xcelium passes (VHDL and Verilog).
 @cocotb.test(
     expect_error=TriggerException
-    if cocotb.LANGUAGE in ["verilog"]
-    and cocotb.SIM_NAME.lower().startswith(("riviera", "modelsim"))
+    if (
+        (
+            cocotb.LANGUAGE in ["verilog"]
+            and cocotb.SIM_NAME.lower().startswith(("riviera", "modelsim"))
+        )
+        or cocotb.SIM_NAME.lower().startswith(("xmsim"))
+    )
     else (),
-    expect_fail=cocotb.SIM_NAME.lower().startswith(("icarus", "ncsim", "xmsim")),
+    expect_fail=cocotb.SIM_NAME.lower().startswith(("icarus", "ncsim")),
 )
 async def test_readwrite_in_readonly(dut):
     """Test doing invalid sim operation"""


### PR DESCRIPTION
Fix the remaining issues which make Xcelium (VPI) fail, and enable the tool in CI.

Xcelium (VHPI) is blocked by https://github.com/cocotb/cocotb/issues/3420 for the moment.

- Xcelium: Update test expectations in test_readwrite_in_readonly
- Pass Xcelium compile-time arguments correctly in test
- CI: Enable Xcelium tests
