### PR TITLE
Changing `TriggerException`

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -223,7 +223,7 @@ class Timer(GPITrigger):
             :func:`~cocotb.utils.get_sim_steps`
 
         Raises:
-            TriggerException: If a negative value is passed for Timer setup.
+            ValueError: If a negative value is passed for Timer setup.
 
         .. versionchanged:: 1.5
             Raise an exception when Timer uses a negative value as it is undefined behavior.
@@ -250,7 +250,7 @@ class Timer(GPITrigger):
                     stacklevel=2,
                 )
             else:
-                raise TriggerException("Timer value time_ps must not be negative")
+                raise ValueError("Timer value time_ps must not be negative")
         if round_mode is None:
             round_mode = type(self).round_mode
         self.sim_steps = get_sim_steps(time, units, round_mode=round_mode)
@@ -607,9 +607,7 @@ class Lock:
     def release(self):
         """Release the lock."""
         if not self.locked:
-            raise TriggerException(
-                "Attempt to release an unacquired Lock %s" % (str(self))
-            )
+            raise RuntimeError("Attempt to release an unacquired Lock %s" % (str(self)))
 
         self.locked = False
 

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -250,7 +250,7 @@ class Timer(GPITrigger):
                     stacklevel=2,
                 )
             else:
-                raise ValueError("Timer value time_ps must not be negative")
+                raise ValueError("Timer argument time must not be negative")
         if round_mode is None:
             round_mode = type(self).round_mode
         self.sim_steps = get_sim_steps(time, units, round_mode=round_mode)

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -61,7 +61,7 @@ def _pointer_str(obj):
     return full_repr.rsplit(" ", 1)[1][:-1]
 
 
-class TriggerException(Exception):
+class _TriggerException(Exception):
     pass
 
 
@@ -262,7 +262,7 @@ class Timer(GPITrigger):
                 self.sim_steps, callback, self
             )
             if self.cbhdl is None:
-                raise TriggerException("Unable set up %s Trigger" % (str(self)))
+                raise _TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger._prime(self, callback)
 
     def __repr__(self):
@@ -301,7 +301,7 @@ class ReadOnly(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         if self.cbhdl is None:
             self.cbhdl = simulator.register_readonly_callback(callback, self)
             if self.cbhdl is None:
-                raise TriggerException("Unable set up %s Trigger" % (str(self)))
+                raise _TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger._prime(self, callback)
 
     def __repr__(self):
@@ -324,7 +324,7 @@ class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         if self.cbhdl is None:
             self.cbhdl = simulator.register_rwsynch_callback(callback, self)
             if self.cbhdl is None:
-                raise TriggerException("Unable set up %s Trigger" % (str(self)))
+                raise _TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger._prime(self, callback)
 
     def __repr__(self):
@@ -347,7 +347,7 @@ class NextTimeStep(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
         if self.cbhdl is None:
             self.cbhdl = simulator.register_nextstep_callback(callback, self)
             if self.cbhdl is None:
-                raise TriggerException("Unable set up %s Trigger" % (str(self)))
+                raise _TriggerException("Unable set up %s Trigger" % (str(self)))
         GPITrigger._prime(self, callback)
 
     def __repr__(self):
@@ -380,7 +380,7 @@ class _EdgeBase(GPITrigger, metaclass=_ParameterizedSingletonAndABC):
                 self.signal._handle, callback, type(self)._edge_type, self
             )
             if self.cbhdl is None:
-                raise TriggerException("Unable set up %s Trigger" % (str(self)))
+                raise _TriggerException("Unable set up %s Trigger" % (str(self)))
         super()._prime(callback)
 
     def __repr__(self):

--- a/tests/test_cases/issue_120/issue_120.py
+++ b/tests/test_cases/issue_120/issue_120.py
@@ -22,7 +22,7 @@ async def monitor(dut):
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )

--- a/tests/test_cases/issue_142/issue_142.py
+++ b/tests/test_cases/issue_142/issue_142.py
@@ -8,7 +8,7 @@ from cocotb.triggers import RisingEdge
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )

--- a/tests/test_cases/issue_348/issue_348.py
+++ b/tests/test_cases/issue_348/issue_348.py
@@ -50,7 +50,7 @@ class DualMonitor:
 
 # Cadence simulators: "Unable set up RisingEdge(ModifiableObject(sample_module.clk)) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )
@@ -61,7 +61,7 @@ async def issue_348_rising(dut):
 
 # Cadence simulators: "Unable set up FallingEdge(ModifiableObject(sample_module.clk)) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )
@@ -72,7 +72,7 @@ async def issue_348_falling(dut):
 
 # Cadence simulators: "Unable set up Edge(ModifiableObject(sample_module.clk)) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -26,8 +26,8 @@ from cocotb.triggers import (
     ReadWrite,
     RisingEdge,
     Timer,
-    TriggerException,
 )
+from cocotb.triggers import _TriggerException as TriggerException
 from cocotb.utils import get_sim_time
 
 
@@ -261,7 +261,7 @@ async def test_singleton_isinstance(dut):
 @cocotb.test()
 async def test_neg_timer(dut):
     """Test negative timer values are forbidden"""
-    with pytest.raises(TriggerException):
+    with pytest.raises(ValueError):
         Timer(-42)  # no need to even `await`, constructing it is an error
     # handle 0 special case
     with warnings.catch_warnings(record=True) as w:

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -89,7 +89,7 @@ async def test_time_in_external(dut):
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )
@@ -122,7 +122,7 @@ async def test_time_in_function(dut):
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )
@@ -186,7 +186,7 @@ async def test_function_from_readonly(dut):
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )
@@ -204,7 +204,7 @@ async def test_function_that_awaits(dut):
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )
@@ -225,7 +225,7 @@ async def test_await_after_function(dut):
 
 # Cadence simulators: "Unable set up RisingEdge(...) Trigger" with VHDL (see #1076)
 @cocotb.test(
-    expect_error=cocotb.triggers.TriggerException
+    expect_error=cocotb.triggers._TriggerException
     if cocotb.SIM_NAME.startswith(("xmsim", "ncsim")) and cocotb.LANGUAGE in ["vhdl"]
     else ()
 )


### PR DESCRIPTION
Changes it's use in user-facing code and then makes it private. There doesn't seem to be any special handling of these in the scheduler, so I'm not entirely sure the point?

Closes #3459.