### PR TITLE
Fix Verilator v5.026 by implementing inertial writes

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -173,7 +173,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v5.024",  # Latest release version.
+        "sim-version": "v5.028",  # Latest release version.
         # Needs 22.04 for newer GCC with C++ coroutine support used with --timing mode
         "os": "ubuntu-22.04",
         "python-version": "3.8",
@@ -191,7 +191,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v5.022",  # Minimum supported version.
+        "sim-version": "v5.026",  # Minimum supported version.
         # Needs 22.04 for newer GCC with C++ coroutine support used with --timing mode
         "os": "ubuntu-22.04",
         "python-version": "3.8",
@@ -216,7 +216,7 @@ ENVS = [
         "python-version": "3.8",
         "group": "experimental",
     },
-    # Verilator macOS
+    # Verilator macOS HEAD
     {
         "lang": "verilog",
         "sim": "verilator",
@@ -229,10 +229,11 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v5.024",
+        "sim-version": "v5.028",
         "os": "macos-13",
         "python-version": "3.8",
         "group": "ci",
+        "may-fail": True,  # verilator/verilator#5404
     },
     # Icarus windows from source
     {

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -72,7 +72,7 @@ Verilator
 
 .. warning::
 
-    **cocotb supports Verilator 5.022 and 5.024 (only).**
+    **cocotb supports Verilator 5.026+.**
 
     Verilator is in the process of adding more functionality to its VPI interface, which is used by cocotb to access the design.
     Therefore, Verilator support in cocotb is currently experimental, and some features of cocotb may not work correctly or at all.

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -97,6 +97,7 @@ int main(int argc, char** argv) {
 
     vlog_startup_routines_bootstrap();
     VerilatedVpi::callCbs(cbStartOfSimulation);
+    settle_value_callbacks();
 
 #if VM_TRACE
 #if VM_TRACE_FST
@@ -113,32 +114,22 @@ int main(int argc, char** argv) {
 #endif
 
     while (!Verilated::gotFinish()) {
-        // Call registered timed callbacks (e.g. clock timer)
-        // These are called at the beginning of the time step
-        // before the iterative regions (IEEE 1800-2012 4.4.1)
-        VerilatedVpi::callTimedCbs();
+        do {
+            // We must evaluate whole design until we process all 'events' for
+            // this time step
+            do {
+                top->eval_step();
+                VerilatedVpi::clearEvalNeeded();
+                VerilatedVpi::doInertialPuts();
+                settle_value_callbacks();
+            } while (VerilatedVpi::evalNeeded());
 
-        // Call Value Change callbacks triggered by Timer callbacks
-        // These can modify signal values
-        settle_value_callbacks();
+            // Run ReadWrite callback as we are done processing this eval step
+            VerilatedVpi::callCbs(cbReadWriteSynch);
+            VerilatedVpi::doInertialPuts();
+            settle_value_callbacks();
+        } while (VerilatedVpi::evalNeeded());
 
-        // We must evaluate whole design until we process all 'events'
-        bool again = true;
-        while (again) {
-            // Evaluate design
-            top->eval_step();
-
-            // Call Value Change callbacks triggered by eval()
-            // These can modify signal values
-            again = settle_value_callbacks();
-
-            // Call registered ReadWrite callbacks
-            again |= VerilatedVpi::callCbs(cbReadWriteSynch);
-
-            // Call Value Change callbacks triggered by ReadWrite callbacks
-            // These can modify signal values
-            again |= settle_value_callbacks();
-        }
         top->eval_end_step();
 
         // Call ReadOnly callbacks
@@ -169,9 +160,12 @@ int main(int argc, char** argv) {
         // It should be called in simulation cycle before everything else
         // but not on first cycle
         VerilatedVpi::callCbs(cbNextSimTime);
+        settle_value_callbacks();
 
-        // Call Value Change callbacks triggered by NextTimeStep callbacks
-        // These can modify signal values
+        // Call registered timed callbacks (e.g. clock timer)
+        // These are called at the beginning of the time step
+        // before the iterative regions (IEEE 1800-2012 4.4.1)
+        VerilatedVpi::callTimedCbs();
         settle_value_callbacks();
     }
 

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -159,7 +159,7 @@ else
     $(warning Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.)
 endif # COCOTB_MAKEFILE_INC_INCLUDED
 
-ifneq ($(filter $(SIM),nvc ghdl),)
+ifneq ($(filter $(SIM),nvc ghdl verilator),)
   COCOTB_TRUST_INERTIAL_WRITES ?= 1
 else
   COCOTB_TRUST_INERTIAL_WRITES ?= 0

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1214,6 +1214,11 @@ class Verilator(Runner):
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}
 
+    def _set_env(self) -> None:
+        super()._set_env()
+        if "COCOTB_TRUST_INERTIAL_WRITES" not in self.env:
+            self.env["COCOTB_TRUST_INERTIAL_WRITES"] = "1"
+
     def _simulator_in_path(self) -> None:
         # the verilator binary is only needed for building
         return

--- a/tests/test_cases/test_force_release/test_force_release.py
+++ b/tests/test_cases/test_force_release/test_force_release.py
@@ -175,7 +175,11 @@ async def test_cocotb_writes_dont_overwrite_force_registered(dut):
 
 
 # Release and Freeze read current simulator values, not scheduled values (gh-3829)
-@cocotb.test(expect_fail=True)
+@cocotb.test(
+    expect_fail=SIM_NAME.startswith(
+        ("icarus", "ghdl", "nvc", "modelsim", "riviera", "xmsim")
+    )
+)
 async def test_force_followed_by_release_correct_value(dut):
     """Test if Forcing then immediately Releasing a signal yields the correct value.
 

--- a/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
+++ b/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
@@ -82,7 +82,7 @@ if simulator_test:
     expect_fail = False
 elif not trust_inertial:
     expect_fail = False
-elif SIM_NAME.startswith(("icarus", "verilator")):
+elif SIM_NAME.startswith("icarus"):
     expect_fail = True
 elif SIM_NAME.startswith("modelsim") and verilog:
     expect_fail = True


### PR DESCRIPTION
Pending https://github.com/verilator/verilator/pull/5065 and probably a Verilator release due to the API change.

This doesn't appear to do much for `test_matrix_multiplier_verilator` but it's made noticeable performance improvements for us locally (think a monitor coro which doesn't touch the DUT).

- [x] Update docs to move minimum supported Verilator version to v5.026.

Depends upon #4080: either the fix, or changing the test.