### PR TITLE
Fix pytest coverage

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -181,6 +181,7 @@ def dev_test_sim(
         "--cov-report=",
         "-k",
         "simulator_required",
+        "tests/pytest/",
         env=env,
     )
     Path(".coverage").rename(".coverage.pytest")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/pytest/__init__.py
+++ b/tests/pytest/__init__.py
@@ -1,0 +1,3 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 import pytest
-from test_cocotb import (
+from tests.pytest.test_cocotb import (
     compile_args,
     gpi_interfaces,
     hdl_toplevel,

--- a/tests/pytest/test_timescale.py
+++ b/tests/pytest/test_timescale.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 
 import pytest
-from test_cocotb import (
+from tests.pytest.test_cocotb import (
     compile_args,
     gpi_interfaces,
     hdl_toplevel,

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import pytest
-from test_cocotb import (
+from tests.pytest.test_cocotb import (
     compile_args,
     gpi_interfaces,
     hdl_toplevel,


### PR DESCRIPTION
Fixes pytest coverage (I think).

See: #3447 
`runner.py` claims to have not coverage (except for things which would get covered by importing the module).  This is clearly not true because the runner is being exercised by `test_runner.py`.  @themperek pointed out that this is because we're missing `__init__.py`.  Adding this angers python in ways I don't understand, but with enough trial and error I found that passing `tests/pytest/` to `pytest` gets around that problem.

I'm definitely just beating on this with a wrench until it works, so please tell me if this is bad in some way.

Running `nox` locally gives me correct looking coverage for `runner.py`.  I'm going to check if codecov agrees with my local results after I post this PR.  For reference, here's a recent run showing the missing `runner.py` coverage:
https://app.codecov.io/gh/cocotb/cocotb/commit/a40673d02c3e304b66cc2a82baaa9496152f76b7/blob/cocotb/runner.py

As an aside, does anyone know if it is possible to run the cocotb CI in my personal fork?  I'd love to check this out before posing the PR but do not know how.