### PR TITLE
GHDL: Only pass --time-resolution if mcode is used

### DIFF
--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -695,6 +695,17 @@ class Ghdl(Simulator):
         if shutil.which("ghdl") is None:
             raise SystemExit("ERROR: ghdl executable not found!")
 
+    def _is_mcode_backend(self) -> bool:
+        """Is GHDL using the mcode backend?"""
+        result = subprocess.run(
+            ["ghdl", "--version"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        return "mcode" in result.stdout
+
     @staticmethod
     def _get_parameter_options(parameters: Mapping[str, object]) -> Command:
         return [f"-g{name}={value}" for name, value in parameters.items()]
@@ -725,7 +736,7 @@ class Ghdl(Simulator):
     def _test_command(self) -> List[Command]:
         ghdl_run_args = self.test_args
 
-        if self.timescale:
+        if self._is_mcode_backend() and self.timescale:
             _, precision = self.timescale
             # Convert the time precision to a format string supported by GHDL,
             # if possible.

--- a/src/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/src/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -64,28 +64,31 @@ ifeq ($(OS),Msys)
 endif
 
 GHDL_RUN_ARGS ?=
-ifneq ($(COCOTB_HDL_TIMEPRECISION),)
-    # Convert the time precision to a format string supported by GHDL, if
-    # possible.
-    # GHDL only supports setting the time precision if the mcode backend is
-    # used, using the --time-resolution argument causes GHDL to error out
-    # otherwise.
-    # https://ghdl.github.io/ghdl/using/InvokingGHDL.html#cmdoption-ghdl-time-resolution
-    ifeq ($(COCOTB_HDL_TIMEPRECISION),1fs)
-        GHDL_TIME_RESOLUTION=fs
-    else ifeq ($(COCOTB_HDL_TIMEPRECISION),1ps)
-        GHDL_TIME_RESOLUTION=ps
-    else ifeq ($(COCOTB_HDL_TIMEPRECISION),1us)
-        GHDL_TIME_RESOLUTION=us
-    else ifeq ($(COCOTB_HDL_TIMEPRECISION),1ms)
-        GHDL_TIME_RESOLUTION=ms
-    else ifeq ($(COCOTB_HDL_TIMEPRECISION),1s)
-        GHDL_TIME_RESOLUTION=sec
-    else
-        $(error GHDL only supports the following values for COCOTB_HDL_TIMEPRECISION: 1fs, 1ps, 1us, 1ms, 1s)
-    endif
 
-    GHDL_RUN_ARGS += --time-resolution=$(GHDL_TIME_RESOLUTION)
+ifeq ($(shell $(CMD) --version | grep -q mcode; echo $$?),0)
+    ifneq ($(COCOTB_HDL_TIMEPRECISION),)
+        # Convert the time precision to a format string supported by GHDL, if
+        # possible.
+        # GHDL only supports setting the time precision if the mcode backend is
+        # used, using the --time-resolution argument causes GHDL to error out
+        # otherwise.
+        # https://ghdl.github.io/ghdl/using/InvokingGHDL.html#cmdoption-ghdl-time-resolution
+        ifeq ($(COCOTB_HDL_TIMEPRECISION),1fs)
+            GHDL_TIME_RESOLUTION=fs
+        else ifeq ($(COCOTB_HDL_TIMEPRECISION),1ps)
+            GHDL_TIME_RESOLUTION=ps
+        else ifeq ($(COCOTB_HDL_TIMEPRECISION),1us)
+            GHDL_TIME_RESOLUTION=us
+        else ifeq ($(COCOTB_HDL_TIMEPRECISION),1ms)
+            GHDL_TIME_RESOLUTION=ms
+        else ifeq ($(COCOTB_HDL_TIMEPRECISION),1s)
+            GHDL_TIME_RESOLUTION=sec
+        else
+            $(error GHDL only supports the following values for COCOTB_HDL_TIMEPRECISION: 1fs, 1ps, 1us, 1ms, 1s)
+        endif
+
+        GHDL_RUN_ARGS += --time-resolution=$(GHDL_TIME_RESOLUTION)
+    endif
 endif
 
 .PHONY: analyse


### PR DESCRIPTION
GHDL errors out if `--time-resolution` is passed and a backend other
than mcode is used (as opposed to silently ignoring this option). This
behavior requires us to check the GHDL backend before calling it.
Implement this behavior in our Makefiles and in the cocotb runner.

Fixes #3629
