### PR TITLE
Runner log redirection

### DIFF
--- a/docs/source/newsfragments/3668.feature.rst
+++ b/docs/source/newsfragments/3668.feature.rst
@@ -1,0 +1,1 @@
+Add `log_file` argument to :ref:`Python Test Runner <howto-python-runner>` to redirect stdout and stderr to the specified file

--- a/docs/source/newsfragments/3668.feature.rst
+++ b/docs/source/newsfragments/3668.feature.rst
@@ -1,1 +1,1 @@
-Add `log_file` argument to :ref:`Python Test Runner <howto-python-runner>` to redirect stdout and stderr to the specified file
+Add `log_file` argument to :ref:`Python Test Runner <howto-python-runner>` to redirect stdout and stderr to the specified file.

--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -20,7 +20,7 @@ import tempfile
 import warnings
 from contextlib import suppress
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import Dict, List, Mapping, Optional, Sequence, TextIO, Tuple, Type, Union
 from xml.etree import ElementTree as ET
 
 import find_libpython
@@ -154,6 +154,7 @@ class Simulator(abc.ABC):
         verbose: bool = False,
         timescale: Optional[Timescale] = None,
         waves: Optional[bool] = None,
+        log_file: Optional[PathLike] = None,
     ) -> None:
         """Build the HDL sources.
 
@@ -172,6 +173,7 @@ class Simulator(abc.ABC):
             verbose: Enable verbose messages.
             timescale: Tuple containing time unit and time precision for simulation.
             waves: Record signal traces.
+            log_file: File to write log
         """
 
         self.clean: bool = clean
@@ -195,6 +197,7 @@ class Simulator(abc.ABC):
         self.hdl_toplevel: Optional[str] = hdl_toplevel
         self.verbose: bool = verbose
         self.timescale: Optional[Timescale] = timescale
+        self.log_file: Optional[PathLike] = log_file
 
         self.waves = bool(waves)
 
@@ -224,6 +227,7 @@ class Simulator(abc.ABC):
         results_xml: str = "results.xml",
         verbose: bool = False,
         timescale: Optional[Timescale] = None,
+        log_file: Optional[PathLike] = None,
     ) -> Path:
         """Run the tests.
 
@@ -250,6 +254,7 @@ class Simulator(abc.ABC):
                 When running with pytest, the testcase name is prefixed to this name.
             verbose: Enable verbose messages.
             timescale: Tuple containing time unit and time precision for simulation.
+            log_file: File to write log
 
         Returns:
             The absolute location of the results XML file which can be
@@ -305,6 +310,7 @@ class Simulator(abc.ABC):
         if seed is not None:
             self.env["RANDOM_SEED"] = str(seed)
 
+        self.log_file = log_file
         self.waves = bool(waves)
         self.gui = bool(gui)
         self.timescale: Optional[Timescale] = timescale
@@ -363,13 +369,27 @@ class Simulator(abc.ABC):
     def _execute(self, cmds: Sequence[Command], cwd: PathLike) -> None:
         __tracebackhide__ = True  # Hide the traceback when using PyTest.
 
+        if self.log_file is None:
+            self._execute_cmds(cmds, cwd)
+        else:
+            with open(self.log_file, "w") as f:
+                self._execute_cmds(cmds, cwd, f)
+
+    def _execute_cmds(
+        self, cmds: Sequence[Command], cwd: PathLike, stdout: Optional[TextIO] = None
+    ) -> None:
+        __tracebackhide__ = True  # Hide the traceback when using PyTest.
+
         for cmd in cmds:
             print(f"INFO: Running command {shlex_join(cmd)} in directory {cwd}")
 
             # TODO: create a thread to handle stderr and log as error?
             # TODO: log forwarding
 
-            subprocess.run(cmd, cwd=cwd, env=self.env, check=True)
+            stderr = None if stdout is None else subprocess.PIPE
+            subprocess.run(
+                cmd, cwd=cwd, env=self.env, check=True, stdout=stdout, stderr=stderr
+            )
 
     def rm_build_folder(self, build_dir: Path):
         if os.path.isdir(build_dir):

--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -173,7 +173,7 @@ class Simulator(abc.ABC):
             verbose: Enable verbose messages.
             timescale: Tuple containing time unit and time precision for simulation.
             waves: Record signal traces.
-            log_file: File to write log
+            log_file: File to write the build log to.
         """
 
         self.clean: bool = clean

