### PR TITLE
Throw an exception with helpful message if libpython is missing

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -133,7 +133,10 @@ class Simulator(abc.ABC):
             self.env[e] = os.environ[e]
 
         if "LIBPYTHON_LOC" not in self.env:
-            self.env["LIBPYTHON_LOC"] = find_libpython.find_libpython()
+            libpython_path = find_libpython.find_libpython()
+            if not libpython_path:
+                raise ValueError("Unable to find libpython, please make sure the appropriate libpython is installed")
+            self.env["LIBPYTHON_LOC"] = libpython_path
 
         self.env["PATH"] += os.pathsep + str(cocotb_tools.config.libs_dir)
         self.env["PYTHONPATH"] = os.pathsep.join(sys.path)

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -135,7 +135,9 @@ class Simulator(abc.ABC):
         if "LIBPYTHON_LOC" not in self.env:
             libpython_path = find_libpython.find_libpython()
             if not libpython_path:
-                raise ValueError("Unable to find libpython, please make sure the appropriate libpython is installed")
+                raise ValueError(
+                    "Unable to find libpython, please make sure the appropriate libpython is installed"
+                )
             self.env["LIBPYTHON_LOC"] = libpython_path
 
         self.env["PATH"] += os.pathsep + str(cocotb_tools.config.libs_dir)

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -7,6 +7,7 @@ import sys
 
 import cocotb
 import pytest
+import find_libpython
 from cocotb.triggers import Timer
 from cocotb_tools.runner import get_runner
 
@@ -94,3 +95,48 @@ def test_runner(parameters, pre_cmd, clean_build):
         assert not os.path.isfile(build_dir + "/clean_test_file")
     else:
         assert os.path.isfile(build_dir + "/clean_test_file")
+
+
+def test_missing_libpython(monkeypatch):
+    hdl_toplevel_lang = os.getenv("HDL_TOPLEVEL_LANG", "verilog")
+    if hdl_toplevel_lang == "verilog":
+        hdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.v")]
+        gpi_interfaces = ["vpi"]
+    else:
+        hdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.vhdl")]
+        gpi_interfaces = [os.getenv("VHDL_GPI_INTERFACE", None)]
+        
+
+    sim_tool = os.getenv("SIM", "icarus")
+    sim_runner = get_runner(sim_tool)
+    sim_params = dict(
+        WIDTH_IN="8",
+        WIDTH_OUT="8",
+    )
+    build_args = ["-v93"] if sim_tool == "xcelium" else []
+    build_dir = os.path.join(sim_build, "test_missing_libpython")
+
+    os.makedirs(build_dir, exist_ok=True)
+
+    sim_runner.build(
+        sources=hdl_sources,
+        hdl_toplevel="runner",
+        parameters=sim_params,
+        defines={"DEFINE": 4},
+        includes=[os.path.join(tests_dir, "designs", "basic_hierarchy_module")],
+        build_args=build_args,
+        build_dir=build_dir,
+    )
+
+    def mock_find_libpython():
+        return None
+
+    monkeypatch.setattr(find_libpython, "find_libpython", mock_find_libpython)
+
+    with pytest.raises(ValueError):
+        sim_runner.test(
+            hdl_toplevel="runner",
+            test_module="test_runner",
+            gpi_interfaces=gpi_interfaces,
+            extra_env=sim_params,
+        )

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -6,8 +6,8 @@ import os
 import sys
 
 import cocotb
-import pytest
 import find_libpython
+import pytest
 from cocotb.triggers import Timer
 from cocotb_tools.runner import get_runner
 
@@ -105,7 +105,6 @@ def test_missing_libpython(monkeypatch):
     else:
         hdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.vhdl")]
         gpi_interfaces = [os.getenv("VHDL_GPI_INTERFACE", None)]
-        
 
     sim_tool = os.getenv("SIM", "icarus")
     sim_runner = get_runner(sim_tool)


### PR DESCRIPTION
Calls to find_libpython.find_libpython() may return an empty string or None if libpython was not properly installed. This was causing a TypeError exception to be thrown with a non-obvious error message. The value returned by find_libpython.find_libpython() is now checked and if not found a more helpful error message is provided.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
