### PR TITLE
Trigger deprecations

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -33,6 +33,7 @@ FIXME: We have a problem here.  If a coroutine schedules a read-only but we
 also have pending writes we have to schedule the ReadWrite callback before
 the ReadOnly (and this is invalid, at least in Modelsim).
 """
+
 import inspect
 import logging
 import os
@@ -634,7 +635,7 @@ class Scheduler:
                 self._resume_coro_upon(
                     coro,
                     NullTrigger(
-                        name="Trigger.prime() Error", outcome=outcomes.Error(e)
+                        name="Trigger.prime() Error", _outcome=outcomes.Error(e)
                     ),
                 )
 
@@ -836,7 +837,7 @@ class Scheduler:
         self._test = test_coro
         self._resume_coro_upon(
             test_coro,
-            NullTrigger(name=f"Start {test_coro!s}", outcome=outcomes.Value(None)),
+            NullTrigger(name=f"Start {test_coro!s}", _outcome=outcomes.Value(None)),
         )
 
     # This collection of functions parses a trigger out of the object
@@ -966,7 +967,7 @@ class Scheduler:
                 except TypeError as exc:
                     # restart this coroutine with an exception object telling it that
                     # it wasn't allowed to yield that
-                    result = NullTrigger(outcome=outcomes.Error(exc))
+                    result = NullTrigger(_outcome=outcomes.Error(exc))
 
                 self._resume_coro_upon(coroutine, result)
 

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -786,22 +786,19 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
         return outcome
 
     @property
+    @deprecated("Use `task.result()` to get the result of a joined Task.")
     def retval(self):
         """The return value of the joined coroutine.
 
-        .. note::
-            Typically there is no need to use this attribute - the
-            following code samples are equivalent::
+        .. deprecated:: 1.9
+
+            Use :meth:`Task.result() <cocotb.task.Task.result` to get the result of a joined Task.
+
+            .. code-block: python3
 
                 forked = cocotb.start_soon(mycoro())
-                j = Join(forked)
-                await j
-                result = j.retval
-
-            ::
-
-                forked = cocotb.start_soon(mycoro())
-                result = await Join(forked)
+                await forked.join()
+                result = forked.result()
         """
         return self._coroutine.result()
 

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -817,6 +817,14 @@ class Join(PythonTrigger, metaclass=_ParameterizedSingletonAndABC):
     def __repr__(self):
         return "{}({!s})".format(type(self).__qualname__, self._coroutine)
 
+    def __await__(self):
+        warnings.warn(
+            "`await`ing a Join trigger will return the Join trigger and not the result of the joined Task in 2.0.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return (yield self)
+
 
 class Waitable(Awaitable):
     """

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -722,11 +722,17 @@ class NullTrigger(Trigger):
     Primarily for internal scheduler use.
     """
 
-    def __init__(self, name=None, outcome=None):
+    def __init__(self, name=None, outcome=None, _outcome=None):
         super().__init__()
         self._callback = None
         self.name = name
-        self.__outcome = outcome
+        if outcome is not None:
+            warnings.warn(
+                "Passing the `outcome` argument and having that be the result of the `await` expression on this Trigger is deprecated.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.__outcome = _outcome if _outcome is not None else outcome
 
     @property
     def _outcome(self):
@@ -961,7 +967,7 @@ class First(_AggregateWaitable):
         #    traceback, even if it is obvious top cocotb maintainers.
         #  - Using `NullTrigger` here instead of `result = completed[0].get()`
         #    means we avoid inserting an `outcome.get` frame in the traceback
-        first_trigger = NullTrigger(outcome=completed[0])
+        first_trigger = NullTrigger(_outcome=completed[0])
         return await first_trigger  # the first of multiple triggers that fired
 
 

--- a/documentation/source/newsfragments/3871.change.4.rst
+++ b/documentation/source/newsfragments/3871.change.4.rst
@@ -1,0 +1,1 @@
+``await``\ ing a :class:`~cocotb.triggers.Join` trigger will yield the Join trigger and not the result of the task in the 2.0 release.

--- a/documentation/source/newsfragments/3871.change.rst
+++ b/documentation/source/newsfragments/3871.change.rst
@@ -1,0 +1,1 @@
+:meth:`Lock.locked <cocotb.triggers.Lock.locked>` is now a method rather than an attribute to mirror :meth:`asyncio.Lock.locked`.

--- a/documentation/source/newsfragments/3871.removal.1.rst
+++ b/documentation/source/newsfragments/3871.removal.1.rst
@@ -1,0 +1,1 @@
+``bool(Lock())`` is deprecated. Use :meth:`~cocotb.triggers.Lock.locked` instead.

--- a/documentation/source/newsfragments/3871.removal.2.rst
+++ b/documentation/source/newsfragments/3871.removal.2.rst
@@ -1,0 +1,1 @@
+:attr:`Join.retval <cocotb.triggers.Join.retval>` is deprecated. Use :meth:`Task.result() <cocotb.task.Task.result>` to get the result of a joined Task.

--- a/documentation/source/newsfragments/3871.removal.3.rst
+++ b/documentation/source/newsfragments/3871.removal.3.rst
@@ -1,0 +1,1 @@
+Passing the *outcome* argument to :class:`~cocotb.triggers.NullTrigger` - which allowed the user to inject arbitrary outcomes when the trigger was ``await``\ ed - is deprecated. There is no alternative.

--- a/documentation/source/newsfragments/3871.removal.rst
+++ b/documentation/source/newsfragments/3871.removal.rst
@@ -1,0 +1,1 @@
+:meth:`Event.fired <cocotb.triggers.Event.fired>` is deprecated. Use :meth:`~cocotb.triggers.Event.is_set` instead.

--- a/tests/test_cases/test_cocotb/test_async_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_async_coroutines.py
@@ -4,6 +4,7 @@
 """
 Test function and substitutability of async coroutines
 """
+
 import pytest
 from common import MyException
 
@@ -119,7 +120,7 @@ def test_undecorated_coroutine_start_soon(dut):
         await cocotb.triggers.Timer(1, "ns")
         ran = True
 
-    yield cocotb.start_soon(example()).join()
+    yield cocotb.start_soon(example())
     assert ran
 
 

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -47,8 +47,8 @@ async def test_unfired_first_triggers(dut):
     await wait_for_firsts()
 
     # make sure the other tasks finish
-    await fire_task.join()
-    await e1_task.join()
+    await fire_task
+    await e1_task
 
 
 @cocotb.test()
@@ -73,7 +73,7 @@ async def test_nested_first(dut):
 
     fire_task = cocotb.start_soon(fire_events())
     await wait_for_nested_first()
-    await fire_task.join()
+    await fire_task
 
 
 @cocotb.test()
@@ -127,7 +127,7 @@ async def test_combine(dut):
 
     tasks = [await cocotb.start(coro(dly)) for dly in [10, 30, 20]]
 
-    await Combine(*(t.join() for t in tasks))
+    await Combine(*tasks)
 
 
 @cocotb.test()
@@ -140,7 +140,7 @@ async def test_fork_combine(dut):
 
     tasks = [cocotb.start_soon(coro(dly)) for dly in [10, 30, 20]]
 
-    await Combine(*(t.join() for t in tasks))
+    await Combine(*tasks)
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -9,6 +9,7 @@ Tests for edge triggers
 * FallingEdge
 * ClockCycles
 """
