### PR TITLE
CI: Use distinct labels for private jobs

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -296,7 +296,7 @@ def main() -> int:
         # provided hosted runners, or an array with special keys if we're
         # using self-hosted runners.
         if "self-hosted" in env and env["self-hosted"] and "runs-on" not in env:
-            env["runs-on"] = ["self-hosted", "cocotb-private", env["os"]]
+            env["runs-on"] = ["self-hosted", f"cocotb-private-{env['os']}"]
         else:
             env["runs-on"] = env["os"]
 


### PR DESCRIPTION
Labels in GitHub Actions are used to determine which runner can execute
a CI job. With our setup of self-hosted and GitHub-hosted runners,
labels decide if a job gets to run on our own infrastructure, or on
GitHub infrastructure.

Right now, we're assinging the labels "self-hosted", "ubuntu-20.04",
"cocotb-private", "X64" and "Linux" to all self-hosted runners.

All jobs that we want to run on our self-hosted runners get the labels
"self-hosted", "cocotb-private", and "ubuntu-20.04" assigned.

Jobs that we want to run on the GitHub-provided runners only get a
single label, the operating system, such as "ubuntu-20.04".

As it turns out, a job gets executed on a particular runner as soon as
all labels assigned *to the job* are matching labels assigned to the
runner.

For us, this meant a job assigned only the label "ubuntu-20.04" (a job
which we want to execute on GitHub-provided runners) got executed on
our self-hosted runners, since "ubuntu-20.04" is one of the labels of
our self-hosted runners as well.

Avoid this situation by using label names for our self-hosted runner
which are not used by GitHub runners
(https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job).

See also https://github.com/philips-labs/terraform-aws-github-runner/issues/3290
for a discussion and
https://github.com/philips-labs/terraform-aws-github-runner/blob/6fa667fae7e4302cf643bcdb4ff3c91b1e4ed8d1/lambdas/functions/webhook/src/webhook/index.ts#L83-L86
for the label matching code.
