### PR TITLE
[Verilog] Interface Array Testcase

### DIFF
--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -13,3 +13,22 @@ async def test_sv_if(dut):
     assert hasattr(dut.sv_if_i, "a")
     assert hasattr(dut.sv_if_i, "b")
     assert hasattr(dut.sv_if_i, "c")
+
+
+@cocotb.test(expect_fail=True)
+async def test_sv_if_arrays(dut):
+    """Test that interface arrays are the correct type and iterable"""
+
+    # should be a HierarchyArrayObject, currently is a NonHierarchyIndexableObject in Xcelium
+    print(dut.sv_if_arr)
+
+    assert isinstance(dut.sv_if_arr, cocotb.handle.HierarchyArrayObject)
+
+    dut.sv_if_arr._discover_all()
+
+    m = len(dut.sv_if_arr)
+    assert m == 3
+    for i in range(m):
+        assert hasattr(dut.sv_if_arr[i], "a")
+        assert hasattr(dut.sv_if_arr[i], "b")
+        assert hasattr(dut.sv_if_arr[i], "c")

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -7,7 +7,7 @@ import cocotb
 
 @cocotb.test()
 async def test_sv_if(dut):
-    """Test that signals in an interface are discovered and iterable"""
+    """Test that signals in an interface are discovered"""
 
     dut.sv_if_i._discover_all()
     assert hasattr(dut.sv_if_i, "a")
@@ -17,7 +17,7 @@ async def test_sv_if(dut):
 
 @cocotb.test()
 async def test_sv_intf_arr_type(dut):
-    """Test that interface arrays are the correct type and iterable"""
+    """Test that interface arrays are the correct type"""
 
     print(dut.sv_if_arr)
 
@@ -30,11 +30,13 @@ async def test_sv_intf_arr_type(dut):
 
 @cocotb.test()
 async def test_sv_intf_arr_len(dut):
+    """Test that interface array length is correct"""
     assert len(dut.sv_if_arr) == 3
 
 
 @cocotb.test()
 async def test_sv_intf_arr_access(dut):
+    """Test that interface array objects can be accessed"""
     for i in range(3):
         assert hasattr(dut.sv_if_arr[i], "a")
         assert hasattr(dut.sv_if_arr[i], "b")
@@ -43,6 +45,7 @@ async def test_sv_intf_arr_access(dut):
 
 @cocotb.test()
 async def test_sv_intf_arr_iteration(dut):
+    """Test that interface arrays can be iterated"""
     count = 0
     for intf in dut.sv_if_arr:
         assert hasattr(intf, "a")

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -36,7 +36,7 @@ async def test_sv_intf_arr_len(dut):
     assert len(dut.sv_if_arr) == 3
 
 
-@cocotb.test()
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"))
 async def test_sv_intf_arr_access(dut):
     """Test that interface array objects can be accessed"""
     for i in range(3):
@@ -45,7 +45,7 @@ async def test_sv_intf_arr_access(dut):
         assert hasattr(dut.sv_if_arr[i], "c")
 
 
-@cocotb.test()
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"))
 async def test_sv_intf_arr_iteration(dut):
     """Test that interface arrays can be iterated"""
     count = 0

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -16,7 +16,7 @@ async def test_sv_if(dut):
 
 
 @cocotb.test()
-async def test_sv_if_arrays(dut):
+async def test_sv_intf_arr_type(dut):
     """Test that interface arrays are the correct type and iterable"""
 
     print(dut.sv_if_arr)
@@ -27,11 +27,27 @@ async def test_sv_if_arrays(dut):
         # This is correct
         assert isinstance(dut.sv_if_arr, cocotb.handle.HierarchyArrayObject)
 
-    dut.sv_if_arr._discover_all()
 
