### PR TITLE
Move triggers list to Library Reference page

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -97,10 +97,73 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
     :members:
     :inherited-members:
 
+
 Triggers
---------
-See :ref:`simulator-triggers` for a list of sub-classes. Below are the internal
-classes used within ``cocotb``.
+========
+
+.. _simulator-triggers:
+
+Simulator Triggers
+------------------
+
+Signals
+^^^^^^^
+
+.. autoclass:: cocotb.triggers.Edge(signal)
+
+.. autoclass:: cocotb.triggers.RisingEdge(signal)
+
+.. autoclass:: cocotb.triggers.FallingEdge(signal)
+
+.. autoclass:: cocotb.triggers.ClockCycles
+
+
+Timing
+^^^^^^
+
+.. autoclass:: cocotb.triggers.Timer
+
+.. autoclass:: cocotb.triggers.ReadOnly()
+
+.. autoclass:: cocotb.triggers.ReadWrite()
+
+.. autoclass:: cocotb.triggers.NextTimeStep()
+
+
+.. _python-triggers:
+
+Python Triggers
+---------------
+
+.. autoclass:: cocotb.triggers.Combine
+
+.. autoclass:: cocotb.triggers.First
+
+.. autoclass:: cocotb.triggers.Join(coroutine)
+    :members: retval
+
+
+Synchronization
+^^^^^^^^^^^^^^^
+
+These are not :class:`Trigger`\ s themselves, but contain methods that can be used as triggers.
+These are used to synchronize coroutines with each other.
+
+.. autoclass:: cocotb.triggers.Event
+    :members:
+    :member-order: bysource
+
+.. autoclass:: cocotb.triggers.Lock
+    :members:
+    :member-order: bysource
+
+.. autofunction:: cocotb.triggers.with_timeout
+
+
+Triggers (Internals)
+--------------------
+
+The following are internal classes used within ``cocotb``.
 
 .. currentmodule:: cocotb.triggers
 

--- a/docs/source/triggers.rst
+++ b/docs/source/triggers.rst
@@ -10,62 +10,9 @@ When the trigger fires, execution of the paused coroutine will resume:
 .. code-block:: python3
 
     async def coro():
-        print("Some time before the edge")
+        print("Some time before a clock edge")
         await RisingEdge(clk)
-        print("Immediately after the edge")
+        print("Immediately after the rising clock edge")
 
-.. _simulator-triggers:
-
-Simulator Triggers
-==================
-
-Signals
--------
-
-.. autoclass:: cocotb.triggers.Edge(signal)
-
-.. autoclass:: cocotb.triggers.RisingEdge(signal)
-
-.. autoclass:: cocotb.triggers.FallingEdge(signal)
-
-.. autoclass:: cocotb.triggers.ClockCycles
-
-
-Timing
-------
-
-.. autoclass:: cocotb.triggers.Timer
-
-.. autoclass:: cocotb.triggers.ReadOnly()
-
-.. autoclass:: cocotb.triggers.ReadWrite()
-
-.. autoclass:: cocotb.triggers.NextTimeStep()
-
-
-Python Triggers
-===============
-
-.. autoclass:: cocotb.triggers.Combine
-
-.. autoclass:: cocotb.triggers.First
-
-.. autoclass:: cocotb.triggers.Join(coroutine)
-    :members: retval
-
-
-Synchronization
----------------
-
-These are not :class:`Trigger`\ s themselves, but contain methods that can be used as triggers.
-These are used to synchronize coroutines with each other.
-
-.. autoclass:: cocotb.triggers.Event
-    :members:
-    :member-order: bysource
-
-.. autoclass:: cocotb.triggers.Lock
-    :members:
-    :member-order: bysource
-
-.. autofunction:: cocotb.triggers.with_timeout
+See :ref:`simulator-triggers` and :ref:`python-triggers`
+for a list of available triggers.


### PR DESCRIPTION
Closes #3640

The Triggers pages under How-tos should certainly be extended,
but the doc structure is better with this PR.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
