### PR TITLE
Remove Bit class

### DIFF
--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -17,7 +17,12 @@ async def dff_simple_test(dut):
     """Test that d propagates to q"""
 
     # Assert initial output is unknown
-    assert LogicArray(dut.q.value) == LogicArray("X")
+    initial = (
+        LogicArray("U")
+        if cocotb.LANGUAGE.lower().startswith("vhdl")
+        else LogicArray("X")
+    )
+    assert LogicArray(dut.q.value) == initial
     # Set initial input value to prevent it from floating
     dut.d.value = 0
 

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -4,7 +4,7 @@
 import typing
 
 from .array import Array  # noqa: F401
-from .logic import Bit, Logic  # noqa: F401
+from .logic import Logic  # noqa: F401
 from .logic_array import LogicArray  # noqa: F401
 from .range import Range  # noqa: F401
 

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -2,13 +2,19 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from cocotb.types import Bit, Logic
+from cocotb.types import Logic
 
 
 def test_logic_conversions():
+    l = Logic("U")
+    assert Logic("u") == l
+    assert Logic(Logic("U")) == l
+
+    l = Logic("X")
+    assert Logic("x") == l
+    assert Logic(Logic("x")) == l
+
     l = Logic("0")
-    assert Logic("l") == l
-    assert Logic("L") == l
     assert Logic(0) == l
     assert Logic(False) == l
     assert Logic(Logic("0")) == l
@@ -16,53 +22,30 @@ def test_logic_conversions():
     l = Logic("1")
     assert Logic(1) == l
     assert Logic(True) == l
-    assert Logic("h") == l
-    assert Logic("H") == l
     assert Logic(Logic("1")) == l
-
-    l = Logic("X")
-    assert Logic("x") == l
-    assert Logic("w") == l
-    assert Logic("W") == l
-    assert Logic("u") == l
-    assert Logic("U") == l
-    assert Logic("-") == l
-    assert Logic(Logic("X")) == l
 
     l = Logic("Z")
     assert Logic("z") == l
     assert Logic(Logic("Z")) == l
 
+    l = Logic("W")
+    assert Logic("w") == l
+    assert Logic(Logic("W")) == l
+
+    l = Logic("L")
+    assert Logic("l") == l
+    assert Logic(Logic("L")) == l
+
+    l = Logic("H")
+    assert Logic("h") == l
+    assert Logic(Logic("H")) == l
+
+    l = Logic("-")
+    assert Logic(Logic("-")) == l
+
     for value in ("j", 2, object()):
         with pytest.raises(ValueError):
             Logic(value)
-
-
-def test_bit_conversions():
-    b = Bit(0)
-    assert Bit(False) == b
-    assert Bit("0") == b
-    assert Bit(Bit(0)) == b
-
-    b = Bit(1)
-    assert Bit(True) == b
-    assert Bit("1") == b
-    assert Bit(Bit(1)) == b
-
-    for value in ("X", 2, object()):
-        with pytest.raises(ValueError):
-            Bit(value)
-
-
-def test_bit_logic_conversions():
-    Logic(Bit(0))
-    Logic(Bit(1))
-    Bit(Logic(0))
-    Bit(Logic(1))
-    with pytest.raises(ValueError):
-        Bit(Logic("X"))
-    with pytest.raises(ValueError):
-        Bit(Logic("Z"))
 
 
 def test_logic_equality():
@@ -71,38 +54,13 @@ def test_logic_equality():
     assert Logic(0) != object()
 
 
-def test_bit_equality():
-    assert Bit(0) == Bit(False)
-    assert Bit(1) != Bit("0")
-    assert Bit(1) != object()
-
-
-def test_logic_bit_equality():
-    assert Logic(0) == Bit(0)
-    assert Logic(1) == Bit(1)
-
-
 def test_logic_hashability():
     s = {Logic("0"), Logic("1"), Logic("X"), Logic("Z")}
     assert len(s) == 4
 
 
-def test_bit_hashability():
-    s = {Bit(0), Bit(1)}
-    assert len(s) == 2
-
-
-def test_logic_bit_hashability():
-    s = {Logic("0"), Logic("1"), Logic("X"), Logic("Z"), Bit("0"), Bit("1")}
-    assert len(s) == 4
-
-
 def test_logic_default_value():
     assert Logic() == Logic("X")
-
-
-def test_bit_default_value():
-    assert Bit() == Bit("0")
 
 
 def test_logic_bool_conversions():
@@ -114,21 +72,11 @@ def test_logic_bool_conversions():
         bool(Logic("Z"))
 
 