-    m = len(dut.sv_if_arr)
-    assert m == 3
-    for i in range(m):
+@cocotb.test()
+async def test_sv_intf_arr_len(dut):
+    assert len(dut.sv_if_arr) == 3
+
+
+@cocotb.test()
+async def test_sv_intf_arr_access(dut):
+    for i in range(3):
         assert hasattr(dut.sv_if_arr[i], "a")
         assert hasattr(dut.sv_if_arr[i], "b")
         assert hasattr(dut.sv_if_arr[i], "c")
+
+
+@cocotb.test()
+async def test_sv_intf_arr_iteration(dut):
+    count = 0
+    for intf in dut.sv_if_arr:
+        assert hasattr(intf, "a")
+        assert hasattr(intf, "b")
+        assert hasattr(intf, "c")
+        count += 1
+
+    assert count == 3

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -15,14 +15,17 @@ async def test_sv_if(dut):
     assert hasattr(dut.sv_if_i, "c")
 
 
-@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("xmsim"))
+@cocotb.test()
 async def test_sv_if_arrays(dut):
     """Test that interface arrays are the correct type and iterable"""
 
-    # should be a HierarchyArrayObject, currently is a NonHierarchyIndexableObject in Xcelium
     print(dut.sv_if_arr)
 
-    assert isinstance(dut.sv_if_arr, cocotb.handle.HierarchyArrayObject)
+    if cocotb.SIM_NAME.lower().startswith("xmsim"):
+        assert isinstance(dut.sv_if_arr, cocotb.handle.ArrayObject)
+    else:
+        # This is correct
+        assert isinstance(dut.sv_if_arr, cocotb.handle.HierarchyArrayObject)
 
     dut.sv_if_arr._discover_all()
 

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -15,26 +15,32 @@ async def test_sv_if(dut):
     assert hasattr(dut.sv_if_i, "c")
 
 
-@cocotb.test()
+@cocotb.test(
+    exepect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
+)
 async def test_sv_intf_arr_type(dut):
     """Test that interface arrays are the correct type"""
 
     print(dut.sv_if_arr)
 
-    if cocotb.SIM_NAME.lower().startswith("xmsim"):
+    if cocotb.SIM_NAME.lower().startswith("xmsim", "modelsim"):
         assert isinstance(dut.sv_if_arr, cocotb.handle.ArrayObject)
     else:
         # This is correct
         assert isinstance(dut.sv_if_arr, cocotb.handle.HierarchyArrayObject)
 
 
-@cocotb.test()
+@cocotb.test(
+    exepect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
+)
 async def test_sv_intf_arr_len(dut):
     """Test that interface array length is correct"""
     assert len(dut.sv_if_arr) == 3
 
 
-@cocotb.test()
+@cocotb.test(
+    exepect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
+)
 async def test_sv_intf_arr_access(dut):
     """Test that interface array objects can be accessed"""
     for i in range(3):
@@ -43,6 +49,9 @@ async def test_sv_intf_arr_access(dut):
         assert hasattr(dut.sv_if_arr[i], "c")
 
 
+@cocotb.test(
+    exepect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
+)
 @cocotb.test()
 async def test_sv_intf_arr_iteration(dut):
     """Test that interface arrays can be iterated"""

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -15,7 +15,7 @@ async def test_sv_if(dut):
     assert hasattr(dut.sv_if_i, "c")
 
 
-@cocotb.test(expect_fail=True)
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("xmsim"))
 async def test_sv_if_arrays(dut):
     """Test that interface arrays are the correct type and iterable"""
 

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -15,15 +15,13 @@ async def test_sv_if(dut):
     assert hasattr(dut.sv_if_i, "c")
 
 
-@cocotb.test(
-    expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
-)
+@cocotb.test()
 async def test_sv_intf_arr_type(dut):
     """Test that interface arrays are the correct type"""
 
     print(dut.sv_if_arr)
 
-    if cocotb.SIM_NAME.lower().startswith(("xmsim", "modelsim")):
+    if cocotb.SIM_NAME.lower().startswith(("xmsim", "modelsim", "riviera")):
         assert isinstance(dut.sv_if_arr, cocotb.handle.ArrayObject)
     else:
         # This is correct
