### PR TITLE
Doc fixes and cleanup

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -87,8 +87,6 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
     :members:
     :exclude-members: count, index
 
-.. autofunction:: cocotb.types.concat
-
 .. autoclass:: cocotb.types.Array
     :members:
     :inherited-members:
@@ -204,7 +202,10 @@ Utilities
 Logging
 -------
 
-.. currentmodule:: cocotb.logging
+.. module:: cocotb.logging
+    :synopsis: Classes for logging messages from cocotb during simulation.
+
+.. autodata:: cocotb.log
 
 .. autofunction:: default_config
 
@@ -289,6 +290,7 @@ Asynchronous Queues
 .. automodule:: cocotb.queue
     :members:
     :member-order: bysource
+    :synopsis: Asynchronous queues.
 
 Other Runtime Information
 -------------------------
@@ -342,7 +344,8 @@ Implementation Details
 The Regression Manager
 ----------------------
 
-.. currentmodule:: cocotb.regression
+.. module:: cocotb.regression
+    :synopsis: Regression test suite manager.
 
 .. autodata:: cocotb.regression_manager
 
@@ -365,3 +368,4 @@ of cocotb.
     :members:
     :undoc-members:
     :member-order: bysource
+    :synopsis: Interface to simulator.

--- a/docs/source/newsfragments/2066.removal.rst
+++ b/docs/source/newsfragments/2066.removal.rst
@@ -1,1 +1,1 @@
-The unmaintained WaveDrom support got removed. Users (if any) are encouraged to include the code in their own codebase, or create a cocotb extension for it.
+Removed unmaintained WaveDrom support. Users (if any) are encouraged to include the code in their own codebase, or create a cocotb extension for it.

--- a/docs/source/newsfragments/2731.feature.rst
+++ b/docs/source/newsfragments/2731.feature.rst
@@ -1,1 +1,1 @@
-Support not using parenthesis on ``@cocotb.test`` decorator
+Not using parentheses on ``@cocotb.test`` decorator is now supported.

--- a/docs/source/newsfragments/3351.feature.rst
+++ b/docs/source/newsfragments/3351.feature.rst
@@ -1,1 +1,1 @@
-Add `clean` argument to :ref:`Python Test Runner <howto-python-runner>` to remove build_dir completely during runner.build() stage
+The :meth:`cocotb_tools.runner.Simulator.build` method now accepts a ``clean`` argument to remove ``build_dir`` completely during build stage.

--- a/docs/source/newsfragments/3427.feature.rst
+++ b/docs/source/newsfragments/3427.feature.rst
@@ -1,1 +1,1 @@
-Add support for the `NVC <https://github.com/nickg/nvc>`_ VHDL simulator.
+Added support for the `NVC <https://github.com/nickg/nvc>`_ VHDL simulator.

--- a/docs/source/newsfragments/3513.feature.rst
+++ b/docs/source/newsfragments/3513.feature.rst
@@ -1,1 +1,1 @@
-Added :func:`cocotb.parameterize`, a decorator that serves as an alternative to :class:`TestFactory`.
+Added :func:`cocotb.parameterize`, a decorator that serves as an alternative to :class:`~cocotb.regression.TestFactory`.

--- a/docs/source/newsfragments/3578.change.rst
+++ b/docs/source/newsfragments/3578.change.rst
@@ -1,1 +1,1 @@
-The :class:`~cocotb.regression.RegressionManager` uses a new mechanism to discover tests. Typical uses of the :func:`cocotb.test` decorator and :class:`~cocotb.test.TestFactory` should be unaffected, but atypical uses may not.
+The :class:`~cocotb.regression.RegressionManager` uses a new mechanism to discover tests. Typical uses of the :func:`cocotb.test` decorator and :class:`~cocotb.regression.TestFactory` should be unaffected, but atypical uses may not.

