### PR TITLE
Improve combine_results script

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -307,6 +307,18 @@ Other Runtime Information
 
 .. autodata:: cocotb.is_simulation
 
+.. _combine-results:
+
+The ``combine_results`` script
+------------------------------
+
+Use ``python -m cocotb_tools.combine_results`` to call the script.
+
+.. sphinx_argparse_cli::
+    :module: cocotb_tools.combine_results
+    :func: _get_parser
+    :prog: combine_results
+
 
 Implementation Details
 ======================

--- a/docs/source/newsfragments/3791.feature.rst
+++ b/docs/source/newsfragments/3791.feature.rst
@@ -1,0 +1,1 @@
+The :ref:`combine_results.py <combine-results>` script now ships with the cocotb installation.


### PR DESCRIPTION
Follow on from #3791.

* Allow multiple directories to be provided to script to search for results.xml files.
* Removed --suppress-rc, just use the shell to ignore the return code if desired.
* Typing and public API cleanup.
* Cleanup configuration of ArgumentParser.
* Added newsfragment.
* Added documentation.