### PR TITLE
Replace flake8, black and isort with ruff and ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,22 +4,17 @@
 
 exclude: "^.*/_vendor/"
 repos:
-- repo: "https://github.com/psf/black"
-  rev: "23.3.0"
+# ruff with --fix should run before other formatting tools
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: "v0.1.4"
   hooks:
-  - id: "black"
-
-- repo: "https://github.com/pycqa/isort"
-  rev: "5.12.0"
-  hooks:
-  - id: "isort"
-    args:
-    - "--profile=black"
-
-- repo: "https://github.com/pycqa/flake8"
-  rev: "6.0.0"
-  hooks:
-  - id: "flake8"
+    # Run the linter.
+    - id: "ruff"
+      args:
+      - "--fix"
+      - "--exit-non-zero-on-fix"
+    # Run the formatter.
+    - id: ruff-format
 
 - repo: "https://github.com/pre-commit/mirrors-clang-format"
   rev: "v16.0.6"

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -83,9 +83,8 @@ def create_sxs_assembly_manifest(
         )
 
     if not dependency_only:
-        manifest_body = (
-            textwrap.dedent(
-                """\
+        manifest_body = textwrap.dedent(
+            """\
             <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
             <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
                 <assemblyIdentity name="%s" version="1.0.0.0" type="win32" processorArchitecture="%s" />
@@ -93,26 +92,21 @@ def create_sxs_assembly_manifest(
                 %s
             </assembly>
             """
-            )
-            % (
-                name,
-                architecture,
-                filename,
-                textwrap.indent("".join(dependencies), "    ").strip(),
-            )
+        ) % (
+            name,
+            architecture,
+            filename,
+            textwrap.indent("".join(dependencies), "    ").strip(),
         )
     else:
-        manifest_body = (
-            textwrap.dedent(
-                """\
+        manifest_body = textwrap.dedent(
+            """\
             <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
             <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
                 %s
             </assembly>
             """
-            )
-            % (textwrap.indent("".join(dependencies), "    ").strip())
-        )
+        ) % (textwrap.indent("".join(dependencies), "    ").strip())
 
     return manifest_body
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,12 +25,10 @@ coverage_deps = ["coverage", "pytest-cov"]
 coverage_report_deps = ["coverage", "jinja2<3.1", "gcovr==5.0"]
 
 dev_deps = [
-    "black",
-    "isort",
     "mypy",
     "pre-commit",
     "nox",
-    "flake8",
+    "ruff",
     "clang-format",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,16 +37,31 @@ build-backend = "setuptools.build_meta"
         name = "Changes"
         showcontent = true
 
-[tool.isort]
-profile = "black"
-extend_skip_glob = [
-    "*/_vendor/*"
+[tool.ruff]
+extend-exclude = [
+    "docs/source/conf.py",
+    "makefiles",
+    "venv",
+    "_vendor",
+    ".nox/",
+]
+ignore = [
+    # ambiguous variable name (preference)
+    "E741",
+    # line too long (preference)
+    "E501",
+    # whitespace before ':' (black)
+    "E203",
+    # line break before binary operator (black)
+    # "W503",  # not implemented by ruff
 ]
 
-[tool.black]
-extend_exclude = '''
-_vendor
-'''
+[tool.ruff.per-file-ignores]
+# necessary because of how file is included into documentation
+"examples/doc_examples/quickstart/test_my_design.py" = [
+    "E402",
+    "F811",
+]
 
 [tool.cibuildwheel]
 # Build for supported platforms only.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,25 +1,3 @@
-[flake8]
-extend-exclude =
-    docs/source/conf.py,
-    makefiles,
-    venv,
-    _vendor,
-    .nox/,
-
-ignore =
-    # ambiguous variable name (preference)
-    E741,
-    # line too long (preference)
-    E501,
-    # whitespace before ':' (black)
-    E203,
-    # line break before binary operator (black)
-    W503,
-
-per-file-ignores =
-    # necessary because of how file is included into documentation
-    examples/doc_examples/quickstart/test_my_design.py: E402,F811
-
 [tool:pytest]
 # Note: Do *not* add files within the cocotb/ tree here. Add them to the
 # noxfile instead.

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -572,7 +572,7 @@ class NonHierarchyIndexableObject(NonHierarchyObject):
 
         See the docstring for this class.
         """
-        if type(value) is not list:
+        if type(value) is not list:  # noqa: E721
             raise TypeError(
                 "Assigning non-list value to object {} of type {}".format(
                     self._name, type(self)

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -177,7 +177,7 @@ class Timer(GPITrigger):
         time: Union[Real, Decimal],
         units: str = "step",
         *,
-        round_mode: Optional[str] = None
+        round_mode: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -688,6 +688,7 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
     If the coroutine threw an exception, the :keyword:`await` will re-raise it.
 
     """
+
     __slots__ = ("_coroutine",)
 
     @classmethod

--- a/src/cocotb/types/logic.py
+++ b/src/cocotb/types/logic.py
@@ -104,6 +104,7 @@ class Logic:
     Raises:
         ValueError: if the value cannot be constructed into a :class:`Logic`.
     """
+
     __slots__ = ("_repr",)
     _repr: int
 
@@ -286,6 +287,7 @@ class Bit(Logic):
     Raises:
         ValueError: if the value cannot be constructed into a :class:`Bit`.
     """
+
     __slots__ = ()
 
     _default = _0

--- a/tests/test_cases/test_cocotb/test_async_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_async_coroutines.py
@@ -141,10 +141,7 @@ async def test_fork_coroutine_function_exception(dut):
     async def coro():
         pass
 
-    pattern = (
-        "Coroutine function {} should be called "
-        "prior to being scheduled.".format(coro)
-    )
+    pattern = f"Coroutine function {coro} should be called prior to being scheduled."
     with pytest.raises(TypeError, match=pattern):
         cocotb.start_soon(coro)
 
@@ -154,9 +151,6 @@ async def test_task_coroutine_function_exception(dut):
     async def coro(dut):
         pass
 
-    pattern = (
-        "Coroutine function {} should be called "
-        "prior to being scheduled.".format(coro)
-    )
+    pattern = f"Coroutine function {coro} should be called prior to being scheduled."
     with pytest.raises(TypeError, match=pattern):
         Task(coro)


### PR DESCRIPTION
Alternative to #3488

Documented deviations from `black` are https://docs.astral.sh/ruff/formatter/black/

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
