### PR TITLE
Validate the pyproject.toml file in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,8 @@ repos:
     - "--fix=lf"
   - id: "end-of-file-fixer"
     exclude: "^docs/source/diagrams/(svg|xml)/"
+
+- repo: https://github.com/henryiii/validate-pyproject-schema-store
+  rev: "2024.01.31"
+  hooks:
+    - id: validate-pyproject


### PR DESCRIPTION
The Python tool "validate-pyproject" validates the pyproject.toml
against a schema. The schemas are shipped in
validate-pyproject-schema-store. We want to pin the version of the
schema used to validate our pyproject.toml. We do that by using
validate-pyproject-schema-store directly (which depends on
validate-pyproject).

As a downside, the schema validation adds around 1.5 seconds to a
pre-commit run (or in relative numbers, a run now takes roughly 2.5x as
long on my machine).

Fixes https://github.com/cocotb/cocotb/issues/3617