### PR TITLE
Remove leftover trace of MEMCHECK envvar

### DIFF
--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -90,7 +90,6 @@ def help_vars_text() -> str:
     COCOTB_ENABLE_PROFILING   Performance analysis of the Python portion of cocotb
     COCOTB_LOG_LEVEL          Default logging level (default INFO)
     COCOTB_RESOLVE_X          How to resolve X, Z, U, W on integer conversion
-    MEMCHECK                  HTTP port to use for debugging Python memory usage
     LIBPYTHON_LOC             Absolute path to libpython
 
     Regression Manager


### PR DESCRIPTION
Support has been removed in #3543

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
