### PR TITLE
Refactoring RegressionManager and test registration

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -154,10 +154,10 @@ Regression Manager
 
 .. envvar:: TESTCASE
 
-    The name of the test function(s) to run.  If this variable is not defined cocotb
-    discovers and executes all functions decorated with the :class:`cocotb.test` decorator in the supplied :envvar:`MODULE` list.
+    A regex matching names of test function(s) to run.
+    If this variable is not defined cocotb discovers and executes all functions decorated with the :class:`cocotb.test` decorator in the supplied :envvar:`MODULE` list.
 
-    Multiple test functions can be specified using a comma-separated list.
+    Multiple test function regexes can be specified using a comma-separated list.
 
 .. envvar:: COCOTB_RESULTS_FILE
 

--- a/docs/source/newsfragments/3578.change.1.rst
+++ b/docs/source/newsfragments/3578.change.1.rst
@@ -1,0 +1,1 @@
+The :func:`cocotb.test` decorator now returns the decorated object instead of a ``Test`` object.

--- a/docs/source/newsfragments/3578.change.2.rst
+++ b/docs/source/newsfragments/3578.change.2.rst
@@ -1,0 +1,1 @@
+The :envvar:`TESTCASE` variable has been changed to be a comma-separated list of regular expressions which match against test names to run. Each element of :envvar:`TESTCASE` can now match more than one test across all :envvar:`MODULE`\ s instead of just the first one found.

--- a/docs/source/newsfragments/3578.change.rst
+++ b/docs/source/newsfragments/3578.change.rst
@@ -1,0 +1,1 @@
+The :class:`~cocotb.regression.RegressionManager` uses a new mechanism to discover tests. Typical uses of the :func:`cocotb.test` decorator and :class:`~cocotb.test.TestFactory` should be unaffected, but atypical uses may not.

--- a/docs/source/newsfragments/3578.feature.rst
+++ b/docs/source/newsfragments/3578.feature.rst
@@ -1,0 +1,1 @@
+The :func:`cocotb.test` decorator now accepts a ``name`` argument to override the name of the test in the :class:`~cocotb.regression.RegressionManager`.

--- a/docs/source/newsfragments/3578.removal.rst
+++ b/docs/source/newsfragments/3578.removal.rst
@@ -1,0 +1,1 @@
+The ``prefix`` and ``postfix`` arguments to :meth:`TestFactory.generate_tests <cocotb.regression.TestFactory.generate_tests>` are deprecated in favor of the more flexible ``name`` argument.

--- a/src/cocotb/decorators.py
+++ b/src/cocotb/decorators.py
@@ -212,10 +212,12 @@ def test(
         if isinstance(_func, TestFactory):
             if cocotb.regression_manager is not None:
                 _func.generate_tests()
+            _func.test_function.__cocotb_test__ = True
             return _func.test_function
         else:
             if cocotb.regression_manager is not None:
                 cocotb.regression_manager.register_test(func=_func)
+            _func.__cocotb_test__ = True
             return _func
 
     def wrapper(f: Union[F, TestFactory[F]]) -> F:
@@ -230,6 +232,7 @@ def test(
                     skip=skip,
                     stage=stage,
                 )
+            f.test_function.__cocotb_test__ = True
             return f.test_function
 
         else:
@@ -244,6 +247,7 @@ def test(
                     skip=skip,
                     stage=stage,
                 )
+            f.__cocotb_test__ = True
             return f
 
     return wrapper

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -245,11 +245,9 @@ class _RunningTest(Task[None]):
 
     _name: str = "Test"
 
-    def __init__(self, inst, parent):
+    def __init__(
+        self, inst: typing.Coroutine[typing.Any, typing.Any, None], name: str
+    ) -> None:
         super().__init__(inst)
-        self._parent = parent
-        self.__doc__ = parent._func.__doc__
-        self.module = parent._func.__module__
-        self.funcname = parent._func.__name__
-        self.__name__ = f"{type(self)._name} {self.funcname}"
+        self.__name__ = f"{type(self)._name} {name}"
         self.__qualname__ = self.__name__

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -199,6 +199,15 @@ async def test_base_exception_in_task_expect_fail(dut):
     await NullTrigger()
 
 
+a = 0
+
+
 @cocotb.test
 async def test_without_parenthesis(dut):
-    pass
+    global a
+    a = 1
+
+
+@cocotb.test()
+async def test_test_without_parenthesis_ran(dut):
+    assert a == 1

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -349,7 +349,6 @@ async def access_constant_boolean(dut):
     skip=cocotb.LANGUAGE in ["verilog"],
     expect_fail=cocotb.SIM_NAME.lower().startswith("ghdl"),
 )
-@cocotb.test()
 async def access_boolean(dut):
     """Test access to a boolean"""
     assert isinstance(dut.stream_out_bool, IntegerObject)

--- a/tests/test_cases/test_module_var_empty/Makefile
+++ b/tests/test_cases/test_module_var_empty/Makefile
@@ -1,5 +1,15 @@
-include ../../designs/sample_module/Makefile
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # test MODULE is empty
+# should cause regression initialization failure so no results.xml is written
 
 MODULE := " "
