### PR TITLE
GHDL: Support COCOTB_HDL_TIMEPRECISION if possible

### DIFF
--- a/src/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/src/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -63,6 +63,31 @@ ifeq ($(OS),Msys)
     export PATH := $(GHDL_BIN_DIR)/../lib:$(PATH)
 endif
 
+GHDL_RUN_ARGS ?=
+ifneq ($(COCOTB_HDL_TIMEPRECISION),)
+    # Convert the time precision to a format string supported by GHDL, if
+    # possible.
+    # GHDL only supports setting the time precision if the mcode backend is
+    # used, using the --time-resolution argument causes GHDL to error out
+    # otherwise.
+    # https://ghdl.github.io/ghdl/using/InvokingGHDL.html#cmdoption-ghdl-time-resolution
+    ifeq ($(COCOTB_HDL_TIMEPRECISION),1fs)
+        GHDL_TIME_RESOLUTION=fs
+    else ifeq ($(COCOTB_HDL_TIMEPRECISION),1ps)
+        GHDL_TIME_RESOLUTION=ps
+    else ifeq ($(COCOTB_HDL_TIMEPRECISION),1us)
+        GHDL_TIME_RESOLUTION=us
+    else ifeq ($(COCOTB_HDL_TIMEPRECISION),1ms)
+        GHDL_TIME_RESOLUTION=ms
+    else ifeq ($(COCOTB_HDL_TIMEPRECISION),1s)
+        GHDL_TIME_RESOLUTION=sec
+    else
+        $(error GHDL only supports the following values for COCOTB_HDL_TIMEPRECISION: 1fs, 1ps, 1us, 1ms, 1s)
+    endif
+
+    GHDL_RUN_ARGS += --time-resolution=$(GHDL_TIME_RESOLUTION)
+endif
+
 .PHONY: analyse
 
 # Compilation phase
@@ -76,7 +101,7 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(SIM_CMD_PREFIX) $(CMD) -r $(GHDL_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) $(ARCH) --vpi=$(shell cocotb-config --lib-name-path vpi ghdl) $(SIM_ARGS) $(PLUSARGS)
+	$(SIM_CMD_PREFIX) $(CMD) -r $(GHDL_ARGS) $(GHDL_RUN_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(TOPLEVEL) $(ARCH) --vpi=$(shell cocotb-config --lib-name-path vpi ghdl) $(SIM_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -63,6 +63,9 @@ elif sim == "nvc":
 hdl_toplevel = "sample_module"
 sys.path.insert(0, os.path.join(tests_dir, "test_cases", "test_cocotb"))
 
+# test_timing_triggers.py requires a 1ps time precision.
+timescale = ("1ps", "1ps")
+
 
 def test_cocotb():
     runner = get_runner(sim)
@@ -73,6 +76,7 @@ def test_cocotb():
         hdl_toplevel=hdl_toplevel,
         build_dir=sim_build,
         build_args=compile_args,
+        timescale=timescale,
     )
 
     runner.test(
@@ -81,6 +85,7 @@ def test_cocotb():
         test_module=module_name,
         gpi_interfaces=gpi_interfaces,
         test_args=sim_args,
+        timescale=timescale,
     )
 
 

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -24,6 +24,9 @@ from test_cocotb import (
 pytestmark = pytest.mark.simulator_required
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
 
+# test_timing_triggers.py requires a 1ps time precision.
+timescale = ("1ps", "1ps")
+
 
 @pytest.mark.compile
 def test_cocotb_parallel_compile():
@@ -36,6 +39,7 @@ def test_cocotb_parallel_compile():
         hdl_toplevel=hdl_toplevel,
         build_dir=sim_build,
         build_args=compile_args,
+        timescale=timescale,
     )
 
 
@@ -53,4 +57,5 @@ def test_cocotb_parallel(seed):
         test_module=module_name,
         test_args=sim_args,
         build_dir=sim_build,
+        timescale=timescale,
     )

--- a/tests/pytest/test_timescale.py
+++ b/tests/pytest/test_timescale.py
@@ -32,8 +32,8 @@ async def check_timescale(dut):
 
 @pytest.mark.simulator_required
 @pytest.mark.skipif(
-    os.getenv("SIM", "icarus") != "icarus",
-    reason="Currently only Icarus simulator supports timescale setting when using Cocotb runner",
+    os.getenv("SIM", "icarus") not in ["icarus", "ghdl"],
+    reason="Currently only Icarus and GHDL support timescale setting when using Cocotb runner",
 )
 @pytest.mark.parametrize("precision", ["fs", "ps", "ns", "us", "ms", "s"])
 def test_precision(precision):
@@ -70,4 +70,5 @@ def test_precision(precision):
             test_module=test_module,
             test_args=sim_args,
             build_dir=build_dir,
+            timescale=timescale,
         )

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -45,11 +45,12 @@ async def test_function_reentrant_clock(dut):
 
 # Xcelium/VHDL does not correctly report the simulator precision.
 # See also https://github.com/cocotb/cocotb/issues/3419
-# NVC and GHDL do not support setting precision and always use 1 fs.
+# NVC does not support setting precision and always uses 1 fs
+# (https://github.com/nickg/nvc/issues/607).
 @cocotb.test(
     skip=(
         cocotb.LANGUAGE == "vhdl"
-        and cocotb.SIM_NAME.lower().startswith(("xmsim", "ghdl", "nvc"))
+        and cocotb.SIM_NAME.lower().startswith(("xmsim", "nvc"))
     )
 )
 async def test_timer_with_units(dut):


### PR DESCRIPTION
GHDL with the mcode backend supports some values of
COCOTB_HDL_TIMEPRECISION (fs, ps, ns, us, ms, s), and only if the
mcode backend is used. Try to pass on the value of
COCOTB_HDL_TIMEPRECISION if possible, without checking for the backend:
GHDL will error out in that case and users have to avoid setting
COCOTB_HDL_TIMEPRECISION when that happens.

See also https://github.com/cocotb/cocotb/pull/3613#discussion_r1439710866