--- a/docs/source/newsfragments/3578.removal.rst
+++ b/docs/source/newsfragments/3578.removal.rst
@@ -1,1 +1,1 @@
-The ``prefix`` and ``postfix`` arguments to :meth:`TestFactory.generate_tests <cocotb.regression.TestFactory.generate_tests>` are deprecated in favor of the more flexible ``name`` argument.
+The ``prefix`` and ``postfix`` arguments to :meth:`TestFactory.generate_tests() <cocotb.regression.TestFactory.generate_tests>` are deprecated in favor of the more flexible ``name`` argument.

--- a/docs/source/newsfragments/3655.feature.1.rst
+++ b/docs/source/newsfragments/3655.feature.1.rst
@@ -1,1 +1,1 @@
-Added :attr:`~cocotb.handle.HierarchyArrayObject.range`, :attr:`~cocotb.handle.HierarchyArrayObject.left`, :attr:`~cocotb.handle.HierarchyArrayObject.direction`, :attr:`~cocotb.handle.HierarchyArrayObject.right`, and :func:`len` support to :meth:`cocotb.handle.HierarchyArrayObject`.
+Added :attr:`~cocotb.handle.HierarchyArrayObject.range`, :attr:`~cocotb.handle.HierarchyArrayObject.left`, :attr:`~cocotb.handle.HierarchyArrayObject.direction`, :attr:`~cocotb.handle.HierarchyArrayObject.right`, and :func:`len` support to :class:`~cocotb.handle.HierarchyArrayObject`.

--- a/docs/source/newsfragments/3655.feature.2.rst
+++ b/docs/source/newsfragments/3655.feature.2.rst
@@ -1,1 +1,1 @@
-Add support for ``handle[sub_handle_name]`` syntax to :class:`cocotb.handle.HierarchyObject` as a more readable alternative to :meth:`~cocotb.handle.HierarchyObject._id`.
+Add support for ``handle[sub_handle_name]`` syntax to :class:`~cocotb.handle.HierarchyObject` as a more readable alternative to :meth:`HierarchyObject._id() <cocotb.handle.HierarchyObject._id>`.

--- a/docs/source/newsfragments/3655.feature.rst
+++ b/docs/source/newsfragments/3655.feature.rst
@@ -1,1 +1,1 @@
-Add :meth:`~cocotb.handle.HierarchyObjectBase._keys`, :meth:`~cocotb.handle.HierarchyObjectBase._values`, and :meth:`~cocotb.handle.HierarchyObjectBase._items` to help users dynamically interact with the DUT object model.
+Added :meth:`~cocotb.handle.HierarchyObjectBase._keys`, :meth:`~cocotb.handle.HierarchyObjectBase._values`, and :meth:`~cocotb.handle.HierarchyObjectBase._items` to help users dynamically interact with the DUT object model.

--- a/docs/source/newsfragments/3655.removal.rst
+++ b/docs/source/newsfragments/3655.removal.rst
@@ -1,1 +1,1 @@
-:meth:`cocotb.handle.HierarchyObject._id` was deprecated. Use ``handle["sub_handle_name"]`` syntax instead.
+:meth:`HierarchyObject._id() <cocotb.handle.HierarchyObject._id>` is now deprecated. Use ``handle["sub_handle_name"]`` syntax instead.

--- a/docs/source/newsfragments/3667.feature.rst
+++ b/docs/source/newsfragments/3667.feature.rst
@@ -1,1 +1,1 @@
-Add `--trace` to Verilator binaries for run-time trace generation and integrate with :ref:`Python Test Runner <howto-python-runner>`.
+Added ``--trace`` command line argument to Verilator simulation binaries for run-time trace generation. This new argument is passed to the binary when the ``waves`` argument to :meth:`cocotb_tools.runner.Simulator.test` is ``True``.

--- a/docs/source/newsfragments/3668.feature.rst
+++ b/docs/source/newsfragments/3668.feature.rst
@@ -1,1 +1,1 @@
-Add `log_file` argument to :ref:`Python Test Runner <howto-python-runner>` to redirect stdout and stderr to the specified file.
+The :meth:`cocotb_tools.runner.Simulator.build` and :meth:`cocotb_tools.runner.Simulator.test` methods now accept a ``log_file`` argument to redirect stdout and stderr to the specified file.

