### PR TITLE
Add more integer parameters to test_package

### DIFF
--- a/tests/test_cases/test_package/cocotb_package_pkg.sv
+++ b/tests/test_cases/test_package/cocotb_package_pkg.sv
@@ -5,6 +5,19 @@
 package cocotb_package_pkg_1;
     parameter int five_int = 5;
     parameter logic [31:0] eight_logic = 8;
+
+    parameter bit [0:0]     bit_1_param     = 1;
+    parameter bit [1:0]     bit_2_param     = 3;
+    parameter bit [599:0]   bit_600_param   = 600'ha364c9849f8298c66d659;
+    parameter byte          byte_param      = 100;
+    parameter shortint      shortint_param  = 63000;
+    parameter int           int_param       = 50;
+    parameter longint       longint_param   = 64'h11c98c031cb;
+
+    parameter integer       integer_param   = 125000;
+    parameter logic [129:0] logic_130_param = 130'h8c523ec7dc553a2b;
+    parameter reg   [7:0]   reg_8_param     = 200;
+    parameter time          time_param      = 64'h2540be400;
 endpackage
 
 package cocotb_package_pkg_2;

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -42,6 +42,51 @@ async def test_stringification(dut):
 
 
 @cocotb.test()
+async def test_integer_parameters(dut):
+    """Test package integer parameter access"""
+
+    pkg1 = cocotb.packages.cocotb_package_pkg_1
+
+    assert str(pkg1.bit_1_param) == "LogicObject(cocotb_package_pkg_1::bit_1_param)"
+    assert pkg1.bit_1_param.value.integer == 1
+
+    assert str(pkg1.bit_2_param) == "LogicObject(cocotb_package_pkg_1::bit_2_param)"
+    assert pkg1.bit_2_param.value.integer == 3
+
+    assert str(pkg1.bit_600_param) == "LogicObject(cocotb_package_pkg_1::bit_600_param)"
+    assert pkg1.bit_600_param.value.integer == 12345678912345678912345689
+
+    assert str(pkg1.byte_param) == "LogicObject(cocotb_package_pkg_1::byte_param)"
+    assert pkg1.byte_param.value.integer == 100
+
+    assert (
+        str(pkg1.shortint_param) == "LogicObject(cocotb_package_pkg_1::shortint_param)"
+    )
+    assert pkg1.shortint_param.value.integer == 63000
+
+    assert str(pkg1.int_param) == "LogicObject(cocotb_package_pkg_1::int_param)"
+    assert pkg1.int_param.value.integer == 50
+
+    assert str(pkg1.longint_param) == "LogicObject(cocotb_package_pkg_1::longint_param)"
+    assert pkg1.longint_param.value.integer == 0x11C98C031CB
+
+    assert str(pkg1.integer_param) == "LogicObject(cocotb_package_pkg_1::integer_param)"
+    assert pkg1.integer_param.value.integer == 125000
+
+    assert (
+        str(pkg1.logic_130_param)
+        == "LogicObject(cocotb_package_pkg_1::logic_130_param)"
+    )
+    assert pkg1.logic_130_param.value.integer == 0x8C523EC7DC553A2B
+
+    assert str(pkg1.reg_8_param) == "LogicObject(cocotb_package_pkg_1::reg_8_param)"
+    assert pkg1.reg_8_param.value.integer == 200
+
+    assert str(pkg1.time_param) == "LogicObject(cocotb_package_pkg_1::time_param)"
+    assert pkg1.time_param.value.integer == 0x2540BE400
+
+
+@cocotb.test()
 async def test_dollar_unit(dut):
     """Test $unit scope"""
     tlog = logging.getLogger("cocotb.test")


### PR DESCRIPTION
Alternative to #3665 with additional integer type parameters.
All should return `LogicObject` handles after #3691 was merged.
