### PR TITLE
Cleanup handle (Part ??? + 1)

### DIFF
--- a/docs/source/newsfragments/3733.change.1.rst
+++ b/docs/source/newsfragments/3733.change.1.rst
@@ -1,1 +1,0 @@
-Renamed ``cocotb.handle.NonHierarchyIndexableObjectBase`` to :class:`~cocotb.handle.IndexableValueObjectBase`.

--- a/docs/source/newsfragments/3733.feature.1.rst
+++ b/docs/source/newsfragments/3733.feature.1.rst
@@ -1,1 +1,1 @@
-Added :attr:`~cocotb.handle.IndexableValueObjectBase.range`, :attr:`~cocotb.handle.IndexableValueObjectBase.left`, :attr:`~cocotb.handle.IndexableValueObjectBase.direction`, and :attr:`~cocotb.handle.IndexableValueObjectBase.right` properties to :class:`~cocotb.handle.ArrayObject`, :class:`~cocotb.handle.LogicObject`, and :class:`~cocotb.handle.StringObject`.
+Added ``range``, ``left``, ``direction``, and ``right`` properties to :class:`~cocotb.handle.ArrayObject`, :class:`~cocotb.handle.LogicObject`, and :class:`~cocotb.handle.StringObject`.

--- a/tests/designs/vhdl_configurations/testbench.sv
+++ b/tests/designs/vhdl_configurations/testbench.sv
@@ -4,7 +4,7 @@ module testbench (
     output logic        data_out
 );
 