--- a/docs/source/newsfragments/3669.feature.rst
+++ b/docs/source/newsfragments/3669.feature.rst
@@ -1,1 +1,1 @@
-Allow `results_xml` argument to :ref:`Python Test Runner <howto-python-runner>` to be an absolute path
+The ``results_xml`` argument to :meth:`cocotb_tools.runner.Simulator.test` can now be an absolute path.

--- a/docs/source/newsfragments/3673.change.rst
+++ b/docs/source/newsfragments/3673.change.rst
@@ -1,1 +1,1 @@
-The module ``cocotb.log`` was renamed to :module:`cocotb.logging` to prevent clashing with :attr:`cocotb.log`.
+The module ``cocotb.log`` was renamed to :mod:`cocotb.logging` to prevent clashing with :attr:`cocotb.log`.

--- a/docs/source/newsfragments/3681.bugfix.rst
+++ b/docs/source/newsfragments/3681.bugfix.rst
@@ -1,1 +1,1 @@
-Support :ref:`Python Test Runner <howto-python-runner>` `waves` parameter for Verilator.
+Support ``waves`` argument to :meth:`cocotb_tools.runner.Simulator.build` for Verilator.

--- a/docs/source/newsfragments/3682.bugfix.rst
+++ b/docs/source/newsfragments/3682.bugfix.rst
@@ -1,1 +1,1 @@
-Pass ``test_args`` to test command when using :ref:`Python Test Runner <howto-python-runner>` for Verilator, which was previously missing.
+The ``test_args`` argument to :meth:`cocotb_tools.runner.Simulator.test` is now passed to the Verilator simulation binary when running the simulation, which was previously missing.

--- a/docs/source/newsfragments/3683.feature.rst
+++ b/docs/source/newsfragments/3683.feature.rst
@@ -1,1 +1,1 @@
-Add ``--trace-file`` to Verilator binaries which specifies the trace file name.
+Added ``--trace-file`` command line argument to Verilator simulation binaries which specifies the trace file name. This can be passed to the binary by using the ``test_args`` argument to :meth:`cocotb_tools.runner.Simulator.test`.

--- a/docs/source/newsfragments/3717.feature.rst
+++ b/docs/source/newsfragments/3717.feature.rst
@@ -1,1 +1,1 @@
-Support specifying arguments like in :meth:`TestFactory.add_option <cocotb.regression.TestFactory.add_option>` in :func:`cocotb.parameterize`.
+Support specifying arguments like in :meth:`TestFactory.add_option() <cocotb.regression.TestFactory.add_option>` in :func:`cocotb.parameterize`.

--- a/docs/source/newsfragments/3717.removal.rst
+++ b/docs/source/newsfragments/3717.removal.rst
@@ -1,1 +1,1 @@
-:class:`TestFactory` is now deprecated. Use :class:`cocotb.parameterize` instead.
+:class:`~cocotb.regression.TestFactory` is now deprecated. Use :class:`cocotb.parameterize` instead.

--- a/docs/source/newsfragments/3744.feature.rst
+++ b/docs/source/newsfragments/3744.feature.rst
@@ -1,1 +1,1 @@
-Add `pre_cmd` in :ref:`Python Test Runner <howto-python-runner>` for Questa simulator to run given commands before simulation start
+The :meth:`cocotb_tools.runner.Simulator.test` method now accepts a ``pre_cmd`` argument to run given commands before the simulation starts. These are typically Tcl commands for simulators that support them. Only support for the Questa simulator has been implemented.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -92,7 +92,7 @@ Bugfixes
 Deprecations and Removals
 -------------------------
 
-- ``cocotb.fork`` has been deprecated in favor of :func:`cocotb.start_soon` or :func:`cocotb.start`. (:pr:`2663`)
+- ``cocotb.fork()`` has been deprecated in favor of :func:`cocotb.start_soon` or :func:`cocotb.start`. (:pr:`2663`)
 
 
 Changes
