### PR TITLE
CI: Show diffs in Lint action logs where possible

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
     - name: pre-commit
       run: |
         pip install pre-commit
-        pre-commit run -a
+        pre-commit run -a --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
   hooks:
   - id: "clang-format"
     exclude: "^src/cocotb/share/include/(sv_vpi|vhpi|vpi)_user(_ext)?.h"
+    types_or: [c, c++]
 
 - repo: "https://github.com/pre-commit/pre-commit-hooks"
   rev: "v4.5.0"


### PR DESCRIPTION
Running `pre-commit` locally should change the files in question,
but for CI it is more useful to show what would be changed rather than just Passed/Failed for each hook.