### PR TITLE
Run tests without clean from nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -168,7 +168,7 @@ def dev_test_sim(
         coverage_file.unlink()
 
     session.log(f"Running 'make test' against a simulator {config_str}")
-    session.run("make", "clean", "test", external=True, env=env)
+    session.run("make", "test", external=True, env=env)
 
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(
@@ -482,7 +482,7 @@ def release_test_sim(
     config_str = stringify_dict(env)
 
     session.log(f"Running tests against a simulator: {config_str}")
-    session.run("make", "clean", "test", external=True, env=env)
+    session.run("make", "test", external=True, env=env)
 
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(


### PR DESCRIPTION
In nox, run "make test" without a "make clean" run first. "make clean" for
the full test suite takes multiple minutes (mostly due to the overhead
of repeatedly calling cocotb-config) and is unnecessary on CI runners,
which always start from a clean state. Remove "make clean" from the
noxfile, developers can still call it on demand if necessary.
