### PR TITLE
Add support for VHDL libraries in NVC Makefile

### DIFF
--- a/src/cocotb/share/makefiles/Makefile.sim
+++ b/src/cocotb/share/makefiles/Makefile.sim
@@ -57,8 +57,8 @@ SIM                       Selects which simulator Makefile to use
 WAVES                     Enable wave traces dump for Riviera-PRO and Questa
 VERILOG_SOURCES           A list of the Verilog source files to include
 VHDL_SOURCES              A list of the VHDL source files to include
-VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/ModelSim/Questa/Xcelium/Incisive only)
-VHDL_LIB_ORDER            Compilation order of VHDL libraries (needed for ModelSim/Questa/Xcelium/Incisive)
+VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/NVC/ModelSim/Questa/Xcelium/Incisive only)
+VHDL_LIB_ORDER            Compilation order of VHDL libraries (needed for NVC/ModelSim/Questa/Xcelium/Incisive)
 SIM_CMD_PREFIX            Prefix for simulation command invocations
 COMPILE_ARGS              Arguments to pass to compile (analysis) stage of simulation
 SIM_ARGS                  Arguments to pass to execution of compiled simulation

--- a/src/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/src/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -41,13 +41,19 @@ NVC_R_ARGS := $(filter-out $(NVC_E_FILTER),$(SIM_ARGS))
 
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD) $(CUSTOM_COMPILE_DEPS)
-	$(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) -a $(VHDL_SOURCES) $(COMPILE_ARGS)
+	# Make sure all libs in SOURCES_VHDL_* are mentioned in VHDL_LIB_ORDER and vice versa
+	$(foreach LIB, $(VHDL_LIB_ORDER), $(check_vhdl_sources))
+	$(foreach SOURCES_VAR, $(filter VHDL_SOURCES_%, $(.VARIABLES)), $(check_lib_order))
+
+	$(foreach LIB_VAR,$(VHDL_LIB_ORDER), \
+		$(CMD) $(EXTRA_ARGS) --work=$(LIB_VAR):$(SIM_BUILD)/$(LIB_VAR) -L $(SIM_BUILD) -a $(VHDL_SOURCES_$(LIB_VAR)) $(COMPILE_ARGS) && ) \
+	$(CMD) $(EXTRA_ARGS) --work=$(RTL_LIBRARY):$(SIM_BUILD)/$(RTL_LIBRARY) -L $(SIM_BUILD) -a $(VHDL_SOURCES) $(COMPILE_ARGS)
 
 $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)
 
 	TESTCASE=$(TESTCASE) MODULE=$(MODULE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	  $(SIM_CMD_PREFIX) $(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) \
+	  $(SIM_CMD_PREFIX) $(CMD) $(EXTRA_ARGS) --work=$(RTL_LIBRARY):$(SIM_BUILD)/$(RTL_LIBRARY) -L $(SIM_BUILD) \
 	  -e $(TOPLEVEL) --no-save $(NVC_E_ARGS) \
 	  -r --load $(shell cocotb-config --lib-name-path vhpi nvc) $(TRACE) $(NVC_R_ARGS) $(PLUSARGS)
 

--- a/tests/test_cases/test_vhdl_libraries/Makefile
+++ b/tests/test_cases/test_vhdl_libraries/Makefile
@@ -12,7 +12,7 @@ ifneq ($(filter $(SIM),xcelium),)
     COMPILE_ARGS += -v93
 endif
 
-ifneq ($(filter questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
+ifneq ($(filter nvc questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
     VHDL_LIB_ORDER := blib
 endif
 
@@ -20,9 +20,9 @@ ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),vhdl)
 all:
 	@echo "Skipping test since only VHDL is supported"
 clean::
-else ifeq ($(filter ghdl questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
+else ifeq ($(filter ghdl nvc questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
 all:
-	@echo "Skipping test since only GHDL, Questa/ModelSim, Xcelium and Incisive are supported"
+	@echo "Skipping test since only GHDL, NVC, Questa/ModelSim, Xcelium and Incisive are supported"
 clean::
 else
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/test_vhdl_libraries_multiple/Makefile
+++ b/tests/test_cases/test_vhdl_libraries_multiple/Makefile
@@ -17,7 +17,7 @@ ifneq ($(filter $(SIM),xcelium),)
     COMPILE_ARGS += -v93
 endif
 
-ifneq ($(filter questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
+ifneq ($(filter nvc questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
     VHDL_LIB_ORDER := elib dlib clib blib
 endif
 
@@ -25,9 +25,9 @@ ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),vhdl)
 all:
 	@echo "Skipping test since only VHDL is supported"
 clean::
-else ifeq ($(filter ghdl questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
+else ifeq ($(filter ghdl nvc questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
 all:
-	@echo "Skipping test since only GHDL, Questa/ModelSim and Xcelium are supported"
+	@echo "Skipping test since only GHDL, NVC, Questa/ModelSim and Xcelium are supported"
 clean::
 else
 include $(shell cocotb-config --makefiles)/Makefile.sim


### PR DESCRIPTION
This PR closes #3598.

It adds support for (multiple) VHDL libraries to the NVC Makefile. NVC seems to need to compile the libraries in the correct order, so the `VHDL_LIB_ORDER` make variable has to be set when using libraries with NVC.

I updated the `test_vhdl_libraries` and `test_vhdl_libraries` test cases accordingly and have run the test suite successfully.

I'm looking forward to your suggestions to get this PR merged as I want to test designs using some VHDL-2019 features with a free VHDL compiler.