### PR TITLE
Decouple implementation of Array and LogicArray

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -107,10 +107,11 @@ as the types used by cocotb's `simulator handles <#simulation-object-handles>`_.
 
 .. autoclass:: cocotb.types.Array
     :members:
-    :exclude-members: count, index
+    :inherited-members:
 
 .. autoclass:: cocotb.types.LogicArray
     :members:
+    :inherited-members:
 
 Triggers
 --------

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -1,15 +1,33 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-import typing
+from abc import ABC, abstractmethod
+from typing import Any, Generic, Iterable, Iterator, Optional, TypeVar, Union, overload
 
-from .array import Array  # noqa: F401
-from .logic import Logic  # noqa: F401
-from .logic_array import LogicArray  # noqa: F401
-from .range import Range  # noqa: F401
+try:
+    from typing import Protocol
+except ImportError:
+    try:
+        from typing_extensions import Protocol
+    except ImportError:
+        Protocol = ABC
+
+T = TypeVar("T")
+Self = TypeVar("Self")
 
 
-def concat(a: typing.Any, b: typing.Any) -> typing.Any:
+class Concatable(Protocol, Generic[T]):
+    def __concat__(self: Self, other: Self) -> Self:
+        return NotImplemented
+
+    def __rconcat__(self: Self, other: Self) -> Self:
+        return NotImplemented
+
+
+ConcatableT = TypeVar("ConcatableT", bound=Concatable[Any])
+
+
+def concat(a: ConcatableT, b: ConcatableT) -> ConcatableT:
     """
     Create a new array that is the concatenation of one array with another.
 
@@ -46,3 +64,117 @@ def concat(a: typing.Any, b: typing.Any) -> typing.Any:
     raise TypeError(
         f"cannot concatenate {type_a.__qualname__!r} with {type_b.__qualname__!r}"
     )
+
+
+from .range import Range  # noqa: F401
+
+
+class ArrayLike(Concatable[T], Protocol, Generic[T]):
+    @property
+    def left(self) -> int:
+        """Leftmost index of the array."""
+        return self.range.left
+
+    @property
+    def direction(self) -> str:
+        """``"to"`` if indexes are ascending, ``"downto"`` otherwise."""
+        return self.range.direction
+
+    @property
+    def right(self) -> int:
+        """Rightmost index of the array."""
+        return self.range.right
+
+    @property
+    @abstractmethod
+    def range(self) -> Range:
+        """:class:`Range` of the indexes of the array."""
+
+    @range.setter
+    @abstractmethod
+    def range(self, new_range: Range) -> None:
+        """Set a new indexing scheme on the array. Must be the same size."""
+
+    def __len__(self) -> int:
+        return len(self.range)
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[T]:
+        ...
+
+    @abstractmethod
+    def __reversed__(self) -> Iterator[T]:
+        ...
+
+    def __contains__(self, item: object) -> bool:
+        for v in self:
+            if v == item:
+                return True
+        return False
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        if len(self) != len(other):
+            return False
+        return all(a == b for a, b in zip(self, other))
+
+    @overload
+    def __getitem__(self, item: int) -> T:
+        ...
+
+    @overload
+    def __getitem__(self: Self, item: slice) -> Self:
+        ...
+
+    @abstractmethod
+    def __getitem__(self: Self, item: Union[int, slice]) -> Union[T, Self]:
+        ...
+
+    @overload
+    def __setitem__(self, item: int, value: T) -> None:
+        ...
+
+    @overload
+    def __setitem__(self, item: slice, value: Iterable[T]) -> None:
+        ...
+
+    @abstractmethod
+    def __setitem__(
+        self, item: Union[int, slice], value: Union[T, Iterable[T]]
+    ) -> None:
+        ...
+
+    def index(
+        self,
+        value: T,
+        start: Optional[int] = None,
+        stop: Optional[int] = None,
+    ) -> int:
+        """
+        Return index of first occurrence of *value*.
+
+        Raises :exc:`IndexError` if the value is not found.
+        Search only within *start* and *stop* if given.
+        """
+        if start is None:
+            start = self.left
+        if stop is None:
+            stop = self.right
+        for i in Range(start, self.direction, stop):
+            if self[i] == value:
+                return i
+        raise IndexError(f"{value!r} not in array")
+
+    def count(self, value: T) -> int:
+        """Return number of occurrences of *value*."""
+        count: int = 0
+        for v in self:
+            if v == value:
+                count += 1
+        return 0
+
+
+from .array import Array  # noqa: F401
+from .logic import Logic  # noqa: F401
+from .logic_array import LogicArray  # noqa: F401

--- a/src/cocotb/types/array.py
+++ b/src/cocotb/types/array.py
@@ -4,14 +4,14 @@
 import typing
 from itertools import chain
 
+from cocotb.types import ArrayLike
 from cocotb.types.range import Range
 
 T = typing.TypeVar("T")
-S = typing.TypeVar("S")
 Self = typing.TypeVar("Self", bound="Array[typing.Any]")
 
 
-class Array(typing.Reversible[T], typing.Collection[T]):
+class Array(ArrayLike[T]):
     r"""
     Fixed-size, arbitrarily-indexed, homogeneous collection type.
 
@@ -143,21 +143,6 @@ class Array(typing.Reversible[T], typing.Collection[T]):
                 )
 
     @property
-    def left(self) -> int:
-        """Leftmost index of the array."""
-        return self.range.left
-
-    @property
-    def direction(self) -> str:
-        """``"to"`` if indexes are ascending, ``"downto"`` otherwise."""
-        return self.range.direction
-
-    @property
-    def right(self) -> int:
-        """Rightmost index of the array."""
-        return self.range.right
-
-    @property
     def range(self) -> Range:
         """:class:`Range` of the indexes of the array."""
         return self._range
@@ -172,9 +157,6 @@ class Array(typing.Reversible[T], typing.Collection[T]):
                 f"{new_range!r} not the same length as old range ({self._range!r})."
             )
         self._range = new_range
-
-    def __len__(self) -> int:
-        return len(self.range)
 
     def __iter__(self) -> typing.Iterator[T]:
         return iter(self._value)
@@ -274,27 +256,6 @@ class Array(typing.Reversible[T], typing.Collection[T]):
         if isinstance(other, type(self)):
             return type(self)(chain(other, self))
         return NotImplemented
-
-    def index(
-        self,
-        value: T,
-        start: typing.Optional[int] = None,
-        stop: typing.Optional[int] = None,
-    ) -> int:
-        """
-        Return index of first occurrence of *value*.
-
-        Raises :exc:`IndexError` if the value is not found.
-        Search only within *start* and *stop* if given.
-        """
-        if start is None:
-            start = self.left
-        if stop is None:
-            stop = self.right
-        for i in Range(start, self.direction, stop):
-            if self[i] == value:
-                return i
-        raise IndexError(f"{value!r} not in array")
 
     def count(self, value: T) -> int:
         """Return number of occurrences of *value*."""


### PR DESCRIPTION
Decouples the implementation of `Array` and `LogicArray`. We create a Protocol for ArrayLike types and move a lot of common functionality into that class. We duplicate the implementation of Array into LogicArray with the anticipation that the implementation of LogicArray will change in the near future for performance reasons.