-dut i_dut (
+dut dut_inst (
     .clk                (clk),
     .data_in            (data_in),
     .data_out           (data_out)

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -329,23 +329,6 @@ async def test_last_scheduled_write_wins_array(dut):
     assert dut.array_7_downto_4.value == [10, 2, 3, 4]
 
 
-# Most simulators do not support setting the value of a single bit of a packed array
-@cocotb.test(
-    skip=not cocotb.SIM_NAME.lower().startswith(("modelsim", "riviera"))
-    or LANGUAGE != "vhdl"
-)
-async def test_last_scheduled_write_wins_array_handle_alias(dut):
-    """
-    Tests case where handles in the scheduled writes cache in the scheduler alias
-    """
-    dut.array_7_downto_4.value = [0, 0, 0, 0]
-    dut.array_7_downto_4[7][0].value = 1
-
-    await ReadOnly()
-
-    assert dut.array_7_downto_4.value == [1, 0, 0, 0]
-
-
 @cocotb.test()
 async def test_task_repr(dut):
     """Test Task.__repr__."""

--- a/tests/test_cases/test_configuration/test_configurations.py
+++ b/tests/test_cases/test_configuration/test_configurations.py
@@ -24,17 +24,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import cocotb
-from cocotb.triggers import Timer
 
 
-def sub_iterate(unit):
-    for thing in unit:
-        thing._log.info(f"Found {unit._name}.{thing._name} {type(thing)}")
-        sub_iterate(thing)
-
-
-@cocotb.test()
-async def iterate(dut):
-    await Timer(1, "ns")
-    sub_iterate(dut)
-    await Timer(1, "ns")
+@cocotb.test
+async def test_configuration(dut):
+    for item in dut.dut_inst:
+        cocotb.log.info("Found %r", item)

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -38,7 +38,7 @@ def recursive_dump(parent, log):
         parent,
         (
             cocotb.handle.HierarchyObjectBase,
-            cocotb.handle.IndexableValueObjectBase,
+            cocotb.handle.ArrayObject,
         ),
     ):
         return 0
@@ -53,16 +53,7 @@ def recursive_dump(parent, log):
 @cocotb.test
 async def recursive_discovery(dut):
     """Recursively discover every single object in the design."""
-    if cocotb.SIM_NAME.lower().startswith("ncsim"):
-        # vpiAlways = 31 and vpiStructVar = 2 do not show up in IUS/Xcelium
-        pass_total = 975
-    elif cocotb.SIM_NAME.lower().startswith("xmsim"):
-        # Xcelium sometimes doesn't find bits in a std_logic_vector
-        pass_total = 1201
-    elif cocotb.SIM_NAME.lower().startswith("modelsim"):
-        pass_total = 1276
-    else:
-        pass_total = 1024
+    pass_total = 275
 
     tlog = logging.getLogger("cocotb.test")
     total = recursive_dump(dut, tlog)
@@ -81,13 +72,7 @@ async def recursive_discovery(dut):
 @cocotb.test
 async def recursive_discovery_boundary(dut):
     """Iteration through the boundary works but this just double checks."""
-    if cocotb.SIM_NAME.lower().startswith("ncsim"):
-        pass_total = 462
-    elif cocotb.SIM_NAME.lower().startswith("xmsim"):
-        # Xcelium sometimes doesn't find bits in a std_logic_vector
-        pass_total = 744
-    else:
-        pass_total = 819
+    pass_total = 160
 
     tlog = logging.getLogger("cocotb.test")
     total = recursive_dump(dut.i_vhdl, tlog)

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -26,7 +26,6 @@
 import logging
 
 import cocotb
-from cocotb._sim_versions import IcarusVersion
 from cocotb.triggers import First
 
 SIM_NAME = cocotb.SIM_NAME.lower()
@@ -39,18 +38,12 @@ async def recursive_discovery(dut):
     """
     if SIM_NAME.startswith("verilator"):
         pass_total = 26
-    elif SIM_NAME.startswith("icarus"):
-        if IcarusVersion(cocotb.SIM_VERSION) <= IcarusVersion("10.3 (stable)"):
-            pass_total = 27
-        else:
-            pass_total = 259
-    elif SIM_NAME.startswith(
-        ("modelsim", "ncsim", "xmsim", "chronologic simulation vcs")
-    ):
-        # vpiAlways does not show up
-        pass_total = 259
+    elif SIM_NAME.startswith("riviera"):
+        # finds always and initial blocks
+        pass_total = 33
     else:
-        pass_total = 265
+        # everyone seems to find the byteswap() function besides verilator
+        pass_total = 27
 
     tlog = logging.getLogger("cocotb.test")
 
@@ -59,7 +52,7 @@ async def recursive_discovery(dut):
             parent,
             (
                 cocotb.handle.HierarchyObjectBase,
-                cocotb.handle.IndexableValueObjectBase,
+                cocotb.handle.ArrayObject,
             ),
         ):
             return 0

--- a/tests/test_cases/test_struct/test_struct.py
+++ b/tests/test_cases/test_struct/test_struct.py
@@ -82,32 +82,3 @@ async def test_struct_format(dut):
     tlog.info(
         f"Value of inout_if => a_in = {structure.a_in.value} ; b_out = {structure.b_out.value}"
     )
-
-
-# GHDL unable to access record signals (gh-2591)
-# Icarus doesn't support structs (gh-2592)
-# Verilator doesn't support structs (gh-1275)
-@cocotb.test(
-    expect_error=(
-        AttributeError if SIM_NAME.startswith(("icarus", "ghdl", "verilator")) else ()
-    )
-)
-async def test_struct_iteration(dut):
-    """
-    Access a structure via issue_330_iteration
-    """
-
-    tlog = logging.getLogger("cocotb.test")
-
-    structure = dut.inout_if
-
-    count = 0
-    for member in structure:
-        tlog.info(f"Found {member._path}")
-        count += 1
-
-    # Riviera-PRO does not discover inout_if correctly over VPI (gh-3587, gh-3933)
-    if SIM_NAME.startswith("riviera") and LANGUAGE == "verilog":
-        assert count == 0
-    else:
-        assert count == 2, "There should have been two members of the structure"

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -63,7 +63,6 @@ async def check_objects(dut):
     check_instance(dut.gen_branch_distance[0], HierarchyObject)
     check_instance(dut.gen_branch_distance[0].inst_branch_distance, HierarchyObject)
     check_instance(dut.gen_acs[0].inbranch_tdata_low, LogicObject)
-    check_instance(dut.gen_acs[0].inbranch_tdata_low[0], LogicObject)
     check_instance(dut.aclk, LogicObject)
     check_instance(dut.s_axis_input_tdata, LogicObject)
     check_instance(dut.current_active, IntegerObject)


### PR DESCRIPTION
Some more changes. Depends on #4038.

* Removes `IndexableValueObjectBase`, only `ArrayObject` now support indexing and iteration.

- [x] Fix discovery tests now...