### PR TITLE
add cocotb.parameterize() similar to nox.parameterize()

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -51,6 +51,8 @@ Writing and Generating tests
 
 .. autoclass:: cocotb.function
 
+.. autofunction:: cocotb.parameterize
+
 .. autoclass:: cocotb.regression.TestFactory
     :members:
     :member-order: bysource

--- a/docs/source/newsfragments/3513.feature.rst
+++ b/docs/source/newsfragments/3513.feature.rst
@@ -1,0 +1,1 @@
+Added :func:`cocotb.parameterize`, a decorator that serves as an alternative to TestFactory

--- a/docs/source/newsfragments/3513.feature.rst
+++ b/docs/source/newsfragments/3513.feature.rst
@@ -1,1 +1,1 @@
-Added :func:`cocotb.parameterize`, a decorator that serves as an alternative to TestFactory
+Added :func:`cocotb.parameterize`, a decorator that serves as an alternative to TestFactory.

--- a/docs/source/newsfragments/3513.feature.rst
+++ b/docs/source/newsfragments/3513.feature.rst
@@ -1,1 +1,1 @@
-Added :func:`cocotb.parameterize`, a decorator that serves as an alternative to TestFactory.
+Added :func:`cocotb.parameterize`, a decorator that serves as an alternative to :class:`TestFactory`.

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -53,6 +53,7 @@ from cocotb.decorators import (  # isort: skip # noqa: F401
     external,
     function,
     test,
+    parameterize,
 )
 from cocotb.log import _filter_from_c, _log_from_c  # isort: skip # noqa: F401
 

--- a/src/cocotb/decorators.py
+++ b/src/cocotb/decorators.py
@@ -198,8 +198,8 @@ def parameterize(
             skip=False,
         )
         @cocotb.parameterize(
-            arg1=[0,1],
-            arg2=['a','b'],
+            arg1=[0, 1],
+            arg2=["a", "b"],
         )
         async def my_test(arg1: int, arg2: str) -> None:
             ...
@@ -210,22 +210,22 @@ def parameterize(
 
         @cocotb.test(skip=False)
         async def my_test_0_a() -> None:
-            arg1, arg2 = 0, 'a'
+            arg1, arg2 = 0, "a"
             ...
 
         @cocotb.test(skip=False)
         async def my_test_0_b() -> None:
-            arg1, arg2 = 0, 'b'
+            arg1, arg2 = 0, "b"
             ...
 
         @cocotb.test(skip=False)
         async def my_test_1_a() -> None:
-            arg1, arg2 = 1, 'a'
+            arg1, arg2 = 1, "a"
             ...
 
         @cocotb.test(skip=False)
         async def my_test_1_b() -> None:
-            arg1, arg2 = 1, 'b'
+            arg1, arg2 = 1, "b"
             ...
 
     Args:

--- a/src/cocotb/decorators.py
+++ b/src/cocotb/decorators.py
@@ -26,7 +26,17 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import functools
-from typing import Any, Callable, Coroutine, Optional, Sequence, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import cocotb
 from cocotb.regression import Test, TestFactory
@@ -174,13 +184,16 @@ def test(
 
 
 def parameterize(
-    **kwargs,
+    **kwargs: List[Any],
 ) -> Callable[[Callable[..., Coroutine[Any, Any, None]]], TestFactory]:
-    """
-    Decorator to more idiomatically parameterize a test.
-    Allows for passing normal test() kwargs
+    """Decorator to generate parameterized tests from a single test function.
 
-    Usage:
+    Decorates a test function with named test parameters.
+    The call to ``parameterize`` should include the name of each test parameter and the possible values each parameter can hold.
+    This will generate a test for each of the Cartesian products of the parameters and their values.
+
+    .. code-block:: python3
+
         @cocotb.test(
             skip=False,
         )
@@ -188,11 +201,36 @@ def parameterize(
             arg1=[0,1],
             arg2=['a','b'],
         )
-        def my_test(arg1: int, arg2: str) -> None:
+        async def my_test(arg1: int, arg2: str) -> None:
             ...
+
+    The above is equivalent to the following.
+
+    .. code-block:: python3
+
+        @cocotb.test(skip=False)
+        async def my_test_0_a() -> None:
+            arg1, arg2 = 0, 'a'
+            ...
+
+        @cocotb.test(skip=False)
+        async def my_test_0_b() -> None:
+            arg1, arg2 = 0, 'b'
+            ...
+
+        @cocotb.test(skip=False)
+        async def my_test_1_a() -> None:
+            arg1, arg2 = 1, 'a'
+            ...
+
+        @cocotb.test(skip=False)
+        async def my_test_1_b() -> None:
+            arg1, arg2 = 1, 'b'
+            ...
+
     Args:
-        **kwargs: (name -> list[options])
-            Cartesian product of all options will be generated
+        kwargs:
+            Mapping of test function parameter names to the list of values each
     """
 
     for key, lis in kwargs.items():

--- a/src/cocotb/decorators.py
+++ b/src/cocotb/decorators.py
@@ -145,7 +145,7 @@ def test(
             Defaults to 0.
     """
 
-    def wrapper(f: Callable[..., None] | TestFactory) -> Optional[Test]:
+    def wrapper(f: Union[Callable[..., None], TestFactory]) -> Optional[Test]:
         if isinstance(f, TestFactory):
             f.generate_tests(
                 test_dec=test(

--- a/tests/test_cases/test_cocotb/test_testfactory.py
+++ b/tests/test_cases/test_cocotb/test_testfactory.py
@@ -61,3 +61,34 @@ class TestClass(Coroutine):
 tf = TestFactory(TestClass)
 tf.add_option("myarg", [1])
 tf.generate_tests()
+
+
+p_testfactory_test_names = set()
+p_testfactory_test_args = set()
+
+
+@cocotb.test()
+@cocotb.parameterize(
+    arg1=["a1v1", "a1v2"],
+    arg2=["a2v1", "a2v2"],
+)
+async def p_run_testfactory_test(dut, arg1, arg2):
+    p_testfactory_test_names.add(cocotb.regression_manager._test.__qualname__)
+    p_testfactory_test_args.add((arg1, arg2))
+
+
+@cocotb.test()
+async def test_params_verify_args(dut):
+    assert p_testfactory_test_args == {
+        ("a1v1", "a2v1"),
+        ("a1v2", "a2v1"),
+        ("a1v1", "a2v2"),
+        ("a1v2", "a2v2"),
+    }
+
+
+@cocotb.test()
+async def test_params_verify_names(dut):
+    assert p_testfactory_test_names == {
+        f"p_run_testfactory_test_{i:03}" for i in range(1, 5)
+    }


### PR DESCRIPTION
- cocotb.parameterize() allows for more idiomatic generation of parameterized tests
- factory.generate_tests() now takes test_dec as an arg, meaning normal test() kwargs are now possible to specify on factory tests