### PR TITLE
CI updates: run extended tests with more tool versions

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -132,10 +132,18 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.11.3",
+        "sim-version": "r1.11.3",  # The latest release version.
         "os": "ubuntu-latest",
         "python-version": "3.8",
         "group": "ci",
+    },
+    {
+        "lang": "vhdl",
+        "sim": "nvc",
+        "sim-version": "master",
+        "os": "ubuntu-latest",
+        "python-version": "3.8",
+        "group": "experimental",
     },
     # Test Verilator on Ubuntu
     {

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -82,15 +82,15 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "icarus",
-        "sim-version": "master",
+        "sim-version": "v12_0",  # The latest release version.
         "os": "ubuntu-20.04",
         "python-version": "3.8",
-        "group": "experimental",
+        "group": "ci",
     },
     {
         "lang": "verilog",
         "sim": "icarus",
-        "sim-version": "v12_0",  # The latest release version.
+        "sim-version": "master",
         "os": "ubuntu-20.04",
         "python-version": "3.8",
         "group": "experimental",

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -286,6 +286,68 @@ ENVS = [
     },
 ]
 
+# Questa: test more versions as part of the extended tests.
+questa_versions_novhpi = ("2021.2", "2021.3", "2021.4", "2022.1", "2022.2")
+questa_versions_vhpi = ("2022.3", "2022.4", "2023.1", "2023.2")
+
+for version in questa_versions_novhpi + questa_versions_vhpi:
+    ENVS += [
+        {
+            "lang": "verilog",
+            "sim": "questa",
+            "sim-version": f"siemens/questa/{version}",
+            "os": "ubuntu-20.04",
+            "self-hosted": True,
+            "python-version": "3.8",
+            "group": "extended",
+        },
+        {
+            "lang": "vhdl and fli",
+            "sim": "questa",
+            "sim-version": f"siemens/questa/{version}",
+            "os": "ubuntu-20.04",
+            "self-hosted": True,
+            "python-version": "3.8",
+            "group": "extended",
+        },
+    ]
+for version in questa_versions_vhpi:
+    ENVS += [
+        {
+            "lang": "vhdl and vhpi",
+            "sim": "questa",
+            "sim-version": f"siemens/questa/{version}",
+            "os": "ubuntu-20.04",
+            "self-hosted": True,
+            "python-version": "3.8",
+            "group": "extended",
+        },
+    ]
+
+# Riviera-PRO: test more versions as part of the extended tests.
+riviera_versions = ("2019.10", "2020.04", "2020.10", "2021.04", "2021.10", "2022.04")
+for version in riviera_versions:
+    ENVS += [
+        {
+            "lang": "verilog",
+            "sim": "riviera",
+            "sim-version": f"aldec/rivierapro/{version}",
+            "os": "ubuntu-20.04",
+            "self-hosted": True,
+            "python-version": "3.8",
+            "group": "extended",
+        },
+        {
+            "lang": "vhdl",
+            "sim": "riviera",
+            "sim-version": f"aldec/rivierapro/{version}",
+            "os": "ubuntu-20.04",
+            "self-hosted": True,
+            "python-version": "3.8",
+            "group": "extended",
+        },
+    ]
+
 
 def append_str_val(listref, my_list, key) -> None:
     if key not in my_list:

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -102,6 +102,22 @@ ENVS = [
         "sim-version": "v2.0.0",  # GHDL 2.0 is the minimum supported version.
         "os": "ubuntu-latest",
         "python-version": "3.8",
+        "group": "extended",
+    },
+    {
+        "lang": "vhdl",
+        "sim": "ghdl",
+        "sim-version": "v3.0.0",
+        "os": "ubuntu-latest",
+        "python-version": "3.8",
+        "group": "extended",
+    },
+    {
+        "lang": "vhdl",
+        "sim": "ghdl",
+        "sim-version": "v4.0.0",  # The latest release version.
+        "os": "ubuntu-latest",
+        "python-version": "3.8",
         "group": "ci",
     },
     {

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -149,7 +149,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v5.022",
+        "sim-version": "v5.022",  # Latest release version.
         # Needs 22.04 for newer GCC with C++ coroutine support used with --timing mode
         "os": "ubuntu-22.04",
         "python-version": "3.8",

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Run tests against an extended set of simulator (versions).
+
+name: Test extended tool versions
+
+on:
+  # Run every Sunday at 2am (UTC).
+  schedule:
+    - cron: '0 2 * * 0'
+  # Allow triggering a CI run from the web UI.
+  workflow_dispatch:
+
+jobs:
+  test_dev:
+    name: Regression Tests
+    uses: ./.github/workflows/regression-tests.yml
+    with:
+      nox_session_test_sim: dev_test_sim
+      nox_session_test_nosim: dev_test_nosim
+      group: extended
+      max_parallel: 15

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -27,6 +27,11 @@ on:
         type: string
         default: "ci"
         description: Group of environments to run the tests against. Leave empty to run them all.
+      max_parallel:
+        required: false
+        type: number
+        default: 0
+        description: Maximum number of parallel matrix jobs
 
 jobs:
 
@@ -60,6 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.generate_envs.outputs.envs) }}
+      max-parallel: ${{ inputs.max_parallel }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Run more tool versions in CI once a week, based on what we had previously in private CI.

- **CI: Run extended tests once a week**
- **CI: Move Icarus master from experimental to CI**
- **CI: Run GHDL 4.0 in CI**
- **CI: Add a test against NVC master**
- **CI: Add a comment to the Verilator version**
- **CI: Test more Questa and Riviera-PRO versions**
