### PR TITLE
CI: Include toplevel language in job name

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -170,7 +170,7 @@ ENVS = [
         "os": "windows-latest",
         "python-version": "3.8",
         "toolchain": "mingw",
-        "extra_name": "mingw | ",
+        "extra-name": "mingw",
         # mingw tests fail silently currently due to test harness limitations.
         "group": "experimental",
     },
@@ -182,7 +182,7 @@ ENVS = [
     #     "os": "windows-latest",
     #     "python-version": "3.11",
     #     "toolchain": "msvc",
-    #     "extra_name": "msvc | ",
+    #     "extra-name": "msvc",
     #     "group": "ci",
     # },
     # Other
@@ -195,7 +195,7 @@ ENVS = [
         "python-version": "3.8",
         "cxx": "clang++",
         "cc": "clang",
-        "extra_name": "clang | ",
+        "extra-name": "clang",
         "group": "ci",
     },
     # Test Siemens Questa on Ubuntu
@@ -268,6 +268,12 @@ ENVS = [
 ]
 
 
+def append_str_val(listref, my_list, key) -> None:
+    if not key in my_list:
+        return
+    listref.append(str(my_list[key]))
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--group")
@@ -286,14 +292,31 @@ def main() -> int:
         # Return all tasks if no group is selected.
         selected_envs = ENVS
 
-    # The "runs-on" job attribute is a string if we're using the GitHub-provided
-    # hosted runners, or an array with special keys if we're using self-hosted
-    # runners.
     for env in selected_envs:
+        # The "runs-on" job attribute is a string if we're using the GitHub-
+        # provided hosted runners, or an array with special keys if we're
+        # using self-hosted runners.
         if "self-hosted" in env and env["self-hosted"] and "runs-on" not in env:
             env["runs-on"] = ["self-hosted", "cocotb-private", env["os"]]
         else:
             env["runs-on"] = env["os"]
+
+        # Assemble the human-readable name of the job.
+        name_parts = []
+        append_str_val(name_parts, env, "extra-name")
+        append_str_val(name_parts, env, "sim")
+        if "/" in env["sim-version"]:
+            # Shorten versions like 'siemens/questa/2023.2' to '2023.2'.
+            name_parts.append(env["sim-version"].split("/")[-1])
+        else:
+            name_parts.append(env["sim-version"])
+        append_str_val(name_parts, env, "lang")
+        append_str_val(name_parts, env, "os")
+        append_str_val(name_parts, env, "python-version")
+        if "may-fail" in env and env["may-fail"]:
+            name_parts.append("May fail")
+
+        env["name"] = "|".join(name_parts)
 
     if args.output_format == "gha":
         # Output for GitHub Actions (GHA). Appends the configuration to

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
     needs: generate_envs
 
-    name: ${{matrix.extra_name}}${{matrix.sim}} (${{matrix.sim-version}}) | ${{matrix.os}} | Python ${{matrix.python-version}} ${{matrix.may_fail && '| May Fail' || ''}}
+    name: ${{matrix.name}}
     runs-on: ${{matrix.runs-on}}
     env:
       SIM: ${{matrix.sim}}
@@ -97,7 +97,7 @@ jobs:
         pip install nox
     - name: Run tests without simulators
       run: nox -s "${{ inputs.nox_session_test_nosim }}"
-      continue-on-error: ${{matrix.may_fail || false}}
+      continue-on-error: ${{matrix.may-fail || false}}
 
       # Install Icarus
     - name: Set up Icarus (Ubuntu - apt)
@@ -189,7 +189,7 @@ jobs:
     - name: Test (Windows)
       if: startsWith(matrix.os, 'windows')
       id: windowstesting
-      continue-on-error: ${{matrix.may_fail || false}}
+      continue-on-error: ${{matrix.may-fail || false}}
       timeout-minutes: 20
       # Virtual environments don't work on Windows with cocotb. Avoid using them
       # in nox testing.
@@ -212,7 +212,7 @@ jobs:
     - name: Test (Ubuntu, MacOS)
       id: unixtesting
       if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-      continue-on-error: ${{matrix.may_fail || false}}
+      continue-on-error: ${{matrix.may-fail || false}}
       timeout-minutes: 30
       run: |
         if [ "${{matrix.self-hosted}}" == "true" ]; then
@@ -233,8 +233,6 @@ jobs:
         CODECOV_TOKEN: 669f2048-851e-479e-a618-8fa64f3736cc
       with:
         files: .python_coverage.xml,.cpp_coverage.xml
-        # There seems to be no way (as of Feb 2021) to get the job name in a
-        # variable; we hence have to re-assemble it here.
-        name: "${{matrix.extra_name}}${{matrix.sim}} (${{matrix.sim-version}}) | ${{matrix.os}} | Python ${{matrix.python-version}}"
+        name: ${{ matrix.name }}
         env_vars: SIM,TOPLEVEL_LANG,CXX,OS,PYTHON_VERSION
         verbose: true


### PR DESCRIPTION
Depending on the toplevel language, we're running a very different set
of tests. Include it in the name to make the tests unambiguous.

While at it, refactor the code a bit to
* place the generation of the human-readable job name into the Python
  script
* reuse the name in the Codecov upload, instead of assembling it twice
  (we can do that now that we have the name in the matrix configuration)
* consistently use hyphens as delimitter in matrix env keys
* shorten the simulator version number by removing the module name
  prefix (e.g. 'siemens/questa/2023.2' to '2023.2')
* shorten the name by removing spaces around the pipe symbol.

A shorter name helps to display more of it in the left navigation bar of
the GH Checks view:

![image](https://github.com/cocotb/cocotb/assets/1467123/445a9a63-6a3b-4ed0-8aa3-b8fcce3a453f)
