### PR TITLE
Riviera-PRO: Always exit the compilation step

### DIFF
--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -798,6 +798,13 @@ class Riviera(Simulator):
         else:
             print("WARNING: Skipping compilation of", out_file)
 
+        # Explicitly exit the script at the end. In batch mode, which is invoked
+        # implicitly by redirecting STDOUT/STDERR of the alog/acom commands,
+        # the tool exits by itself even without this 'exit' command -- but not
+        # when running from an interactive terminal. Be explicit for predictable
+        # behavior.
+        do_script += "\nexit"
+
         do_file = tempfile.NamedTemporaryFile(delete=False)
         do_file.write(do_script.encode())
         do_file.close()


### PR DESCRIPTION
Riviera ("vsimsa") automatically switches to "batch" mode when output is
redirected, and stays in interactive mode otherwise. In our Makefiles,
we always redirect the output and hence produce predictable behavior. In
our runner, we don't redirect output. Depending on how tests get run,
the output then gets redirected, or not: in CI, output always gets
redirected, hence the alog/acom commands terminate. In manual testing in
an interactive terminal, that's not the case and the tests are stuck.

Provide predictable behavior by always exiting at the end.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
