### PR TITLE
Add missing `--trace` option to Verilator docs

### DIFF
--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -128,7 +128,7 @@ To enable FST tracing, add ``--trace-fst`` to :make:var:`EXTRA_ARGS` as shown be
 
   .. code-block:: make
 
-    EXTRA_ARGS += --trace-fst --trace-structs
+    EXTRA_ARGS += --trace --trace-fst --trace-structs
 
 The resulting file will be :file:`dump.fst` and can be opened by ``gtkwave dump.fst``.
 


### PR DESCRIPTION
Closes #3687

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
