### PR TITLE
Simplify VpiArrayObjHdl::initialise

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiObj.cpp
+++ b/src/cocotb/share/lib/vpi/VpiObj.cpp
@@ -76,11 +76,11 @@ int VpiArrayObjHdl::initialise(const std::string &name,
             }
         }
 #endif
-        vpi_free_object(iter);  // Need to free iterator since exited early
         if (rangeHdl == NULL) {
             LOG_ERROR("Unable to get range for indexable array");
             return -1;
         }
+        vpi_free_object(iter);  // Need to free iterator since exited early
     } else if (range_idx == 0) {
         rangeHdl = hdl;
     } else {

--- a/src/cocotb/share/lib/vpi/VpiObj.cpp
+++ b/src/cocotb/share/lib/vpi/VpiObj.cpp
@@ -56,7 +56,7 @@ int VpiArrayObjHdl::initialise(const std::string &name,
             return -1;
         }
         // count occurences of [
-        range_idx = (int)std::count(name.begin() + idx_str, name.end(), '[');
+        range_idx = (int)std::count(&name.begin()[idx_str], name.end(), '[');
     }
 
     /* After determining the range_idx, get the range and set the limits */

--- a/src/cocotb/share/lib/vpi/VpiObj.cpp
+++ b/src/cocotb/share/lib/vpi/VpiObj.cpp
@@ -56,7 +56,9 @@ int VpiArrayObjHdl::initialise(const std::string &name,
             return -1;
         }
         // count occurences of [
-        range_idx = (int)std::count(&name.begin()[idx_str], name.end(), '[');
+        auto start =
+            name.begin() + static_cast<std::string::difference_type>(idx_str);
+        range_idx = std::count(start, name.end(), '[');
     }
 
     /* After determining the range_idx, get the range and set the limits */

--- a/src/cocotb/share/lib/vpi/VpiObj.cpp
+++ b/src/cocotb/share/lib/vpi/VpiObj.cpp
@@ -56,7 +56,7 @@ int VpiArrayObjHdl::initialise(const std::string &name,
             return -1;
         }
         // count occurences of [
-        range_idx = std::count(name.begin() + idx_str, name.end(), '[');
+        range_idx = (int)std::count(name.begin() + idx_str, name.end(), '[');
     }
 
     /* After determining the range_idx, get the range and set the limits */

--- a/src/cocotb/share/lib/vpi/VpiObj.cpp
+++ b/src/cocotb/share/lib/vpi/VpiObj.cpp
@@ -58,7 +58,7 @@ int VpiArrayObjHdl::initialise(const std::string &name,
         // count occurences of [
         auto start =
             name.begin() + static_cast<std::string::difference_type>(idx_str);
-        range_idx = std::count(start, name.end(), '[');
+        range_idx = static_cast<int>(std::count(start, name.end(), '['));
     }
 
     /* After determining the range_idx, get the range and set the limits */

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -47,7 +47,6 @@ async def recursive_discovery(dut):
 
     # Icarus doesn't support array indexes like get_handle_by_name("some_path[x]")
     SKIP_HANDLE_ASSERT = cocotb.SIM_NAME.lower().startswith(("riviera", "icarus"))
-    # SKIP_HANDLE_ASSERT = cocotb.SIM_NAME.lower().startswith(("icarus")
 
     tlog = logging.getLogger("cocotb.test")
 

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -46,9 +46,7 @@ async def recursive_discovery(dut):
         pass_total = 27
 
     # Icarus doesn't support array indexes like get_handle_by_name("some_path[x]")
-    SKIP_HANDLE_ASSERT = cocotb.SIM_NAME.lower().startswith(
-        ("riviera", "icarus")
-    ) or cocotb.LANGUAGE in ["vhdl"]
+    SKIP_HANDLE_ASSERT = cocotb.SIM_NAME.lower().startswith(("riviera", "icarus"))
     # SKIP_HANDLE_ASSERT = cocotb.SIM_NAME.lower().startswith(("icarus")
 
     tlog = logging.getLogger("cocotb.test")


### PR DESCRIPTION
I had issues with range_idx being calculated incorrectly, so I wanted to see what simulators actually require this, if at all. It gets calculated incorrectly when using get_handle_by_name() with a fully qualified name (not from handle.py) with brackets in other parts of the path. I didn't see range_idx being actually used in testing on Xcelium.  It doesn't look like there were any tests when it was put in https://github.com/cocotb/cocotb/commit/54d2965dc29f226f3971ca6e5b6b3cc67149fbc1 
