### PR TITLE
Update to the latest version of Riviera in CI

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -230,7 +230,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "riviera",
-        "sim-version": "aldec/rivierapro/2022.04",
+        "sim-version": "aldec/rivierapro/2023.10",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -239,7 +239,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "riviera",
-        "sim-version": "aldec/rivierapro/2022.04",
+        "sim-version": "aldec/rivierapro/2023.10",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -6,6 +6,7 @@ import contextlib
 import logging
 
 import cocotb
+from cocotb._sim_versions import RivieraVersion
 from cocotb.clock import Clock
 from cocotb.triggers import Timer
 
@@ -139,9 +140,15 @@ async def test_ndim_array_indexes(dut):
 
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
+# Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
 @cocotb.test(
     expect_error=AttributeError
     if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl"))
+    or (
+        cocotb.SIM_NAME.lower().startswith("riviera")
+        and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
+        and cocotb.LANGUAGE == "verilog"
+    )
     else ()
 )
 async def test_struct(dut):

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -11,6 +11,7 @@ Tests for edge triggers
 """
 import cocotb
 import pytest
+from cocotb._sim_versions import RivieraVersion
 from cocotb.clock import Clock
 from cocotb.result import SimTimeoutError
 from cocotb.triggers import (
@@ -234,11 +235,12 @@ async def test_clock_cycles_forked(dut):
 @cocotb.test(
     timeout_time=100,
     timeout_unit="ns",
-    expect_error=(
+    expect_error=(  # gh-2344
         SimTimeoutError
         if (
             cocotb.LANGUAGE in ["verilog"]
-            and cocotb.SIM_NAME.lower().startswith(("riviera", "aldec"))  # gh-2344
+            and cocotb.SIM_NAME.lower().startswith(("riviera", "aldec"))
+            and RivieraVersion(cocotb.SIM_VERSION) < RivieraVersion("2023.04")
         )
         else ()
     ),

--- a/tests/test_cases/test_packed_union/test_packed_union.py
+++ b/tests/test_cases/test_packed_union/test_packed_union.py
@@ -3,11 +3,18 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import cocotb
+from cocotb._sim_versions import RivieraVersion
 
 
+# Riviera-PRO 2022.10 (VPI) and newer does not discover dut.t correctly (gh-3587)
 @cocotb.test(
     expect_error=Exception
     if cocotb.SIM_NAME.lower().startswith(("verilator", "icarus", "ghdl"))
+    or (
+        cocotb.SIM_NAME.lower().startswith("riviera")
+        and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
+        and cocotb.LANGUAGE == "verilog"
+    )
     else ()
 )
 async def test_packed_union(dut):


### PR DESCRIPTION
- Remove test waiver for test_both_edge_triggers on recent Riviera
- Use the latest version of Riviera in CI
