### PR TITLE
Fix instructions for extending build flow with Verilator

### DIFF
--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -38,7 +38,7 @@ Verilator
       --vpi --public-flat-rw --prefix Vtop \
       -LDFLAGS "-Wl,-rpath,$(cocotb-config --lib-dir) \
           -L$(cocotb-config --lib-dir) \
-          -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils" \
+          -lcocotbvpi_verilator" \
       $(cocotb-config --share)/lib/verilator/verilator.cpp
 
 * Run Verilator's makefile as follows: ``CPPFLAGS="-std=c++11" make -f Vtop.mk``


### PR DESCRIPTION
Documentation has not kept up with the code changes that loads the cocotb lib at runtime.