### PR TITLE
Print exception before launching pdb

### DIFF
--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -460,6 +460,7 @@ class RegressionManager:
             result_pass = False
 
             if _pdb_on_exception:
+                print(result)
                 pdb.post_mortem(result.__traceback__)
 
         return result_pass, sim_failed


### PR DESCRIPTION
When running with COCOTB_PDB_ON_EXCEPTION, the exception wasn't getting printed out