### PR TITLE
Reintroduced casts on handles

### DIFF
--- a/docs/source/newsfragments/2720.change.4.rst
+++ b/docs/source/newsfragments/2720.change.4.rst
@@ -1,0 +1,1 @@
+All casts on :class:`simulator value objects <cocotb.handle.ValueObjectBase>` have been deprecated. If you want to get the value from a simulator value object, use the :meth:`~cocotb.handle.ValueObjectBase.value` property; then cast the value.

--- a/docs/source/newsfragments/2720.removal.2.rst
+++ b/docs/source/newsfragments/2720.removal.2.rst
@@ -1,1 +1,0 @@
-All casts on :class:`simulator value objects <cocotb.handle.ValueObjectBase>` have been removed. If you want to get the value from a simulator value object, use the :meth:`~cocotb.handle.ValueObjectBase.value` property.

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -1002,6 +1002,18 @@ class LogicObject(
     def value(self, value: LogicArray) -> None:
         self.set(value)
 
+    @deprecated(
+        "`int(handle)` casts have been deprecated. Use `int(handle.value)` instead."
+    )
+    def __int__(self) -> int:
+        return int(self.value)
+
+    @deprecated(
+        "`str(handle)` casts have been deprecated. Use `str(handle.value)` instead."
+    )
+    def __str__(self) -> str:
+        return str(self.value)
+
 
 class RealObject(ValueObjectBase[float, float]):
     """A real/float simulation object.
@@ -1045,6 +1057,12 @@ class RealObject(ValueObjectBase[float, float]):
     @value.setter
     def value(self, value: float) -> None:
         self.set(value)
+
+    @deprecated(
+        "`float(handle)` casts have been deprecated. Use `float(handle.value)` instead."
+    )
+    def __float__(self) -> float:
+        return self.value
 
 
 class EnumObject(ValueObjectBase[int, int]):
@@ -1099,6 +1117,12 @@ class EnumObject(ValueObjectBase[int, int]):
     @value.setter
     def value(self, value: int) -> None:
         self.set(value)
+
+    @deprecated(
+        "`int(handle)` casts have been deprecated. Use `int(handle.value)` instead."
+    )
+    def __int__(self) -> int:
+        return int(self.value)
 
 
 class IntegerObject(ValueObjectBase[int, int]):
@@ -1164,6 +1188,12 @@ class IntegerObject(ValueObjectBase[int, int]):
     @value.setter
     def value(self, value: int) -> None:
         self.set(value)
+
+    @deprecated(
+        "`int(handle)` casts have been deprecated. Use `int(handle.value)` instead."
+    )
+    def __int__(self) -> int:
+        return self.value
 
 
 class StringObject(
@@ -1234,6 +1264,12 @@ class StringObject(
     @value.setter
     def value(self, value: bytes) -> None:
         self.set(value)
+
+    @deprecated(
+        '`str(handle)` casts have been deprecated. Use `handle.value.decode("ascii")` instead.'
+    )
+    def __str__(self) -> str:
+        return self.value.decode("ascii")
 
 
 _ConcreteHandleTypes = Union[

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -7,6 +7,7 @@ import warnings
 import cocotb
 import pytest
 from cocotb.regression import TestFactory
+from cocotb.triggers import Timer
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 
@@ -52,3 +53,37 @@ async def test_runner_deprecated(_):
 async def test_config_deprecated(_):
     with pytest.warns(DeprecationWarning):
         import cocotb.config  # noqa: F401
+
+
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")))
+async def test_real_handle_casts_deprecated(dut):
+    dut.stream_in_real.value = 5.03
+    await Timer(1, "ns")
+    with pytest.warns(DeprecationWarning):
+        float(dut.stream_in_real)
+
+
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("icarus"))
+async def test_int_handle_casts_deprecated(dut):
+    dut.stream_in_int.value = 100
+    await Timer(1, "ns")
+    with pytest.warns(DeprecationWarning):
+        int(dut.stream_in_int)
+
+
+@cocotb.test
+async def test_logic_handle_casts_deprecated(dut):
+    dut.stream_in_data.value = 1
+    await Timer(1, "ns")
+    with pytest.warns(DeprecationWarning):
+        int(dut.stream_in_data)
+    with pytest.warns(DeprecationWarning):
+        str(dut.stream_in_data)
+
+
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl")))
+async def test_string_handle_casts_deprecated(dut):
+    dut.stream_in_string.value = b"sample"
+    await Timer(1, "ns")
+    with pytest.warns(DeprecationWarning):
+        str(dut.stream_in_string)

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -6,100 +6,87 @@
 A set of tests that demonstrate package access
 """
 
-import logging
-
 import cocotb
-from cocotb.result import TestSuccess
+from cocotb.handle import HierarchyObject, LogicObject
 
 
 @cocotb.test()
-async def test_params(dut):
+async def test_package_access(_) -> None:
     """Test package parameter access"""
-    tlog = logging.getLogger("cocotb.test")
 
-    tlog.info("Checking Parameters:")
-    assert dut.seven_int.value == 7
     pkg1 = cocotb.packages.cocotb_package_pkg_1
+    assert isinstance(pkg1, HierarchyObject)
+    assert pkg1._path.startswith("cocotb_package_pkg_1")
+
+    assert isinstance(pkg1.five_int, LogicObject)
+    assert pkg1.five_int._path == "cocotb_package_pkg_1::five_int"
     assert pkg1.five_int.value == 5
+
+    assert isinstance(pkg1.eight_logic, LogicObject)
+    assert pkg1.eight_logic._path == "cocotb_package_pkg_1::eight_logic"
     assert pkg1.eight_logic.value == 8
+
+    assert isinstance(pkg1.bit_1_param, LogicObject)
+    assert pkg1.bit_1_param._path == "cocotb_package_pkg_1::bit_1_param"
+    assert pkg1.bit_1_param.value.integer == 1
+
+    assert isinstance(pkg1.bit_2_param, LogicObject)
+    assert pkg1.bit_2_param._path == "cocotb_package_pkg_1::bit_2_param"
+    assert pkg1.bit_2_param.value.integer == 3
+
+    assert isinstance(pkg1.bit_600_param, LogicObject)
+    assert pkg1.bit_600_param._path == "cocotb_package_pkg_1::bit_600_param"
+    assert pkg1.bit_600_param.value.integer == 12345678912345678912345689
+
+    assert isinstance(pkg1.byte_param, LogicObject)
+    assert pkg1.byte_param._path == "cocotb_package_pkg_1::byte_param"
+    assert pkg1.byte_param.value.integer == 100
+
+    assert isinstance(pkg1.shortint_param, LogicObject)
+    assert pkg1.shortint_param._path == "cocotb_package_pkg_1::shortint_param"
+    assert pkg1.shortint_param.value.integer == 63000
+
+    assert isinstance(pkg1.int_param, LogicObject)
+    assert pkg1.int_param._path == "cocotb_package_pkg_1::int_param"
+    assert pkg1.int_param.value.integer == 50
+
+    assert isinstance(pkg1.longint_param, LogicObject)
+    assert pkg1.longint_param._path == "cocotb_package_pkg_1::longint_param"
+    assert pkg1.longint_param.value.integer == 0x11C98C031CB
+
+    assert isinstance(pkg1.integer_param, LogicObject)
+    assert pkg1.integer_param._path == "cocotb_package_pkg_1::integer_param"
+    assert pkg1.integer_param.value.integer == 125000
+
+    assert isinstance(pkg1.logic_130_param, LogicObject)
+    assert pkg1.logic_130_param._path == "cocotb_package_pkg_1::logic_130_param"
+    assert pkg1.logic_130_param.value.integer == 0x8C523EC7DC553A2B
+
+    assert isinstance(pkg1.reg_8_param, LogicObject)
+    assert pkg1.reg_8_param._path == "cocotb_package_pkg_1::reg_8_param"
+    assert pkg1.reg_8_param.value.integer == 200
+
+    assert isinstance(pkg1.time_param, LogicObject)
+    assert pkg1.time_param._path == "cocotb_package_pkg_1::time_param"
+    assert pkg1.time_param.value.integer == 0x2540BE400
+
     pkg2 = cocotb.packages.cocotb_package_pkg_2
+    assert isinstance(pkg2, HierarchyObject)
+    assert pkg2._path.startswith("cocotb_package_pkg_2")
+
+    assert isinstance(pkg2.eleven_int, LogicObject)
+    assert pkg2.eleven_int._path == "cocotb_package_pkg_2::eleven_int"
     assert pkg2.eleven_int.value == 11
 
 
-@cocotb.test()
-async def test_stringification(dut):
-    """Test package stringification"""
-    tlog = logging.getLogger("cocotb.test")
-
-    tlog.info("Checking Strings:")
-    pkg1 = cocotb.packages.cocotb_package_pkg_1
-    assert str(pkg1).startswith("HierarchyObject(cocotb_package_pkg_1")
-    assert str(pkg1.five_int) == "LogicObject(cocotb_package_pkg_1::five_int)"
-    assert str(pkg1.eight_logic) == "LogicObject(cocotb_package_pkg_1::eight_logic)"
-    pkg2 = cocotb.packages.cocotb_package_pkg_2
-    assert str(pkg2).startswith("HierarchyObject(cocotb_package_pkg_2")
-    assert str(pkg2.eleven_int) == "LogicObject(cocotb_package_pkg_2::eleven_int)"
-
-
-@cocotb.test()
-async def test_integer_parameters(dut):
-    """Test package integer parameter access"""
-
-    pkg1 = cocotb.packages.cocotb_package_pkg_1
-
-    assert str(pkg1.bit_1_param) == "LogicObject(cocotb_package_pkg_1::bit_1_param)"
-    assert pkg1.bit_1_param.value.integer == 1
-
-    assert str(pkg1.bit_2_param) == "LogicObject(cocotb_package_pkg_1::bit_2_param)"
-    assert pkg1.bit_2_param.value.integer == 3
-
-    assert str(pkg1.bit_600_param) == "LogicObject(cocotb_package_pkg_1::bit_600_param)"
-    assert pkg1.bit_600_param.value.integer == 12345678912345678912345689
-
-    assert str(pkg1.byte_param) == "LogicObject(cocotb_package_pkg_1::byte_param)"
-    assert pkg1.byte_param.value.integer == 100
-
-    assert (
-        str(pkg1.shortint_param) == "LogicObject(cocotb_package_pkg_1::shortint_param)"
-    )
-    assert pkg1.shortint_param.value.integer == 63000
-
-    assert str(pkg1.int_param) == "LogicObject(cocotb_package_pkg_1::int_param)"
-    assert pkg1.int_param.value.integer == 50
-
-    assert str(pkg1.longint_param) == "LogicObject(cocotb_package_pkg_1::longint_param)"
-    assert pkg1.longint_param.value.integer == 0x11C98C031CB
-
-    assert str(pkg1.integer_param) == "LogicObject(cocotb_package_pkg_1::integer_param)"
-    assert pkg1.integer_param.value.integer == 125000
-
-    assert (
-        str(pkg1.logic_130_param)
-        == "LogicObject(cocotb_package_pkg_1::logic_130_param)"
-    )
-    assert pkg1.logic_130_param.value.integer == 0x8C523EC7DC553A2B
-
-    assert str(pkg1.reg_8_param) == "LogicObject(cocotb_package_pkg_1::reg_8_param)"
-    assert pkg1.reg_8_param.value.integer == 200
-
-    assert str(pkg1.time_param) == "LogicObject(cocotb_package_pkg_1::time_param)"
-    assert pkg1.time_param.value.integer == 0x2540BE400
-
-
-@cocotb.test()
+@cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("riviera"))
 async def test_dollar_unit(dut):
     """Test $unit scope"""
-    tlog = logging.getLogger("cocotb.test")
 
-    if cocotb.SIM_NAME.lower().startswith("riviera"):
-        tlog.info("Riviera does not support $unit access via vpiInstance")
-        raise TestSuccess
-
-    tlog.info("Checking $unit:")
     # Is $unit even a package?  Xcelium says yes and 37.10 detail 5 would also suggest yes
     pkgs = vars(cocotb.packages).keys()
     f = filter(lambda x: "unit" in x, pkgs)
     unit = list(f)[0]
-    tlog.info(f"Found $unit as {unit}")
+    cocotb.log.info(f"Found $unit as {unit}")
     unit_pkg = getattr(cocotb.packages, unit)
     assert unit_pkg.unit_four_int.value == 4


### PR DESCRIPTION
Closes #3565. Reintroduced the value casts on handles, but they are deprecated. Will go through `LogicArray` and add a bunch more deprecations soon too.