### PR TITLE
Replace lazy_property with cached_property

### DIFF
--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -64,7 +64,7 @@ else:
 
 
 # simple, but less than optimal backport of Python 3.8's cached_property
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from functools import lru_cache

--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -61,3 +61,13 @@ else:
     import collections
 
     insertion_ordered_dict = collections.OrderedDict
+
+
+# simple, but less than optimal backport of Python 3.8's cached_property
+if sys.version_info >= (3, 12):
+    from functools import cached_property
+else:
+    from functools import lru_cache
+
+    def cached_property(meth):
+        return property(lru_cache(maxsize=None)(meth))

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -32,9 +32,10 @@ from decimal import Decimal
 from numbers import Real
 from typing import Union
 
+from cocotb._py_compat import cached_property
 from cocotb.log import SimLog
 from cocotb.triggers import Timer
-from cocotb.utils import get_sim_steps, get_time_from_sim_steps, lazy_property
+from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 
 
 class BaseClock:
@@ -43,7 +44,7 @@ class BaseClock:
     def __init__(self, signal):
         self.signal = signal
 
-    @lazy_property
+    @cached_property
     def log(self):
         return SimLog(f"cocotb.{type(self).__qualname__}.{self.signal._name}")
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -42,6 +42,7 @@ from typing import Any, Iterable, Optional, Tuple, Type
 
 import cocotb
 from cocotb import ANSI, simulator
+from cocotb._py_compat import cached_property
 from cocotb.handle import SimHandle
 from cocotb.log import SimLog
 from cocotb.outcomes import Error, Outcome
@@ -49,7 +50,6 @@ from cocotb.result import SimFailure, TestSuccess
 from cocotb.task import Task, _RunningTest
 from cocotb.utils import (
     get_sim_time,
-    lazy_property,
     remove_traceback_frames,
     want_color_output,
 )
@@ -145,7 +145,7 @@ class Test:
         inst = self._func(*args, **kwargs)
         return _RunningTest(inst, self)
 
-    @lazy_property
+    @cached_property
     def log(self):
         return SimLog(f"cocotb.test.{self._func.__qualname__}.{id(self)}")
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -11,8 +11,9 @@ from asyncio import CancelledError, InvalidStateError
 import cocotb
 import cocotb.triggers
 from cocotb import outcomes
+from cocotb._py_compat import cached_property
 from cocotb.log import SimLog
-from cocotb.utils import extract_coro_stack, lazy_property, remove_traceback_frames
+from cocotb.utils import extract_coro_stack, remove_traceback_frames
 
 T = typing.TypeVar("T")
 Self = typing.TypeVar("Self")
@@ -65,7 +66,7 @@ class Task(typing.Coroutine[typing.Any, typing.Any, T]):
         self.__name__ = f"{type(self)._name} {self._task_id}"
         self.__qualname__ = self.__name__
 
-    @lazy_property
+    @cached_property
     def log(self) -> SimLog:
         # Creating a logger is expensive, only do it if we actually plan to
         # log anything

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -38,12 +38,12 @@ from typing import Any, Coroutine, Optional, TypeVar, Union
 import cocotb
 import cocotb.task
 from cocotb import outcomes, simulator
+from cocotb._py_compat import cached_property
 from cocotb.log import SimLog
 from cocotb.utils import (
     ParametrizedSingleton,
     get_sim_steps,
     get_time_from_sim_steps,
-    lazy_property,
     remove_traceback_frames,
 )
 
@@ -68,7 +68,7 @@ class _TriggerException(Exception):
 class Trigger(Awaitable):
     """Base class to derive from."""
 
-    # __dict__ is needed here for the `.log` lazy_property below to work.
+    # __dict__ is needed here for the `.log` cached_property below to work.
     # The implementation of `_PyObject_GenericGetAttrWithDict` suggests that
     # despite its inclusion, __slots__ will overall give speed and memory
     # improvements:
@@ -82,7 +82,7 @@ class Trigger(Awaitable):
     def __init__(self):
         self.primed = False
 
-    @lazy_property
+    @cached_property
     def log(self):
         return SimLog("cocotb.%s" % (type(self).__qualname__), id(self))
 

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -212,32 +212,6 @@ class ParametrizedSingleton(type):
         return inspect.signature(cls.__singleton_key__)
 
 
-class lazy_property:
-    """
-    A property that is executed the first time, then cached forever.
-
-    It does this by replacing itself on the instance, which works because
-    unlike `@property` it does not define __set__.
-
-    This should be used for expensive members of objects that are not always
-    used.
-    """
-
-    def __init__(self, fget):
-        self.fget = fget
-
-        # copy the getter function's docstring and other attributes
-        functools.update_wrapper(self, fget)
-
-    def __get__(self, obj, cls):
-        if obj is None:
-            return self
-
-        value = self.fget(obj)
-        setattr(obj, self.fget.__name__, value)
-        return value
-
-
 def want_color_output():
     """Return ``True`` if colored output is possible/requested and not running in GUI.
 


### PR DESCRIPTION
We don't use lazy_property's implementation before Python 3.8 because sphinx doesn't detect them as valid properties and generate documentation for them. Following on from https://github.com/cocotb/cocotb/pull/2720#discussion_r1412165833.
