### PR TITLE
Allow indexing to vpiscope objects

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -596,7 +596,7 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
         vpiPrimitive, vpiPrimitiveArray,
         // vpiContAssign,        // Don't care
         vpiProcess,  // Don't care
-        vpiModPath, vpiTchk, vpiAttribute, vpiPort, vpiInternalScope,
+        vpiModPath, vpiTchk, vpiAttribute, vpiPort, vpiInternalScope, vpiScope,
         // vpiInterface,         // Aldec SEGV on mixed language
         // vpiInterfaceArray,    // Aldec SEGV on mixed language
     };
@@ -618,6 +618,7 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
         {vpiModule, module_options},
         {vpiInterface, instance_options},
         {vpiGenScope, module_options},
+        {vpiScope, module_options},
 
         {vpiStructVar, struct_options},
         {vpiStructNet, struct_options},

--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -141,7 +141,8 @@ static gpi_objtype_t to_gpi_objtype(int32_t vpitype) {
         case vpiInitial:
         case vpiGate:
         case vpiPrimTerm:
-        case vpiGenScope:
+        case vpiGenScope: 
+        case vpiScope:
             return GPI_MODULE;
 
         case vpiPackage:
@@ -246,16 +247,20 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiGate:
         case vpiPrimTerm:
         case vpiGenScope:
+        case vpiScope:
         case vpiGenScopeArray: {
             std::string hdl_name = vpi_get_str(vpiName, new_hdl);
 
+            #ifdef MODELSIM
             if (hdl_name != name) {
                 LOG_DEBUG("Found pseudo-region %s (hdl_name=%s but name=%s)",
                           fq_name.c_str(), hdl_name.c_str(), name.c_str());
                 new_obj = new VpiObjHdl(this, new_hdl, GPI_GENARRAY);
-            } else {
-                new_obj = new VpiObjHdl(this, new_hdl, to_gpi_objtype(type));
-            }
+                break;
+            } 
+            #endif
+
+            new_obj = new VpiObjHdl(this, new_hdl, to_gpi_objtype(type));
             break;
         }
         default:

--- a/tests/test_cases/test_package/cocotb_package.sv
+++ b/tests/test_cases/test_package/cocotb_package.sv
@@ -8,4 +8,14 @@ module cocotb_package;
     import cocotb_package_pkg_2::*;
 
     parameter int seven_int = 7;
+
+    generate
+        begin: always_scope
+            parameter int six_int = 6;
+        end
+        if (seven_int == 7) begin: cond_scope
+            parameter int nine_int = 9;
+        end
+        
+    endgenerate
 endmodule

--- a/tests/test_cases/test_package/cocotb_package_pkg.sv
+++ b/tests/test_cases/test_package/cocotb_package_pkg.sv
@@ -2,9 +2,11 @@
 // Licensed under the Revised BSD License, see LICENSE for details.
 // SPDX-License-Identifier: BSD-3-Clause
 
+/* verilator public_on */
 package cocotb_package_pkg_1;
     parameter int five_int = 5;
     parameter logic [31:0] eight_logic = 8;
+    parameter logic [63:0] long_param = '1;
 endpackage
 
 package cocotb_package_pkg_2;
@@ -12,3 +14,5 @@ package cocotb_package_pkg_2;
 endpackage
 
 parameter int unit_four_int = 4;
+
+/* verilator public_off */

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -25,6 +25,15 @@ async def test_params(dut):
     pkg2 = cocotb.packages.cocotb_package_pkg_2
     assert pkg2.eleven_int.value == 11
 
+    found_len = len([hdl for hdl in dut])
+
+    if cocotb.SIM_NAME.lower().startswith("verilator"):
+        # misses both scopes on iterate
+        assert found_len == 1
+
+    assert dut.always_scope.six_int.value == 6
+    assert dut.cond_scope.seven_int.value == 7
+
 
 @cocotb.test()
 async def test_stringification(dut):
@@ -39,6 +48,16 @@ async def test_stringification(dut):
     pkg2 = cocotb.packages.cocotb_package_pkg_2
     assert str(pkg2).startswith("HierarchyObject(cocotb_package_pkg_2")
     assert str(pkg2.eleven_int) == "IntegerObject(cocotb_package_pkg_2::eleven_int)"
+
+
+@cocotb.test(expect_fail=True)
+def test_long_parameter(dut):
+    # On verilator:
+    # 0.00ns ERROR    gpi                                VPI error
+    # 0.00ns ERROR    gpi                                vl_check_format: Unsupported format (vpiIntVal) for cocotb_package_pkg_1.long_param
+    # 0.00ns ERROR    cocotb.regression                  Failed to initialize test test_long_parameter
+    pkg1 = cocotb.packages.cocotb_package_pkg_1
+    assert pkg1.long_param.value != 0
 
 
 @cocotb.test()


### PR DESCRIPTION
This allows for accessing vpiScope objects, but they are still invisible in iteration in verilator at least. Addresses https://github.com/cocotb/cocotb/issues/1884

Questions: 

- Can someone confirm that the pseudo-handle stuff is only needed for modelsim/questa? without that ifdef the nine_int inside the scope was not found, because the scope was GPI_GEN_ARRAY
- Is a better solution to just have verilator to return vpiGenScope? What's the correct thing to do here?


tagging @marlonjames in case there's any repeated work

