### PR TITLE
Ensure initial happens before cocotb starts

### DIFF
--- a/docs/source/newsfragments/3642.bugfix.rst
+++ b/docs/source/newsfragments/3642.bugfix.rst
@@ -1,0 +1,1 @@
+Fix tests being started before initial blocks are evaluated under Verilator.

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -58,6 +58,9 @@ int main(int argc, char** argv) {
     Verilated::internalsDump();
 #endif
 
+    // Evaluate initial blocks before starting cocotb
+    top->eval_step();
+
     vlog_startup_routines_bootstrap();
     VerilatedVpi::callCbs(cbStartOfSimulation);
 

--- a/tests/test_cases/test_initial/Makefile
+++ b/tests/test_cases/test_initial/Makefile
@@ -1,0 +1,27 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+TOPLEVEL_LANG ?= verilog
+ifneq ($(TOPLEVEL_LANG),verilog)
+SKIP := 1
+$(info "Skipping . . . Verilog only")
+endif
+
+ifeq ($(SKIP),)
+
+VERILOG_SOURCES = test_initial.sv
+TOPLEVEL := cocotb_initial
+MODULE = test_initial
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+else
+
+all:
+	@echo "Skipping test_initial"
+
+clean::
+# nothing to clean, just define target in this branch
+
+endif

--- a/tests/test_cases/test_initial/test_initial.py
+++ b/tests/test_cases/test_initial/test_initial.py
@@ -1,0 +1,20 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+A test to demonstrate initial has happened before cocotb is invoked
+"""
+
+import logging
+
+import cocotb
+
+
+@cocotb.test()
+async def test_initial(dut):
+    """Test that initial has already happened"""
+    tlog = logging.getLogger("cocotb.test")
+
+    tlog.info("Checking foo:")
+    assert dut.foo.value == 123

--- a/tests/test_cases/test_initial/test_initial.sv
+++ b/tests/test_cases/test_initial/test_initial.sv
@@ -1,0 +1,11 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+module cocotb_initial;
+
+    int foo;
+    initial foo = 123;
+
+endmodule


### PR DESCRIPTION
Tests were starting before initial blocks had been evaluated for Verilator sims.  This fixes the issue and adds a test to demonstrate / enforce consistent behavior.