### PR TITLE
Fix incorrect comparison of generate region labels

### DIFF
--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -349,7 +349,7 @@ GpiObjHdl *FliImpl::native_check_create(const std::string &name,
             if (acc_fetch_fulltype(rgn) == accForGenerate) {
                 std::string rgn_name =
                     mti_GetRegionName(static_cast<mtiRegionIdT>(rgn));
-                if (rgn_name.compare(0, name.length(), name) == 0) {
+                if (compare_generate_labels(rgn_name, name)) {
                     FliObj *fli_obj = dynamic_cast<FliObj *>(parent);
                     return create_gpi_obj_from_handle(
                         parent->get_handle<HANDLE>(), name, fq_name,
@@ -631,6 +631,14 @@ GpiIterator *FliImpl::iterate_handle(GpiObjHdl *obj_hdl,
     return new_iter;
 }
 
+bool FliImpl::compare_generate_labels(const std::string &a,
+                                      const std::string &b) {
+    /* Compare two generate labels for equality ignoring any suffixed index. */
+    std::size_t a_idx = a.rfind("(");
+    std::size_t b_idx = b.rfind("(");
+    return a.substr(0, a_idx) == b.substr(0, b_idx);
+}
+
 decltype(FliIterator::iterate_over) FliIterator::iterate_over = [] {
     std::initializer_list<FliIterator::OneToMany> region_options = {
         FliIterator::OTM_CONSTANTS,
@@ -783,8 +791,8 @@ GpiIterator::Status FliIterator::next_handle(std::string &name, GpiObjHdl **hdl,
                 if (acc_fetch_fulltype(obj) == accForGenerate) {
                     std::string rgn_name =
                         mti_GetRegionName(static_cast<mtiRegionIdT>(obj));
-                    if (rgn_name.compare(0, parent_name.length(),
-                                         parent_name) != 0) {
+                    if (!FliImpl::compare_generate_labels(rgn_name,
+                                                          parent_name)) {
                         obj = NULL;
                         continue;
                     }

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -448,6 +448,9 @@ class FliImpl : public GpiImplInterface {
                                           const std::string &fq_name,
                                           int accType, int accFullType);
 
+    static bool compare_generate_labels(const std::string &a,
+                                        const std::string &b);
+
   private:
     bool isValueConst(int kind);
     bool isValueLogic(mtiTypeIdT type);

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -1086,8 +1086,8 @@ GpiIterator::Status VhpiIterator::next_handle(std::string &name,
             if (obj != NULL && obj_type == GPI_GENARRAY) {
                 if (vhpi_get(vhpiKindP, obj) == vhpiForGenerateK) {
                     std::string rgn_name = vhpi_get_str(vhpiCaseNameP, obj);
-                    if (rgn_name.compare(0, parent_name.length(),
-                                         parent_name) != 0) {
+                    if (!VhpiImpl::compare_generate_labels(rgn_name,
+                                                           parent_name)) {
                         obj = NULL;
                         continue;
                     }

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -551,7 +551,7 @@ GpiObjHdl *VhpiImpl::native_check_create(const std::string &name,
             for (rgn = vhpi_scan(iter); rgn != NULL; rgn = vhpi_scan(iter)) {
                 if (vhpi_get(vhpiKindP, rgn) == vhpiForGenerateK) {
                     std::string rgn_name = vhpi_get_str(vhpiCaseNameP, rgn);
-                    if (rgn_name.compare(0, name.length(), name) == 0) {
+                    if (compare_generate_labels(rgn_name, name)) {
                         new_hdl = vhpi_hdl;
                         vhpi_release_handle(iter);
                         break;
@@ -985,6 +985,14 @@ void VhpiImpl::sim_end() {
         vhpi_control(vhpiFinish, vhpiDiagTimeLoc);
         check_vhpi_error();
     }
+}
+
+bool VhpiImpl::compare_generate_labels(const std::string &a,
+                                       const std::string &b) {
+    /* Compare two generate labels for equality ignoring any suffixed index. */
+    std::size_t a_idx = a.rfind(GEN_IDX_SEP_LHS);
+    std::size_t b_idx = b.rfind(GEN_IDX_SEP_LHS);
+    return a.substr(0, a_idx) == b.substr(0, b_idx);
 }
 
 extern "C" {

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -303,6 +303,9 @@ class VhpiImpl : public GpiImplInterface {
                                           const std::string &name,
                                           const std::string &fq_name);
 
+    static bool compare_generate_labels(const std::string &a,
+                                        const std::string &b);
+
   private:
     VhpiReadWriteCbHdl m_read_write;
     VhpiNextPhaseCbHdl m_next_phase;

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -756,8 +756,8 @@ GpiIterator::Status VpiIterator::next_handle(std::string &name, GpiObjHdl **hdl,
             if (obj != NULL && obj_type == GPI_GENARRAY) {
                 if (vpi_get(vpiType, obj) == vpiGenScope) {
                     std::string rgn_name = vpi_get_str(vpiName, obj);
-                    if (rgn_name.compare(0, parent_name.length(),
-                                         parent_name) != 0) {
+                    if (!VpiImpl::compare_generate_labels(rgn_name,
+                                                          parent_name)) {
                         obj = NULL;
                         continue;
                     }

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -631,6 +631,14 @@ void VpiImpl::sim_end() {
     }
 }
 
+bool VpiImpl::compare_generate_labels(const std::string &a,
+                                      const std::string &b) {
+    /* Compare two generate labels for equality ignoring any suffixed index. */
+    std::size_t a_idx = a.rfind("[");
+    std::size_t b_idx = b.rfind("[");
+    return a.substr(0, a_idx) == b.substr(0, b_idx);
+}
+
 extern "C" {
 
 // Main re-entry point for callbacks from simulator

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -292,6 +292,9 @@ class VpiImpl : public GpiImplInterface {
                                           const std::string &name,
                                           const std::string &fq_name);
 
+    static bool compare_generate_labels(const std::string &a,
+                                        const std::string &b);
+
   private:
     /* Singleton callbacks */
     VpiReadWriteCbHdl m_read_write;

--- a/documentation/source/newsfragments/2255.bugfix.rst
+++ b/documentation/source/newsfragments/2255.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a potential issue where pseudo-region lookup may find the wrong
+generate block if the name of one generate block starts with the name of
+another generate block.

--- a/tests/test_cases/issue_2255/Makefile
+++ b/tests/test_cases/issue_2255/Makefile
@@ -1,0 +1,20 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+PROJ_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+TOPLEVEL_LANG ?= verilog
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+VERILOG_SOURCES := $(PROJ_DIR)/test.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+VHDL_SOURCES := $(PROJ_DIR)/test.vhd
+endif
+
+TOPLEVEL := test
+
+export MODULE := test_issue2255
+export COCOTB_LOG_LEVEL := DEBUG
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/issue_2255/test.sv
+++ b/tests/test_cases/issue_2255/test.sv
@@ -1,0 +1,23 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+`timescale 1us/1us
+
+module test (output [15:0] o);
+
+  genvar idx1;
+  generate for (idx1 = 0; idx1 < 10; idx1 = idx1 + 1)
+    begin: foobar
+      assign o[idx1] = 1;
+    end
+  endgenerate
+
+  genvar idx2;
+  generate for (idx2 = 10; idx2 < 16; idx2 = idx2 + 1)
+    begin: foo   // Should not be confused with "foobar" which shares the same prefix
+      assign o[idx2] = 1;
+    end
+  endgenerate
+
+endmodule

--- a/tests/test_cases/issue_2255/test.vhd
+++ b/tests/test_cases/issue_2255/test.vhd
@@ -1,0 +1,23 @@
+-- Copyright cocotb contributors
+-- Licensed under the Revised BSD License, see LICENSE for details.
+-- SPDX-License-Identifier: BSD-3-Clause
+
+entity test is
+    port ( o : out bit_vector(15 downto 0) );
+end entity test;
+
+architecture rtl of test is
+begin
+
+    foobar: for i in 0 to 9 generate
+    begin
+        o(i) <= '1';
+    end generate;
+
+    -- Should not be confused with "foobar" which shares the same prefix
+    foo: for i in 10 to 15 generate
+    begin
+        o(i) <= '1';
+    end generate;
+
+end architecture rtl;

--- a/tests/test_cases/issue_2255/test_issue2255.py
+++ b/tests/test_cases/issue_2255/test_issue2255.py
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+
+import cocotb
+
+
+# GHDL doesn't discover the generate blocks
+@cocotb.test(
+    expect_error=AssertionError if cocotb.SIM_NAME.lower().startswith("ghdl") else ()
+)
+async def test_distinct_generates(dut):
+    tlog = logging.getLogger("cocotb.test")
+
+    foobar = dut.foobar
+    foo = dut.foo
+
+    tlog.info("Length of foobar is %d", len(foobar))
+    tlog.info("Length of foo is %d", len(foo))
+
+    assert len(foobar) == 10
+    assert len(foo) == 6


### PR DESCRIPTION
In various places we compare two generate labels by checking if the second label starts with the first. But this fails if two generate blocks with different names share the same prefix - e.g. "foo" and "foobar". Instead we should strip off any index suffix like "[0]" and then compare the full strings.

The included test fails with current cocotb and `SIM=icarus` with `ValueError: Unable to match an index pattern: foobar[0]` but passes after this change. I tested the VHPI implementation with NVC by rebasing on top of #3427. I have no way to test the FLI implementation but it does build.

Fixes #2255

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
