### PR TITLE
Test better error messages when Makefiles fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ clean:
 
 .PHONY: do_tests
 do_tests::
-	$(MAKE) -k -C tests
+	$(MAKE) -C tests
 do_tests::
-	$(MAKE) -k -C examples
+	$(MAKE) -C examples
 
 # For Jenkins we use the exit code to detect compile errors or catastrophic
 # failures and the XML to track test results

--- a/noxfile.py
+++ b/noxfile.py
@@ -188,7 +188,7 @@ def dev_test_sim(
         coverage_file.unlink()
 
     session.log(f"Running 'make test' against a simulator {config_str}")
-    session.run("make", "test", external=True, env=env)
+    session.run("make", "-k", "test", external=True, env=env)
 
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(
@@ -487,7 +487,7 @@ def release_test_sim(
     config_str = stringify_dict(env)
 
     session.log(f"Running tests against a simulator: {config_str}")
-    session.run("make", "test", external=True, env=env)
+    session.run("make", "-k", "test", external=True, env=env)
 
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,17 +32,9 @@ export PYTHONWARNINGS = error,ignore::DeprecationWarning:site,always::FutureWarn
 
 REGRESSIONS :=  $(shell ls test_cases/)
 
-.PHONY: $(REGRESSIONS)
-
 all: $(REGRESSIONS)
 
+.PHONY: $(REGRESSIONS)
 $(REGRESSIONS):
-	cd test_cases/$@ && $(MAKE)
-
-
-
-clean:
-	$(foreach TEST, $(REGRESSIONS), $(MAKE) -C test_cases/$(TEST) clean;)
-
-regression:
-	$(foreach TEST, $(REGRESSIONS), $(MAKE) -C test_cases/$(TEST) regression;)
+	@echo Running regression suite $@
+	@cd test_cases/$@ && $(MAKE); ret=$$?; if [ $$ret -ne 0 ]; then echo "::error ::Failed regression suite $@"; fi; exit $$ret;


### PR DESCRIPTION
We get error messages when tests fail in cocotb, but not if the Makefile fails. This should help.