### PR TITLE
Add failing testcase for vhdl architecture naming

### DIFF
--- a/tests/test_cases/issue_3769/Makefile
+++ b/tests/test_cases/issue_3769/Makefile
@@ -1,0 +1,20 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+TOPLEVEL_LANG ?= vhdl
+TOPLEVEL := test
+VHDL_SOURCES := test.vhdl
+MODULE := test_issue3769
+
+ifneq ($(filter $(SIM),ius xcelium),)
+COMPILE_ARGS += -v93
+endif
+
+ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),vhdl)
+all:
+	@echo "Skipping test since only VHDL is supported"
+clean::
+else
+include $(shell cocotb-config --makefiles)/Makefile.sim
+endif

--- a/tests/test_cases/issue_3769/Makefile
+++ b/tests/test_cases/issue_3769/Makefile
@@ -16,5 +16,11 @@ all:
 	@echo "Skipping test since only VHDL is supported"
 clean::
 else
+ifeq ($(SIM),xcelium)
+.PHONY: override_for_this_test
+# This test is expected to fail until a fix exists.
+override_for_this_test:
+	if $(MAKE) all; then echo "Expected this to fail"; false; else echo "Failed as expected"; fi
+endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 endif

--- a/tests/test_cases/issue_3769/test.vhdl
+++ b/tests/test_cases/issue_3769/test.vhdl
@@ -1,0 +1,13 @@
+-- Copyright cocotb contributors
+-- Licensed under the Revised BSD License, see LICENSE for details.
+-- SPDX-License-Identifier: BSD-3-Clause
+
+entity test is
+    port ( x : in boolean );
+end entity test;
+
+architecture test of test is
+begin
+    -- This architecture has the same name as the entity, which is
+    -- what this testcase is testing.
+end architecture test;

--- a/tests/test_cases/issue_3769/test_issue3769.py
+++ b/tests/test_cases/issue_3769/test_issue3769.py
@@ -1,0 +1,11 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import cocotb
+
+
+@cocotb.test()
+async def test_architecture_name(dut):
+    # This test does not need to do anything to hit this issue.
+    pass


### PR DESCRIPTION
With Xcelium and a vhdl top level, a design where the top level has an entity and architecture with the same name will lead to an error: `VHPI: Not able to map type (vhpiArchBodyK) 1007 to object`. This testcase deliberately hits this error.

This is detailed in https://github.com/cocotb/cocotb/issues/3769.

---

CI is expected to fail in the current state.
