### PR TITLE
Fix artifact upload

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install nox
         run: python3 -m pip install nox
 
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - uses: actions/download-artifact@v4
       with:
         name: cocotb-dist
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - uses: actions/download-artifact@v4
       with:
         name: cocotb-dist

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cocotb-dist
+          name: cocotb-dist-${{ matrix.os }}
           path: |
             dist/*.whl
             dist/*.tar.gz
@@ -56,8 +56,9 @@ jobs:
         python-version: "3.12"
     - uses: actions/download-artifact@v4
       with:
-        name: cocotb-dist
         path: dist
+        pattern: cocotb-dist-*
+        merge-multiple: true
     - name: Install nox
       run: python3 -m pip install nox
     - name: Smoke-test the sdist
@@ -88,8 +89,9 @@ jobs:
         python-version: "3.12"
     - uses: actions/download-artifact@v4
       with:
-        name: cocotb-dist
         path: dist
+        pattern: cocotb-dist-*
+        merge-multiple: true
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: pre-commit
       run: |
         pip install pre-commit

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Update pre-commit hooks
       run: |
         pip install pre-commit

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -70,8 +70,9 @@ jobs:
      # Download distribution artifacts (if any).
     - uses: actions/download-artifact@v4
       with:
-        name: cocotb-dist
         path: dist
+        pattern: cocotb-dist-*
+        merge-multiple: true
       if: ${{ inputs.download_artifacts }}
 
       # Install Python


### PR DESCRIPTION
https://github.com/cocotb/cocotb/pull/3593 updated the version of
actions/upload-artifact from 3 to 4, but didn't perform the migration as
described at
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md.
Do that to fix the broken release CI.

While at it, update all jobs where the Python version doesn't matter from Python 3.11 to Python 3.12

- CI: Run build tasks with latest Python
- CI: Fix artifact upload