### PR TITLE
Use NVC in benchmark instead of GHDL

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,13 +33,13 @@ jobs:
       run: |
         sudo apt-get install -y --no-install-recommends iverilog
 
-    - name: Set up GHDL (Ubuntu)
+    - name: Set up NVC (Ubuntu)
       run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends gnat
-        git clone https://github.com/ghdl/ghdl.git
-        cd ghdl
-        git reset --hard v3.0.0
+        sudo apt install -y --no-install-recommends llvm-dev libdw-dev flex libzstd-dev pkg-config
+        git clone https://github.com/nickg/nvc.git
+        cd nvc
+        git reset --hard ${{matrix.sim-version}}
+        ./autogen.sh
         mkdir build
         cd build
         ../configure

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -10,10 +10,11 @@ from cocotb.runner import get_runner
 
 def build_and_run_matrix_multiplier(benchmark, sim):
     hdl_toplevel_lang = "verilog"
-    extra_args = []
+    build_args = []
+    test_args = []
 
-    if sim == "ghdl":
-        extra_args = ["--std=08"]
+    if sim == "nvc":
+        build_args = ["--std=08"]
         hdl_toplevel_lang = "vhdl"
 
     verilog_sources = []
@@ -39,7 +40,7 @@ def build_and_run_matrix_multiplier(benchmark, sim):
         hdl_toplevel="matrix_multiplier",
         verilog_sources=verilog_sources,
         vhdl_sources=vhdl_sources,
-        build_args=extra_args,
+        build_args=build_args,
     )
 
     @benchmark
@@ -48,7 +49,7 @@ def build_and_run_matrix_multiplier(benchmark, sim):
             hdl_toplevel="matrix_multiplier",
             hdl_toplevel_lang=hdl_toplevel_lang,
             test_module="test_matrix_multiplier",
-            test_args=extra_args,
+            test_args=test_args,
             seed=123456789,
         )
 
@@ -57,5 +58,5 @@ def test_matrix_multiplier_icarus(benchmark):
     build_and_run_matrix_multiplier(benchmark, "icarus")
 
 
-def test_matrix_multiplier_ghdl(benchmark):
-    build_and_run_matrix_multiplier(benchmark, "ghdl")
+def test_matrix_multiplier_nvc(benchmark):
+    build_and_run_matrix_multiplier(benchmark, "nvc")


### PR DESCRIPTION
GHDL can't run the matrix_multiplier, so there never was any sense in using it in the benchmark. Closes #3526.