### PR TITLE
Fix docstring links to SimTimeoutError

### DIFF
--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -950,26 +950,26 @@ async def with_timeout(
     the caller blocks until the callee completes,
     and the callee's result is returned to the caller.
     If timeout occurs, the callee is killed
-    and :exc:`SimTimeoutError` is raised.
+    and :exc:`~cocotb.result.SimTimeoutError` is raised.
 
     When an unstarted :class:`~cocotb.coroutine`\ is passed,
     the callee coroutine is started,
     the caller blocks until the callee completes,
     and the callee's result is returned to the caller.
     If timeout occurs, the callee `continues to run`
-    and :exc:`SimTimeoutError` is raised.
+    and :exc:`~cocotb.result.SimTimeoutError` is raised.
 
     When a :term:`task` is passed,
     the caller blocks until the callee completes
     and the callee's result is returned to the caller.
     If timeout occurs, the callee `continues to run`
-    and :exc:`SimTimeoutError` is raised.
+    and :exc:`~cocotb.result.SimTimeoutError` is raised.
 
     If a :class:`~cocotb.triggers.Trigger` or :class:`~cocotb.triggers.Waitable` is passed,
     the caller blocks until the trigger fires,
     and the trigger is returned to the caller.
     If timeout occurs, the trigger is cancelled
-    and :exc:`SimTimeoutError` is raised.
+    and :exc:`~cocotb.result.SimTimeoutError` is raised.
 
     Usage:
 
@@ -993,7 +993,7 @@ async def with_timeout(
         First trigger that completed if timeout did not occur.
 
     Raises:
-        :exc:`SimTimeoutError`: If timeout occurs.
+        :exc:`~cocotb.result.SimTimeoutError`: If timeout occurs.
 
     .. versionadded:: 1.3
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
