### PR TITLE
Long parameter test case

### DIFF
--- a/tests/test_cases/test_package/cocotb_package_pkg.sv
+++ b/tests/test_cases/test_package/cocotb_package_pkg.sv
@@ -5,8 +5,8 @@
 package cocotb_package_pkg_1;
     parameter int five_int = 5;
     parameter logic [31:0] eight_logic = 8;
-    parameter logic [63:0] long_param = 64'hFF;
-    parameter logic [99:0] really_long_param = 100'hFF;
+    parameter longint unsigned long_param = 64'h5a89901af1;
+    parameter logic [99:0] really_long_param = 100'h5a89901af1;
 endpackage
 
 package cocotb_package_pkg_2;

--- a/tests/test_cases/test_package/cocotb_package_pkg.sv
+++ b/tests/test_cases/test_package/cocotb_package_pkg.sv
@@ -5,6 +5,8 @@
 package cocotb_package_pkg_1;
     parameter int five_int = 5;
     parameter logic [31:0] eight_logic = 8;
+    parameter logic [63:0] long_param = 64'hFF;
+    parameter logic [99:0] really_long_param = 100'hFF;
 endpackage
 
 package cocotb_package_pkg_2;

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -41,7 +41,7 @@ async def test_stringification(dut):
     assert str(pkg2.eleven_int) == "IntegerObject(cocotb_package_pkg_2::eleven_int)"
 
 
-@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("verilator"))
+@cocotb.test()
 async def test_long_parameter(dut):
     # On verilator:
     # 0.00ns ERROR    gpi                                VPI error
@@ -50,8 +50,17 @@ async def test_long_parameter(dut):
 
     # returns 0 on verilator for unsupported format
     pkg1 = cocotb.packages.cocotb_package_pkg_1
-    assert pkg1.long_param.value == 255
-    assert pkg1.really_long_param.value == 255
+    assert pkg1.five_int.value == 5
+    assert str(pkg1.five_int) == "IntegerObject(cocotb_package_pkg_1::five_int)"
+
+    assert pkg1.long_param.value.integer == int("5a89901af1", 16)
+    assert str(pkg1.long_param) == "LogicObject(cocotb_package_pkg_1::long_param)"
+
+    assert pkg1.really_long_param.value.integer == int("5a89901af1", 16)
+    assert (
+        str(pkg1.really_long_param)
+        == "LogicObject(cocotb_package_pkg_1::really_long_param)"
+    )
 
 
 @cocotb.test()

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -41,14 +41,17 @@ async def test_stringification(dut):
     assert str(pkg2.eleven_int) == "IntegerObject(cocotb_package_pkg_2::eleven_int)"
 
 
-@cocotb.test()
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("verilator"))
 async def test_long_parameter(dut):
-    # On verilator:
-    # 0.00ns ERROR    gpi                                VPI error
-    # 0.00ns ERROR    gpi                                vl_check_format: Unsupported format (vpiIntVal) for cocotb_package_pkg_1.long_param
-    # 0.00ns ERROR    cocotb.regression                  Failed to initialize test test_long_parameter
+    """
+    Test package parameter access
 
-    # returns 0 on verilator for unsupported format
+    # On verilator:
+    # 0.00ns ERROR    VPI error
+    # 0.00ns ERROR    vl_check_format: Unsupported format (vpiIntVal) for cocotb_package_pkg_1.long_param
+    # 0.00ns ERROR    Failed to initialize test test_long_parameter
+    """
+
     pkg1 = cocotb.packages.cocotb_package_pkg_1
     assert pkg1.five_int.value == 5
     assert str(pkg1.five_int) == "IntegerObject(cocotb_package_pkg_1::five_int)"

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -41,7 +41,7 @@ async def test_stringification(dut):
     assert str(pkg2.eleven_int) == "IntegerObject(cocotb_package_pkg_2::eleven_int)"
 
 
