### PR TITLE
fix signed representation of zero

### DIFF
--- a/src/cocotb/binary.py
+++ b/src/cocotb/binary.py
@@ -413,6 +413,8 @@ class BinaryValue:
     @property
     def signed_integer(self):
         """The signed integer representation of the underlying vector."""
+        if len(self._str) == 0:
+            return 0
         ival = int(self._str.translate(_resolve_table), 2)
         bits = len(self._str)
         signbit = 1 << (bits - 1)

--- a/tests/pytest/test_binary_value.py
+++ b/tests/pytest/test_binary_value.py
@@ -227,6 +227,16 @@ def test_init_little_endian_twos_comp():
     assert bin7.get_value_signed() == -980
     assert bin7.integer == -980
 
+    bin8 = BinaryValue(
+        value=0,
+        n_bits=4,
+        bigEndian=False,
+        binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT,
+    )
+    assert bin8.integer == 0
+    assert bin8.signed_integer == 0
+
+
 
 def test_init_unsigned_negative_value():
     with pytest.raises(ValueError):


### PR DESCRIPTION
In this case `_str` is `""` so the translation through the resolve table explodes:
```
ValueError: invalid literal for int() with base 2: ''
```