### PR TITLE
Improve Aldec compile/sim flows

### DIFF
--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -66,7 +66,7 @@ Aldec Riviera-PRO
 
    .. group-tab:: Design with a VHDL Toplevel
 
-      For a design with a VHDL toplevel, call the ``asim`` executable with the option
+      For a design with a VHDL toplevel, call ``asim`` with the option
       ``-loadvhpi $(cocotb-config --lib-name-path vhpi riviera):vhpi_startup_routines_bootstrap``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
@@ -75,7 +75,7 @@ Aldec Riviera-PRO
 
    .. group-tab:: Design with a (System)Verilog Toplevel
 
-      For a design with a (System)Verilog toplevel, call the ``asim`` executable with the option
+      For a design with a (System)Verilog toplevel, call ``asim`` with the option
       ``-pli $(cocotb-config --lib-name-path vpi riviera)``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
@@ -93,7 +93,7 @@ Aldec Active-HDL
 
    .. group-tab:: Design with a VHDL Toplevel
 
-      For a design with a VHDL toplevel, call the ``asim`` executable with the option
+      For a design with a VHDL toplevel, call ``asim`` with the option
       ``-loadvhpi $(cocotb-config --lib-name-path vhpi activehdl):vhpi_startup_routines_bootstrap``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
@@ -102,7 +102,7 @@ Aldec Active-HDL
 
    .. group-tab:: Design with a (System)Verilog Toplevel
 
-      For a design with a (System)Verilog toplevel, call the ``asim`` executable with the option
+      For a design with a (System)Verilog toplevel, call ``asim`` with the option
       ``-pli $(cocotb-config --lib-name-path vpi activehdl)``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to

--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -60,7 +60,7 @@ Aldec Riviera-PRO
 =================
 
 * The ``alog`` call needs the ``-pli libgpi`` option set.
-* The ``asim`` call needs the ``+access +w`` option set to allow cocotb to access values in the design.
+* The ``asim`` call needs the ``+access +w_nets`` option set to allow cocotb to access values in the design.
 
 .. tabs::
 
@@ -87,7 +87,7 @@ Aldec Riviera-PRO
 Aldec Active-HDL
 ================
 
-* The ``asim`` call needs the ``+access +w`` option set to allow cocotb to access values in the design.
+* The ``asim`` call needs the ``+access +w_nets`` option set to allow cocotb to access values in the design.
 
 .. tabs::
 

--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -59,7 +59,6 @@ Synopsys VCS
 Aldec Riviera-PRO
 =================
 
-* The ``alog`` call needs the ``-pli libgpi`` option set.
 * The ``asim`` call needs the ``+access +w_nets`` option set to allow cocotb to access values in the design.
 
 .. tabs::
@@ -75,7 +74,7 @@ Aldec Riviera-PRO
 
    .. group-tab:: Design with a (System)Verilog Toplevel
 
-      For a design with a (System)Verilog toplevel, call ``asim`` with the option
+      For a design with a (System)Verilog toplevel, call ``alog`` and ``asim`` with the option
       ``-pli $(cocotb-config --lib-name-path vpi riviera)``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
@@ -102,7 +101,7 @@ Aldec Active-HDL
 
    .. group-tab:: Design with a (System)Verilog Toplevel
 
-      For a design with a (System)Verilog toplevel, call ``asim`` with the option
+      For a design with a (System)Verilog toplevel, call ``alog`` and ``asim`` with the option
       ``-pli $(cocotb-config --lib-name-path vpi activehdl)``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to

--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -805,7 +805,7 @@ class Riviera(Simulator):
         do_script = "\nonerror {\n quit -code 1 \n} \n"
 
         if self.hdl_toplevel_lang == "vhdl":
