### PR TITLE
Deprecate `cocotb.runner.Simulator.build` parameters `verilog_sources` and `vhdl_sources`

### DIFF
--- a/docs/source/newsfragments/3836.removal.rst
+++ b/docs/source/newsfragments/3836.removal.rst
@@ -1,0 +1,1 @@
+Deprecated the ``verilog_sources`` and ``vhdl_sources`` parameters to :meth:`cocotb.runner.Simulator.build`. Use the language-agnostic ``sources`` parameter instead.

--- a/examples/adder/tests/test_adder.py
+++ b/examples/adder/tests/test_adder.py
@@ -61,13 +61,10 @@ def test_adder_runner():
     # equivalent to setting the PYTHONPATH environment variable
     sys.path.append(str(proj_path / "model"))
 
-    verilog_sources = []
-    vhdl_sources = []
-
     if hdl_toplevel_lang == "verilog":
-        verilog_sources = [proj_path / "hdl" / "adder.sv"]
+        sources = [proj_path / "hdl" / "adder.sv"]
     else:
-        vhdl_sources = [proj_path / "hdl" / "adder.vhdl"]
+        sources = [proj_path / "hdl" / "adder.vhdl"]
 
     build_test_args = []
     if hdl_toplevel_lang == "vhdl" and sim == "xcelium":
