### PR TITLE
Remove experimental status for NVC

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -116,10 +116,10 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "master",  # Only master supported for now
+        "sim-version": "r1.11.0",
         "os": "ubuntu-latest",
         "python-version": "3.8",
-        "group": "experimental",
+        "group": "ci",
     },
     # Test Verilator on Ubuntu
     {

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -156,7 +156,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && matrix.sim == 'nvc'
       run: |
         sudo apt install -y --no-install-recommends llvm-dev libdw-dev flex
-        git clone https://github.com/nickg/nvc.git
+        git clone --depth=1 --no-single-branch https://github.com/nickg/nvc.git
         cd nvc
         git reset --hard ${{matrix.sim-version}}
         ./autogen.sh

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -303,7 +303,7 @@ The following variables are makefile variables, not environment variables.
 
 .. make:var:: COMPILE_ARGS
 
-      Any arguments or flags to pass to the compile stage of the simulation.
+      Any arguments or flags to pass to the compile (analysis) stage of the simulation.
 
 .. make:var:: SIM_ARGS
 

--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -170,6 +170,14 @@ GHDL
 * Extend the ``ghdl -r`` call with the option
   ``--vpi=$(cocotb-config --lib-name-path vpi ghdl)``.
 
+.. _custom-flows-nvc:
+
+NVC
+===
+
+* Extend the ``nvc -r`` call with the option
+  ``--load=$(cocotb-config --lib-name-path vhpi nvc)``.
+
 .. _custom-flows-cvc:
 
 Tachyon DA CVC

--- a/docs/source/newsfragments/3427.feature.rst
+++ b/docs/source/newsfragments/3427.feature.rst
@@ -1,1 +1,1 @@
-Add experimental support for the `NVC <https://github.com/nickg/nvc>`_ VHDL simulator.
+Add support for the `NVC <https://github.com/nickg/nvc>`_ VHDL simulator.

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -381,11 +381,9 @@ A VCD file named :file:`anyname.vcd` will be generated in the current directory.
 NVC
 ===
 
-.. warning::
+.. note::
 
-    NVC support in cocotb is experimental.
-    Some features of cocotb may not work correctly or at all.
-    A current master build of NVC is required.
+    NVC version **1.11.0** or later is required.
 
 In order to use this simulator, set :make:var:`SIM` to ``nvc``:
 

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -400,6 +400,39 @@ Issues for this simulator
 
 * `All issues with label category:simulators:nvc <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Anvc>`_
 
+Coverage
+--------
+
+To enable code coverage, add ``--cover`` to :make:var:`SIM_ARGS`, for example
+in a Makefile:
+
+.. code-block:: make
+
+    SIM_ARGS += --cover
+
+Specifying types of coverage is also supported.
+For example, to collect statement and branch coverage:
+
+.. code-block:: make
+
+    SIM_ARGS += --cover=statement,branch
+
+The ``covdb`` files will be placed in the :make:var:`RTL_LIBRARY` subdirectory of :make:var:`SIM_BUILD`.
+For instructions on how to specify coverage types and produce a report, refer to `NVC's code coverage documentation <https://www.nickg.me.uk/nvc/manual.html#CODE_COVERAGE>`_.
+
+.. _sim-nvc-waveforms:
+
+Waveforms
+---------
+
+To get waveforms in FST format, set the :make:var:`SIM_ARGS` option to ``--wave=anyname.fst``, for example in a Makefile:
+
+.. code-block:: make
+
+    SIM_ARGS += --wave=anyname.fst
+
+:make:var:`SIM_ARGS` can also be used to set the waveform output to VCD by adding ``--format=vcd``.
+
 
 .. _sim-cvc:
 

--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -243,6 +243,8 @@ def test_matrix_multiplier_runner():
 
         if sim in ["questa", "modelsim", "riviera", "activehdl"]:
             build_args = ["-2008"]
+        elif sim == "nvc":
+            build_args = ["--std=08"]
     else:
         raise ValueError(
             f"A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG={hdl_toplevel_lang}"

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -117,7 +117,7 @@ sim = os.getenv("SIM", "icarus")
 
 
 @pytest.mark.skipif(
-    sim in ["icarus", "ghdl", "verilator"],
+    sim in ["icarus", "ghdl", "verilator", "nvc"],
     reason=f"Skipping example mixed_language since {sim} doesn't support this",
 )
 def test_mixed_language_runner():

--- a/src/cocotb/share/makefiles/Makefile.sim
+++ b/src/cocotb/share/makefiles/Makefile.sim
@@ -60,7 +60,7 @@ VHDL_SOURCES              A list of the VHDL source files to include
 VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/ModelSim/Questa/Xcelium/Incisive only)
 VHDL_LIB_ORDER            Compilation order of VHDL libraries (needed for ModelSim/Questa/Xcelium/Incisive)
 SIM_CMD_PREFIX            Prefix for simulation command invocations
-COMPILE_ARGS              Arguments to pass to compile stage of simulation
+COMPILE_ARGS              Arguments to pass to compile (analysis) stage of simulation
 SIM_ARGS                  Arguments to pass to execution of compiled simulation
 EXTRA_ARGS                Arguments for compile and execute phases
 PLUSARGS                  Plusargs to pass to the simulator

--- a/src/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/src/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -34,7 +34,7 @@ RTL_LIBRARY ?= work
 
 # Split SIM_ARGS into those options that need to be passed to -e and
 # those that need to be passed to -r
-NVC_E_FILTER := -g%
+NVC_E_FILTER := -g% --cover --cover=%
 
 NVC_E_ARGS := $(filter $(NVC_E_FILTER),$(SIM_ARGS))
 NVC_R_ARGS := $(filter-out $(NVC_E_FILTER),$(SIM_ARGS))

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -57,6 +57,8 @@ if sim == "questa":
     sim_args = ["-t", "ps"]
 elif sim == "xcelium":
     compile_args = ["-v93"]
+elif sim == "nvc":
+    compile_args = ["--std=08"]
 
 hdl_toplevel = "sample_module"
 sys.path.insert(0, os.path.join(tests_dir, "test_cases", "test_cocotb"))


### PR DESCRIPTION
Follow-on from #3427.
Closes #3556.
Also brought in the non-Makefile changes from #3346.