+
+.PHONY: override_for_this_test
+override_for_this_test:
+	-$(MAKE) all
+	@test ! -f $(COCOTB_RESULTS_FILE)
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_module_var_messy/Makefile
+++ b/tests/test_cases/test_module_var_messy/Makefile
@@ -1,5 +1,15 @@
-include ../../designs/sample_module/Makefile
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # test MODULE contains leading and trailing separators
+# should cause regression initialization failure so no results.xml is written
 
 MODULE=" , test_nothing  ,"
+
+.PHONY: override_for_this_test
+override_for_this_test:
+	-$(MAKE) all
+	@test ! -f $(COCOTB_RESULTS_FILE)
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_module_without_tests/Makefile
+++ b/tests/test_cases/test_module_without_tests/Makefile
@@ -1,5 +1,15 @@
-include ../../designs/sample_module/Makefile
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 
-# test MODULE is set, but there are no tests across any of the modules
+# test MODULE is set
+# should cause regression initialization failure so no results.xml is written
 
 MODULE=test_nothing
+
+.PHONY: override_for_this_test
+override_for_this_test:
+	-$(MAKE) all
+	@test ! -f $(COCOTB_RESULTS_FILE)
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_select_testcase/Makefile
+++ b/tests/test_cases/test_select_testcase/Makefile
@@ -1,4 +1,10 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# select only y_tests from all MODULEs
+
 include ../../designs/sample_module/Makefile
 
 MODULE := x_tests,y_tests,y_tests_again
-TESTCASE := y_test,y_test
+TESTCASE := y_test

--- a/tests/test_cases/test_select_testcase/x_tests.py
+++ b/tests/test_cases/test_select_testcase/x_tests.py
@@ -3,4 +3,4 @@ import cocotb
 
 @cocotb.test()
 async def x_test(dut):
-    dut._log.info("x_test")
+    assert False

--- a/tests/test_cases/test_select_testcase/y_tests.py
+++ b/tests/test_cases/test_select_testcase/y_tests.py
@@ -3,4 +3,4 @@ import cocotb
 
 @cocotb.test()
 async def y_test(dut):
-    dut._log.info("y_test")
+    pass

--- a/tests/test_cases/test_select_testcase/y_tests_again.py
+++ b/tests/test_cases/test_select_testcase/y_tests_again.py
@@ -3,5 +3,4 @@ import cocotb
 
 @cocotb.test()
 async def y_test(dut):
-    dut._log.error("y_test_again")
-    raise Exception("Only the first test that matches TESTCASE should be run")
+    pass

--- a/tests/test_cases/test_select_testcase_error/Makefile
+++ b/tests/test_cases/test_select_testcase_error/Makefile
@@ -1,11 +1,12 @@
-# detecting an expected failure has to happen here, as the python code is invalid
-.PHONY: override_for_this_test
-override_for_this_test:
-	if $(MAKE) all; then echo "Expected this to fail"; false; else echo "Failed as expected"; fi
-
-include ../../designs/sample_module/Makefile
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # This module exists, but...
 MODULE := x_tests
-# ...this test does not exist, so an error should be raised
+# ...this test does not exist
 TESTCASE := y_test
+
+# TESTCASE filtering out all tests results in a warning
+
+include ../../designs/sample_module/Makefile


### PR DESCRIPTION
This PR was initially intended to close #3461. It makes changes to the `RegressionManager`, and the `test` decorator and `TestFactory` such that tests are "registered" to the `RegressionManager` when the decorator is invoked, or `TestFactory.generate` is called. This allows the decorated test function to be returned by the `test` decorator.

There were several follow on changes:
* The way TESTCASE worked previously doesn't really work with this method, so it was changed to be a general-purpose test filter, which filters tests (whitelist) according to comma-separated regular expressions.
* The `_Test` class is now inaccessible by the user, so it was made private. Some cleanup was done on this class, especially with regards to the abuse of special attributes (`__name__`, etc.)
* The regression start time is set in better place to make it more accurate (the new `start_regression` method)
* Documentation of `test` decorator and `TestFactory` are greatly improved.
* Typing of `test` decorator and `TestFactory` are greatly improved.
* The functionality added by #3387 was accidentally broken at some point and we didn't know because the test wasn't great. So the functionality was fixed, documentation improved, and the test improved.
* The use of "registration" means we can override test names, so a `name` parameter was added to the `test` decorator and `TestFactory`.
* The `name` parameter makes the `prefix` and `postfix` parameter of `TestFactory.generate` superfluous, so they were deprecated (#2575).
* cocotb library coverage collection setup was moved into its own function and improved (there was no check if `coverage` was not installed)
* cocotb setup errors are better covered by moving the exception handling to the root-most function call in Python (this will be handled in C++ in the future).

TODO:
- [x] We need to decide if no tests being discovered is an error or not
- [x] Add newsfrags
- [x] change how skip and TESTCASE interact
- [x] remove oopsies