### PR TITLE
Add  to GHDL makefile to simulate different VHDL architectures from the top level

### DIFF
--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -343,6 +343,8 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
 
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.
 
+To specify a VHDL architecture to simulate, use the `$(ARCH)` make variable
+
 .. _sim-ghdl-issues:
 
 Issues for this simulator

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -343,7 +343,7 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
 
 Noteworthy is that despite GHDL being a VHDL simulator, it implements the :term:`VPI` interface.
 
-To specify a VHDL architecture to simulate, use the `$(ARCH)` make variable
+To specify a VHDL architecture to simulate, set the ``ARCH`` make variable to the architecture name.
 
 .. _sim-ghdl-issues:
 

--- a/src/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/src/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -70,13 +70,13 @@ analyse: $(VHDL_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	$(foreach SOURCES_VAR, $(filter VHDL_SOURCES_%, $(.VARIABLES)), \
 		$(CMD) -i $(GHDL_ARGS) $(COMPILE_ARGS) --workdir=$(SIM_BUILD) --work=$(SOURCES_VAR:VHDL_SOURCES_%=%) $($(SOURCES_VAR)) && ) \
 	$(CMD) -i $(GHDL_ARGS) $(COMPILE_ARGS) --workdir=$(SIM_BUILD) --work=$(RTL_LIBRARY) $(VHDL_SOURCES) && \
-	$(CMD) -m $(GHDL_ARGS) $(COMPILE_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL)
+	$(CMD) -m $(GHDL_ARGS) $(COMPILE_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) $(ARCH)
 
 $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(SIM_CMD_PREFIX) $(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) --vpi=$(shell cocotb-config --lib-name-path vpi ghdl) $(SIM_ARGS) $(PLUSARGS)
+	$(SIM_CMD_PREFIX) $(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) $(ARCH) --vpi=$(shell cocotb-config --lib-name-path vpi ghdl) $(SIM_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 


### PR DESCRIPTION
Closes #3525.

This will make it possible with the MAKE build flow to specify the VHDL architecture to use for a specific test. Without this, the architecture would default to the last one in a VHDL file and can not be specified for COCOTB driven tests. 


<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