-def test_bit_bool_conversions():
-    assert bool(Bit(1)) is True
-    assert bool(Bit(0)) is False
-
-
 def test_logic_str_conversions():
     assert str(Logic("0")) == "0"
     assert str(Logic("1")) == "1"
     assert str(Logic("X")) == "X"
     assert str(Logic("Z")) == "Z"
-
-
-def test_bit_str_conversions():
-    assert str(Bit(0)) == "0"
-    assert str(Bit(1)) == "1"
 
 
 def test_logic_int_conversions():
@@ -140,21 +88,11 @@ def test_logic_int_conversions():
         int(Logic("Z"))
 
 
-def test_bit_int_conversions():
-    assert int(Bit("0")) == 0
-    assert int(Bit("1")) == 1
-
-
 def test_logic_repr():
     assert eval(repr(Logic("0"))) == Logic("0")
     assert eval(repr(Logic("1"))) == Logic("1")
     assert eval(repr(Logic("X"))) == Logic("X")
     assert eval(repr(Logic("Z"))) == Logic("Z")
-
-
-def test_bit_repr():
-    assert eval(repr(Bit("0"))) == Bit("0")
-    assert eval(repr(Bit("1"))) == Bit("1")
 
 
 def test_logic_and():
@@ -168,24 +106,6 @@ def test_logic_and():
         8 & Logic("1")
 
 
-def test_bit_and():
-    assert Bit("0") & Bit("1") == Bit(0)
-    assert Bit(1) & Bit("1") == Bit(1)
-    with pytest.raises(TypeError):
-        Bit("1") & 8
-    with pytest.raises(TypeError):
-        8 & Bit("1")
-
-
-def test_logic_bit_and():
-    r = Logic(0) & Bit(1)
-    assert type(r) == Logic
-    assert r == Logic(0)
-    r = Bit(1) & Logic(0)
-    assert type(r) == Logic
-    assert r == Logic(0)
-
-
 def test_logic_or():
     # will not be exhaustive
     assert Logic("1") | Logic("Z") == Logic("1")
@@ -195,24 +115,6 @@ def test_logic_or():
         8 | Logic(0)
     with pytest.raises(TypeError):
         Logic(0) | 8
-
-
-def test_bit_or():
-    assert Bit("0") | Bit("1") == Bit(1)
-    assert Bit(0) | Bit(False) == Bit(0)
-    with pytest.raises(TypeError):
-        8 | Bit(0)
-    with pytest.raises(TypeError):
-        Bit(0) | 8
-
-
-def test_logic_bit_or():
-    r = Logic(0) | Bit(1)
-    assert type(r) == Logic
-    assert r == Logic(1)
-    r = Bit(1) | Logic(0)
-    assert type(r) == Logic
-    assert r == Logic(1)
 
 
 def test_logic_xor():
@@ -226,24 +128,6 @@ def test_logic_xor():
         () ^ Logic(1)
 
 
-def test_bit_xor():
-    assert Bit(0) ^ Bit("1") == Bit(1)
-    assert Bit(False) ^ Bit(0) == Bit("0")
-    with pytest.raises(TypeError):
-        Bit(1) ^ ()
-    with pytest.raises(TypeError):
-        () ^ Bit(1)
-
-
-def test_logic_bit_xor():
-    r = Logic(0) ^ Bit(1)
-    assert type(r) == Logic
-    assert r == Logic(1)
-    r = Bit(0) ^ Logic(0)
-    assert type(r) == Logic
-    assert r == Logic(0)
-
-
 def test_logic_invert():
     assert ~Logic(0) == Logic(1)
     assert ~Logic(1) == Logic(0)
@@ -251,18 +135,8 @@ def test_logic_invert():
     assert ~Logic("Z") == Logic("X")
 
 
-def test_bit_invert():
-    assert ~Bit(0) == Bit(1)
-    assert ~Bit(1) == Bit(0)
-
-
 def test_logic_identity():
     assert Logic(0) is Logic(False)
     assert Logic("1") is Logic(1)
     assert Logic("X") is Logic("x")
     assert Logic("z") is Logic("Z")
-
-
-def test_bit_identity():
-    assert Bit(0) is Bit(False)
-    assert Bit(Logic(1)) is Bit("1")


### PR DESCRIPTION
Previously Bit was supposed to be a part of a grander plan to incorporate more HDL types, but that plan was abandoned and Bit is now useless.

Additionally, Logic was expanded to cover the whole 9-value VHDL std_logic type because SV's 4-value type is a strict subset and why not have more features than less?

Closes #2666.