+
 import cocotb
 from cocotb._sim_versions import RivieraVersion
 from cocotb.clock import Clock
@@ -57,7 +58,7 @@ async def test_rising_edge(dut):
     await Timer(10, "ns")
     dut.clk.value = 1
     fail_timer = Timer(1000, "ns")
-    result = await First(fail_timer, test.join())
+    result = await First(fail_timer, test)
     assert result is not fail_timer, "Test timed out"
 
 
@@ -70,7 +71,7 @@ async def test_falling_edge(dut):
     await Timer(10, "ns")
     dut.clk.value = 0
     fail_timer = Timer(1000, "ns")
-    result = await First(fail_timer, test.join())
+    result = await First(fail_timer, test)
     assert result is not fail_timer, "Test timed out"
 
 
@@ -117,7 +118,7 @@ async def test_fork_and_monitor(dut, period=1000, clocks=6):
     expect = clocks - 1
 
     while True:
-        result = await First(timer, task.join())
+        result = await First(timer, task)
         assert count <= expect, "Task didn't complete in expected time"
         if result is timer:
             dut._log.info("Count %d: Task still running" % count)
@@ -226,8 +227,8 @@ async def test_clock_cycles_forked(dut):
 
     a = cocotb.start_soon(wait_ten())
     b = cocotb.start_soon(wait_ten())
-    await a.join()
-    await b.join()
+    await a
+    await b
 
 
 @cocotb.test(

--- a/tests/test_cases/test_cocotb/test_generator_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_generator_coroutines.py
@@ -183,7 +183,7 @@ def test_exceptions_forked(dut):
     def raise_soon():
         yield Timer(1)
         coro = cocotb.start_soon(raise_inner())
-        yield coro.join()
+        yield coro
 
     yield _check_traceback(
         raise_soon(), ValueError, r".*in raise_soon.*in raise_inner", re.DOTALL

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -221,13 +221,13 @@ async def test_external_from_start_soon(dut):
     cocotb.start_soon(Clock(dut.clk, 100, units="ns").start())
 
     coro1 = cocotb.start_soon(run_function(dut))
-    value = await coro1.join()
+    value = await coro1
     assert value == 2
     dut._log.info("Back from join 1")
 
     value = 0
     coro2 = cocotb.start_soon(run_external(dut))
-    value = await coro2.join()
+    value = await coro2
     assert value == 2
     dut._log.info("Back from join 2")
 
@@ -338,7 +338,7 @@ async def test_function_from_weird_thread_fails(dut):
     assert not func_started, "Function should never have started"
     assert raised, "No exception was raised to warn the user"
 
-    await task.join()
+    await task
 
 
 @cocotb.test()

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -77,4 +77,4 @@ async def dual_iteration(dut):
     loop_one = cocotb.start_soon(iteration_loop(dut))
     loop_two = cocotb.start_soon(iteration_loop(dut))
 
-    await First(loop_one.join(), loop_two.join())
+    await First(loop_one, loop_two)


### PR DESCRIPTION
This includes deprecations for "public" APIs on `Trigger`s ported from #3851, #3931, and #3969. The changes to "private" APIs are not included since they are a PITA.