### PR TITLE
Better parameterize names

### DIFF
--- a/docs/source/newsfragments/3717.feature.1.rst
+++ b/docs/source/newsfragments/3717.feature.1.rst
@@ -1,0 +1,1 @@
+Use parameter values in generated test names of :func:`cocotb.parameterize`, which should be clearer and allow the user to better group tests using :envvar:`TESTCASE`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ ignore = [
     "PLR0915", # Too many statements (>50) (preference)
     "PLR2004", # Magic value used in comparison (preference)
     "PLW0603", # Using the global statement (preference)
+    "PLR0911", # Too many return statements (preference)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/pytest/test_parameterize.py
+++ b/tests/pytest/test_parameterize.py
@@ -1,0 +1,52 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from enum import Enum
+
+import cocotb
+import pytest
+from cocotb.decorators import _repr, _reprs
+
+
+class MyEnum(Enum):
+    ENUM_VALUE = 1
+
+
+class A:
+    ...
+
+
+def b():
+    ...
+
+
+def test_parameterize_repr():
+    assert _repr(1) == "1"
+    assert _repr(False) == "False"
+    assert _repr(0.14) == "0.14"
+    assert _repr(None) == "None"
+    assert _repr("wow") == "wow"
+    assert _repr("has space") is None
+    assert _repr("😊") is None
+    assert _repr("wowthisisareallylongnamethatidontwantonmyterminal") is None
+    assert _repr(A) == "A"
+    assert _repr(b) == "b"
+    assert _repr(MyEnum.ENUM_VALUE) == "ENUM_VALUE"
+    assert _repr(object()) is None
+
+
+def test_parameterize_reprs():
+    assert _reprs([1, 0.5, False]) == ["1", "0.5", "False"]
+    assert _reprs([9, 9, object()]) == ["0", "1", "2"]
+
+
+def test_parameterize_bad_args():
+    with pytest.raises(ValueError):
+        cocotb.parameterize(("not valid", [1, 2, 3], "extra arg whoops"))
+    with pytest.raises(ValueError):
+        cocotb.parameterize(("not valid", [1, 2, 3]))
+    with pytest.raises(ValueError):
+        cocotb.parameterize((("not valid", "valid"), [(1, 2), (3, 4)]))
+    with pytest.raises(ValueError):
+        cocotb.parameterize((("a", "b"), [(1, 2, "too", "many", "args"), (3, 4)]))

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -22,11 +22,12 @@ async def test_testfactory_deprecated_test(dut, a):
     test_testfactory_deprecated_values.append(a)
 
 
-tf = TestFactory(test_testfactory_deprecated_test)
-tf.add_option("a", [1, 2])
 with warnings.catch_warnings(record=True) as tf_warns:
     warnings.simplefilter("default", category=DeprecationWarning)
-    tf.generate_tests()
+    tf = TestFactory(test_testfactory_deprecated_test)
+
+tf.add_option("a", [1, 2])
+tf.generate_tests()
 
 
 @cocotb.test

--- a/tests/test_cases/test_cocotb/test_testfactory.py
+++ b/tests/test_cases/test_cocotb/test_testfactory.py
@@ -29,8 +29,15 @@ async def test_testfactory_verify_args(dut):
         ("a1v1", "a2v2", "a3v2"),
         ("a1v2", "a2v2", "a3v2"),
     }
+
+
+@cocotb.test
+async def test_testfactory_verify_names(dut):
     assert testfactory_test_names == {
-        f"run_testfactory_test_{i:03}" for i in range(1, 5)
+        "run_testfactory_test/arg1=a1v1/arg2=a2v1/arg3=a3v1",
+        "run_testfactory_test/arg1=a1v1/arg2=a2v2/arg3=a3v2",
+        "run_testfactory_test/arg1=a1v2/arg2=a2v1/arg3=a3v1",
+        "run_testfactory_test/arg1=a1v2/arg2=a2v2/arg3=a3v2",
     }
 
 
@@ -77,10 +84,13 @@ async def test_params_verify_args(dut):
     }
 
 
-@cocotb.test()
+@cocotb.test
 async def test_params_verify_names(dut):
     assert p_testfactory_test_names == {
-        f"p_run_testfactory_test_{i:03}" for i in range(1, 5)
+        "p_run_testfactory_test/arg1=a1v1/arg2=a2v1",
+        "p_run_testfactory_test/arg1=a1v1/arg2=a2v2",
+        "p_run_testfactory_test/arg1=a1v2/arg2=a2v1",
+        "p_run_testfactory_test/arg1=a1v2/arg2=a2v2",
     }
 
 


### PR DESCRIPTION
Follow on from #3717. Changes how `cocotb.parameterize` names tests to make them more descriptive and easier to match with `TESTCASE`. Closes #2373.