### PR TITLE
Skip test_iteration_mixedlang on Riviera

### DIFF
--- a/tests/test_cases/test_iteration_mixedlang/Makefile
+++ b/tests/test_cases/test_iteration_mixedlang/Makefile
@@ -25,5 +25,13 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+ifeq ($(shell echo $(SIM) | tr A-Z a-z),riviera)
+all:
+	@echo "Skipping test_iteration_mixedlang since Riviera-PRO crashes (see https://github.com/cocotb/cocotb/issues/3293)"
+clean::
+
+else
+
 include ../../designs/uart2bus/Makefile
 MODULE = test_iteration
+endif


### PR DESCRIPTION
This test crashes on Riviera-PRO, skip it.

See https://github.com/cocotb/cocotb/issues/3293