--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -254,7 +254,7 @@ class Simulator(abc.ABC):
                 When running with pytest, the testcase name is prefixed to this name.
             verbose: Enable verbose messages.
             timescale: Tuple containing time unit and time precision for simulation.
-            log_file: File to write log
+            log_file: File to write the test log to.
 
         Returns:
             The absolute location of the results XML file which can be

--- a/src/cocotb/runner.py
+++ b/src/cocotb/runner.py
@@ -386,7 +386,7 @@ class Simulator(abc.ABC):
             # TODO: create a thread to handle stderr and log as error?
             # TODO: log forwarding
 
-            stderr = None if stdout is None else subprocess.PIPE
+            stderr = None if stdout is None else subprocess.STDOUT
             subprocess.run(
                 cmd, cwd=cwd, env=self.env, check=True, stdout=stdout, stderr=stderr
             )

--- a/tests/pytest/test_logs.py
+++ b/tests/pytest/test_logs.py
@@ -1,3 +1,7 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import sys
 from pathlib import Path
@@ -20,8 +24,8 @@ from test_cocotb import (
     vhdl_sources,
 )
 
-sys.path.insert(0, os.path.join(tests_dir, "pytest"))
-test_module = os.path.basename(os.path.splitext(__file__)[0])
+sys.path.insert(0, str(Path(tests_dir) / "pytest"))
+test_module = Path(__file__).stem
 sim = os.getenv("SIM", "icarus")
 
 
@@ -62,5 +66,5 @@ def test_wave_dump():
     temp_dir = TemporaryDirectory()
     log_dir = Path(temp_dir.name)
     run_simulation(sim=sim, log_dir=log_dir)
-    assert os.path.exists(log_dir / "build.log")
-    assert os.path.exists(log_dir / "test.log")
+    assert (log_dir / "build.log").exists()
+    assert (log_dir / "test.log").exists()

--- a/tests/pytest/test_logs.py
+++ b/tests/pytest/test_logs.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.runner import get_runner
+from cocotb.triggers import ClockCycles
+from test_cocotb import (
+    compile_args,
+    gpi_interfaces,
+    hdl_toplevel,
+    hdl_toplevel_lang,
+    sim_args,
+    sim_build,
+    tests_dir,
+    verilog_sources,
+    vhdl_sources,
+)
+
+sys.path.insert(0, os.path.join(tests_dir, "pytest"))
+test_module = os.path.basename(os.path.splitext(__file__)[0])
+sim = os.getenv("SIM", "icarus")
+
+
+@cocotb.test()
+async def clock_design(dut):
+    clock = Clock(dut.clk, 10, units="us")
+    cocotb.start_soon(clock.start())
+    await ClockCycles(dut.clk, 10)
+
+
+def run_simulation(sim, log_dir):
+    runner = get_runner(sim)
+    runner.build(
+        always=True,
+        clean=True,
+        verilog_sources=verilog_sources,
+        vhdl_sources=vhdl_sources,
+        hdl_toplevel=hdl_toplevel,
+        build_dir=sim_build,
+        build_args=compile_args,
+        defines={"NODUMPFILE": 1},
+        log_file=log_dir / "build.log",
+    )
+
+    runner.test(
+        hdl_toplevel_lang=hdl_toplevel_lang,
+        hdl_toplevel=hdl_toplevel,
+        gpi_interfaces=gpi_interfaces,
+        test_module=test_module,
+        test_args=sim_args,
+        build_dir=sim_build,
+        log_file=log_dir / "test.log",
+    )
+
+
+@pytest.mark.simulator_required
+def test_wave_dump():
+    temp_dir = TemporaryDirectory()
+    log_dir = Path(temp_dir.name)
+    run_simulation(sim=sim, log_dir=log_dir)
+    assert os.path.exists(log_dir / "build.log")
+    assert os.path.exists(log_dir / "test.log")


### PR DESCRIPTION
Adds an option to send runner build or test logs to a file instead of stdout / stderr.  Currently just squishes the two together, but a separate stderr file option could be added later.  Also added a test to demonstrate.