### PR TITLE
Fix configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,8 @@ omit = [
 ]
 exclude_lines = [
     "pragma: no cover",
-    "# for excluding typing stubs",
+    # for excluding typing stubs
     "\\.\\.\\.",
-    "# for excluding abstractmethods",
+    # for excluding abstractmethods
     "raise\\s+NotImplementedError",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ manylinux-i686-image = "manylinux1"
 testpaths = [
     "tests/pytest",
 ]
+
+# Ensure that all markers used in pytests are declared (in here).
+addopts = "--strict-markers"
+
 markers = [
     "simulator_required: mark tests as needing a simulator",
     "compile: the compile step in runner-based tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,12 +100,12 @@ manylinux-i686-image = "manylinux1"
 testpaths = [
     "tests/pytest",
 ]
+markers = [
+    "simulator_required: mark tests as needing a simulator",
+    "compile: the compile step in runner-based tests",
+]
 # log_cli = true
 # log_cli_level = DEBUG
-
-[tool.pytest.ini_options.markers]
-simulator_required = "mark tests as needing a simulator"
-compile = "the compile step in runner-based tests"
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
Fix the recently converted configuration in pyproject.toml to define the pytest test markers again, and fix the coverage exclusion pattern.

- pytest: Fix marker declaration
- Fix coverage exclusion in pyproject.toml
- Require explicit marker declarations in pytest
