### PR TITLE
stable/1.9 backports (part 2)

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -132,10 +132,10 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "master",  # Only master supported for now
+        "sim-version": "r1.11.0",
         "os": "ubuntu-latest",
         "python-version": "3.8",
-        "group": "experimental",
+        "group": "ci",
     },
     # Test Verilator on Ubuntu
     {

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -132,7 +132,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.11.0",
+        "sim-version": "r1.11.3",
         "os": "ubuntu-latest",
         "python-version": "3.8",
         "group": "ci",

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -128,6 +128,15 @@ ENVS = [
         "python-version": "3.8",
         "group": "experimental",
     },
+    # Test NVC on Ubuntu
+    {
+        "lang": "vhdl",
+        "sim": "nvc",
+        "sim-version": "master",  # Only master supported for now
+        "os": "ubuntu-latest",
+        "python-version": "3.8",
+        "group": "experimental",
+    },
     # Test Verilator on Ubuntu
     {
         "lang": "verilog",

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -157,7 +157,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && matrix.sim == 'nvc'
       run: |
         sudo apt install -y --no-install-recommends llvm-dev libdw-dev flex
-        git clone https://github.com/nickg/nvc.git
+        git clone --depth=1 --no-single-branch https://github.com/nickg/nvc.git
         cd nvc
         git reset --hard ${{matrix.sim-version}}
         ./autogen.sh

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -152,6 +152,21 @@ jobs:
         make -j $(nproc)
         sudo make install
 
+      # Install NVC
+    - name: Set up NVC (Ubuntu)
+      if: startsWith(matrix.os, 'ubuntu') && matrix.sim == 'nvc'
+      run: |
+        sudo apt install -y --no-install-recommends llvm-dev libdw-dev flex
+        git clone https://github.com/nickg/nvc.git
+        cd nvc
+        git reset --hard ${{matrix.sim-version}}
+        ./autogen.sh
+        mkdir build
+        cd build
+        ../configure
+        make -j $(nproc)
+        sudo make install
+
       # Install Verilator
     - name: Set up Verilator (Ubunutu - source)
       if: startsWith(matrix.os, 'ubuntu') && matrix.sim == 'verilator'

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -403,7 +403,7 @@ class HierarchyArrayObject(RegionObject):
 
         result = re.match(rf"{self._name}__(?P<index>\d+)$", name)
         if not result:
-            result = re.match(rf"{self._name}\((?P<index>\d+)\)$", name)
+            result = re.match(rf"{self._name}\((?P<index>\d+)\)$", name, re.IGNORECASE)
         if not result:
             result = re.match(rf"{self._name}\[(?P<index>\d+)\]$", name)
 

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -492,7 +492,7 @@ class Icarus(Simulator):
             f.write("+timescale+{}/{}\n".format(*self.timescale))
 
     def _create_iverilog_dump_file(self) -> None:
-        dumpfile_path = self.build_dir / f"{self.hdl_toplevel}.fst"
+        dumpfile_path = Path(self.build_dir, f"{self.hdl_toplevel}.fst").as_posix()
         with open(self.iverilog_dump_file, "w") as f:
             f.write("module cocotb_iverilog_dump();\n")
             f.write("initial begin\n")

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -1056,6 +1056,16 @@ class Xcelium(Simulator):
         else:
             xrun_top = self.sim_hdl_toplevel
 
+        if self.waves:
+            input_tcl = [
+                f'-input "@database -open cocotb_waves -default" '
+                f'-input "@probe -database cocotb_waves -create {xrun_top} -all -depth all" '
+                f'-input "@run" '
+                f'-input "@exit" '
+            ]
+        else:
+            input_tcl = ["-input", "@run; exit;"]
+
         cmds = [["mkdir", "-p", tmpdir]]
         cmds += [
             ["xrun"]
@@ -1071,15 +1081,7 @@ class Xcelium(Simulator):
             + self.test_args
             + self.plusargs
             + ["-gui" if self.gui else ""]
-            + ["-input"]
-            + [
-                f'-input "@database -open cocotb_waves -default" '
-                f'-input "@probe -database cocotb_waves -create {xrun_top} -all -depth all" '
-                f'-input "@run" '
-                f'-input "@exit" '
-                if self.waves
-                else "@run; exit;"
-            ]
+            + input_tcl
         ]
         self.env["GPI_EXTRA"] = (
             cocotb.config.lib_name_path("vhpi", "xcelium") + ":cocotbvhpi_entry_point"

--- a/cocotb/runner.py
+++ b/cocotb/runner.py
@@ -151,6 +151,7 @@ class Simulator(abc.ABC):
         hdl_toplevel: Optional[str] = None,
         always: bool = False,
         build_dir: PathLike = "sim_build",
+        clean: bool = False,
         verbose: bool = False,
     ) -> None:
         """Build the HDL sources.
@@ -166,10 +167,14 @@ class Simulator(abc.ABC):
             hdl_toplevel: The name of the HDL toplevel module.
             always: Always run the build step.
             build_dir: Directory to run the build step in.
+            clean: Delete build_dir before building
             verbose: Enable verbose messages.
         """
 
+        self.clean: bool = clean
         self.build_dir = get_abs_path(build_dir)
+        if self.clean:
+            self.rm_build_folder(self.build_dir)
         os.makedirs(self.build_dir, exist_ok=True)
 
         # note: to avoid mutating argument defaults, we ensure that no value
@@ -362,6 +367,11 @@ class Simulator(abc.ABC):
                 raise SystemExit(
                     f"Process {process.args[0]!r} terminated with error {process.returncode}"
                 )
+
+    def rm_build_folder(self, build_dir: Path):
+        if os.path.isdir(build_dir):
+            print("Removing:", build_dir)
+            shutil.rmtree(build_dir, ignore_errors=True)
 
 
 def get_results(results_xml_file: Path) -> Tuple[int, int]:

--- a/cocotb/share/lib/fli/FliImpl.cpp
+++ b/cocotb/share/lib/fli/FliImpl.cpp
@@ -349,7 +349,7 @@ GpiObjHdl *FliImpl::native_check_create(const std::string &name,
             if (acc_fetch_fulltype(rgn) == accForGenerate) {
                 std::string rgn_name =
                     mti_GetRegionName(static_cast<mtiRegionIdT>(rgn));
-                if (rgn_name.compare(0, name.length(), name) == 0) {
+                if (compare_generate_labels(rgn_name, name)) {
                     FliObj *fli_obj = dynamic_cast<FliObj *>(parent);
                     return create_gpi_obj_from_handle(
                         parent->get_handle<HANDLE>(), name, fq_name,
@@ -631,6 +631,14 @@ GpiIterator *FliImpl::iterate_handle(GpiObjHdl *obj_hdl,
     return new_iter;
 }
 
+bool FliImpl::compare_generate_labels(const std::string &a,
+                                      const std::string &b) {
+    /* Compare two generate labels for equality ignoring any suffixed index. */
+    std::size_t a_idx = a.rfind("(");
+    std::size_t b_idx = b.rfind("(");
+    return a.substr(0, a_idx) == b.substr(0, b_idx);
+}
+
 decltype(FliIterator::iterate_over) FliIterator::iterate_over = [] {
     std::initializer_list<FliIterator::OneToMany> region_options = {
         FliIterator::OTM_CONSTANTS,
@@ -783,8 +791,8 @@ GpiIterator::Status FliIterator::next_handle(std::string &name, GpiObjHdl **hdl,
                 if (acc_fetch_fulltype(obj) == accForGenerate) {
                     std::string rgn_name =
                         mti_GetRegionName(static_cast<mtiRegionIdT>(obj));
-                    if (rgn_name.compare(0, parent_name.length(),
-                                         parent_name) != 0) {
+                    if (!FliImpl::compare_generate_labels(rgn_name,
+                                                          parent_name)) {
                         obj = NULL;
                         continue;
                     }

--- a/cocotb/share/lib/fli/FliImpl.h
+++ b/cocotb/share/lib/fli/FliImpl.h
@@ -448,6 +448,9 @@ class FliImpl : public GpiImplInterface {
                                           const std::string &fq_name,
                                           int accType, int accFullType);
 
+    static bool compare_generate_labels(const std::string &a,
+                                        const std::string &b);
+
   private:
     bool isValueConst(int kind);
     bool isValueLogic(mtiTypeIdT type);

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -240,7 +240,7 @@ int VhpiArrayObjHdl::initialise(const std::string &name,
 int VhpiObjHdl::initialise(const std::string &name,
                            const std::string &fq_name) {
     vhpiHandleT handle = GpiObjHdl::get_handle<vhpiHandleT>();
-    if (handle != NULL) {
+    if (handle != NULL && m_type != GPI_STRUCTURE) {
         vhpiHandleT du_handle = vhpi_handle(vhpiDesignUnit, handle);
         if (du_handle != NULL) {
             vhpiHandleT pu_handle = vhpi_handle(vhpiPrimaryUnit, du_handle);

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -1086,8 +1086,8 @@ GpiIterator::Status VhpiIterator::next_handle(std::string &name,
             if (obj != NULL && obj_type == GPI_GENARRAY) {
                 if (vhpi_get(vhpiKindP, obj) == vhpiForGenerateK) {
                     std::string rgn_name = vhpi_get_str(vhpiCaseNameP, obj);
-                    if (rgn_name.compare(0, parent_name.length(),
-                                         parent_name) != 0) {
+                    if (!VhpiImpl::compare_generate_labels(rgn_name,
+                                                           parent_name)) {
                         obj = NULL;
                         continue;
                     }

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -294,6 +294,7 @@ int VhpiSignalObjHdl::initialise(const std::string &name,
     switch (m_value.format) {
         case vhpiIntVal:
         case vhpiEnumVal:
+        case vhpiSmallEnumVal:
         case vhpiRealVal:
         case vhpiCharVal: {
             break;
@@ -600,6 +601,11 @@ int VhpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action_t action) {
         case vhpiLogicVal:
         case vhpiEnumVal: {
             m_value.value.enumv = static_cast<vhpiEnumT>(value);
+            break;
+        }
+
+        case vhpiSmallEnumVal: {
+            m_value.value.smallenumv = static_cast<vhpiSmallEnumT>(value);
             break;
         }
 

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -294,16 +294,6 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl,
     vhpiHandleT query_hdl = (base_hdl != NULL) ? base_hdl : new_hdl;
 
     vhpiIntT base_type = vhpi_get(vhpiKindP, query_hdl);
-    vhpiIntT is_static = vhpi_get(vhpiStaticnessP, query_hdl);
-
-    /* Non locally static objects are not accessible for read/write
-       so we create this as a GpiObjType
-    */
-    if (is_static == vhpiGloballyStatic) {
-        gpi_type = GPI_MODULE;
-        goto create;
-    }
-
     switch (base_type) {
         case vhpiArrayTypeDeclK: {
             vhpiIntT num_dim = vhpi_get(vhpiNumDimensionsP, query_hdl);
@@ -440,6 +430,16 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl,
         }
 
         default: {
+            vhpiIntT is_static = vhpi_get(vhpiStaticnessP, query_hdl);
+
+            /* Non locally static objects are not accessible for read/write
+               so we create this as a GpiObjType
+            */
+            if (is_static == vhpiGloballyStatic) {
+                gpi_type = GPI_MODULE;
+                break;
+            }
+
             LOG_ERROR("VHPI: Not able to map type (%s) %u to object",
                       vhpi_get_str(vhpiKindStrP, query_hdl), type);
             new_obj = NULL;
@@ -447,7 +447,6 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl,
         }
     }
 
-create:
     LOG_DEBUG("VHPI: Creating %s of type %d (%s)",
               vhpi_get_str(vhpiFullCaseNameP, new_hdl), gpi_type,
               vhpi_get_str(vhpiKindStrP, query_hdl));

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -49,6 +49,7 @@ const char *VhpiImpl::format_to_string(int format) {
         CASE_STR(vhpiDecStrVal);
         CASE_STR(vhpiHexStrVal);
         CASE_STR(vhpiEnumVal);
+        CASE_STR(vhpiSmallEnumVal);
         CASE_STR(vhpiIntVal);
         CASE_STR(vhpiLogicVal);
         CASE_STR(vhpiRealVal);

--- a/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -551,7 +551,7 @@ GpiObjHdl *VhpiImpl::native_check_create(const std::string &name,
             for (rgn = vhpi_scan(iter); rgn != NULL; rgn = vhpi_scan(iter)) {
                 if (vhpi_get(vhpiKindP, rgn) == vhpiForGenerateK) {
                     std::string rgn_name = vhpi_get_str(vhpiCaseNameP, rgn);
-                    if (rgn_name.compare(0, name.length(), name) == 0) {
+                    if (compare_generate_labels(rgn_name, name)) {
                         new_hdl = vhpi_hdl;
                         vhpi_release_handle(iter);
                         break;
@@ -985,6 +985,14 @@ void VhpiImpl::sim_end() {
         vhpi_control(vhpiFinish, vhpiDiagTimeLoc);
         check_vhpi_error();
     }
+}
+
+bool VhpiImpl::compare_generate_labels(const std::string &a,
+                                       const std::string &b) {
+    /* Compare two generate labels for equality ignoring any suffixed index. */
+    std::size_t a_idx = a.rfind(GEN_IDX_SEP_LHS);
+    std::size_t b_idx = b.rfind(GEN_IDX_SEP_LHS);
+    return a.substr(0, a_idx) == b.substr(0, b_idx);
 }
 
 extern "C" {

--- a/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -303,6 +303,9 @@ class VhpiImpl : public GpiImplInterface {
                                           const std::string &name,
                                           const std::string &fq_name);
 
+    static bool compare_generate_labels(const std::string &a,
+                                        const std::string &b);
+
   private:
     VhpiReadWriteCbHdl m_read_write;
     VhpiNextPhaseCbHdl m_next_phase;

--- a/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -765,8 +765,8 @@ GpiIterator::Status VpiIterator::next_handle(std::string &name, GpiObjHdl **hdl,
             if (obj != NULL && obj_type == GPI_GENARRAY) {
                 if (vpi_get(vpiType, obj) == vpiGenScope) {
                     std::string rgn_name = vpi_get_str(vpiName, obj);
-                    if (rgn_name.compare(0, parent_name.length(),
-                                         parent_name) != 0) {
+                    if (!VpiImpl::compare_generate_labels(rgn_name,
+                                                          parent_name)) {
                         obj = NULL;
                         continue;
                     }

--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -631,6 +631,14 @@ void VpiImpl::sim_end() {
     }
 }
 
+bool VpiImpl::compare_generate_labels(const std::string &a,
+                                      const std::string &b) {
+    /* Compare two generate labels for equality ignoring any suffixed index. */
+    std::size_t a_idx = a.rfind("[");
+    std::size_t b_idx = b.rfind("[");
+    return a.substr(0, a_idx) == b.substr(0, b_idx);
+}
+
 extern "C" {
 
 // Main re-entry point for callbacks from simulator

--- a/cocotb/share/lib/vpi/VpiImpl.h
+++ b/cocotb/share/lib/vpi/VpiImpl.h
@@ -292,6 +292,9 @@ class VpiImpl : public GpiImplInterface {
                                           const std::string &name,
                                           const std::string &fq_name);
 
+    static bool compare_generate_labels(const std::string &a,
+                                        const std::string &b);
+
   private:
     /* Singleton callbacks */
     VpiReadWriteCbHdl m_read_write;

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -60,7 +60,7 @@ VHDL_SOURCES              A list of the VHDL source files to include
 VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/ModelSim/Questa/Xcelium/Incisive only)
 VHDL_LIB_ORDER            Compilation order of VHDL libraries (needed for ModelSim/Questa/Xcelium/Incisive)
 SIM_CMD_PREFIX            Prefix for simulation command invocations
-COMPILE_ARGS              Arguments to pass to compile stage of simulation
+COMPILE_ARGS              Arguments to pass to compile (analysis) stage of simulation
 SIM_ARGS                  Arguments to pass to execution of compiled simulation
 EXTRA_ARGS                Arguments for compile and execute phases
 PLUSARGS                  Plusargs to pass to the simulator

--- a/cocotb/share/makefiles/Makefile.sim
+++ b/cocotb/share/makefiles/Makefile.sim
@@ -57,8 +57,8 @@ SIM                       Selects which simulator Makefile to use
 WAVES                     Enable wave traces dump for Riviera-PRO and Questa
 VERILOG_SOURCES           A list of the Verilog source files to include
 VHDL_SOURCES              A list of the VHDL source files to include
-VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/ModelSim/Questa/Xcelium/Incisive only)
-VHDL_LIB_ORDER            Compilation order of VHDL libraries (needed for ModelSim/Questa/Xcelium/Incisive)
+VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/NVC/ModelSim/Questa/Xcelium/Incisive only)
+VHDL_LIB_ORDER            Compilation order of VHDL libraries (needed for NVC/ModelSim/Questa/Xcelium/Incisive)
 SIM_CMD_PREFIX            Prefix for simulation command invocations
 COMPILE_ARGS              Arguments to pass to compile (analysis) stage of simulation
 SIM_ARGS                  Arguments to pass to execution of compiled simulation

--- a/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -41,13 +41,19 @@ NVC_R_ARGS := $(filter-out $(NVC_E_FILTER),$(SIM_ARGS))
 
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD) $(CUSTOM_COMPILE_DEPS)
-	$(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) -a $(VHDL_SOURCES) $(COMPILE_ARGS)
+	# Make sure all libs in SOURCES_VHDL_* are mentioned in VHDL_LIB_ORDER and vice versa
+	$(foreach LIB, $(VHDL_LIB_ORDER), $(check_vhdl_sources))
+	$(foreach SOURCES_VAR, $(filter VHDL_SOURCES_%, $(.VARIABLES)), $(check_lib_order))
+
+	$(foreach LIB_VAR,$(VHDL_LIB_ORDER), \
+		$(CMD) $(EXTRA_ARGS) --work=$(LIB_VAR):$(SIM_BUILD)/$(LIB_VAR) -L $(SIM_BUILD) -a $(VHDL_SOURCES_$(LIB_VAR)) $(COMPILE_ARGS) && ) \
+	$(CMD) $(EXTRA_ARGS) --work=$(RTL_LIBRARY):$(SIM_BUILD)/$(RTL_LIBRARY) -L $(SIM_BUILD) -a $(VHDL_SOURCES) $(COMPILE_ARGS)
 
 $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)
 
 	TESTCASE=$(TESTCASE) MODULE=$(MODULE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	  $(SIM_CMD_PREFIX) $(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) \
+	  $(SIM_CMD_PREFIX) $(CMD) $(EXTRA_ARGS) --work=$(RTL_LIBRARY):$(SIM_BUILD)/$(RTL_LIBRARY) -L $(SIM_BUILD) \
 	  -e $(TOPLEVEL) --no-save $(NVC_E_ARGS) \
 	  -r --load $(shell cocotb-config --lib-name-path vhpi nvc) $(TRACE) $(NVC_R_ARGS) $(PLUSARGS)
 

--- a/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -32,6 +32,13 @@ RTL_LIBRARY ?= work
 
 .PHONY: analyse
 
+# Split SIM_ARGS into those options that need to be passed to -e and
+# those that need to be passed to -r
+NVC_E_FILTER := -g%
+
+NVC_E_ARGS := $(filter $(NVC_E_FILTER),$(SIM_ARGS))
+NVC_R_ARGS := $(filter-out $(NVC_E_FILTER),$(SIM_ARGS))
+
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD) $(CUSTOM_COMPILE_DEPS)
 	$(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) -a $(VHDL_SOURCES) $(COMPILE_ARGS)
@@ -41,8 +48,8 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 
 	TESTCASE=$(TESTCASE) MODULE=$(MODULE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	  $(SIM_CMD_PREFIX) $(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) \
-	  -e $(TOPLEVEL) --no-save \
-	  -r --load $(shell cocotb-config --lib-name-path vhpi nvc) $(TRACE) $(SIM_ARGS) $(PLUSARGS)
+	  -e $(TOPLEVEL) --no-save $(NVC_E_ARGS) \
+	  -r --load $(shell cocotb-config --lib-name-path vhpi nvc) $(TRACE) $(NVC_R_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 

--- a/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -34,7 +34,7 @@ RTL_LIBRARY ?= work
 
 # Split SIM_ARGS into those options that need to be passed to -e and
 # those that need to be passed to -r
-NVC_E_FILTER := -g%
+NVC_E_FILTER := -g% --cover --cover=%
 
 NVC_E_ARGS := $(filter $(NVC_E_FILTER),$(SIM_ARGS))
 NVC_R_ARGS := $(filter-out $(NVC_E_FILTER),$(SIM_ARGS))

--- a/cocotb/share/makefiles/simulators/Makefile.nvc
+++ b/cocotb/share/makefiles/simulators/Makefile.nvc
@@ -1,4 +1,6 @@
-# -*- mode: makefile-gmake -*-
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
 
 include $(shell cocotb-config --makefiles)/Makefile.inc
 
@@ -30,23 +32,20 @@ RTL_LIBRARY ?= work
 
 .PHONY: analyse
 
-VHPI_LIB := $(shell cocotb-config --lib-name-path vhpi nvc)
-
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD) $(CUSTOM_COMPILE_DEPS)
-	cd $(SIM_BUILD) && $(CMD) --work=$(RTL_LIBRARY) -a $(VHDL_SOURCES) $(COMPILE_ARGS) $(EXTRA_ARGS)
+	$(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) -a $(VHDL_SOURCES) $(COMPILE_ARGS)
 
 $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
-	-@rm -f $(COCOTB_RESULTS_FILE)
+	$(RM) $(COCOTB_RESULTS_FILE)
 
-	cd $(SIM_BUILD) && \
-		$(CMD) --work=$(RTL_LIBRARY) -e $(TOPLEVEL)
-	cd $(SIM_BUILD) && MODULE=$(MODULE) \
-		TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) COCOTB_SIM=1 \
-		$(CMD) $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS) --work=$(RTL_LIBRARY) -r --load $(VHPI_LIB) $(TRACE) $(TOPLEVEL)
+	TESTCASE=$(TESTCASE) MODULE=$(MODULE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
+	  $(SIM_CMD_PREFIX) $(CMD) $(EXTRA_ARGS) --work=$(SIM_BUILD)/$(RTL_LIBRARY) \
+	  -e $(TOPLEVEL) --no-save \
+	  -r --load $(shell cocotb-config --lib-name-path vhpi nvc) $(TRACE) $(SIM_ARGS) $(PLUSARGS)
 
 	$(call check_for_results_file)
 
 clean::
-	-@rm -rf $(SIM_BUILD)
+	$(RM) -r $(SIM_BUILD)
 endif

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -310,7 +310,7 @@ The following variables are makefile variables, not environment variables.
 
 .. make:var:: COMPILE_ARGS
 
-      Any arguments or flags to pass to the compile stage of the simulation.
+      Any arguments or flags to pass to the compile (analysis) stage of the simulation.
 
 .. make:var:: SIM_ARGS
 

--- a/documentation/source/custom_flows.rst
+++ b/documentation/source/custom_flows.rst
@@ -170,6 +170,14 @@ GHDL
 * Extend the ``ghdl -r`` call with the option
   ``--vpi=$(cocotb-config --lib-name-path vpi ghdl)``.
 
+.. _custom-flows-nvc:
+
+NVC
+===
+
+* Extend the ``nvc -r`` call with the option
+  ``--load=$(cocotb-config --lib-name-path vhpi nvc)``.
+
 .. _custom-flows-cvc:
 
 Tachyon DA CVC

--- a/documentation/source/newsfragments/2255.bugfix.rst
+++ b/documentation/source/newsfragments/2255.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a potential issue where pseudo-region lookup may find the wrong
+generate block if the name of one generate block starts with the name of
+another generate block.

--- a/documentation/source/newsfragments/3351.feature.rst
+++ b/documentation/source/newsfragments/3351.feature.rst
@@ -1,0 +1,1 @@
+Add `clean` argument to :ref:`Python Test Runner <howto-python-runner>` to remove build_dir completely during runner.build() stage

--- a/documentation/source/newsfragments/3427.feature.rst
+++ b/documentation/source/newsfragments/3427.feature.rst
@@ -1,0 +1,2 @@
+Add experimental support for the `NVC <https://github.com/nickg/nvc>`_
+VHDL simulator.

--- a/documentation/source/newsfragments/3427.feature.rst
+++ b/documentation/source/newsfragments/3427.feature.rst
@@ -1,2 +1,1 @@
-Add experimental support for the `NVC <https://github.com/nickg/nvc>`_
-VHDL simulator.
+Add support for the `NVC <https://github.com/nickg/nvc>`_ VHDL simulator.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -398,6 +398,39 @@ Issues for this simulator
 
 * `All issues with label category:simulators:nvc <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Anvc>`_
 
+Coverage
+--------
+
+To enable code coverage, add ``--cover`` to :make:var:`SIM_ARGS`, for example
+in a Makefile:
+
+.. code-block:: make
+
+    SIM_ARGS += --cover
+
+Specifying types of coverage is also supported.
+For example, to collect statement and branch coverage:
+
+.. code-block:: make
+
+    SIM_ARGS += --cover=statement,branch
+
+The ``covdb`` files will be placed in the :make:var:`RTL_LIBRARY` subdirectory of :make:var:`SIM_BUILD`.
+For instructions on how to specify coverage types and produce a report, refer to `NVC's code coverage documentation <https://www.nickg.me.uk/nvc/manual.html#CODE_COVERAGE>`_.
+
+.. _sim-nvc-waveforms:
+
+Waveforms
+---------
+
+To get waveforms in FST format, set the :make:var:`SIM_ARGS` option to ``--wave=anyname.fst``, for example in a Makefile:
+
+.. code-block:: make
+
+    SIM_ARGS += --wave=anyname.fst
+
+:make:var:`SIM_ARGS` can also be used to set the waveform output to VCD by adding ``--format=vcd``.
+
 
 .. _sim-cvc:
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -379,11 +379,9 @@ A VCD file named :file:`anyname.vcd` will be generated in the current directory.
 NVC
 ===
 
-.. warning::
+.. note::
 
-    NVC support in cocotb is experimental.
-    Some features of cocotb may not work correctly or at all.
-    A current master build of NVC is required.
+    NVC version **1.11.0** or later is required.
 
 In order to use this simulator, set :make:var:`SIM` to ``nvc``:
 

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -379,13 +379,24 @@ A VCD file named :file:`anyname.vcd` will be generated in the current directory.
 NVC
 ===
 
+.. warning::
+
+    NVC support in cocotb is experimental.
+    Some features of cocotb may not work correctly or at all.
+    A current master build of NVC is required.
+
 In order to use this simulator, set :make:var:`SIM` to ``nvc``:
 
 .. code-block:: bash
 
     make SIM=nvc
 
-To enable display of VHPI traces, use ``SIM_ARGS=--vhpi-trace make ...``.
+.. _sim-nvc-issues:
+
+Issues for this simulator
+-------------------------
+
+* `All issues with label category:simulators:nvc <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Anvc>`_
 
 
 .. _sim-cvc:

--- a/examples/matrix_multiplier/tests/Makefile
+++ b/examples/matrix_multiplier/tests/Makefile
@@ -18,7 +18,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     # Set module parameters
     ifeq ($(SIM),icarus)
         COMPILE_ARGS += -Pmatrix_multiplier.DATA_WIDTH=$(DATA_WIDTH) -Pmatrix_multiplier.A_ROWS=$(A_ROWS) -Pmatrix_multiplier.B_COLUMNS=$(B_COLUMNS) -Pmatrix_multiplier.A_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
-    else ifneq ($(filter $(SIM),questa modelsim riviera activehdl),)
+    else ifneq ($(filter $(SIM),questa modelsim riviera activehdl nvc),)
         SIM_ARGS += -gDATA_WIDTH=$(DATA_WIDTH) -gA_ROWS=$(A_ROWS) -gB_COLUMNS=$(B_COLUMNS) -gA_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
     else ifeq ($(SIM),vcs)
         COMPILE_ARGS += -pvalue+matrix_multiplier/DATA_WIDTH=$(DATA_WIDTH) -pvalue+matrix_multiplier/A_ROWS=$(A_ROWS) -pvalue+matrix_multiplier/B_COLUMNS=$(B_COLUMNS) -pvalue+matrix_multiplier/A_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
@@ -45,6 +45,9 @@ else ifeq ($(TOPLEVEL_LANG),vhdl)
     ifeq ($(SIM),ghdl)
         EXTRA_ARGS += --std=08
         SIM_ARGS += --wave=wave.ghw
+    else ifeq ($(SIM),nvc)
+        EXTRA_ARGS += --std=08
+        SIM_ARGS += --wave=wave.fst
     else ifneq ($(filter $(SIM),ius xcelium),)
         COMPILE_ARGS += -v200x
     else ifneq ($(filter $(SIM),questa modelsim riviera activehdl),)

--- a/examples/matrix_multiplier/tests/Makefile
+++ b/examples/matrix_multiplier/tests/Makefile
@@ -35,7 +35,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES = $(PWD)/../hdl/matrix_multiplier_pkg.vhd $(PWD)/../hdl/matrix_multiplier.vhd
 
-    ifneq ($(filter $(SIM),ghdl questa modelsim riviera activehdl),)
+    ifneq ($(filter $(SIM),ghdl questa modelsim riviera activehdl nvc),)
         # ghdl, questa, and aldec all use SIM_ARGS with '-g' for setting generics
         SIM_ARGS += -gDATA_WIDTH=$(DATA_WIDTH) -gA_ROWS=$(A_ROWS) -gB_COLUMNS=$(B_COLUMNS) -gA_COLUMNS_B_ROWS=$(A_COLUMNS_B_ROWS)
     else ifneq ($(filter $(SIM),ius xcelium),)

--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -242,6 +242,8 @@ def test_matrix_multiplier_runner():
 
         if sim in ["questa", "modelsim", "riviera", "activehdl"]:
             build_args = ["-2008"]
+        elif sim == "nvc":
+            build_args = ["--std=08"]
     else:
         raise ValueError(
             f"A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG={hdl_toplevel_lang}"

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -119,7 +119,7 @@ sim = os.getenv("SIM", "icarus")
 
 
 @pytest.mark.skipif(
-    sim in ["icarus", "ghdl", "verilator"],
+    sim in ["icarus", "ghdl", "verilator", "nvc"],
     reason=f"Skipping example mixed_language since {sim} doesn't support this",
 )
 def test_mixed_language_runner():

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,6 +58,7 @@ def simulator_support_matrix() -> List[Tuple[str, str, str]]:
         ("cvc", "verilog", "vpi"),
         ("ghdl", "vhdl", "vpi"),
         ("icarus", "verilog", "vpi"),
+        ("nvc", "vhdl", "vhpi"),
         ("questa", "verilog", "vpi"),
         ("questa", "vhdl", "fli"),
         ("questa", "vhdl", "vhpi"),

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -27,7 +27,9 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //-----------------------------------------------------------------------------
 
+`ifndef NOTIMESCALE
 `timescale 1 ps / 1 ps
+`endif
 
 `ifndef __ICARUS__
 typedef struct packed
@@ -117,10 +119,12 @@ test_if struct_var;
 
 and test_and_gate(and_output, stream_in_ready, stream_in_valid);
 
+`ifndef NODUMPFILE
 initial begin
     $dumpfile("waveform.vcd");
     $dumpvars(0,sample_module);
 end
+`endif
 
 parameter NUM_OF_MODULES = 4;
 reg[NUM_OF_MODULES-1:0] temp;

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -59,6 +59,8 @@ if sim == "questa":
     sim_args = ["-t", "ps"]
 elif sim == "xcelium":
     compile_args = ["-v93"]
+elif sim == "nvc":
+    compile_args = ["--std=08"]
 
 hdl_toplevel = "sample_module"
 sys.path.insert(0, os.path.join(tests_dir, "test_cases", "test_cocotb"))

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -46,6 +46,8 @@ def test_cocotb_parallel(seed):
 
     runner = get_runner(sim)
 
+    runner.build_args = compile_args
+
     runner.test(
         seed=seed,
         hdl_toplevel_lang=hdl_toplevel_lang,

--- a/tests/pytest/test_timescale.py
+++ b/tests/pytest/test_timescale.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import tempfile
+
+import pytest
+from test_cocotb import (
+    compile_args,
+    gpi_interfaces,
+    hdl_toplevel,
+    hdl_toplevel_lang,
+    sim,
+    sim_args,
+    sim_build,
+    tests_dir,
+    verilog_sources,
+    vhdl_sources,
+)
+
+from cocotb.runner import get_runner
+from cocotb.utils import _get_log_time_scale
+
+sys.path.insert(0, os.path.join(tests_dir, "pytest"))
+
+cocotb_test_contents = """
+import cocotb
+from cocotb.utils import _get_simulator_precision
+
+@cocotb.test()
+async def check_timescale(dut):
+    assert _get_simulator_precision() == {precision}
+"""
+
+
+@pytest.mark.simulator_required
+@pytest.mark.skipif(
+    os.getenv("SIM", "icarus") != "icarus",
+    reason="Currently only Icarus simulator supports timescale setting when using Cocotb runner",
+)
+@pytest.mark.parametrize("precision", ["fs", "ps", "ns", "us", "ms", "s"])
+def test_precision(precision):
+    build_dir = os.path.join(sim_build, "test_timescale_{}".format(precision))
+
+    timescale = (f"1{precision}", f"1{precision}")
+    precision_log = _get_log_time_scale(precision if precision != "s" else "sec")
+
+    with tempfile.TemporaryDirectory() as d:
+        sys.path.insert(0, d)
+        test_module_path = os.path.join(d, "test_precision.py")
+        test_module = os.path.basename(os.path.splitext(test_module_path)[0])
+        with open(test_module_path, "w") as f:
+            f.write(cocotb_test_contents.format(precision=precision_log))
+            f.flush()
+
+        runner = get_runner(sim)
+        runner.build(
+            always=True,
+            clean=True,
+            verilog_sources=verilog_sources,
+            vhdl_sources=vhdl_sources,
+            hdl_toplevel=hdl_toplevel,
+            build_dir=build_dir,
+            build_args=compile_args,
+            defines={"NOTIMESCALE": 1},
+            timescale=timescale,
+        )
+
+        runner.test(
+            hdl_toplevel_lang=hdl_toplevel_lang,
+            hdl_toplevel=hdl_toplevel,
+            gpi_interfaces=gpi_interfaces,
+            test_module=test_module,
+            test_args=sim_args,
+            build_dir=build_dir,
+        )

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -21,6 +21,7 @@ from cocotb.triggers import ClockCycles
 
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
 test_module = os.path.basename(os.path.splitext(__file__)[0])
+sim = os.getenv("SIM", "icarus")
 
 
 @cocotb.test()
@@ -57,10 +58,15 @@ def run_simulation(sim):
 
 @pytest.mark.simulator_required
 @pytest.mark.skipif(
-    os.getenv("SIM", "icarus") != "icarus",
-    reason="Skipping test because it is only for Icarus simulator",
+    sim not in ["icarus", "xcelium"],
+    reason="Skipping test because it is only for Icarus or Xcelium simulators",
 )
-def test_iverilog():
-    run_simulation(sim="icarus")
-    dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")
+def test_wave_dump():
+    run_simulation(sim=sim)
+    if sim == "icarus":
+        dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")
+    elif sim == "xcelium":
+        dumpfile_path = os.path.join(sim_build, "cocotb_waves.shm", "cocotb_waves.trn")
+    else:
+        raise RuntimeError("Not a supported simulator")
     assert os.path.exists(dumpfile_path)

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+import pytest
+from test_cocotb import (
+    compile_args,
+    gpi_interfaces,
+    hdl_toplevel,
+    hdl_toplevel_lang,
+    sim_args,
+    sim_build,
+    tests_dir,
+    verilog_sources,
+    vhdl_sources,
+)
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.runner import get_runner
+from cocotb.triggers import ClockCycles
+
+sys.path.insert(0, os.path.join(tests_dir, "pytest"))
+test_module = os.path.basename(os.path.splitext(__file__)[0])
+
+
+@cocotb.test()
+async def clock_design(dut):
+    clock = Clock(dut.clk, 10, units="us")
+    cocotb.start_soon(clock.start())
+    await ClockCycles(dut.clk, 10)
+
+
+def run_simulation(sim):
+    runner = get_runner(sim)
+    runner.build(
+        always=True,
+        clean=True,
+        verilog_sources=verilog_sources,
+        vhdl_sources=vhdl_sources,
+        hdl_toplevel=hdl_toplevel,
+        build_dir=sim_build,
+        build_args=compile_args,
+        defines={"NODUMPFILE": 1},
+        waves=True,
+    )
+
+    runner.test(
+        hdl_toplevel_lang=hdl_toplevel_lang,
+        hdl_toplevel=hdl_toplevel,
+        gpi_interfaces=gpi_interfaces,
+        test_module=test_module,
+        test_args=sim_args,
+        build_dir=sim_build,
+        waves=True,
+    )
+
+
+@pytest.mark.simulator_required
+@pytest.mark.skipif(
+    os.getenv("SIM", "icarus") != "icarus",
+    reason="Skipping test because it is only for Icarus simulator",
+)
+def test_iverilog():
+    run_simulation(sim="icarus")
+    dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")
+    assert os.path.exists(dumpfile_path)

--- a/tests/test_cases/issue_2255/Makefile
+++ b/tests/test_cases/issue_2255/Makefile
@@ -1,0 +1,20 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+PROJ_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+TOPLEVEL_LANG ?= verilog
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+VERILOG_SOURCES := $(PROJ_DIR)/test.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+VHDL_SOURCES := $(PROJ_DIR)/test.vhd
+endif
+
+TOPLEVEL := test
+
+export MODULE := test_issue2255
+export COCOTB_LOG_LEVEL := DEBUG
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/issue_2255/test.sv
+++ b/tests/test_cases/issue_2255/test.sv
@@ -1,0 +1,23 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+`timescale 1us/1us
+
+module test (output [15:0] o);
+
+  genvar idx1;
+  generate for (idx1 = 0; idx1 < 10; idx1 = idx1 + 1)
+    begin: foobar
+      assign o[idx1] = 1;
+    end
+  endgenerate
+
+  genvar idx2;
+  generate for (idx2 = 10; idx2 < 16; idx2 = idx2 + 1)
+    begin: foo   // Should not be confused with "foobar" which shares the same prefix
+      assign o[idx2] = 1;
+    end
+  endgenerate
+
+endmodule

--- a/tests/test_cases/issue_2255/test.vhd
+++ b/tests/test_cases/issue_2255/test.vhd
@@ -1,0 +1,23 @@
+-- Copyright cocotb contributors
+-- Licensed under the Revised BSD License, see LICENSE for details.
+-- SPDX-License-Identifier: BSD-3-Clause
+
+entity test is
+    port ( o : out bit_vector(15 downto 0) );
+end entity test;
+
+architecture rtl of test is
+begin
+
+    foobar: for i in 0 to 9 generate
+    begin
+        o(i) <= '1';
+    end generate;
+
+    -- Should not be confused with "foobar" which shares the same prefix
+    foo: for i in 10 to 15 generate
+    begin
+        o(i) <= '1';
+    end generate;
+
+end architecture rtl;

--- a/tests/test_cases/issue_2255/test_issue2255.py
+++ b/tests/test_cases/issue_2255/test_issue2255.py
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+
+import cocotb
+
+
+# GHDL doesn't discover the generate blocks
+@cocotb.test(
+    expect_error=AssertionError if cocotb.SIM_NAME.lower().startswith("ghdl") else ()
+)
+async def test_distinct_generates(dut):
+    tlog = logging.getLogger("cocotb.test")
+
+    foobar = dut.foobar
+    foo = dut.foo
+
+    tlog.info("Length of foobar is %d", len(foobar))
+    tlog.info("Length of foo is %d", len(foo))
+
+    assert len(foobar) == 10
+    assert len(foo) == 6

--- a/tests/test_cases/test_vhdl_libraries/Makefile
+++ b/tests/test_cases/test_vhdl_libraries/Makefile
@@ -12,7 +12,7 @@ ifneq ($(filter $(SIM),xcelium),)
     COMPILE_ARGS += -v93
 endif
 
-ifneq ($(filter questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
+ifneq ($(filter nvc questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
     VHDL_LIB_ORDER := blib
 endif
 
@@ -20,9 +20,9 @@ ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),vhdl)
 all:
 	@echo "Skipping test since only VHDL is supported"
 clean::
-else ifeq ($(filter ghdl questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
+else ifeq ($(filter ghdl nvc questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
 all:
-	@echo "Skipping test since only GHDL, Questa/ModelSim, Xcelium and Incisive are supported"
+	@echo "Skipping test since only GHDL, NVC, Questa/ModelSim, Xcelium and Incisive are supported"
 clean::
 else
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/test_vhdl_libraries_multiple/Makefile
+++ b/tests/test_cases/test_vhdl_libraries_multiple/Makefile
@@ -17,7 +17,7 @@ ifneq ($(filter $(SIM),xcelium),)
     COMPILE_ARGS += -v93
 endif
 
-ifneq ($(filter questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
+ifneq ($(filter nvc questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
     VHDL_LIB_ORDER := elib dlib clib blib
 endif
 
@@ -25,9 +25,9 @@ ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),vhdl)
 all:
 	@echo "Skipping test since only VHDL is supported"
 clean::
-else ifeq ($(filter ghdl questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
+else ifeq ($(filter ghdl nvc questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
 all:
-	@echo "Skipping test since only GHDL, Questa/ModelSim and Xcelium are supported"
+	@echo "Skipping test since only GHDL, NVC, Questa/ModelSim and Xcelium are supported"
 clean::
 else
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
+++ b/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
@@ -26,7 +26,7 @@ async def test_long_signal(dut):
 @cocotb.test(
     expect_error=AttributeError
     if cocotb.SIM_NAME.lower().startswith(
-        ("ghdl", "xmsim", "ncsim", "riviera", "aldec")
+        ("ghdl", "xmsim", "ncsim", "riviera", "aldec", "nvc")
     )
     or is_questa_vhpi
     else ()
@@ -39,7 +39,7 @@ async def test_read_zero_signal(dut):
 @cocotb.test(
     expect_error=AttributeError
     if cocotb.SIM_NAME.lower().startswith(
-        ("ghdl", "xmsim", "ncsim", "riviera", "aldec")
+        ("ghdl", "xmsim", "ncsim", "riviera", "aldec", "nvc")
     )
     or is_questa_vhpi
     else ()
@@ -54,7 +54,7 @@ async def test_write_zero_signal_with_0(dut):
 @cocotb.test(
     expect_error=AttributeError
     if cocotb.SIM_NAME.lower().startswith(
-        ("ghdl", "xmsim", "ncsim", "riviera", "aldec")
+        ("ghdl", "xmsim", "ncsim", "riviera", "aldec", "nvc")
     )
     or is_questa_vhpi
     else ()


### PR DESCRIPTION
Another set of stable/1.9 backports.

- **Add support for timescale and wave dumping in Icarus Verilog runner**
- **runner: Fix generating FST files on Windows when using Icarus**
- **Fix incorrect comparison of generate region labels (#3439)**
- **Case-insensitive name comparison for NVC**
- **Adjust NVC makefile to match others**
- **Add NVC arguments to matrix_multiplier Makefile**
- **Add NVC to CI regression tests**
- **Update documentation for NVC**
- **Add NVC expected failure for test_vhdl_zerovector**
- **Extract VHPI fully qualified name construction to a helper function**
- **Add a news fragment for experimental NVC support**
- **Fix tracing for Xcelium runner (#3447)**
- **Fix passing generics from NVC makefile**
- **Add additional NVC support (from #3346)**
- **NVC: Remove experimental status**
- **NVC: Fix remaining CI issues with Python runner**
- **Add support for VHDL libraries in NVC Makefile (#3599)**
