### PR TITLE
Don't require Verilator binary for testing

### DIFF
--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -946,6 +946,10 @@ class Verilator(Simulator):
     supported_gpi_interfaces = {"verilog": ["vpi"]}
 
     def _simulator_in_path(self) -> None:
+        # the verilator binary is only needed for building
+        return
+
+    def _simulator_in_path_build_only(self) -> None:
         executable = shutil.which("verilator")
         if executable is None:
             raise SystemExit("ERROR: verilator executable not found!")
@@ -964,6 +968,8 @@ class Verilator(Simulator):
         return [f"-G{name}={value}" for name, value in parameters.items()]
 
     def _build_command(self) -> List[Command]:
+        self._simulator_in_path_build_only()
+
         if self.vhdl_sources:
             raise ValueError(
                 f"{type(self).__qualname__}: Simulator does not support VHDL"


### PR DESCRIPTION
Verilator is different from other simulators in that the tool install is not required past the build stage.  Requiring the `verilator` binary to be present when testing presents challenges, especially in distributed  compute settings.

I'm not exactly sure how to test this in CI, but it's getting me past my current problem locally.