### PR TITLE
Fix ruff config

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -269,7 +269,7 @@ ENVS = [
 
 
 def append_str_val(listref, my_list, key) -> None:
-    if not key in my_list:
+    if key not in my_list:
         return
     listref.append(str(my_list[key]))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ extend-exclude = [
     ".nox/",
 ]
 target-version = "py37"
-select = [
+extend-select = [
     "I",  # isort
     "UP", # pyupgrade
     "PL", # pylint

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -314,7 +314,7 @@ def _start_library_coverage() -> None:  # pragma: no cover
     if "COCOTB_LIBRARY_COVERAGE" in os.environ:
         try:
             import coverage
-        except ImportError as e:
+        except ImportError:
             log.error(
                 "cocotb library coverage collection requested but coverage package not available. Install it using `pip install coverage`."
             )
@@ -396,7 +396,7 @@ def _start_user_coverage() -> None:
     if "COVERAGE" in os.environ:
         try:
             import coverage
-        except ImportError as e:
+        except ImportError:
             cocotb.log.error(
                 "Coverage collection requested but coverage module not available. Install it using `pip install coverage`."
             )

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -37,7 +37,6 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Set,
     Tuple,
     TypeVar,
 )

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -38,7 +38,6 @@ import re
 import sys
 import time
 import warnings
-from enum import Enum, auto
 from itertools import product
 from typing import (
     Any,
@@ -966,7 +965,7 @@ class TestFactory(Generic[F]):
         for index, testoptions in enumerate(
             dict(zip(d, v)) for v in product(*d.values())
         ):
-            name = f"%s%s%s_%03d" % (
+            name = "%s%s%s_%03d" % (
                 prefix,
                 test_func_name,
                 postfix,

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -66,7 +66,7 @@ def concat(a: ConcatableT, b: ConcatableT) -> ConcatableT:
     )
 
 
-from .range import Range  # noqa: F401
+from .range import Range  # noqa: E402 F401
 
 
 class ArrayLike(Concatable[T], Protocol, Generic[T]):
@@ -175,6 +175,6 @@ class ArrayLike(Concatable[T], Protocol, Generic[T]):
         return 0
 
 
-from .array import Array  # noqa: F401
-from .logic import Logic  # noqa: F401
-from .logic_array import LogicArray  # noqa: F401
+from .array import Array  # noqa: E402 F401
+from .logic import Logic  # noqa: E402 F401
+from .logic_array import LogicArray  # noqa: E402 F401

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -26,7 +26,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Collection of handy functions."""
-import functools
 import inspect
 import math
 import os

--- a/tests/test_cases/issue_142/issue_142.py
+++ b/tests/test_cases/issue_142/issue_142.py
@@ -4,7 +4,6 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge
 from cocotb.types import LogicArray, Range
-from cocotb.types.range import Range
 
 
 @cocotb.test()


### PR DESCRIPTION
We should have used `extend-select` instead of just `select`. By default the `E` and `F` rules are applied, which are pycodestyle errors and pyflakes rulesets, respectively.