### PR TITLE
Remove redundant coverage configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,12 +114,6 @@ markers = [
 # log_cli = true
 # log_cli_level = DEBUG
 
-[tool.coverage.run]
-omit = [
-    "*/cocotb/config.py",
-    "*/cocotb/_vendor/*",
-]
-
 [tool.coverage.paths]
 source = [
     "src/cocotb/",


### PR DESCRIPTION
The `run` section is only applied when `coverage run` is used. We are never doing this. Also, the configuration was stale.