-@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("verilator"))
+@cocotb.test()
 async def test_long_parameter(dut):
     """
     Test package parameter access
@@ -56,8 +56,12 @@ async def test_long_parameter(dut):
     assert pkg1.five_int.value == 5
     assert str(pkg1.five_int) == "IntegerObject(cocotb_package_pkg_1::five_int)"
 
-    assert pkg1.long_param.value.integer == int("5a89901af1", 16)
-    assert str(pkg1.long_param) == "LogicObject(cocotb_package_pkg_1::long_param)"
+    if cocotb.SIM_NAME.lower().startswith(("verilator", "icarus")):
+        assert pkg1.long_param.value == int("5a89901af1", 16)
+        assert str(pkg1.long_param) == "IntegerObject(cocotb_package_pkg_1::long_param)"
+    else:
+        assert pkg1.long_param.value.integer == int("5a89901af1", 16)
+        assert str(pkg1.long_param) == "LogicObject(cocotb_package_pkg_1::long_param)"
 
     assert pkg1.really_long_param.value.integer == int("5a89901af1", 16)
     assert (

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -60,24 +60,19 @@ async def test_long_parameter(dut):
     """
 
     pkg1 = cocotb.packages.cocotb_package_pkg_1
-
-    # icarus and xcelium truncate the value to 32 bits, and ignore the signedness
-
-    if cocotb.SIM_NAME.lower().startswith(("icarus", "xmsim")):
+    if cocotb.SIM_NAME.lower().startswith("verilator"):
+        pass
+    else:
+        # most sims truncate the value to 32 bits, and interpret as signed despite the marking
+        assert str(pkg1.long_param) == "IntegerObject(cocotb_package_pkg_1::long_param)"
+        # should really be 0x5A89901AF1 (40 bits)
+        # -1987044623 = (two's comp) 0b10001001100100000001101011110001 = 0x5A89901AF1[31:0]
         assert get_integer(pkg1.long_param) == -1987044623
         assert (
             str(pkg1.really_long_param)
             == "IntegerObject(cocotb_package_pkg_1::really_long_param)"
         )
         assert get_integer(pkg1.really_long_param) == -1987044623
-
-    elif not cocotb.SIM_NAME.lower().startswith("verilator"):
-        assert (
-            str(pkg1.really_long_param)
-            == "LogicObject(cocotb_package_pkg_1::really_long_param)"
-        )
-        assert get_integer(pkg1.long_param) == int("5a89901af1", 16)
-        assert get_integer(pkg1.really_long_param) == int("5a89901af1", 16)
 
 
 @cocotb.test()

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -41,6 +41,19 @@ async def test_stringification(dut):
     assert str(pkg2.eleven_int) == "IntegerObject(cocotb_package_pkg_2::eleven_int)"
 
 
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("verilator"))
+async def test_long_parameter(dut):
+    # On verilator:
+    # 0.00ns ERROR    gpi                                VPI error
+    # 0.00ns ERROR    gpi                                vl_check_format: Unsupported format (vpiIntVal) for cocotb_package_pkg_1.long_param
+    # 0.00ns ERROR    cocotb.regression                  Failed to initialize test test_long_parameter
+
+    # returns 0 on verilator for unsupported format
+    pkg1 = cocotb.packages.cocotb_package_pkg_1
+    assert pkg1.long_param.value == 255
+    assert pkg1.really_long_param.value == 255
+
+
 @cocotb.test()
 async def test_dollar_unit(dut):
     """Test $unit scope"""


### PR DESCRIPTION
Verilator raises an error when calling vpiIntVal on long parameters in packages, however Xcelium lets this through. We should be checking the size of these parameters, as the Vpi doesn't specify the size for these types on vpiDecConst, vpiBinConst, vpiHexConst and vpiOctConst. I think we ought to set the format to vpiLongIntVal for 64 bit integers, not sure how we want to approach this.

- Adds check for size on ambiguous types
- Adds test case for parameters > 32 bits, and longint

https://github.com/cocotb/cocotb/issues/3662
