### PR TITLE
Fix lazy_property

### DIFF
--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -234,7 +234,7 @@ class lazy_property:
             return self
 
         value = self.fget(obj)
-        setattr(obj, self.fget.__qualname__, value)
+        setattr(obj, self.fget.__name__, value)
         return value
 
 


### PR DESCRIPTION
Use __name__ in lazy_property to get it to work correctly. Not sure how this was working before?