@@ -139,12 +139,12 @@ Features
 - Xcelium now supports compilation into a named VHDL library ``lib`` using ``VHDL_SOURCES_<lib>``. (:pr:`2614`)
 - Add the :make:var:`SIM_CMD_PREFIX` to supported Makefile variables, allowing users to pass environment variables and other command prefixes to simulators. (:pr:`2615`)
 - To support VHDL libraries in ModelSim/Questa/Xcelium, :make:var:`VHDL_LIB_ORDER` has been added to specify a library compilation order. (:pr:`2635`)
-- ``cocotb.fork``, :func:`cocotb.start`, :func:`cocotb.start_soon`, and :func:`cocotb.create_task` now accept any object that implements the :class:`collections.abc.Coroutine` protocol. (:pr:`2647`)
+- ``cocotb.fork()``, :func:`cocotb.start`, :func:`cocotb.start_soon`, and :func:`cocotb.create_task` now accept any object that implements the :class:`collections.abc.Coroutine` protocol. (:pr:`2647`)
 - :class:`~cocotb.regression.TestFactory` and :class:`cocotb.test` now accept any :class:`collections.abc.Callable` object which returns a :class:`collections.abc.Coroutine` as a test function. (:pr:`2647`)
 - Added :func:`cocotb.start` and :func:`cocotb.start_soon` scheduling functions. (:pr:`2660`)
 - Add :func:`cocotb.create_task` API for creating a Task from a Coroutine without scheduling. (:pr:`2665`)
 - Support rounding modes in :class:`~cocotb.triggers.Timer`. (:pr:`2684`)
-- Support rounding modes in :class:`cocotb.utils.get_sim_steps`. (:pr:`2684`)
+- Support rounding modes in :func:`~cocotb.utils.get_sim_steps`. (:pr:`2684`)
 - Support passing ``'step'`` as a time unit in :func:`cocotb.utils.get_sim_time`. (:pr:`2691`)
 
 
@@ -154,7 +154,7 @@ Bugfixes
 - VHDL signals that are zero bits in width now read as the integer ``0``, instead of raising an exception. (:pr:`2294`)
 - Correctly parse plusargs with ``=``\ s in the value. (:pr:`2483`)
 - :envvar:`COCOTB_RESULTS_FILE` now properly communicates with the :data:`Regression Manager <cocotb.regression_manager>` to allow overloading the result filename. (:pr:`2487`)
-- Fixed several scheduling issues related to the use of :meth:`cocotb.start_soon <cocotb.start_soon>`. (:pr:`2504`)
+- Fixed several scheduling issues related to the use of :func:`cocotb.start_soon`. (:pr:`2504`)
 - Verilator and Icarus now support running without specifying a :envvar:`TOPLEVEL`. (:pr:`2547`)
 - Fixed discovery of signals inside SystemVerilog interfaces. (:pr:`2683`)
 
@@ -195,8 +195,8 @@ cocotb 1.5.2 (2021-05-03)
 Bugfixes
 --------
 
-- Change some makefile syntax to support GNU Make 3 (:pr:`2496`)
-- Fix behavior of ``cocotb-config --libpython`` when finding libpython fails (:pr:`2522`)
+- Changed some makefile syntax to support GNU Make 3. (:pr:`2496`)
+- Fixed behavior of ``cocotb-config --libpython`` when finding libpython fails. (:pr:`2522`)
 
 
 cocotb 1.5.1 (2021-03-20)
@@ -205,7 +205,7 @@ cocotb 1.5.1 (2021-03-20)
 Bugfixes
 --------
 
-- Prevent pytest assertion rewriting (:pr:`2028`) from capturing stdin, which causes problems with IPython support (:pr:`1649`). (:pr:`2462`)
+- Prevent pytest assertion rewriting (:pr:`2028`) from capturing stdin, which causes problems with IPython support. (:pr:`1649`) (:pr:`2462`)
 - Add dependency on `cocotb_bus <https://github.com/cocotb/cocotb-bus>`_ to prevent breaking users that were previously using the bus and testbenching objects. (:pr:`2477`)
 - Add back functionality to ``cocotb.binary.BinaryValue`` that allows the user to change ``binaryRepresentation`` after object creation. (:pr:`2480`)
 
