### PR TITLE
Make stable/1.8 tests pass

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -165,7 +165,7 @@ def dev_test_sim(
         coverage_file.unlink()
 
     session.log(f"Running 'make test' against a simulator {config_str}")
-    session.run("make", "clean", "test", external=True, env=env)
+    session.run("make", "test", external=True, env=env)
 
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(
@@ -479,7 +479,7 @@ def release_test_sim(
     config_str = stringify_dict(env)
 
     session.log(f"Running tests against a simulator: {config_str}")
-    session.run("make", "clean", "test", external=True, env=env)
+    session.run("make", "test", external=True, env=env)
 
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(

--- a/tests/test_cases/test_iteration_mixedlang/Makefile
+++ b/tests/test_cases/test_iteration_mixedlang/Makefile
@@ -25,5 +25,13 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+ifeq ($(shell echo $(SIM) | tr A-Z a-z),riviera)
+all:
+	@echo "Skipping test_iteration_mixedlang since Riviera-PRO crashes (see https://github.com/cocotb/cocotb/issues/3293)"
+clean::
+
+else
+
 include ../../designs/uart2bus/Makefile
 MODULE = test_iteration
+endif


### PR DESCRIPTION
Various further pull requests to make stable/1.8 pass all CI tests.

- Run tests without clean from nox
- Skip test_iteration_mixedlang on Riviera
