### PR TITLE
Verilator trace file name parameter

### DIFF
--- a/docs/source/newsfragments/3683.feature.rst
+++ b/docs/source/newsfragments/3683.feature.rst
@@ -1,0 +1,1 @@
+Add ``--trace-file`` to Verilator binaries which specifies the trace file name.

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -48,20 +48,34 @@ static inline bool settle_value_callbacks() {
 
 int main(int argc, char** argv) {
     bool traceOn = false;
+#if VM_TRACE_FST
+    const char* traceFile = "dump.fst";
+#else
+    const char* traceFile = "dump.vcd";
+#endif
 
     for (int i = 1; i < argc; i++) {
         std::string arg = std::string(argv[i]);
         if (arg == "--trace") {
             traceOn = true;
+        } else if (arg == "--trace-file") {
+            if (++i < argc) {
+                traceFile = argv[i];
+            } else {
+                fprintf(stderr, "Error: --trace-file requires a parameter\n");
+                return -1;
+            }
         } else if (arg == "--help") {
             fprintf(stderr,
-                    "usage: %s [--trace]\n"
+                    "usage: %s [--trace] [--trace-file TRACEFILE]\n"
                     "\n"
                     "Cocotb + Verilator sim\n"
                     "\n"
                     "options:\n"
-                    "  --trace      Enables tracing (VCD or FST)\n",
-                    basename(argv[0]));
+                    "  --trace      Enables tracing (VCD or FST)\n"
+                    "  --trace-file Specifies the trace file name (%s by "
+                    "default)\n",
+                    basename(argv[0]), traceFile);
             return 0;
         }
     }
@@ -83,10 +97,8 @@ int main(int argc, char** argv) {
 #if VM_TRACE
 #if VM_TRACE_FST
     std::unique_ptr<VerilatedFstC> tfp(new VerilatedFstC);
-    const char* traceFile = "dump.fst";
 #else
     std::unique_ptr<VerilatedVcdC> tfp(new VerilatedVcdC);
-    const char* traceFile = "dump.vcd";
 #endif
 
     if (traceOn) {

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -71,7 +71,7 @@ def test_wave_dump():
     if sim == "icarus":
         dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")
     elif sim == "verilator":
-        dumpfile_path = os.path.join(sim_build, f"dump.vcd")
+        dumpfile_path = os.path.join(sim_build, "dump.vcd")
     elif sim == "xcelium":
         dumpfile_path = os.path.join(sim_build, "cocotb_waves.shm", "cocotb_waves.trn")
     else:

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import tempfile
+from pathlib import Path
 
 import cocotb
 import pytest
@@ -30,7 +32,7 @@ async def clock_design(dut):
     await ClockCycles(dut.clk, 10)
 
 
-def run_simulation(sim):
+def run_simulation(sim, test_args=None):
     runner = get_runner(sim)
     runner.build(
         always=True,
@@ -44,12 +46,16 @@ def run_simulation(sim):
         waves=True,
     )
 
+    _test_args = sim_args
+    if test_args is not None:
+        _test_args.extend(test_args)
+
     runner.test(
         hdl_toplevel_lang=hdl_toplevel_lang,
         hdl_toplevel=hdl_toplevel,
         gpi_interfaces=gpi_interfaces,
         test_module=test_module,
-        test_args=sim_args,
+        test_args=_test_args,
         build_dir=sim_build,
         waves=True,
     )
@@ -57,15 +63,31 @@ def run_simulation(sim):
 
 @pytest.mark.simulator_required
 @pytest.mark.skipif(
-    sim not in ["icarus", "xcelium"],
-    reason="Skipping test because it is only for Icarus or Xcelium simulators",
+    sim not in ["icarus", "verilator", "xcelium"],
+    reason="Skipping test because it is only for Icarus, Verilator or Xcelium simulators",
 )
 def test_wave_dump():
     run_simulation(sim=sim)
     if sim == "icarus":
         dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")
+    elif sim == "verilator":
+        dumpfile_path = os.path.join(sim_build, f"dump.vcd")
     elif sim == "xcelium":
         dumpfile_path = os.path.join(sim_build, "cocotb_waves.shm", "cocotb_waves.trn")
     else:
         raise RuntimeError("Not a supported simulator")
     assert os.path.exists(dumpfile_path)
+
+
+@pytest.mark.simulator_required
+@pytest.mark.skipif(
+    sim not in ["verilator"],
+    reason="Skipping test because it is only for Verilator simulators",
+)
+def test_named_wave_dump():
+    temp_dir = Path(tempfile.mkdtemp())
+    waves_file = temp_dir / "waves.vcd"
+    run_simulation(sim=sim, test_args=["--trace-file", str(waves_file)])
+    if sim not in ["verilator"]:
+        raise RuntimeError("Not a supported simulator")
+    assert waves_file.exists()


### PR DESCRIPTION
Not sure about `waves_file` since not all simulators support providing a path for this, nor do they all just write out a single file.  I was going to make Icarus observe `waves_file` too, but then I noticed that I'd need to specify it during the build phase.  So I could:

- Leave it as is
- Assert for non-Verilator simulators
- Drop `waves_file` and just pass what I need via `test_args`

Regardless, the `verilator.cpp` changes are needed and I can make the test work whichever way we want to go.