### PR TITLE
Add Verilator run-time trace switch

### DIFF
--- a/docs/source/newsfragments/3667.feature.rst
+++ b/docs/source/newsfragments/3667.feature.rst
@@ -1,1 +1,1 @@
-Add `--trace` to Verilator binaries for run-time trace generation and integrate with :ref:`Python Test Runner <howto-python-runner>`
+Add `--trace` to Verilator binaries for run-time trace generation and integrate with :ref:`Python Test Runner <howto-python-runner>`.

--- a/docs/source/newsfragments/3667.feature.rst
+++ b/docs/source/newsfragments/3667.feature.rst
@@ -1,0 +1,1 @@
+Add `--trace` to Verilator binaries for run-time trace generation and integrate with :ref:`Python Test Runner <howto-python-runner>`

--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -1028,7 +1028,7 @@ class Verilator(Simulator):
 
     def _test_command(self) -> List[Command]:
         out_file = self.build_dir / self.sim_hdl_toplevel
-        return [[str(out_file)] + self.plusargs]
+        return [[str(out_file)] + (["--trace"] if self.waves else []) + self.plusargs]
 
 
 class Xcelium(Simulator):

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
     std::unique_ptr<VerilatedFstC> tfp(new VerilatedFstC);
     const char* traceFile = "dump.fst";
 #else
-    std::unique_ptr<VerilatedvcdC> tfp(new VerilatedVcdC);
+    std::unique_ptr<VerilatedVcdC> tfp(new VerilatedVcdC);
     const char* traceFile = "dump.vcd";
 #endif
 

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -47,6 +47,25 @@ static inline bool settle_value_callbacks() {
 }
 
 int main(int argc, char** argv) {
+    bool traceOn = false;
+
+    for (int i = 1; i < argc; i++) {
+        std::string arg = std::string(argv[i]);
+        if (arg == "--trace") {
+            traceOn = true;
+        } else if (arg == "--help") {
+            fprintf(stderr,
+                    "usage: %s [--trace]\n"
+                    "\n"
+                    "Cocotb + Verilator sim\n"
+                    "\n"
+                    "options:\n"
+                    "  --trace      Enables tracing (VCD or FST)\n",
+                    basename(argv[0]));
+            return 0;
+        }
+    }
+
     Verilated::commandArgs(argc, argv);
 #ifdef VERILATOR_SIM_DEBUG
     Verilated::debug(99);
@@ -62,16 +81,19 @@ int main(int argc, char** argv) {
     VerilatedVpi::callCbs(cbStartOfSimulation);
 
 #if VM_TRACE
-    Verilated::traceEverOn(true);
 #if VM_TRACE_FST
     std::unique_ptr<VerilatedFstC> tfp(new VerilatedFstC);
-    top->trace(tfp.get(), 99);
-    tfp->open("dump.fst");
+    const char* traceFile = "dump.fst";
 #else
-    std::unique_ptr<VerilatedVcdC> tfp(new VerilatedVcdC);
-    top->trace(tfp.get(), 99);
-    tfp->open("dump.vcd");
+    std::unique_ptr<VerilatedvcdC> tfp(new VerilatedVcdC);
+    const char* traceFile = "dump.vcd";
 #endif
+
+    if (traceOn) {
+        Verilated::traceEverOn(true);
+        top->trace(tfp.get(), 99);
+        tfp->open(traceFile);
+    }
 #endif
 
     while (!Verilated::gotFinish()) {
@@ -107,7 +129,9 @@ int main(int argc, char** argv) {
         VerilatedVpi::callCbs(cbReadOnlySynch);
 
 #if VM_TRACE
-        tfp->dump(main_time);
+        if (traceOn) {
+            tfp->dump(main_time);
+        }
 #endif
         // cocotb controls the clock inputs using cbAfterDelay so
         // skip ahead to the next registered callback
@@ -140,7 +164,9 @@ int main(int argc, char** argv) {
     top->final();
 
 #if VM_TRACE
-    tfp->close();
+    if (traceOn) {
+        tfp->close();
+    }
 #endif
 
 // VM_COVERAGE is a define which is set if Verilator is


### PR DESCRIPTION
Adds support for enabling tracing at test-time for Verilator.

This doesn't exactly fit the mold of the runner class, but there is also not a consistent story across the various simulators right now.  Currently some simulators (e.g. Icarus) will only compile in trace support if `waves` is `True`, while others (e.g. Xcelium) always compile in trace support and only observe `waves` at test time.

If the status quo is fine, I'm happy to leave things as-is.  However, if it's desirable to split `waves` into `build_for_waves` and `waves` (or whatever) I can add that here as well.

This is useful to us (and probably others) since monolithic Verilator builds are painfully slow once you reach a certain point.  I don't believe solving that problem is in scope for the cocotb runner, so we (and possibly others) will be using `test()` but not `build()` for Verilator.

Related: Wilson has some good notes on Verilator building here:
https://veripool.org/papers/Verilator_Accelerated_OSDA2020.pdf