### PR TITLE
Fix passing generics from NVC makefile

### DIFF
--- a/examples/matrix_multiplier/tests/Makefile
+++ b/examples/matrix_multiplier/tests/Makefile
@@ -35,7 +35,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES = $(PWD)/../hdl/matrix_multiplier_pkg.vhd $(PWD)/../hdl/matrix_multiplier.vhd
 
-    ifneq ($(filter $(SIM),ghdl questa modelsim riviera activehdl),)
+    ifneq ($(filter $(SIM),ghdl questa modelsim riviera activehdl nvc),)
         # ghdl, questa, and aldec all use SIM_ARGS with '-g' for setting generics
         SIM_ARGS += -gDATA_WIDTH=$(DATA_WIDTH) -gA_ROWS=$(A_ROWS) -gB_COLUMNS=$(B_COLUMNS) -gA_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
     else ifneq ($(filter $(SIM),ius xcelium),)

--- a/src/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/src/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -32,6 +32,13 @@ RTL_LIBRARY ?= work
 
 .PHONY: analyse
 
+# Split SIM_ARGS into those options that need to be passed to -e and
+# those that need to be passed to -r
+NVC_E_FILTER := -g%
+
+NVC_E_ARGS := $(filter $(NVC_E_FILTER),$(SIM_ARGS))
+NVC_R_ARGS := $(filter-out $(NVC_E_FILTER),$(SIM_ARGS))
+
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD) $(CUSTOM_COMPILE_DEPS)
 	$(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) -a $(VHDL_SOURCES) $(COMPILE_ARGS)
@@ -41,8 +48,8 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 
 	TESTCASE=$(TESTCASE) MODULE=$(MODULE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	  $(SIM_CMD_PREFIX) $(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) \
-	  -e $(TOPLEVEL) --no-save \
-	  -r --load $(shell cocotb-config --lib-name-path vhpi nvc) $(TRACE) $(SIM_ARGS) $(PLUSARGS)
+	  -e $(TOPLEVEL) --no-save $(NVC_E_ARGS) \
+	  -r --load $(shell cocotb-config --lib-name-path vhpi nvc) $(TRACE) $(NVC_R_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 


### PR DESCRIPTION
This was reported in nickg/nvc#797. The -g option should be passed when elaborating rather than when running the simulation.

To avoid adding another argument variable I just split SIM_ARGS into those that need to be passed to -e and those that need to be passed to -r.
