### PR TITLE
Small runner cleanups

### DIFF
--- a/tests/pytest/test_version.py
+++ b/tests/pytest/test_version.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 
 import cocotb
-import pytest
 
 
 def test_version():

--- a/tests/pytest/test_vhdl_libraries_multiple.py
+++ b/tests/pytest/test_vhdl_libraries_multiple.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(src_path))
 
 
 @pytest.mark.skipif(
-    os.getenv("TOPLEVEL_LANG", "vhdl") != "vhdl",
+    os.getenv("HDL_TOPLEVEL_LANG", "vhdl") != "vhdl",
     reason="Skipping test since only VHDL is supported",
 )
 @pytest.mark.skipif(


### PR DESCRIPTION
- Cleanup: Remove unused import
- cocotb runner uses HDL_TOPLEVEL_LANG instead of TOPLEVEL_LANG