@@ -220,20 +220,20 @@ Features
   See :ref:`install` for more details. (:pr:`1798`)
 - Makefiles now automatically deduce :make:var:`TOPLEVEL_LANG` based on the value of :make:var:`VERILOG_SOURCES` and :make:var:`VHDL_SOURCES`.
   Makefiles also detect incorrect usage of :make:var:`TOPLEVEL_LANG` for simulators that only support one language. (:pr:`1982`)
-- ``cocotb.fork`` will now raise a descriptive :class:`TypeError` if a coroutine function is passed into them. (:pr:`2006`)
-- Added ``cocotb.scheduler.start_soon`` which schedules a coroutine to start *after* the current coroutine yields control.
-  This behavior is distinct from ``cocotb.fork`` which schedules the given coroutine immediately. (:pr:`2023`)
+- ``cocotb.fork()`` will now raise a descriptive :class:`TypeError` if a coroutine function is passed into them. (:pr:`2006`)
+- Added ``cocotb.scheduler.start_soon()`` which schedules a coroutine to start *after* the current coroutine yields control.
+  This behavior is distinct from ``cocotb.fork()`` which schedules the given coroutine immediately. (:pr:`2023`)
 - If ``pytest`` is installed, its assertion-rewriting framework will be used to
   produce more informative tracebacks from the :keyword:`assert` statement. (:pr:`2028`)
 - The handle to :envvar:`TOPLEVEL`, typically seen as the first argument to a cocotb test function, is now available globally as :data:`cocotb.top`. (:pr:`2134`)
-- The ``units`` argument to :class:`cocotb.triggers.Timer`,
-  :class:`cocotb.clock.Clock` and :func:`cocotb.utils.get_sim_steps`,
+- The ``units`` argument to :class:`~cocotb.triggers.Timer`,
+  :class:`~cocotb.clock.Clock` and :func:`~cocotb.utils.get_sim_steps`,
   and the ``timeout_unit`` argument to
-  :func:`cocotb.triggers.with_timeout` and :class:`cocotb.test`
+  :func:`~cocotb.triggers.with_timeout` and :class:`cocotb.test`
   now accepts ``'step'`` to mean the simulator time step.
   This used to be expressed using ``None``, which is now deprecated. (:pr:`2171`)
-- :func:`cocotb.regression.TestFactory.add_option` now supports groups of options when a full Cartesian product is not desired (:pr:`2175`)
-- Added asyncio-style queues, :class:`cocotb.queue.Queue`, :class:`cocotb.queue.PriorityQueue`, and :class:`cocotb.queue.LifoQueue`. (:pr:`2297`)
+- :meth:`TestFactory.add_option() <cocotb.regression.TestFactory.add_option>` now supports groups of options when a full Cartesian product is not desired. (:pr:`2175`)
+- Added asyncio-style queues, :class:`~cocotb.queue.Queue`, :class:`~cocotb.queue.PriorityQueue`, and :class:`~cocotb.queue.LifoQueue`. (:pr:`2297`)
 - Support for the SystemVerilog type ``bit`` has been added. (:pr:`2322`)
 - Added the ``--lib-dir``,  ``--lib-name`` and ``--lib-name-path`` options to the ``cocotb-config`` command to make cocotb integration into existing flows easier. (:pr:`2387`)
 - Support for using Questa's VHPI has been added.
@@ -317,7 +317,7 @@ Features
 
 - :class:`~cocotb.triggers.Lock` can now be used in :keyword:`async with` statements. (:pr:`1031`)
 - Add support for distinguishing between ``net`` (``vpiNet``) and ``reg`` (``vpiReg``) type when using the VPI interface. (:pr:`1107`)
-- Support for dropping into :mod:`pdb` upon failure, via the new :envvar:`COCOTB_PDB_ON_EXCEPTION` environment variable (:pr:`1180`)
+- Support for dropping into :mod:`pdb` upon failure, via the new :envvar:`COCOTB_PDB_ON_EXCEPTION` environment variable. (:pr:`1180`)
 - Simulators run through a Tcl script (Aldec Riviera Pro and Mentor simulators) now support a new :make:var:`RUN_ARGS` Makefile variable, which is passed to the first invocation of the tool during runtime. (:pr:`1244`)
 - Cocotb now supports the following example of forking a *non-decorated* :ref:`async coroutine <async_functions>`.
 