-            do_script += "asim +access +w -interceptcoutput -O2 -loadvhpi {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUSARGS}\n".format(
+            do_script += "asim +access +w_nets -interceptcoutput -O2 -loadvhpi {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUSARGS}\n".format(
                 TOPLEVEL=as_tcl_value(
                     f"{self.hdl_toplevel_library}.{self.sim_hdl_toplevel}"
                 ),
@@ -823,7 +823,7 @@ class Riviera(Simulator):
                 cocotb.config.lib_name_path("vpi", "riviera") + ":cocotbvpi_entry_point"
             )
         else:
-            do_script += "asim +access +w -interceptcoutput -O2 -pli {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUSARGS} \n".format(
+            do_script += "asim +access +w_nets -interceptcoutput -O2 -pli {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUSARGS} \n".format(
                 TOPLEVEL=as_tcl_value(
                     f"{self.hdl_toplevel_library}.{self.sim_hdl_toplevel}"
                 ),

--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -805,7 +805,7 @@ class Riviera(Simulator):
         do_script = "\nonerror {\n quit -code 1 \n} \n"
 
         if self.hdl_toplevel_lang == "vhdl":
-            do_script += "asim +access +w_nets -interceptcoutput -O2 -loadvhpi {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUSARGS}\n".format(
+            do_script += "asim +access +w_nets -interceptcoutput -loadvhpi {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUSARGS}\n".format(
                 TOPLEVEL=as_tcl_value(
                     f"{self.hdl_toplevel_library}.{self.sim_hdl_toplevel}"
                 ),
@@ -823,7 +823,7 @@ class Riviera(Simulator):
                 cocotb.config.lib_name_path("vpi", "riviera") + ":cocotbvpi_entry_point"
             )
         else:
-            do_script += "asim +access +w_nets -interceptcoutput -O2 -pli {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUSARGS} \n".format(
+            do_script += "asim +access +w_nets -interceptcoutput -pli {EXT_NAME} {EXTRA_ARGS} {TOPLEVEL} {PLUSARGS} \n".format(
                 TOPLEVEL=as_tcl_value(
                     f"{self.hdl_toplevel_library}.{self.sim_hdl_toplevel}"
                 ),

--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -783,8 +783,11 @@ class Riviera(Simulator):
                 )
 
             if self.verilog_sources:
-                do_script += "alog -work {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
+                do_script += "alog -work {RTL_LIBRARY} +define+COCOTB_SIM -pli {EXT_NAME} -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
                     RTL_LIBRARY=as_tcl_value(self.hdl_library),
+                    EXT_NAME=as_tcl_value(
+                        cocotb.config.lib_name_path("vpi", "riviera")
+                    ),
                     VERILOG_SOURCES=" ".join(
                         as_tcl_value(str(v)) for v in self.verilog_sources
                     ),

--- a/src/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/src/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -54,7 +54,7 @@ endif
 ifneq ($(VERILOG_SOURCES),)
 	@echo "alog $(ALOG_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
 endif
-	@echo "asim $(ASIM_ARGS) $(PLUSARGS) +access +w -interceptcoutput -O2 -dbg $(GPI_ARGS) $(TOPLEVEL) $(EXTRA_TOPS)" >> $@
+	@echo "asim $(ASIM_ARGS) $(PLUSARGS) +access +w_nets -interceptcoutput -O2 -dbg $(GPI_ARGS) $(TOPLEVEL) $(EXTRA_TOPS)" >> $@
 	@echo "run -all" >> $@
 	@echo "endsim" >> $@
 

--- a/src/cocotb/share/makefiles/simulators/Makefile.activehdl
+++ b/src/cocotb/share/makefiles/simulators/Makefile.activehdl
@@ -54,7 +54,7 @@ endif
 ifneq ($(VERILOG_SOURCES),)
 	@echo "alog $(ALOG_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
 endif
-	@echo "asim $(ASIM_ARGS) $(PLUSARGS) +access +w_nets -interceptcoutput -O2 -dbg $(GPI_ARGS) $(TOPLEVEL) $(EXTRA_TOPS)" >> $@
+	@echo "asim $(ASIM_ARGS) $(PLUSARGS) +access +w_nets -interceptcoutput $(GPI_ARGS) $(TOPLEVEL) $(EXTRA_TOPS)" >> $@
 	@echo "run -all" >> $@
 	@echo "endsim" >> $@
 

--- a/src/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -70,8 +70,7 @@ ASIM_ARGS += $(SIM_ARGS)
 ASIM_ARGS += $(PLUSARGS)
 
 RTL_LIBRARY ?= $(SIM_BUILD)/work
-ALOG_ARGS += +define+COCOTB_SIM -dbg -pli libgpi
-ACOM_ARGS += -dbg
+ALOG_ARGS += +define+COCOTB_SIM -pli libgpi
 
 # Aldec-specific coverage types:
 # - (s)tatement
@@ -84,8 +83,10 @@ ACOM_ARGS += -dbg
 # Documentation: Riviera Pro 2017.02 Documentation - Page 359
 COVERAGE_TYPES ?= sb
 ifeq ($(COVERAGE),1)
-    ASIM_ARGS += -acdb -acdb_cov $(COVERAGE_TYPES)
-    ALOG_ARGS += -coverage $(COVERAGE_TYPES)
+    ALOG_ARGS += -dbg -coverage $(COVERAGE_TYPES)
+    ACOM_ARGS += -dbg -coverage $(COVERAGE_TYPES)
+
+    ASIM_ARGS += -dbg -acdb -acdb_cov $(COVERAGE_TYPES)
 endif
 
 GPI_EXTRA:=
@@ -126,9 +127,9 @@ ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@
 endif
 ifneq ($(CFG_TOPLEVEL),)
-	@echo "asim $(ASIM_ARGS) +access +w_nets -interceptcoutput -O2 -dbg $(GPI_ARGS) $(CFG_TOPLEVEL) $(EXTRA_TOPS)" >> $@
+	@echo "asim $(ASIM_ARGS) +access +w_nets -interceptcoutput $(GPI_ARGS) $(CFG_TOPLEVEL) $(EXTRA_TOPS)" >> $@
 else
-	@echo "asim $(ASIM_ARGS) +access +w_nets -interceptcoutput -O2 -dbg $(GPI_ARGS) $(TOPLEVEL) $(EXTRA_TOPS)" >> $@
+	@echo "asim $(ASIM_ARGS) +access +w_nets -interceptcoutput $(GPI_ARGS) $(TOPLEVEL) $(EXTRA_TOPS)" >> $@
 endif
 ifeq ($(WAVES),1)
 	@echo "log -recursive *" >> $@

--- a/src/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -70,7 +70,10 @@ ASIM_ARGS += $(SIM_ARGS)
 ASIM_ARGS += $(PLUSARGS)
 
 RTL_LIBRARY ?= $(SIM_BUILD)/work
-ALOG_ARGS += +define+COCOTB_SIM -pli libgpi
+ALOG_ARGS += +define+COCOTB_SIM
+
+# Pass the VPI library to the Verilog compilation to get extended checking.
+ALOG_ARGS += -pli $(shell cocotb-config --lib-name-path vpi riviera)
 
 # Aldec-specific coverage types:
 # - (s)tatement

--- a/src/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -126,9 +126,9 @@ ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@
 endif
 ifneq ($(CFG_TOPLEVEL),)
-	@echo "asim $(ASIM_ARGS) +access +w -interceptcoutput -O2 -dbg $(GPI_ARGS) $(CFG_TOPLEVEL) $(EXTRA_TOPS)" >> $@
+	@echo "asim $(ASIM_ARGS) +access +w_nets -interceptcoutput -O2 -dbg $(GPI_ARGS) $(CFG_TOPLEVEL) $(EXTRA_TOPS)" >> $@
 else
-	@echo "asim $(ASIM_ARGS) +access +w -interceptcoutput -O2 -dbg $(GPI_ARGS) $(TOPLEVEL) $(EXTRA_TOPS)" >> $@
+	@echo "asim $(ASIM_ARGS) +access +w_nets -interceptcoutput -O2 -dbg $(GPI_ARGS) $(TOPLEVEL) $(EXTRA_TOPS)" >> $@
 endif
 ifeq ($(WAVES),1)
 	@echo "log -recursive *" >> $@


### PR DESCRIPTION
A small set of changes to improve the Aldec (Riviera-PRO and Active-HDL) simulation flows. Please take a look at the individual commits for a detailed discussion of the changes.

- Aldec: Explicitly allow signal access
- Aldec: Reduce command-line options to a minium
- Aldec: alog/acom/asim are TCL macros, not executables
- Aldec: Pass VPI library to Verilog compile
