### PR TITLE
Fix tracing for Xcelium runner

### DIFF
--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -1033,6 +1033,16 @@ class Xcelium(Simulator):
         else:
             xrun_top = self.sim_hdl_toplevel
 
+        if self.waves:
+            input_tcl = [
+                f'-input "@database -open cocotb_waves -default" '
+                f'-input "@probe -database cocotb_waves -create {xrun_top} -all -depth all" '
+                f'-input "@run" '
+                f'-input "@exit" '
+            ]
+        else:
+            input_tcl = ["-input", "@run; exit;"]
+
         cmds = [["mkdir", "-p", tmpdir]]
         cmds += [
             ["xrun"]
@@ -1048,15 +1058,7 @@ class Xcelium(Simulator):
             + self.test_args
             + self.plusargs
             + ["-gui" if self.gui else ""]
-            + ["-input"]
-            + [
-                f'-input "@database -open cocotb_waves -default" '
-                f'-input "@probe -database cocotb_waves -create {xrun_top} -all -depth all" '
-                f'-input "@run" '
-                f'-input "@exit" '
-                if self.waves
-                else "@run; exit;"
-            ]
+            + input_tcl
         ]
         self.env["GPI_EXTRA"] = (
             cocotb.config.lib_name_path("vhpi", "xcelium") + ":cocotbvhpi_entry_point"

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -61,7 +61,7 @@ def run_simulation(sim):
     sim not in ["icarus", "xcelium"],
     reason="Skipping test because it is only for Icarus or Xcelium simulators",
 )
-def test_iverilog():
+def test_wave_dump():
     run_simulation(sim=sim)
     if sim == "icarus":
         dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -21,6 +21,7 @@ from cocotb.triggers import ClockCycles
 
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
 test_module = os.path.basename(os.path.splitext(__file__)[0])
+sim = os.getenv("SIM", "icarus")
 
 
 @cocotb.test()
@@ -57,10 +58,15 @@ def run_simulation(sim):
 
 @pytest.mark.simulator_required
 @pytest.mark.skipif(
-    os.getenv("SIM", "icarus") != "icarus",
-    reason="Skipping test because it is only for Icarus simulator",
+    sim not in ["icarus", "xcelium"],
+    reason="Skipping test because it is only for Icarus or Xcelium simulators",
 )
 def test_iverilog():
-    run_simulation(sim="icarus")
-    dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")
+    run_simulation(sim=sim)
+    if sim == "icarus":
+        dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")
+    elif sim == "xcelium":
+        dumpfile_path = os.path.join(sim_build, "cocotb_waves.shm", "cocotb_waves.trn")
+    else:
+        raise RuntimeError("Not a supported simulator")
     assert os.path.exists(dumpfile_path)


### PR DESCRIPTION
Previously trying to trace with Xcelium would yield `-input '-input @database . . .` for the runner command which is not correct / makes Xcelium mad.  I see that there is Xcelium CI:
https://github.com/cocotb/cocotb/pull/3437
but am not sure how to add a test for this.  Please advise if that would be desirable.

For what it's worth, the runner now works for me with `waves` as both `True` and `False`.