### PR TITLE
Fix watching code changes for doc live preview

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -556,7 +556,7 @@ def docs_preview(session: nox.Session) -> None:
         # Also watch the cocotb source directory to rebuild the API docs on
         # changes to cocotb code.
         "--watch",
-        "cocotb",
+        "src/cocotb",
         "./docs/source",
         str(outdir),
     )


### PR DESCRIPTION
Required since we now use the src/ layout.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
