### PR TITLE
Update NVC expected results for test_discovery

### DIFF
--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -523,9 +523,8 @@ async def discover_all_in_component_vhdl(dut):
         # doesn't find elements of stream_in_data or stream_out_data_registered
         assert total_count == 7
     elif sim.startswith("nvc"):
-        # doesn't find elements of string
         # finds SAMPLE_BLOCK.clk_inv twice?
-        assert total_count == 26
+        assert total_count == 33
     else:
         cocotb.log.info(
             "Found %d items in component instantion. Simulator is not checked.",


### PR DESCRIPTION
I fixed discovering the string elements in nickg/nvc@3ce014f.

I think `SAMPLE_BLOCK.clk_inv` gets discovered twice because it's returned once when iterating over `vhpiDecls` and again when iterating `vhpiSigDecls`. I can't find anything in the LRM which specifies what `vhpiDecls` is supposed to return so I'm happy to change it to behave the same as other simulators if someone can tell me what that is.