### PR TITLE
Random changes

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -166,7 +166,7 @@ def test(
     expect_error: Union[bool, Type[Exception], Sequence[Type[Exception]]] = (),
     skip: bool = False,
     stage: int = 0,
-) -> Callable[[Callable[..., None]], Test]:
+) -> Callable[[Callable[..., Coroutine[Any, Any, None]]], Test]:
     """
     Decorator to mark a Callable which returns a Coroutine as a test.
 

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -36,9 +36,9 @@ from numbers import Real
 from typing import Any, Coroutine, Optional, TypeVar, Union
 
 import cocotb
+import cocotb.task
 from cocotb import outcomes, simulator
 from cocotb.log import SimLog
-from cocotb.task import Task
 from cocotb.utils import (
     ParametrizedSingleton,
     get_sim_steps,
@@ -766,7 +766,7 @@ class _AggregateWaitable(Waitable):
 
         # Do some basic type-checking up front, rather than waiting until we
         # await them.
-        allowed_types = (Trigger, Waitable, Task)
+        allowed_types = (Trigger, Waitable, cocotb.task.Task)
         for trigger in self.triggers:
             if not isinstance(trigger, allowed_types):
                 raise TypeError(
@@ -781,7 +781,8 @@ class _AggregateWaitable(Waitable):
         return "{}({})".format(
             type(self).__qualname__,
             ", ".join(
-                repr(Join(t)) if isinstance(t, Task) else repr(t) for t in self.triggers
+                repr(Join(t)) if isinstance(t, cocotb.task.Task) else repr(t)
+                for t in self.triggers
             ),
         )
 
@@ -922,7 +923,7 @@ class ClockCycles(Waitable):
 
 
 async def with_timeout(
-    trigger: Union[Trigger, Waitable, Task, Coroutine[Any, Any, T]],
+    trigger: Union[Trigger, Waitable, "cocotb.task.Task", Coroutine[Any, Any, T]],
     timeout_time: Union[float, Decimal],
     timeout_unit: str = "step",
     round_mode: Optional[str] = None,

--- a/documentation/source/newsfragments/3461.change.rst
+++ b/documentation/source/newsfragments/3461.change.rst
@@ -1,0 +1,1 @@
+:func:`cocotb.function` and :func:`cocotb.external` are now implemented as decorator functions and not types. All attributes, e.g. ``log``, are no longer available.

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -100,9 +100,9 @@ async def test_time_in_function(dut):
     """
 
     @cocotb.function
-    def wait_cycles(dut, n):
+    async def wait_cycles(dut, n):
         for _ in range(n):
-            yield RisingEdge(dut.clk)
+            await RisingEdge(dut.clk)
 
     @external
     def wait_cycles_wrapper(dut, n):
@@ -311,9 +311,8 @@ async def test_function_returns_exception(dut):
     """
 
     @cocotb.function
-    def gen_func():
+    async def gen_func():
         return ValueError()
-        yield
 
     @external
     def ext():


### PR DESCRIPTION
Closes #3464, for now. Also fixes the typing on `cocotb.test` and makes the `cocotb.external` and `cocotb.function` into function-based decorators, which does change the interface, but simplifies the implementation and makes the resulting object more like the regular `async def` functions that cocotb has now, instead of unique types like `cocotb.coroutine`.

Next will be the removal of `cocotb.coroutine` (which requires I first support `coroutines` in `First` and `Combine`), then privatization of `Test` (since there is now no way for the user to get a handle on the object, and it might move to another module).