### PR TITLE
expect failure for test_force_release with Verilator

### DIFF
--- a/tests/test_cases/test_force_release/test_force_release.py
+++ b/tests/test_cases/test_force_release/test_force_release.py
@@ -5,7 +5,8 @@ from cocotb.handle import Force, Release
 from cocotb.triggers import Timer
 
 
-@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("ghdl"))
+# Verilator does not observe the vpi_put_value() flags field
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith(("ghdl", "verilator")))
 async def test_force_release(dut):
     """
     Test force and release on simulation handles


### PR DESCRIPTION
As noted in the comment, Verilator currently ignores the `flags` field to `vpi_put_value()`.  I was looking at adding some kind of assert to `VpiSignalObjHdl::set_signal_value()` but then I noticed that `vpiInertialDelay` is usually provided for `GPI_DEPOSIT`.

Would it be better to also assert `action == GPI_DEPOSIT` for Verilator?  And are there other issues because Verilator doesn't do `vpiInertialDelay`?  I'm unclear of the implications for cocotb.