### PR TITLE
Add graphviz package to doc build config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
 
 python:
   install:

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -342,6 +342,10 @@ spelling_ignore_wiki_words = False
 spelling_show_suggestions = True
 spelling_ignore_acronyms = True
 
+# -- Extra setup for inheritance_diagram directive which uses graphviz ---------
+
+graphviz_output_format = "svg"
+
 # -- Extra setup for towncrier -------------------------------------------------
 # see also https://towncrier.readthedocs.io/en/actual-freaking-docs/
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -342,10 +342,6 @@ spelling_ignore_wiki_words = False
 spelling_show_suggestions = True
 spelling_ignore_acronyms = True
 
-# -- Extra setup for inheritance_diagram directive which uses graphviz ---------
-
-graphviz_output_format = "svg"
-
 # -- Extra setup for towncrier -------------------------------------------------
 # see also https://towncrier.readthedocs.io/en/actual-freaking-docs/
 

--- a/documentation/source/diagrams/svg/inheritance-cocotb.handle.svg
+++ b/documentation/source/diagrams/svg/inheritance-cocotb.handle.svg
@@ -1,0 +1,201 @@
+<ns0:svg xmlns:ns0="http://www.w3.org/2000/svg" xmlns:ns1="http://www.w3.org/1999/xlink" width="576pt" height="179pt" viewBox="0.00 0.00 576.00 178.68">
+<ns0:g id="graph0" class="graph" transform="scale(0.753927 0.753927) rotate(0) translate(4 233)">
+<ns0:title>inheritanceb0493da095</ns0:title>
+
+<ns0:g id="node1" class="node"><ns0:title>ConstantObject</ns0:title>
+<ns0:g id="a_node1"><ns0:a ns1:href="../library_reference.html#cocotb.handle.ConstantObject" ns1:title="An object which has a value that can be read, but not set." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="361.21,-134 282.79,-134 282.79,-114 361.21,-114 361.21,-134" />
+<ns0:text text-anchor="middle" x="322" y="-121" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">ConstantObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="node2" class="node"><ns0:title>NonHierarchyObject</ns0:title>
+<ns0:g id="a_node2"><ns0:a ns1:href="../library_reference.html#cocotb.handle.NonHierarchyObject" ns1:title="Common base class for all non-hierarchy objects." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="215.847,-96 116.153,-96 116.153,-76 215.847,-76 215.847,-96" />
+<ns0:text text-anchor="middle" x="166" y="-83" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">NonHierarchyObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge1" class="edge"><ns0:title>NonHierarchyObject-&gt;ConstantObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M207.865,-96.0835C229.487,-101.419 256.025,-107.967 277.963,-113.381" />
+<ns0:polygon fill="black" stroke="black" points="277.584,-115.089 282.858,-114.588 278.423,-111.691 277.584,-115.089" />
+</ns0:g>
+
+<ns0:g id="node13" class="node"><ns0:title>NonHierarchyIndexableObject</ns0:title>
+<ns0:g id="a_node13"><ns0:a ns1:href="../library_reference.html#cocotb.handle.NonHierarchyIndexableObject" ns1:title="A non-hierarchy indexable object." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="391.772,-96 252.228,-96 252.228,-76 391.772,-76 391.772,-96" />
+<ns0:text text-anchor="middle" x="322" y="-83" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">NonHierarchyIndexableObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge8" class="edge"><ns0:title>NonHierarchyObject-&gt;NonHierarchyIndexableObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M216.15,-86C225.984,-86 236.519,-86 246.98,-86" />
+<ns0:polygon fill="black" stroke="black" points="247.106,-87.7501 252.106,-86 247.106,-84.2501 247.106,-87.7501" />
+</ns0:g>
+
+<ns0:g id="node3" class="node"><ns0:title>Deposit</ns0:title>
+<ns0:g id="a_node3"><ns0:a ns1:href="../library_reference.html#cocotb.handle.Deposit" ns1:title="Action used for placing a value into a given handle." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="67,-115 13,-115 13,-95 67,-95 67,-115" />
+<ns0:text text-anchor="middle" x="40" y="-102" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">Deposit</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="node4" class="node"><ns0:title>EnumObject</ns0:title>
+<ns0:g id="a_node4"><ns0:a ns1:href="../library_reference.html#cocotb.handle.EnumObject" ns1:title="Specific object handle for enumeration signals and variables." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="753.045,-153 686.955,-153 686.955,-133 753.045,-133 753.045,-153" />
+<ns0:text text-anchor="middle" x="720" y="-140" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">EnumObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="node5" class="node"><ns0:title>ModifiableObject</ns0:title>
+<ns0:g id="a_node5"><ns0:a ns1:href="../library_reference.html#cocotb.handle.ModifiableObject" ns1:title="Base class for simulator objects whose values can be modified." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="647.588,-96 560.412,-96 560.412,-76 647.588,-76 647.588,-96" />
+<ns0:text text-anchor="middle" x="604" y="-83" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">ModifiableObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge2" class="edge"><ns0:title>ModifiableObject-&gt;EnumObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M625.118,-96.0592C644.372,-105.686 673.466,-120.233 694.157,-130.578" />
+<ns0:polygon fill="black" stroke="black" points="693.444,-132.179 698.699,-132.85 695.01,-129.048 693.444,-132.179" />
+</ns0:g>
+
+<ns0:g id="node11" class="node"><ns0:title>IntegerObject</ns0:title>
+<ns0:g id="a_node11"><ns0:a ns1:href="../library_reference.html#cocotb.handle.IntegerObject" ns1:title="Specific object handle for integer and enumeration signals and variables." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="755.47,-115 684.53,-115 684.53,-95 755.47,-95 755.47,-115" />
+<ns0:text text-anchor="middle" x="720" y="-102" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">IntegerObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge5" class="edge"><ns0:title>ModifiableObject-&gt;IntegerObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M647.774,-93.129C658.198,-94.8664 669.301,-96.7169 679.562,-98.4271" />
+<ns0:polygon fill="black" stroke="black" points="679.306,-100.158 684.526,-99.2543 679.881,-96.706 679.306,-100.158" />
+</ns0:g>
+
+<ns0:g id="node15" class="node"><ns0:title>RealObject</ns0:title>
+<ns0:g id="a_node15"><ns0:a ns1:href="../library_reference.html#cocotb.handle.RealObject" ns1:title="Specific object handle for Real signals and variables." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="750.481,-77 689.519,-77 689.519,-57 750.481,-57 750.481,-77" />
+<ns0:text text-anchor="middle" x="720" y="-64" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">RealObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge10" class="edge"><ns0:title>ModifiableObject-&gt;RealObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M647.774,-78.871C659.827,-76.8621 672.787,-74.7021 684.305,-72.7825" />
+<ns0:polygon fill="black" stroke="black" points="684.843,-74.4671 689.487,-71.9188 684.267,-71.0147 684.843,-74.4671" />
+</ns0:g>
+
+<ns0:g id="node17" class="node"><ns0:title>StringObject</ns0:title>
+<ns0:g id="a_node17"><ns0:a ns1:href="../library_reference.html#cocotb.handle.StringObject" ns1:title="Specific object handle for String variables." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="753.601,-39 686.399,-39 686.399,-19 753.601,-19 753.601,-39" />
+<ns0:text text-anchor="middle" x="720" y="-26" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">StringObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge12" class="edge"><ns0:title>ModifiableObject-&gt;StringObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M625.118,-75.9408C644.372,-66.3138 673.466,-51.7672 694.157,-41.4217" />
+<ns0:polygon fill="black" stroke="black" points="695.01,-42.9518 698.699,-39.1504 693.444,-39.8213 695.01,-42.9518" />
+</ns0:g>
+
+<ns0:g id="node6" class="node"><ns0:title>Force</ns0:title>
+<ns0:g id="a_node6"><ns0:a ns1:href="../library_reference.html#cocotb.handle.Force" ns1:title="Action used to force a handle to a given value until a release is applied." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="67,-153 13,-153 13,-133 67,-133 67,-153" />
+<ns0:text text-anchor="middle" x="40" y="-140" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">Force</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="node7" class="node"><ns0:title>Freeze</ns0:title>
+<ns0:g id="a_node7"><ns0:a ns1:href="../library_reference.html#cocotb.handle.Freeze" ns1:title="Action used to make a handle keep its current value until a release is used." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="67,-191 13,-191 13,-171 67,-171 67,-191" />
+<ns0:text text-anchor="middle" x="40" y="-178" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">Freeze</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="node8" class="node"><ns0:title>HierarchyArrayObject</ns0:title>
+<ns0:g id="a_node8"><ns0:a ns1:href="../library_reference.html#cocotb.handle.HierarchyArrayObject" ns1:title="Hierarchy Arrays are containers of Hierarchy Objects." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="374.944,-58 269.056,-58 269.056,-38 374.944,-38 374.944,-58" />
+<ns0:text text-anchor="middle" x="322" y="-45" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">HierarchyArrayObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="node9" class="node"><ns0:title>RegionObject</ns0:title>
+<ns0:g id="a_node9"><ns0:a ns1:href="../library_reference.html#cocotb.handle.RegionObject" ns1:title="A region object, such as a scope or namespace." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="201.543,-58 130.457,-58 130.457,-38 201.543,-38 201.543,-58" />
+<ns0:text text-anchor="middle" x="166" y="-45" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">RegionObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge3" class="edge"><ns0:title>RegionObject-&gt;HierarchyArrayObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M201.561,-48C219.873,-48 242.843,-48 263.734,-48" />
+<ns0:polygon fill="black" stroke="black" points="263.997,-49.7501 268.997,-48 263.997,-46.2501 263.997,-49.7501" />
+</ns0:g>
+
+<ns0:g id="node10" class="node"><ns0:title>HierarchyObject</ns0:title>
+<ns0:g id="a_node10"><ns0:a ns1:href="../library_reference.html#cocotb.handle.HierarchyObject" ns1:title="Hierarchy objects are namespace/scope objects." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="363.129,-20 280.871,-20 280.871,-0 363.129,-0 363.129,-20" />
+<ns0:text text-anchor="middle" x="322" y="-7" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">HierarchyObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge4" class="edge"><ns0:title>RegionObject-&gt;HierarchyObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M201.561,-39.4721C223.5,-34.0584 252.125,-26.9951 275.852,-21.1405" />
+<ns0:polygon fill="black" stroke="black" points="276.401,-22.8075 280.836,-19.9106 275.562,-19.4095 276.401,-22.8075" />
+</ns0:g>
+
+<ns0:g id="node12" class="node"><ns0:title>NonConstantObject</ns0:title>
+<ns0:g id="a_node12"><ns0:a ns1:href="../library_reference.html#cocotb.handle.NonConstantObject" ns1:title="A non-constant object" target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="523.93,-96 428.07,-96 428.07,-76 523.93,-76 523.93,-96" />
+<ns0:text text-anchor="middle" x="476" y="-83" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">NonConstantObject</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge6" class="edge"><ns0:title>NonConstantObject-&gt;ModifiableObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M523.918,-86C534.047,-86 544.77,-86 554.942,-86" />
+<ns0:polygon fill="black" stroke="black" points="555.205,-87.7501 560.205,-86 555.205,-84.2501 555.205,-87.7501" />
+</ns0:g>
+
+<ns0:g id="edge7" class="edge"><ns0:title>NonHierarchyIndexableObject-&gt;NonConstantObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M391.884,-86C402.319,-86 412.934,-86 422.934,-86" />
+<ns0:polygon fill="black" stroke="black" points="423.103,-87.7501 428.103,-86 423.103,-84.2501 423.103,-87.7501" />
+</ns0:g>
+
+<ns0:g id="node14" class="node"><ns0:title>SimHandleBase</ns0:title>
+<ns0:g id="a_node14"><ns0:a ns1:href="../library_reference.html#cocotb.handle.SimHandleBase" ns1:title="Base class for all simulation objects." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="80.4302,-77 -0.43015,-77 -0.43015,-57 80.4302,-57 80.4302,-77" />
+<ns0:text text-anchor="middle" x="40" y="-64" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">SimHandleBase</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+
+<ns0:g id="edge9" class="edge"><ns0:title>SimHandleBase-&gt;NonHierarchyObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M80.2344,-73.0117C89.9905,-74.5066 100.62,-76.1353 110.95,-77.7181" />
+<ns0:polygon fill="black" stroke="black" points="110.785,-79.4631 115.992,-78.4907 111.315,-76.0035 110.785,-79.4631" />
+</ns0:g>
+
+<ns0:g id="edge11" class="edge"><ns0:title>SimHandleBase-&gt;RegionObject</ns0:title>
+<ns0:path fill="none" stroke="black" stroke-width="0.5" d="M80.2344,-60.9883C94.516,-58.8 110.669,-56.3249 125.015,-54.1267" />
+<ns0:polygon fill="black" stroke="black" points="125.534,-55.8177 130.212,-53.3305 125.004,-52.358 125.534,-55.8177" />
+</ns0:g>
+
+<ns0:g id="node16" class="node"><ns0:title>Release</ns0:title>
+<ns0:g id="a_node16"><ns0:a ns1:href="../library_reference.html#cocotb.handle.Release" ns1:title="Action used to stop the effects of a previously applied force/freeze action." target="_top">
+<ns0:polygon fill="white" stroke="black" stroke-width="0.5" points="67,-229 13,-229 13,-209 67,-209 67,-229" />
+<ns0:text text-anchor="middle" x="40" y="-216" font-family="Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans" font-size="10.00">Release</ns0:text>
+</ns0:a>
+</ns0:g>
+</ns0:g>
+</ns0:g>
+</ns0:svg>

--- a/documentation/source/library_reference.rst
+++ b/documentation/source/library_reference.rst
@@ -190,8 +190,8 @@ Logging
 Simulation Object Handles
 =========================
 
-.. inheritance-diagram:: cocotb.handle
-   :parts: 1
+.. image:: diagrams/svg/inheritance-cocotb.handle.svg
+   :alt: The class inheritance diagram for cocotb.handle
 
 .. currentmodule:: cocotb.handle
 


### PR DESCRIPTION
This makes the 'dot' binary available to sphinx.ext.inheritance-diagrams
See also https://github.com/readthedocs/readthedocs.org/issues/8672

Closes #3449

In addition, remove the `graphviz_output_format = "svg"` setting since this
renders badly (much too big and without scrollbars) with the currently used
package versions (this could be https://github.com/sphinx-doc/sphinx/issues/10117).

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `documentation/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `documentation/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
