### PR TITLE
Packed struct fields

### DIFF
--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -1272,6 +1272,36 @@ class StringObject(
         return self.value.decode("ascii")
 
 
+class PackedStructObject(LogicObject, HierarchyObject):
+    """
+    Incorperates the functionality of both HierarchyObject and LogicObject
+
+    For getting struct children with a name collision, use handle["name"]
+
+    Since this class lists LogicObject first for inheritance, conflicting methods will call LogicObject's method
+    """
+
+    def __init__(self, handle, path):
+        # Use HierarchyObject because _sub_handles contains SimHandleBase, which is a broader type
+        HierarchyObject.__init__(self, handle, path)
+
+    def __getattr__(self, name: str) -> Any:
+        if name in {"value", "set", "setimmediatevalue", "is_const"}:
+            return LogicObject.__getattribute__(self, name)
+        # private properties will be resolved in HierarchyObject
+        return HierarchyObject.__getattr__(self, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "value":
+            return LogicObject.__setattr__(self, "value", value)
+
+        return HierarchyObject.__setattr__(self, name, value)
+
+    def __getitem__(self, index: str) -> SimHandleBase:
+        # we can't index into packed structs, so only support HierarchyObject's __getitem__
+        return HierarchyObject.__getitem__(self, index)
+
+
 _ConcreteHandleTypes = Union[
     HierarchyObject,
     HierarchyArrayObject,
@@ -1292,7 +1322,7 @@ _handle2obj: Dict[
 _type2cls: Dict[int, Type[_ConcreteHandleTypes]] = {
     simulator.MODULE: HierarchyObject,
     simulator.STRUCTURE: HierarchyObject,
-    simulator.PACKED_STRUCTURE: LogicObject,
+    simulator.PACKED_STRUCTURE: PackedStructObject,
     simulator.REG: LogicObject,
     simulator.NET: LogicObject,
     simulator.NETARRAY: ArrayObject[Any, ValueObjectBase[Any, Any]],

--- a/tests/test_cases/test_struct/test_struct.py
+++ b/tests/test_cases/test_struct/test_struct.py
@@ -25,7 +25,10 @@ EXPECT_VAL = "000" if SIM_NAME.startswith("verilator") else "ZZZ"
 )
 async def test_packed_struct_format(dut):
     """Test that the correct objects are returned for a struct"""
-    assert repr(dut.my_struct) == "LogicObject(sample_module.my_struct)"
+    if SIM_NAME.startswith("verilator"):
+        assert repr(dut.my_struct) == "LogicObject(sample_module.my_struct)"
+    else:
+        assert repr(dut.my_struct) == "PackedStructObject(sample_module.my_struct)"
     assert (
         repr(dut.my_struct.value)
         == f"LogicArray('{EXPECT_VAL}', Range(2, 'downto', 0))"
@@ -48,6 +51,32 @@ async def test_packed_struct_setting(dut):
     await Timer(1000, "ns")
 
     assert str(dut.my_struct.value) == "000"
+
+    if SIM_NAME.startswith("verilator"):
+        return
+
+    assert dut.my_struct.val_a.value == 0
+    assert dut.my_struct.val_b.value == 0
+    assert dut.my_struct["value"].value == 0
+
+    # test logic object fields
+    dut.my_struct.set(0)
+    dut.my_struct.setimmediatevalue(0)
+    assert dut.my_struct.is_const is False
+
+    # test individual signals -> struct
+
+    dut.my_struct.val_a.value = 1
+    dut.my_struct["value"].value = 1
+
+    await Timer(1000, "ns")
+
+    assert str(dut.my_struct.value) == "101"
+    assert dut.my_struct.val_a.value == 1
+    assert dut.my_struct.val_b.value == 0
+    assert dut.my_struct["value"].value == 1
+
+    assert len(dut.my_struct) == 3
 
 
 # GHDL unable to access record signals (gh-2591)


### PR DESCRIPTION
This adds in some of the functionality to access packed struct fields that was removed in https://github.com/cocotb/cocotb/pull/3608