### PR TITLE
Fix test_parallel_cocotb.py test with NVC

### DIFF
--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -761,9 +761,14 @@ class Nvc(Simulator):
         return cmds
 
     def _test_command(self) -> List[Command]:
+        build_args = []
+        if hasattr(self, "build_args"):
+            # May not be set if build() was not called
+            build_args = self.build_args
+
         cmds = [
             ["nvc", f"--work={self.hdl_toplevel_library}"]
-            + self.build_args
+            + build_args
             + ["-e", self.sim_hdl_toplevel, "--no-save", "--jit"]
             + self._get_parameter_options(self.parameters)
             + ["-r"]

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -12,9 +12,10 @@ def build_and_run_matrix_multiplier(benchmark, sim):
     hdl_toplevel_lang = "verilog"
     build_args = []
     test_args = []
+    extra_args = []
 
     if sim == "nvc":
-        build_args = ["--std=08"]
+        extra_args = ["--std=08"]
         hdl_toplevel_lang = "vhdl"
 
     verilog_sources = []
@@ -41,6 +42,7 @@ def build_and_run_matrix_multiplier(benchmark, sim):
         verilog_sources=verilog_sources,
         vhdl_sources=vhdl_sources,
         build_args=build_args,
+        extra_args=extra_args,
     )
 
     @benchmark
@@ -50,6 +52,7 @@ def build_and_run_matrix_multiplier(benchmark, sim):
             hdl_toplevel_lang=hdl_toplevel_lang,
             test_module="test_matrix_multiplier",
             test_args=test_args,
+            extra_args=extra_args,
             seed=123456789,
         )
 


### PR DESCRIPTION
NVC has two kinds of arguments: "global" ones (e.g. for setting standard version, library path, etc.) and command-specific ones (e.g. to set generics for elaboration). In `runner.py` I borrowed the `build_args` property for the global arguments but that is only set if `build()` is called on the `Runner` object before `test()` which `test_parallel_cocotb` doesn't do. 

This patch seems like a bit of a hack so I'm not sure it's the best way to resolve this. An alternative might be to add an `extra_args` property that can be set on `build()` and `test()` similar to the makefile.