### PR TITLE
CI: Only attempt to push the benchmark on master

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,11 @@ jobs:
         pip install .
         pytest -c /dev/null tests/benchmark.py --benchmark-json output.json
 
+    # Pushing the benchmark requires elevated permissions to the
+    # cocotb/cocotb-benchmark-results repository, which we only grant for
+    # master builds, not for PR builds.
     - name: Generate a token to access cocotb/cocotb-benchmark-results
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       id: generate_token
       uses: actions/create-github-app-token@v1
       with:
@@ -62,7 +66,6 @@ jobs:
         repositories: cocotb-benchmark-results
 
     - name: Store benchmark result
-      # Will only run on the master branch and not on pull request
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       uses: benchmark-action/github-action-benchmark@v1
       continue-on-error: true


### PR DESCRIPTION
PR builds from a fork fail due to secrets not being available. These
secrets are not available by design, so let's avoid running the step
altogether.

Error message:
```
Run actions/create-github-app-token@v1
  with:
    owner: cocotb
    repositories: cocotb-benchmark-results
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.18/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
/home/runner/work/_actions/actions/create-github-app-token/v1/dist/main.cjs:10116
  throw new Error("Input required and not supplied: app-id");
  ^

Error: Input required and not supplied: app-id
    at Object.<anonymous> (/home/runner/work/_actions/actions/create-github-app-token/v1/dist/main.cjs:10116:9)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47
```
