### PR TITLE
Monkeytype integration

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ import nox
 nox.options.sessions = ["dev_test"]
 
 test_deps = ["pytest"]
-coverage_deps = ["coverage", "pytest-cov"]
+coverage_deps = ["coverage", "pytest-cov", "monkeytype"]
 # gcovr 5.1 has an issue parsing some gcov files, so pin to 5.0. See
 # https://github.com/gcovr/gcovr/issues/596
 # When using gcovr 5.0, deprecated jinja2.Markup was removed in 3.1, so an
@@ -138,6 +138,14 @@ def dev_test(session: nox.Session) -> None:
     dev_test_nosim(session)
     dev_coverage_combine(session)
 
+@nox.session
+def dev_test_typing(session: nox.Session) -> None:
+    """generate type annotations in monkeytype.sqlite3 for cocotb"""
+    session.env.update({
+        "MONKEYTYPE_TRACE_MODULES": "cocotb",
+        "MT_DB_PATH": os.getcwd() + "/monkeytype.sqlite3",
+    })
+    dev_test(session)
 
 @nox.session
 @nox.parametrize("sim,toplevel_lang,gpi_interface", simulator_support_matrix())

--- a/src/cocotb/config.py
+++ b/src/cocotb/config.py
@@ -77,6 +77,8 @@ def help_vars_text():
     COCOTB_REDUCED_LOG_FMT    Display log lines shorter
     COCOTB_ATTACH             Pause time value in seconds before the simulator start
     COCOTB_ENABLE_PROFILING   Performance analysis of the Python portion of cocotb
+    MONKEYTYPE_TRACE_MODULES  Record type data for this list of modules
+    MT_DB_PATH                Path to the MonkeyType database
     COCOTB_LOG_LEVEL          Default logging level (default INFO)
     COCOTB_RESOLVE_X          How to resolve X, Z, U, W on integer conversion
     MEMCHECK                  HTTP port to use for debugging Python memory usage


### PR DESCRIPTION
This adds a [https://github.com/Instagram/MonkeyType](https://github.com/Instagram/MonkeyType) integration to cocotb. Users can override the MONKEYTYPE_TRACE_MODULES env var to specify modules to trace, and MT_DB_PATH to record the types to a local path. I used this to generate better type hints for cocotb, and I plan on adding those in separate PRs.

Open questions:
- what is the oldest version of python new cocotb is trying to support? this determines the style of type annotations I'll put in
- should this be a cocotb dependency? I think it shouldn't since it's not core to cocotb, and it should give a useful error message if the user tries to use it but doesn't have monkeytype installed. I can add that if requested