### PR TITLE
Cleanup startup errors

### DIFF
--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -295,13 +295,21 @@ def _initialise_testbench_(argv_):
     except BaseException as e:
         log.error(e)
         simulator.stop_simulator()
-        return
+        _stop_library_coverage()
+        return  # pragma: no cover
 
     global scheduler
     scheduler = Scheduler(handle_result=regression_manager._handle_result)
 
     # start Regression Manager
     regression_manager._execute()
+
+
+def _stop_library_coverage() -> None:
+    if _library_coverage is not None:
+        # TODO: move this once we have normal shutdown behavior to _sim_event
+        _library_coverage.stop()
+        _library_coverage.save()  # pragma: no cover
 
 
 def _sim_event(message):
@@ -316,6 +324,7 @@ def _sim_event(message):
         scheduler._finish_scheduler(SimFailure(msg))
     else:
         log.error(msg)
+        _stop_library_coverage()
 
 
 def _process_plusargs() -> None:

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -311,8 +311,11 @@ def _sim_event(message):
     # We simply return here as the simulator will exit
     # so no cleanup is needed
     msg = f"Failing test at simulator request before test run completion: {message}"
-    scheduler.log.error(msg)
-    scheduler._finish_scheduler(SimFailure(msg))
+    if scheduler is not None:
+        scheduler.log.error(msg)
+        scheduler._finish_scheduler(SimFailure(msg))
+    else:
+        log.error(msg)
 
 
 def _process_plusargs() -> None:

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -290,7 +290,12 @@ def _initialise_testbench_(argv_):
     top = cocotb.handle.SimHandle(handle)
 
     global regression_manager
-    regression_manager = RegressionManager.from_discovery(top)
+    try:
+        regression_manager = RegressionManager.from_discovery(top)
+    except BaseException as e:
+        log.error(e)
+        simulator.stop_simulator()
+        return
 
     global scheduler
     scheduler = Scheduler(handle_result=regression_manager._handle_result)

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -203,7 +203,6 @@ class RegressionManager:
             except Exception as E:
                 _logger.critical("Failed to import module %s: %s", module_name, E)
                 _logger.info('MODULE variable was "%s"', ".".join(modules))
-                _logger.info("Traceback: ")
                 _logger.info(traceback.format_exc())
                 raise
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -298,13 +298,10 @@ class RegressionManager:
             self.log.info("Writing coverage data")
             self._cov.save()
             self._cov.html_report()
-        if cocotb._library_coverage is not None:
-            # TODO: move this once we have normal shutdown behavior to _sim_event
-            cocotb._library_coverage.stop()
-            cocotb._library_coverage.save()
 
         # Setup simulator finalization
         simulator.stop_simulator()
+        cocotb._stop_library_coverage()
 
     def _next_test(self) -> Optional[Test]:
         """Get the next test to run"""


### PR DESCRIPTION
This fixes part of #2018, but the catch and cleanup is in `_initialise_testbench_()` instead of `_embed_sim_init()`.

If the error occurs in setting up the `RegressionManager`, then `cocotb._sim_event()` won't be called any longer, we instead properly shut down the simulation.

xref #2342