### PR TITLE
VPI: Use iteration fallback when looking for vpiGenScope by name

### DIFF
--- a/docs/source/newsfragments/3817.feature.rst
+++ b/docs/source/newsfragments/3817.feature.rst
@@ -1,0 +1,1 @@
+Enable use of VPI fallback in all simulators when attempting to access generate blocks directly via lookup. This enables better support for simulators that don't support ``vpiGenScopeArray``, allowing discovery of generate blocks without having to iterate over the parent handle.

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -78,11 +78,7 @@ async def test_arr_scope(dut):
     assert dut.arr[1].arr_sub._path == f"{dut._path}.arr[1].arr_sub"
 
 
-@verilog_test(
-    expect_error=AttributeError
-    if SIM_NAME.startswith(("verilator", "modelsim"))
-    else ()
-)
+@verilog_test(expect_error=AttributeError if SIM_NAME.startswith("verilator") else ())
 async def test_nested_scope(dut):
     assert (
         dut.outer_scope[1].inner_scope[1]._path
@@ -91,9 +87,7 @@ async def test_nested_scope(dut):
 
 
 @verilog_test(
-    expect_error=AttributeError
-    if SIM_NAME.startswith(("verilator", "modelsim"))
-    else (),
+    expect_error=AttributeError if SIM_NAME.startswith("verilator") else (),
 )
 async def test_scoped_params(dut):
     assert dut.cond_scope.scoped_param.value == 1


### PR DESCRIPTION
Like Icarus Verilog, Verilator does not support vpiGenScopeArray, but vpiGenScope support has been added.

When looking up a vpiGenScopeArray handle by name, iterate over parent handle to check if a vpiGenScope object exists with the right prefix. If it does, create the pseudo-region.

This implements just the Verilator `vpiGenScope` support from #3756.

- [x] Add newsfragment