### PR TITLE
CI: Version updates for Icarus and Python

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -90,7 +90,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "icarus",
-        "sim-version": "v11_0",  # The latest release version.
+        "sim-version": "v12_0",  # The latest release version.
         "os": "ubuntu-20.04",
         "python-version": "3.8",
         "group": "experimental",
@@ -166,7 +166,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "icarus",
-        "sim-version": "b83daa3ae36891a372655652e53c9b4eefdfcafa",
+        "sim-version": "v12_0",
         "os": "windows-latest",
         "python-version": "3.8",
         "toolchain": "mingw",
@@ -178,7 +178,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "icarus",
-        "sim-version": "b83daa3ae36891a372655652e53c9b4eefdfcafa",
+        "sim-version": "v12_0",
         "os": "windows-latest",
         "python-version": "3.11",
         "toolchain": "msvc",
@@ -190,7 +190,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "icarus",
-        "sim-version": "b83daa3ae36891a372655652e53c9b4eefdfcafa",
+        "sim-version": "v12_0",
         "os": "ubuntu-20.04",
         "python-version": "3.8",
         "cxx": "clang++",

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -66,19 +66,18 @@ ENVS = [
         "sim": "icarus",
         "sim-version": "apt",
         "os": "ubuntu-20.04",
-        "python-version": "3.12.0-rc - 3.12",
+        "python-version": "3.12",
         "group": "ci",
     },
     # A single test for the upcoming Python version.
-    # TODO: Enable once Python 3.13 development starts.
-    # {
-    #    "lang": "verilog",
-    #    "sim": "icarus",
-    #    "sim-version": "apt",
-    #    "os": "ubuntu-20.04",
-    #    "python-version": "3.13.0-alpha - 3.13.0",
-    #    "group": "experimental",
-    # },
+    {
+        "lang": "verilog",
+        "sim": "icarus",
+        "sim-version": "apt",
+        "os": "ubuntu-20.04",
+        "python-version": "3.13.0-alpha - 3.13.0",
+        "group": "experimental",
+    },
     # Test Icarus on Ubuntu
     {
         "lang": "verilog",


### PR DESCRIPTION
- CI: Enable tests for Python 3.13
- CI: Use the latest icarus release
