### PR TITLE
Remove unused Queue._finished Event

### DIFF
--- a/src/cocotb/queue.py
+++ b/src/cocotb/queue.py
@@ -32,9 +32,6 @@ class Queue(Generic[T]):
     def __init__(self, maxsize: int = 0):
         self._maxsize = maxsize
 
-        self._finished = Event()
-        self._finished.set()
-
         self._getters = collections.deque()
         self._putters = collections.deque()
 
@@ -120,7 +117,6 @@ class Queue(Generic[T]):
         if self.full():
             raise QueueFull()
         self._put(item)
-        self._finished.clear()
         self._wakeup_next(self._getters)
 
     async def get(self) -> T:


### PR DESCRIPTION
This was used to support the proposed Queue.task_done() and Queue.join(), but those were removed during review of #2404. Removing the unused _finished Event was overlooked.