### PR TITLE
Move extensions page from Reference to Howto

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -122,6 +122,7 @@ A test can spawn multiple coroutines, allowing for independent flows of executio
    triggers
    custom_flows
    rotating_logger
+   extensions
 
 .. todo::
    - Add IPython section
@@ -176,7 +177,6 @@ A test can spawn multiple coroutines, allowing for independent flows of executio
    GPI Library Reference <library_reference_c>
    simulator_support
    platform_support
-   extensions
    refcard
 
 .. toctree::


### PR DESCRIPTION
Closes #3641

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