@@ -78,8 +75,7 @@ def test_adder_runner():
 
     runner = get_runner(sim)
     runner.build(
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         hdl_toplevel="adder",
         always=True,
         build_args=build_test_args,

--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -230,18 +230,16 @@ def test_matrix_multiplier_runner():
 
     proj_path = Path(__file__).resolve().parent.parent
 
-    verilog_sources = []
-    vhdl_sources = []
     build_args = []
 
     if hdl_toplevel_lang == "verilog":
-        verilog_sources = [proj_path / "hdl" / "matrix_multiplier.sv"]
+        sources = [proj_path / "hdl" / "matrix_multiplier.sv"]
 
         if sim in ["riviera", "activehdl"]:
             build_args = ["-sv2k12"]
 
     elif hdl_toplevel_lang == "vhdl":
-        vhdl_sources = [
+        sources = [
             proj_path / "hdl" / "matrix_multiplier_pkg.vhd",
             proj_path / "hdl" / "matrix_multiplier.vhd",
         ]
@@ -275,8 +273,7 @@ def test_matrix_multiplier_runner():
 
     runner.build(
         hdl_toplevel="matrix_multiplier",
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         build_args=build_args + extra_args,
         parameters=parameters,
         always=True,

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -57,18 +57,14 @@ def test_simple_dff_runner():
 
     proj_path = Path(__file__).resolve().parent
 
-    verilog_sources = []
-    vhdl_sources = []
-
     if hdl_toplevel_lang == "verilog":
-        verilog_sources = [proj_path / "dff.sv"]
+        sources = [proj_path / "dff.sv"]
     else:
-        vhdl_sources = [proj_path / "dff.vhdl"]
+        sources = [proj_path / "dff.vhdl"]
 
     runner = get_runner(sim)
     runner.build(
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         hdl_toplevel="dff",
         always=True,
     )

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -223,6 +223,10 @@ class Simulator(abc.ABC):
             timescale: Tuple containing time unit and time precision for simulation.
             waves: Record signal traces.
             log_file: File to write the build log to.
+
+        .. deprecated:: 2.0
+
+            Uses of the *verilog_sources* and *vhdl_sources* parameters should be replaced with the language-agnostic *sources* argument.
         """
 
         self.clean: bool = clean
@@ -236,7 +240,19 @@ class Simulator(abc.ABC):
         # a better docstring than using `None` as a default in the parameters
         # list.
         self.hdl_library: str = hdl_library
+        if verilog_sources:
+            warnings.warn(
+                "Simulator.build *verilog_sources* parameter is deprecated. Use the language-agnostic *sources* parameter instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.verilog_sources: List[Path] = get_abs_paths(verilog_sources)
+        if vhdl_sources:
+            warnings.warn(
+                "Simulator.build *vhdl_sources* parameter is deprecated. Use the language-agnostic *sources* parameter instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.vhdl_sources: List[Path] = get_abs_paths(vhdl_sources)
         self.sources: List[Path] = get_abs_paths(sources)
         self.includes: List[Path] = get_abs_paths(includes)

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -17,9 +17,6 @@ def build_and_run_matrix_multiplier(benchmark, sim):
         build_args = ["--std=08"]
         hdl_toplevel_lang = "vhdl"
 
-    verilog_sources = []
-    vhdl_sources = []
-
     proj_path = (
         Path(__file__).resolve().parent.parent / "examples" / "matrix_multiplier"
     )
@@ -27,9 +24,9 @@ def build_and_run_matrix_multiplier(benchmark, sim):
     sys.path.append(str(proj_path / "tests"))
 
     if hdl_toplevel_lang == "verilog":
-        verilog_sources = [proj_path / "hdl" / "matrix_multiplier.sv"]
+        sources = [proj_path / "hdl" / "matrix_multiplier.sv"]
     else:
-        vhdl_sources = [
+        sources = [
             proj_path / "hdl" / "matrix_multiplier_pkg.vhd",
             proj_path / "hdl" / "matrix_multiplier.vhd",
         ]
@@ -38,8 +35,7 @@ def build_and_run_matrix_multiplier(benchmark, sim):
 
     runner.build(
         hdl_toplevel="matrix_multiplier",
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         build_args=build_args,
     )
 

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -31,18 +31,14 @@ module_name = [
     "test_timing_triggers",
 ]
 
-verilog_sources = []
-vhdl_sources = []
 hdl_toplevel_lang = os.getenv("HDL_TOPLEVEL_LANG", "verilog")
 vhdl_gpi_interfaces = os.getenv("VHDL_GPI_INTERFACE", None)
 
 if hdl_toplevel_lang == "verilog":
-    verilog_sources = [
-        os.path.join(tests_dir, "designs", "sample_module", "sample_module.sv")
-    ]
+    sources = [os.path.join(tests_dir, "designs", "sample_module", "sample_module.sv")]
     gpi_interfaces = ["vpi"]
 else:
-    vhdl_sources = [
+    sources = [
         os.path.join(tests_dir, "designs", "sample_module", "sample_module_pack.vhdl"),
         os.path.join(tests_dir, "designs", "sample_module", "sample_module_1.vhdl"),
         os.path.join(tests_dir, "designs", "sample_module", "sample_module.vhdl"),
@@ -71,8 +67,7 @@ def test_cocotb():
     runner = get_runner(sim)
 
     runner.build(
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         hdl_toplevel=hdl_toplevel,
         build_dir=sim_build,
         build_args=compile_args,

--- a/tests/pytest/test_logs.py
+++ b/tests/pytest/test_logs.py
@@ -19,9 +19,8 @@ from test_cocotb import (
     hdl_toplevel_lang,
     sim_args,
     sim_build,
+    sources,
     tests_dir,
-    verilog_sources,
-    vhdl_sources,
 )
 
 sys.path.insert(0, str(Path(tests_dir) / "pytest"))
@@ -41,8 +40,7 @@ def run_simulation(sim, log_dir):
     runner.build(
         always=True,
         clean=True,
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         hdl_toplevel=hdl_toplevel,
         build_dir=sim_build,
         build_args=compile_args,

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -16,9 +16,8 @@ from test_cocotb import (
     sim,
     sim_args,
     sim_build,
+    sources,
     tests_dir,
-    verilog_sources,
-    vhdl_sources,
 )
 
 pytestmark = pytest.mark.simulator_required
@@ -34,8 +33,7 @@ def test_cocotb_parallel_compile():
 
     runner.build(
         always=True,
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         hdl_toplevel=hdl_toplevel,
         build_dir=sim_build,
         build_args=compile_args,

--- a/tests/pytest/test_plusargs.py
+++ b/tests/pytest/test_plusargs.py
@@ -33,19 +33,15 @@ def test_toplevel_library():
     if sim == "verilator":
         build_test_args = ["--timing"]
 
-    verilog_sources = []
-    vhdl_sources = []
-
     if hdl_toplevel_lang == "verilog":
-        verilog_sources = [src_path / "tb_top.v"]
+        sources = [src_path / "tb_top.v"]
         gpi_interfaces = ["vpi"]
     else:
-        vhdl_sources = [src_path / "tb_top.vhd"]
+        sources = [src_path / "tb_top.vhd"]
         gpi_interfaces = [vhdl_gpi_interfaces]
 
     runner.build(
-        vhdl_sources=vhdl_sources,
-        verilog_sources=verilog_sources,
+        sources=sources,
         hdl_toplevel="tb_top",
         build_dir=str(test_module_path / "sim_build" / "pytest"),
         build_args=build_test_args,

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -37,14 +37,11 @@ def test_runner(parameters, pre_cmd, clean_build):
     hdl_toplevel_lang = os.getenv("HDL_TOPLEVEL_LANG", "verilog")
     vhdl_gpi_interfaces = os.getenv("VHDL_GPI_INTERFACE", None)
 
-    verilog_sources = []
-    vhdl_sources = []
-
     if hdl_toplevel_lang == "verilog":
-        verilog_sources = [os.path.join(tests_dir, "designs", "runner", "runner.v")]
+        sources = [os.path.join(tests_dir, "designs", "runner", "runner.v")]
         gpi_interfaces = ["vpi"]
     else:
-        vhdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.vhdl")]
+        sources = [os.path.join(tests_dir, "designs", "runner", "runner.vhdl")]
         gpi_interfaces = [vhdl_gpi_interfaces]
 
     sim = os.getenv("SIM", "icarus")
@@ -66,8 +63,7 @@ def test_runner(parameters, pre_cmd, clean_build):
     open(build_dir + "/clean_test_file", "a").close()
 
     runner.build(
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         hdl_toplevel="runner",
         parameters=parameters,
         defines={"DEFINE": 4},

--- a/tests/pytest/test_timescale.py
+++ b/tests/pytest/test_timescale.py
@@ -13,9 +13,8 @@ from test_cocotb import (
     sim,
     sim_args,
     sim_build,
+    sources,
     tests_dir,
-    verilog_sources,
-    vhdl_sources,
 )
 
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
@@ -54,8 +53,7 @@ def test_precision(precision):
         runner.build(
             always=True,
             clean=True,
-            verilog_sources=verilog_sources,
-            vhdl_sources=vhdl_sources,
+            sources=sources,
             hdl_toplevel=hdl_toplevel,
             build_dir=build_dir,
             build_args=compile_args,

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -15,9 +15,8 @@ from test_cocotb import (
     hdl_toplevel_lang,
     sim_args,
     sim_build,
+    sources,
     tests_dir,
-    verilog_sources,
-    vhdl_sources,
 )
 
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
@@ -37,8 +36,7 @@ def run_simulation(sim, test_args=None):
     runner.build(
         always=True,
         clean=True,
-        verilog_sources=verilog_sources,
-        vhdl_sources=vhdl_sources,
+        sources=sources,
         hdl_toplevel=hdl_toplevel,
         build_dir=sim_build,
         build_args=compile_args,


### PR DESCRIPTION
Deprecate `verilog_sources` and `vhdl_sources` arguments  to `cocotb_tools.runner.Simulator.build`.