### PR TITLE
Updates to CI

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -116,7 +116,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.11.0",
+        "sim-version": "r1.11.3",
         "os": "ubuntu-latest",
         "python-version": "3.8",
         "group": "ci",

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends llvm-dev libdw-dev flex libzstd-dev pkg-config
         git clone https://github.com/nickg/nvc.git
         cd nvc
-        git reset --hard ${{matrix.sim-version}}
+        git reset --hard r1.11.3
         ./autogen.sh
         mkdir build
         cd build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - 'stable/**'
+  workflow_call:
 
 jobs:
 

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -33,3 +33,7 @@ jobs:
           Update pre-commit hooks to most recent versions
         reviewers: |
           cocotb/maintainers
+  lint:
+    uses: ./.github/workflows/lint.yml
+  regression:
+    uses: ./.github/workflows/regression-tests.yml

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -46,6 +46,8 @@ jobs:
 
     name: ${{matrix.name}}
     runs-on: ${{matrix.runs-on}}
+    timeout-minutes: 40
+
     env:
       SIM: ${{matrix.sim}}
       TOPLEVEL_LANG: ${{matrix.lang}}


### PR DESCRIPTION
One update gets the lint and regression to run when the pre-commit is autoupdated and the other pins the version of NVC used for benchmarking so we get more consistent results.