@@ -38,9 +36,7 @@ async def test_sv_intf_arr_len(dut):
     assert len(dut.sv_if_arr) == 3
 
 
-@cocotb.test(
-    expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
-)
+@cocotb.test()
 async def test_sv_intf_arr_access(dut):
     """Test that interface array objects can be accessed"""
     for i in range(3):
@@ -49,9 +45,6 @@ async def test_sv_intf_arr_access(dut):
         assert hasattr(dut.sv_if_arr[i], "c")
 
 
-@cocotb.test(
-    expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
-)
 @cocotb.test()
 async def test_sv_intf_arr_iteration(dut):
     """Test that interface arrays can be iterated"""

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -34,7 +34,9 @@ async def test_sv_intf_arr_len(dut):
     assert len(dut.sv_if_arr) == 3
 
 
-@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"))
+@cocotb.test(
+    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("riviera") else ()
+)
 async def test_sv_intf_arr_access(dut):
     """Test that interface array objects can be accessed"""
     for i in range(3):

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -16,14 +16,14 @@ async def test_sv_if(dut):
 
 
 @cocotb.test(
-    exepect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
+    expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
 )
 async def test_sv_intf_arr_type(dut):
     """Test that interface arrays are the correct type"""
 
     print(dut.sv_if_arr)
 
-    if cocotb.SIM_NAME.lower().startswith("xmsim", "modelsim"):
+    if cocotb.SIM_NAME.lower().startswith(("xmsim", "modelsim")):
         assert isinstance(dut.sv_if_arr, cocotb.handle.ArrayObject)
     else:
         # This is correct
@@ -31,7 +31,7 @@ async def test_sv_intf_arr_type(dut):
 
 
 @cocotb.test(
-    exepect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
+    expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
 )
 async def test_sv_intf_arr_len(dut):
     """Test that interface array length is correct"""
@@ -39,7 +39,7 @@ async def test_sv_intf_arr_len(dut):
 
 
 @cocotb.test(
-    exepect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
+    expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
 )
 async def test_sv_intf_arr_access(dut):
     """Test that interface array objects can be accessed"""
@@ -50,7 +50,7 @@ async def test_sv_intf_arr_access(dut):
 
 
 @cocotb.test(
-    exepect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
+    expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
 )
 @cocotb.test()
 async def test_sv_intf_arr_iteration(dut):

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -28,9 +28,7 @@ async def test_sv_intf_arr_type(dut):
         assert isinstance(dut.sv_if_arr, cocotb.handle.HierarchyArrayObject)
 
 
-@cocotb.test(
-    expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"),
-)
+@cocotb.test(expect_fail=cocotb.SIM_NAME.lower().startswith("riviera"))
 async def test_sv_intf_arr_len(dut):
     """Test that interface array length is correct"""
     assert len(dut.sv_if_arr) == 3

--- a/tests/test_cases/test_sv_interface/top.sv
+++ b/tests/test_cases/test_sv_interface/top.sv
@@ -14,4 +14,6 @@ module top ();
 
 sv_if sv_if_i();
 
+sv_if sv_if_arr[3]();
+
 endmodule


### PR DESCRIPTION
This should be a HierarchyArrayObject, not a NonHierarchyIndexableObject. I'm not sure how we'd like to approach this. I would think it should be a cast to GPI_GENARRAY. I'm not sure what this is, there's no comments in gpi.h about it except for mentioning pseudo handles with it. Do pseudo handles (GPI_GENARRAY) mean that the handle doesn't exist in the hierarchy that we query from? Or does it just mean arrays that are in the structure?

I can't map vpiInstanceArray / vpiInterfaceArray to GPI_GENARRAY because it needs vpi_iterate with vpiRange. Indexing works however with this approach. Should I make a range iterator, and use that depending on the vpitype? Or try and get it to map these special types of GPI_ARRAY to HierarhcyObjectArray?