### PR TITLE
enable Verilator CI

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -126,23 +126,10 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v4.106",
-        "os": "ubuntu-20.04",
-        "python-version": "3.8",
-        # Various cocotb tests are known to fail with Verilator 4.106.
-        # Newer versions of Verilator are not working at all.
-        # See also https://github.com/cocotb/cocotb/issues/2300
-        "group": "experimental",
-    },
-    {
-        "lang": "verilog",
-        "sim": "verilator",
         "sim-version": "master",
         "os": "ubuntu-20.04",
         "python-version": "3.8",
-        # Tests are currently not expected to work at all.
-        # See also https://github.com/cocotb/cocotb/issues/2300
-        "group": "experimental",
+        "group": "ci",
     },
     # Test other OSes
     # Icarus homebrew


### PR DESCRIPTION
I believe this should be possible now.  Most things pass when I run `nox` but there are also a number of failures.  I'm posting this separately from the test fixes as I'm thinking it may be desirable to have separate conversations for some of those tests and their implications.  But if it's preferred I can lump everything together here.  Obviously this is not land-able until all of the tests are passing / skipped / something.