@@ -347,7 +347,7 @@ Features
       logging.basicConfig()
 
   .. consume the towncrier issue number on this line. (:pr:`1266`)
-- Support for ``vpiRealNet`` (:pr:`1282`)
+- Support for ``vpiRealNet``. (:pr:`1282`)
 - The colored output can now be disabled by the :envvar:`NO_COLOR` environment variable. (:pr:`1309`)
 - Cocotb now supports deposit/force/release/freeze actions on simulator handles, exposing functionality similar to the respective Verilog/VHDL assignments.
 
@@ -397,7 +397,7 @@ Features
 Bugfixes
 --------
 
-- Tests which fail at initialization, for instance due to no ``yield`` being present, are no longer silently ignored (:pr:`1253`)
+- Tests which fail at initialization, for instance due to no ``yield`` being present, are no longer silently ignored. (:pr:`1253`)
 - Tests that were not run because predecessors threw :class:`cocotb.result.SimFailure`, and caused the simulator to exit, are now recorded with an outcome of :class:`cocotb.result.SimFailure`.
   Previously, these tests were ignored. (:pr:`1279`)
 - Makefiles now correctly fail if the simulation crashes before a ``results.xml`` file can be written. (:pr:`1314`)
@@ -504,9 +504,9 @@ New features
   Please use the latest version of Verilator, and `report bugs <https://github.com/cocotb/cocotb/issues/new>`_ if you experience problems.
 - New makefile variables :make:var:`COCOTB_HDL_TIMEUNIT` and :make:var:`COCOTB_HDL_TIMEPRECISION` for setting the default time unit and precision that should be assumed for simulation when not specified by modules in the design. (:pr:`1113`)
 - New ``timeout_time`` and ``timeout_unit`` arguments to :func:`cocotb.test`, for adding test timeouts. (:pr:`1119`)
-- :func:`cocotb.triggers.with_timeout`, for a shorthand for waiting for a trigger with a timeout. (:pr:`1119`)
+- :func:`~cocotb.triggers.with_timeout`, for a shorthand for waiting for a trigger with a timeout. (:pr:`1119`)
 - The ``expect_error`` argument to :func:`cocotb.test` now accepts a specific exception type. (:pr:`1116`)
-- New environment variable :envvar:`COCOTB_RESULTS_FILE`, to allow configuration of the xUnit XML output filename.  (:pr:`1053`)
+- New environment variable :envvar:`COCOTB_RESULTS_FILE`, to allow configuration of the xUnit XML output filename. (:pr:`1053`)
 - A new ``bus_separator`` argument to :class:`cocotb.drivers.BusDriver`. (:pr:`1160`)
 - A new ``start_high`` argument to :meth:`cocotb.clock.Clock.start`. (:pr:`1036`)
 - A new :data:`cocotb.__version__` constant, which contains the version number of the running cocotb. (:pr:`1196`)
@@ -520,7 +520,7 @@ Notable changes and bug fixes
 - :func:`cocotb.external` and :func:`cocotb.function` now work more reliably and with fewer race conditions.
 - A failing ``assert`` will be considered a test failure. Previously, it was considered a test *error*.
 - :meth:`~cocotb.handle.NonConstantObject.drivers` and :meth:`~cocotb.handle.NonConstantObject.loads` now also work correctly in Python 3.7 onwards.
-- :class:`cocotb.triggers.Timer` can now be used with :class:`decimal.Decimal` instances, allowing constructs like ``Timer(Decimal('1e-9'), units='sec')`` as an alternate spelling for ``Timer(100, units='us')``. (:pr:`1114`)
+- :class:`~cocotb.triggers.Timer` can now be used with :class:`decimal.Decimal` instances, allowing constructs like ``Timer(Decimal("1e-9"), units="sec")`` as an alternate spelling for ``Timer(100, units="us")``. (:pr:`1114`)
 - Many (editorial) documentation improvements.
 
 Deprecations

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -77,7 +77,7 @@ Verilator
     Verilator is in the process of adding more functionality to its VPI interface, which is used by cocotb to access the design.
     Therefore, Verilator support in cocotb is currently experimental, and some features of cocotb may not work correctly or at all.
     If you encounter an issue using Verilator with cocotb, please try the newest release and
