### PR TITLE
make setimmediatevalue immediately set

### DIFF
--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -546,6 +546,7 @@ class _GPISetAction(enum.IntEnum):
     DEPOSIT = 0
     FORCE = 1
     RELEASE = 2
+    NO_DELAY = 3
 
 
 #: The type of the value a :class:`Deposit` or :class:`Force` action contains.
@@ -688,6 +689,8 @@ class ValueObjectBase(SimHandleBase, Generic[ValuePropertyT, ValueSetT]):
             f(*args)
 
         value_, action = _map_action_obj_to_value_action_enum_pair(self, value)
+        if action == _GPISetAction.DEPOSIT:
+            action = _GPISetAction.NO_DELAY
 
         self._set_value(value_, action, _call_now)
 

--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -171,6 +171,7 @@ typedef enum gpi_set_action_e {
     GPI_DEPOSIT = 0,
     GPI_FORCE = 1,
     GPI_RELEASE = 2,
+    GPI_NO_DELAY = 3,
 } gpi_set_action_t;
 
 // Functions for iterating over entries of a handle

--- a/src/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/src/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -245,6 +245,7 @@ int FliEnumObjHdl::set_signal_value(const int32_t value,
     if (m_is_var) {
         switch (action) {
             case GPI_DEPOSIT:
+            case GPI_NO_DELAY:
                 mti_SetVarValue(get_handle<mtiVariableIdT>(),
                                 static_cast<mtiLongT>(value));
                 return 0;

--- a/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -160,6 +160,7 @@ vhpiPutValueModeT map_put_value_mode(gpi_set_action_t action) {
     vhpiPutValueModeT put_value_mode = vhpiDeposit;
     switch (action) {
         case GPI_DEPOSIT:
+        case GPI_NO_DELAY:
             put_value_mode = vhpiDepositPropagate;
             break;
         case GPI_FORCE:

--- a/src/cocotb/share/lib/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/vpi/VpiSignal.cpp
@@ -223,6 +223,9 @@ int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s,
             vpi_get_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s);
             vpi_put_flag = vpiReleaseFlag;
             break;
+        case GPI_NO_DELAY:
+            vpi_put_flag = vpiNoDelay;
+            break;
         default:
             assert(0);
     }

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -431,12 +431,13 @@ async def test_assign_immediate(dut):
 async def test_immediate_reentrace(dut):
     dut.mybits_uninitialized.value = 0
     await Timer(1, "ns")
-    seen = False
+    seen = 0
 
     async def watch():
-        global seen
+        nonlocal seen
         await Edge(dut.mybits_uninitialized)
-        seen = True
+        dut._log.warning("SEEN")
+        seen += 1
 
     cocotb.start_soon(watch())
     await Timer(1, "ns")

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -419,3 +419,9 @@ async def test_assign_Logic(dut):
     assert dut.stream_in_ready.value.binstr.lower() == "x"
     with pytest.raises(ValueError):
         dut.stream_in_data.value = Logic("U")  # not the correct size
+
+
+@cocotb.test()
+async def test_assign_immediate(dut):
+    dut.mybits_uninitialized.setimmediatevalue(2)
+    assert dut.mybits_uninitialized.value == 2


### PR DESCRIPTION
See: #1024 

Currently `vpiInertialDelay` prevents `setimmediatevalue()` from immediately setting a value.  This attempts to fix that, but honestly raises more questions in my mind.  Namely that the VHPI and FLI interfaces don't seem to have a notion analogous to `vpiIntertialDelay`.  So I'm once again wondering if we really want that for the VPI?  It seems odd that putting a value would be incongruous like that between the different GPI impls.

In any case, I'm positive that `setimmediatevalue()` should set immediately and `test_assign_immediate` attempts to lock that in.