### PR TITLE
Fix Task repr for Coroutine objects

### DIFF
--- a/cocotb/task.py
+++ b/cocotb/task.py
@@ -117,7 +117,10 @@ class Task(typing.Coroutine[typing.Any, typing.Any, T]):
         # - exhausted generator
         # - finished coroutine
         except IndexError:
-            coro_name = self._coro.__name__
+            try:
+                coro_name = self._coro.__name__
+            except AttributeError:
+                coro_name = type(self._coro).__name__
 
         repr_string = fmt.format(
             name=self.__name__,

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -475,6 +475,26 @@ async def test_task_repr(dut):
     log.info(str(coro_task))
     assert re.match(r"<Task \d+>", str(coro_task))
 
+    class CoroutineClass(Coroutine):
+        def __init__(self):
+            self._coro = self.run()
+
+        async def run(self):
+            pass
+
+        def send(self, value):
+            self._coro.send(value)
+
+        def throw(self, exception):
+            self._coro.throw(exception)
+
+        def __await__(self):
+            yield from self._coro.__await__()
+
+    object_task = cocotb.create_task(CoroutineClass())
+    log.info(repr(object_task))
+    assert re.match(r"<Task \d+ created coro=CoroutineClass\(\)>", repr(object_task))
+
 
 @cocotb.test()
 async def test_test_repr(_):

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -512,6 +512,33 @@ async def test_test_repr(_):
 
 
 @cocotb.test()
+class TestClassRepr(Coroutine):
+    def __init__(self, dut):
+        self._coro = self.check_repr(dut)
+
+    async def check_repr(self, dut):
+        log = logging.getLogger("cocotb.test")
+
+        current_test = cocotb.scheduler._test
+        log.info(repr(current_test))
+        assert re.match(
+            r"<Test TestClassRepr running coro=TestClassRepr\(\)>", repr(current_test)
+        )
+
+        log.info(str(current_test))
+        assert re.match(r"<Test TestClassRepr>", str(current_test))
+
+    def send(self, value):
+        self._coro.send(value)
+
+    def throw(self, exception):
+        self._coro.throw(exception)
+
+    def __await__(self):
+        yield from self._coro.__await__()
+
+
+@cocotb.test()
 async def test_start_soon_async(_):
     """Tests start_soon works with coroutines"""
     a = 0


### PR DESCRIPTION
`Task.__repr__` would raise an exception if the wrapped object does not have a `__name__` attribute.
Added fallback to `type().__name__` in that case.