-    [check existing issues](https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Averilator)
+    `check existing issues <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Averilator>`_
     before opening a new one.
 
 In order to use this simulator, set :make:var:`SIM` to ``verilator``:
@@ -93,7 +93,7 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
 
 .. note::
 
-    Delayed assignments require the use of Verilator's `--timing <https://verilator.org/guide/latest/exe_verilator.html#cmdoption-timing>`_ argument.
+    Delayed assignments require the use of Verilator's `timing <https://verilator.org/guide/latest/exe_verilator.html#cmdoption-timing>`_ argument.
 
 To run cocotb with Verilator, you need ``verilator`` in your PATH.
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -125,6 +125,7 @@ Embedding an IPython shell
 ==========================
 
 .. module:: cocotb.ipython_support
+    :synopsis: Support for embedding an IPython shell.
 
 .. versionadded:: 1.4
 

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -401,11 +401,14 @@ class HierarchyObject(HierarchyObjectBase[str]):
         If *extended* is ``True``, run the query only for VHDL extended identifiers.
         For Verilog, only ``extended=False`` is supported.
 
+        :meta public:
+
         Args:
             name: The child object by name.
             extended: If ``True``, treat the *name* as an extended identifier.
 
-        Returns: The child object.
+        Returns:
+            The child object.
 
         Raises:
             AttributeError: If the child object is not found.
@@ -414,7 +417,6 @@ class HierarchyObject(HierarchyObjectBase[str]):
             Use ``handle[child_name]`` syntax instead.
             If extended identifiers are needed simply add a ``\\`` character before and after the name.
 
-        :meta public:
         """
         if extended:
             name = "\\" + name + "\\"
@@ -1313,7 +1315,8 @@ def SimHandle(
         handle: The GPI handle to the simulator object.
         path: Path to this handle.
 
-    Returns: An appropriate :class:`SimHandleBase` object.
+    Returns:
+        An appropriate :class:`SimHandleBase` object.
 
     Raises:
         NotImplementedError: If no matching object for GPI type could be found.

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -170,7 +170,7 @@ class Simulator(abc.ABC):
             hdl_toplevel: The name of the HDL toplevel module.
             always: Always run the build step.
             build_dir: Directory to run the build step in.
-            clean: Delete build_dir before building
+            clean: Delete *build_dir* before building.
             verbose: Enable verbose messages.
             timescale: Tuple containing time unit and time precision for simulation.
             waves: Record signal traces.
@@ -258,6 +258,7 @@ class Simulator(abc.ABC):
                 This argument should not be set when run with ``pytest``.
             verbose: Enable verbose messages.
             pre_cmd: Commands to run before simulation begins.
+                Typically Tcl commands for simulators that support them.
             timescale: Tuple containing time unit and time precision for simulation.
             log_file: File to write the test log to.
 
@@ -1243,7 +1244,14 @@ class Xcelium(Simulator):
 
 
 def get_runner(simulator_name: str) -> Simulator:
-    """Return the *simulator_name* instance."""
+    """Return an instance of a runner for *simulator_name*.
+
+    Args:
+        simulator_name: Name of simulator to get runner for.
+
+    Raises:
+        ValueError: If *simulator_name* is not one of the supported simulators or an alias of one.
+    """
 
     supported_sims: Dict[str, Type[Simulator]] = {
         "icarus": Icarus,


### PR DESCRIPTION
* Remove leftover reference to cocotb.types.concat()
* Add cocotb.logging module to Global Module Index and fix newsfragment link to it
* Add cocotb.log default Logger
* Add missing synopses for cocotb modules
* Clean up various function/method docstrings
* Clean up various newsfragments and release notes
