### PR TITLE
Move around commandline args in Makefile.icarus

### DIFF
--- a/src/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/src/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -62,7 +62,7 @@ else
   TOPMODULE_ARG :=
 endif
 
-COMPILE_ARGS += -f $(SIM_BUILD)/cmds.f -g2012 # Default to latest SystemVerilog standard
+COMPILE_ARGS += -f $(SIM_BUILD)/cmds.f
 
 ifdef VERILOG_INCLUDE_DIRS
     COMPILE_ARGS += $(addprefix -I, $(VERILOG_INCLUDE_DIRS))
@@ -78,7 +78,7 @@ endif
 
 $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	@echo "+timescale+$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)" > $(SIM_BUILD)/cmds.f
-	$(CMD) -o $(SIM_BUILD)/sim.vvp -D COCOTB_SIM=1 $(TOPMODULE_ARG) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+	$(CMD) -o $(SIM_BUILD)/sim.vvp -D COCOTB_SIM=1 $(TOPMODULE_ARG) -g2012 $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
 $(SIM_BUILD)/cocotb_iverilog_dump.v: | $(SIM_BUILD)
 	@echo 'module cocotb_iverilog_dump();' > $@


### PR DESCRIPTION
Moves default language version in iverilog commandline args earlier to allow the user to override it later with COMPILE_ARGS. Closes #3635.
