### PR TITLE
Set author name in pre-commit-autoupdate.yml

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:
+        author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
         commit-message: "Update pre-commit hooks"
         branch: update-pre-commit
         title: "Update pre-commit hooks"


### PR DESCRIPTION
By default it uses the action's actor as the author, I guess because I authored the action file with the cron line in it that means it's me? Either way I'm explicitly setting it to the Github Actions bot account.
