### PR TITLE
Edge count callbacks.

### DIFF
--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -243,9 +243,9 @@ GPI_EXPORT gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
 GPI_EXPORT gpi_cb_hdl gpi_register_value_change_callback(
     int (*gpi_function)(void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl,
     int edge);
-GPI_EXPORT gpi_cb_hdl gpi_register_edge_count_callback(
-    int (*gpi_function)(void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl,
-    int edge, uint64_t count);
+GPI_EXPORT gpi_cb_hdl
+gpi_register_edge_count_callback(int (*gpi_function)(void *), void *gpi_cb_data,
+                                 gpi_sim_hdl gpi_hdl, int edge, uint64_t count);
 GPI_EXPORT gpi_cb_hdl
 gpi_register_readonly_callback(int (*gpi_function)(void *), void *gpi_cb_data);
 GPI_EXPORT gpi_cb_hdl

--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -243,6 +243,9 @@ GPI_EXPORT gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
 GPI_EXPORT gpi_cb_hdl gpi_register_value_change_callback(
     int (*gpi_function)(void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl,
     int edge);
+GPI_EXPORT gpi_cb_hdl gpi_register_edge_count_callback(
+    int (*gpi_function)(void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl,
+    int edge, uint64_t count);
 GPI_EXPORT gpi_cb_hdl
 gpi_register_readonly_callback(int (*gpi_function)(void *), void *gpi_cb_data);
 GPI_EXPORT gpi_cb_hdl

--- a/src/cocotb/share/lib/fli/FliImpl.h
+++ b/src/cocotb/share/lib/fli/FliImpl.h
@@ -171,7 +171,7 @@ class FliObjHdl : public GpiObjHdl, public FliObj {
                    const std::string &fq_name) override;
 };
 
-class FliEdgeCbScheduler: public GpiEdgeCbScheduler {
+class FliEdgeCbScheduler : public GpiEdgeCbScheduler {
   public:
     FliEdgeCbScheduler(GpiSignalObjHdl *handle);
     ~FliEdgeCbScheduler();
@@ -215,7 +215,7 @@ class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
     FliSignalCbHdl m_falling_cb;
     FliSignalCbHdl m_either_cb;
 
-   std::unique_ptr<FliEdgeCbScheduler> edge_cbs;
+    std::unique_ptr<FliEdgeCbScheduler> edge_cbs;
 };
 
 class FliValueObjHdl : public FliSignalObjHdl {

--- a/src/cocotb/share/lib/fli/FliImpl.h
+++ b/src/cocotb/share/lib/fli/FliImpl.h
@@ -171,6 +171,23 @@ class FliObjHdl : public GpiObjHdl, public FliObj {
                    const std::string &fq_name) override;
 };
 
+class FliEdgeCbScheduler: public GpiEdgeCbScheduler {
+  public:
+    FliEdgeCbScheduler(GpiSignalObjHdl *handle);
+    ~FliEdgeCbScheduler();
+
+    int track_edges() override;
+
+  private:
+    // If at least one edge callback is registered, we ask to be notified of
+    // value changes for this signal
+    void process_edge_cbs(char value);
+    static void value_change_cb(void *data);
+
+    mtiProcessIdT edge_cb_proc_hdl = nullptr;
+    bool sensitized = false;
+};
+
 class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
   public:
     FliSignalObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
@@ -186,6 +203,9 @@ class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
                    const std::string &fq_name) override;
     GpiCbHdl *register_value_change_callback(int edge, int (*function)(void *),
                                              void *cb_data) override;
+    GpiCbHdl *register_edge_count_callback(int edge, uint64_t count,
+                                           int (*function)(void *),
+                                           void *cb_data) override;
 
     bool is_var() { return m_is_var; }
 
@@ -194,6 +214,8 @@ class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
     FliSignalCbHdl m_rising_cb;
     FliSignalCbHdl m_falling_cb;
     FliSignalCbHdl m_either_cb;
+
+   std::unique_ptr<FliEdgeCbScheduler> edge_cbs;
 };
 
 class FliValueObjHdl : public FliSignalObjHdl {

--- a/src/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/src/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -65,9 +65,11 @@ GpiCbHdl *FliSignalObjHdl::register_value_change_callback(
     return (GpiCbHdl *)cb;
 }
 
-GpiCbHdl *FliSignalObjHdl::register_edge_count_callback(
-    int edge, uint64_t count, int (*function)(void *), void *cb_data) {
-    if ((edge == 0) || (edge & (GPI_RISING|GPI_FALLING)) != edge) {
+GpiCbHdl *FliSignalObjHdl::register_edge_count_callback(int edge,
+                                                        uint64_t count,
+                                                        int (*function)(void *),
+                                                        void *cb_data) {
+    if ((edge == 0) || (edge & (GPI_RISING | GPI_FALLING)) != edge) {
         return nullptr;
     }
     if (!edge_cbs) {
@@ -84,11 +86,10 @@ GpiCbHdl *FliSignalObjHdl::register_edge_count_callback(
     return ret;
 }
 
-FliEdgeCbScheduler::FliEdgeCbScheduler(GpiSignalObjHdl *handle):
-    GpiEdgeCbScheduler(handle) {
-    edge_cb_proc_hdl =
-        mti_CreateProcess(NULL, &FliEdgeCbScheduler::value_change_cb,
-                          (void*) this);
+FliEdgeCbScheduler::FliEdgeCbScheduler(GpiSignalObjHdl *handle)
+    : GpiEdgeCbScheduler(handle) {
+    edge_cb_proc_hdl = mti_CreateProcess(
+        NULL, &FliEdgeCbScheduler::value_change_cb, (void *)this);
 }
 
 FliEdgeCbScheduler::~FliEdgeCbScheduler() {
@@ -112,8 +113,7 @@ void FliEdgeCbScheduler::process_edge_cbs(char value) {
 }
 
 void FliEdgeCbScheduler::value_change_cb(void *data) {
-    FliEdgeCbScheduler *cb_sched =
-        reinterpret_cast<FliEdgeCbScheduler*>(data);
+    FliEdgeCbScheduler *cb_sched = reinterpret_cast<FliEdgeCbScheduler *>(data);
     cb_sched->process_edge_cbs(
         cb_sched->signal_obj->get_signal_value_binstr()[0]);
 }

--- a/src/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -130,15 +130,15 @@ int GpiValueCbHdl::run_callback() {
 }
 
 void GpiEdgeCbScheduler::init(GpiEdgeCbHdl *cbh) {
-    cbh->it = tracker[cbh->edge-1].cbm.end();
+    cbh->it = tracker[cbh->edge - 1].cbm.end();
 }
 
 int GpiEdgeCbScheduler::arm(GpiEdgeCbHdl *cbh) {
-    EdgeCbMap &cbmap = tracker[cbh->edge-1].cbm;
+    EdgeCbMap &cbmap = tracker[cbh->edge - 1].cbm;
     if (cbh->it != cbmap.end()) {
         cbmap.erase(cbh->it);
     }
-    cbh->it = cbmap.emplace(tracker[cbh->edge-1].ctr + cbh->count + 1, cbh);
+    cbh->it = cbmap.emplace(tracker[cbh->edge - 1].ctr + cbh->count + 1, cbh);
     total_cb_count++;
     if (total_cb_count == 1) {
         if (track_edges() != 0) {
@@ -151,7 +151,7 @@ int GpiEdgeCbScheduler::arm(GpiEdgeCbHdl *cbh) {
 }
 
 void GpiEdgeCbScheduler::cleanup(GpiEdgeCbHdl *cbh) {
-    EdgeCbMap &cbmap = tracker[cbh->edge-1].cbm;
+    EdgeCbMap &cbmap = tracker[cbh->edge - 1].cbm;
     if (cbh->it != cbmap.end()) {
         cbmap.erase(cbh->it);
         cbh->it = cbmap.end();
@@ -174,7 +174,7 @@ bool GpiEdgeCbScheduler::process_edge(bool rising, bool falling) {
 GpiEdgeCbScheduler::EdgeCbTracker::~EdgeCbTracker() {
     if (!cbm.empty()) {
         LOG_WARN("EdgeCbTracker not empty on destruction")
-        for (std::pair<const uint64_t, GpiEdgeCbHdl*> &kv: cbm) {
+        for (std::pair<const uint64_t, GpiEdgeCbHdl *> &kv : cbm) {
             kv.second->scheduler = nullptr;
         }
     }
@@ -188,8 +188,7 @@ void GpiEdgeCbScheduler::EdgeCbTracker::on_edge() {
     EdgeCbMap::iterator it = cbm.lower_bound(ctr);
 
     while (it != cbm.end()) {
-        if (it->first != ctr)
-            break;
+        if (it->first != ctr) break;
         GpiEdgeCbHdl *cb = it->second;
         // increment iterator here: deleting/cleaning up cb will remove from
         // map and decrease counter.
@@ -201,12 +200,13 @@ void GpiEdgeCbScheduler::EdgeCbTracker::on_edge() {
     ctr++;
 }
 
-
 GpiEdgeCbHdl::GpiEdgeCbHdl(GpiEdgeCbScheduler *_scheduler,
-                           GpiImplInterface *impl,
-                           int _edge, uint64_t _count):
-    GpiCbHdl(impl), GpiCommonCbHdl(impl),
-    edge(_edge), count(_count), scheduler(_scheduler)  {
+                           GpiImplInterface *impl, int _edge, uint64_t _count)
+    : GpiCbHdl(impl),
+      GpiCommonCbHdl(impl),
+      edge(_edge),
+      count(_count),
+      scheduler(_scheduler) {
     scheduler->init(this);
 }
 

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -553,13 +553,14 @@ gpi_cb_hdl gpi_register_edge_count_callback(int (*gpi_function)(void *),
                                             void *gpi_cb_data,
                                             gpi_sim_hdl sig_hdl, int edge,
                                             uint64_t count) {
-    GpiSignalObjHdl *signal_hdl = dynamic_cast<GpiSignalObjHdl *>(sig_hdl);
-    if (!signal_hdl) {
-        LOG_ERROR(
-            "Attempted to register an edge count callback on "
-            "wrong object type.");
-        return NULL;
-    }
+    // GpiSignalObjHdl *signal_hdl = dynamic_cast<GpiSignalObjHdl *>(sig_hdl);
+    // if (!signal_hdl) {
+    //     LOG_ERROR(
+    //         "Attempted to register an edge count callback on "
+    //         "wrong object type.");
+    //     return NULL;
+    // }
+    GpiSignalObjHdl *signal_hdl = static_cast<GpiSignalObjHdl *>(sig_hdl);
     GpiCbHdl *gpi_hdl = signal_hdl->register_edge_count_callback(
         edge, count, gpi_function, gpi_cb_data);
     if (!gpi_hdl) {

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -551,12 +551,13 @@ gpi_cb_hdl gpi_register_value_change_callback(int (*gpi_function)(void *),
 
 gpi_cb_hdl gpi_register_edge_count_callback(int (*gpi_function)(void *),
                                             void *gpi_cb_data,
-                                            gpi_sim_hdl sig_hdl,
-                                            int edge, uint64_t count) {
+                                            gpi_sim_hdl sig_hdl, int edge,
+                                            uint64_t count) {
     GpiSignalObjHdl *signal_hdl = dynamic_cast<GpiSignalObjHdl *>(sig_hdl);
     if (!signal_hdl) {
-        LOG_ERROR("Attempted to register an edge count callback on "
-                  "wrong object type.");
+        LOG_ERROR(
+            "Attempted to register an edge count callback on "
+            "wrong object type.");
         return NULL;
     }
     GpiCbHdl *gpi_hdl = signal_hdl->register_edge_count_callback(

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -549,6 +549,26 @@ gpi_cb_hdl gpi_register_value_change_callback(int (*gpi_function)(void *),
     }
 }
 
+gpi_cb_hdl gpi_register_edge_count_callback(int (*gpi_function)(void *),
+                                            void *gpi_cb_data,
+                                            gpi_sim_hdl sig_hdl,
+                                            int edge, uint64_t count) {
+    GpiSignalObjHdl *signal_hdl = dynamic_cast<GpiSignalObjHdl *>(sig_hdl);
+    if (!signal_hdl) {
+        LOG_ERROR("Attempted to register an edge count callback on "
+                  "wrong object type.");
+        return NULL;
+    }
+    GpiCbHdl *gpi_hdl = signal_hdl->register_edge_count_callback(
+        edge, count, gpi_function, gpi_cb_data);
+    if (!gpi_hdl) {
+        LOG_ERROR("Failed to register an edge count callback");
+        return NULL;
+    } else {
+        return gpi_hdl;
+    }
+}
+
 gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
                                        void *gpi_cb_data, uint64_t time) {
     // It should not matter which implementation we use for this so just pick

--- a/src/cocotb/share/lib/gpi/gpi_priv.h
+++ b/src/cocotb/share/lib/gpi/gpi_priv.h
@@ -170,8 +170,9 @@ class GPI_EXPORT GpiSignalObjHdl : public GpiObjHdl {
 
     virtual GpiCbHdl *register_value_change_callback(
         int edge, int (*gpi_function)(void *), void *gpi_cb_data) = 0;
-    virtual GpiCbHdl *register_edge_count_callback(
-        int edge, uint64_t count, int (*function)(void *), void *cb_data) = 0;
+    virtual GpiCbHdl *register_edge_count_callback(int edge, uint64_t count,
+                                                   int (*function)(void *),
+                                                   void *cb_data) = 0;
 };
 
 /* GPI Callback handle */
@@ -227,14 +228,14 @@ class GPI_EXPORT GpiValueCbHdl : public virtual GpiCommonCbHdl {
 // at the appropriate time.
 class GPI_EXPORT GpiEdgeCbScheduler {
   public:
-    GpiEdgeCbScheduler(GpiSignalObjHdl *handle): signal_obj(handle) {}
+    GpiEdgeCbScheduler(GpiSignalObjHdl *handle) : signal_obj(handle) {}
     virtual ~GpiEdgeCbScheduler() = default;
 
     void init(GpiEdgeCbHdl *cbh);
     int arm(GpiEdgeCbHdl *cbh);
     void cleanup(GpiEdgeCbHdl *cbh);
 
-    using EdgeCbMap = std::multimap<uint64_t, GpiEdgeCbHdl*>;
+    using EdgeCbMap = std::multimap<uint64_t, GpiEdgeCbHdl *>;
 
   protected:
     GpiSignalObjHdl *signal_obj = nullptr;
@@ -262,11 +263,11 @@ class GPI_EXPORT GpiEdgeCbScheduler {
     // callback.
 
     struct GPI_EXPORT EdgeCbTracker {
-      ~EdgeCbTracker();
-      // Increment the counter and return the number of callbacks dispatched
-      void on_edge();
-      uint64_t ctr = 0;
-      EdgeCbMap cbm;
+        ~EdgeCbTracker();
+        // Increment the counter and return the number of callbacks dispatched
+        void on_edge();
+        uint64_t ctr = 0;
+        EdgeCbMap cbm;
     };
 
     // There are three separate trackers for GPI_RISING, GPI_FALLING, and

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -589,7 +589,7 @@ static PyObject *register_edge_count_callback(
         return NULL;
     }
     if ((edge != GPI_RISING) && (edge != GPI_FALLING) &&
-        (edge != (GPI_RISING|GPI_FALLING))) {
+        (edge != (GPI_RISING | GPI_FALLING))) {
         PyErr_SetString(PyExc_TypeError,
                         "Attempt to register value change callback for an "
                         "invalid edge!");
@@ -615,9 +615,9 @@ static PyObject *register_edge_count_callback(
         return NULL;
     }
 
-    GpiCbHdl *hdl = gpi_register_edge_count_callback(
-        (gpi_function_t)handle_gpi_callback,
-        cb_data, sig_hdl, int(edge), count);
+    GpiCbHdl *hdl =
+        gpi_register_edge_count_callback((gpi_function_t)handle_gpi_callback,
+                                         cb_data, sig_hdl, int(edge), count);
 
     if (!hdl) {
         callback_data_delete(cb_data);
@@ -633,7 +633,7 @@ static PyObject *register_edge_count_callback(
         callback_data_delete(cb_data);
         // Unfortunately here GpiCbHdl is only forward declared and cannot
         // be deleted.
-        //delete hdl;
+        // delete hdl;
         PyErr_SetString(PyExc_RuntimeError,
                         "Failed to create python object "
                         "for edge callback handle!");
@@ -1036,16 +1036,16 @@ static PyMethodDef SimulatorMethods[] = {
                "cocotb.simulator.gpi_sim_hdl, func: Callable[..., None], edge: "
                "int, *args: Any) -> cocotb.simulator.gpi_cb_hdl\n"
                "Register a signal change callback.")},
-    {"register_edge_count_callback", register_edge_count_callback,
-     METH_VARARGS,
-     PyDoc_STR("register_edge_count_callback(signal, func, edge, count, /, *args)\n"
-               "--\n\n"
-               "register_edge_count_callback(signal: "
-               "cocotb.simulator.gpi_sim_hdl, func: Callable[..., None], edge: "
-               "int, count: int, *args: Any) -> cocotb.simulator.gpi_cb_hdl\n"
-               "Register a callback to happen on the specified edge of the given "
-               "signal. Count indicates how many of the desired edges to ignore "
-               "before running the callback (so 0 is the next edge).")},
+    {"register_edge_count_callback", register_edge_count_callback, METH_VARARGS,
+     PyDoc_STR(
+         "register_edge_count_callback(signal, func, edge, count, /, *args)\n"
+         "--\n\n"
+         "register_edge_count_callback(signal: "
+         "cocotb.simulator.gpi_sim_hdl, func: Callable[..., None], edge: "
+         "int, count: int, *args: Any) -> cocotb.simulator.gpi_cb_hdl\n"
+         "Register a callback to happen on the specified edge of the given "
+         "signal. Count indicates how many of the desired edges to ignore "
+         "before running the callback (so 0 is the next edge).")},
     {"register_readonly_callback", register_readonly_callback, METH_VARARGS,
      PyDoc_STR("register_readonly_callback(func, /, *args)\n"
                "--\n\n"

--- a/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -847,7 +847,7 @@ GpiCbHdl *VhpiSignalObjHdl::register_value_change_callback(
 
 GpiCbHdl *VhpiSignalObjHdl::register_edge_count_callback(
     int edge, uint64_t count, int (*function)(void *), void *cb_data) {
-    if ((edge == 0) || (edge & (GPI_RISING|GPI_FALLING)) != edge) {
+    if ((edge == 0) || (edge & (GPI_RISING | GPI_FALLING)) != edge) {
         return nullptr;
     }
     if (!edge_cbs) {
@@ -886,7 +886,7 @@ void VhpiEdgeCbScheduler::process_edge_cbs(char value) {
 
 void VhpiEdgeCbScheduler::value_change_cb(const vhpiCbDataT *cb_data) {
     VhpiEdgeCbScheduler *cb_sched =
-        reinterpret_cast<VhpiEdgeCbScheduler*>(cb_data->user_data);
+        reinterpret_cast<VhpiEdgeCbScheduler *>(cb_data->user_data);
     cb_sched->process_edge_cbs(
         cb_sched->signal_obj->get_signal_value_binstr()[0]);
 }
@@ -900,18 +900,13 @@ int VhpiEdgeCbScheduler::track_edges() {
         return 0;
     }
 
-    vhpiTimeT vhpi_time = {
-        .high = 0,
-        .low = 0
-    };
-    vhpiCbDataT cb_data = {
-        .reason = vhpiCbValueChange,
-        .cb_rtn = &VhpiEdgeCbScheduler::value_change_cb,
-        .obj = signal_obj->get_handle<vhpiHandleT>(),
-        .time = &vhpi_time,
-        .value = nullptr,
-        .user_data = (char *) this
-    };
+    vhpiTimeT vhpi_time = {.high = 0, .low = 0};
+    vhpiCbDataT cb_data = {.reason = vhpiCbValueChange,
+                           .cb_rtn = &VhpiEdgeCbScheduler::value_change_cb,
+                           .obj = signal_obj->get_handle<vhpiHandleT>(),
+                           .time = &vhpi_time,
+                           .value = nullptr,
+                           .user_data = (char *)this};
 
     edge_cb_hdl = vhpi_register_cb(&cb_data, vhpiReturnCb);
 

--- a/src/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -190,7 +190,7 @@ class VhpiObjHdl : public GpiObjHdl {
                    const std::string &fq_name) override;
 };
 
-class VhpiEdgeCbScheduler: public GpiEdgeCbScheduler {
+class VhpiEdgeCbScheduler : public GpiEdgeCbScheduler {
   public:
     using GpiEdgeCbScheduler::GpiEdgeCbScheduler;
     ~VhpiEdgeCbScheduler();

--- a/src/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -190,6 +190,20 @@ class VhpiObjHdl : public GpiObjHdl {
                    const std::string &fq_name) override;
 };
 
+class VhpiEdgeCbScheduler: public GpiEdgeCbScheduler {
+  public:
+    using GpiEdgeCbScheduler::GpiEdgeCbScheduler;
+    ~VhpiEdgeCbScheduler();
+
+    int track_edges() override;
+
+  private:
+    void process_edge_cbs(char value);
+    static void value_change_cb(const vhpiCbDataT *cb_data);
+
+    vhpiHandleT edge_cb_hdl = NULL;
+};
+
 class VhpiSignalObjHdl : public GpiSignalObjHdl {
   public:
     VhpiSignalObjHdl(GpiImplInterface *impl, vhpiHandleT hdl,
@@ -218,6 +232,9 @@ class VhpiSignalObjHdl : public GpiSignalObjHdl {
                    const std::string &fq_name) override;
     GpiCbHdl *register_value_change_callback(int edge, int (*function)(void *),
                                              void *cb_data) override;
+    GpiCbHdl *register_edge_count_callback(int edge, uint64_t count,
+                                           int (*function)(void *),
+                                           void *cb_data) override;
 
   protected:
     vhpiEnumT chr2vhpi(char value);
@@ -226,6 +243,7 @@ class VhpiSignalObjHdl : public GpiSignalObjHdl {
     VhpiValueCbHdl m_rising_cb;
     VhpiValueCbHdl m_falling_cb;
     VhpiValueCbHdl m_either_cb;
+    std::unique_ptr<VhpiEdgeCbScheduler> edge_cbs;
 };
 
 class VhpiLogicSignalObjHdl : public VhpiSignalObjHdl {

--- a/src/cocotb/share/lib/vpi/VpiImpl.h
+++ b/src/cocotb/share/lib/vpi/VpiImpl.h
@@ -176,7 +176,7 @@ class VpiObjHdl : public GpiObjHdl {
     const char *get_definition_file() override;
 };
 
-class VpiEdgeCbScheduler: public GpiEdgeCbScheduler {
+class VpiEdgeCbScheduler : public GpiEdgeCbScheduler {
   public:
     using GpiEdgeCbScheduler::GpiEdgeCbScheduler;
     ~VpiEdgeCbScheduler();

--- a/src/cocotb/share/lib/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/vpi/VpiSignal.cpp
@@ -324,16 +324,18 @@ int VpiEdgeCbScheduler::track_edges() {
     }
 
     s_vpi_time vpi_time;
-    s_vpi_value vpi_value;
     vpi_time.type = vpiSuppressTime;
-    vpi_value.format = vpiBinStrVal;
-    s_cb_data edge_cb_data = {.reason = cbValueChange,
-                              .cb_rtn = &VpiEdgeCbScheduler::value_change_cb,
-                              .obj = signal_obj->get_handle<vpiHandle>(),
-                              .time = &vpi_time,
-                              .value = &vpi_value,
-                              .index = 0,
-                              .user_data = (char *)this};
+
+    s_vpi_value vpi_value = {vpiRealVal, {nullptr}};
+
+    s_cb_data edge_cb_data;
+    edge_cb_data.reason = cbValueChange;
+    edge_cb_data.cb_rtn = &VpiEdgeCbScheduler::value_change_cb;
+    edge_cb_data.obj = signal_obj->get_handle<vpiHandle>();
+    edge_cb_data.time = &vpi_time;
+    edge_cb_data.value = &vpi_value;
+    edge_cb_data.index = 0;
+    edge_cb_data.user_data = (char *)this;
 
     edge_cb_hdl = vpi_register_cb(&edge_cb_data);
 

--- a/src/cocotb/share/lib/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/vpi/VpiSignal.cpp
@@ -266,9 +266,11 @@ GpiCbHdl *VpiSignalObjHdl::register_value_change_callback(
     return cb;
 }
 
-GpiCbHdl *VpiSignalObjHdl::register_edge_count_callback(
-    int edge, uint64_t count, int (*function)(void *), void *cb_data) {
-    if ((edge == 0) || (edge & (GPI_RISING|GPI_FALLING)) != edge) {
+GpiCbHdl *VpiSignalObjHdl::register_edge_count_callback(int edge,
+                                                        uint64_t count,
+                                                        int (*function)(void *),
+                                                        void *cb_data) {
+    if ((edge == 0) || (edge & (GPI_RISING | GPI_FALLING)) != edge) {
         return nullptr;
     }
     if (!edge_cbs) {
@@ -308,7 +310,7 @@ int VpiEdgeCbScheduler::process_edge_cbs(char value) {
 
 int VpiEdgeCbScheduler::value_change_cb(p_cb_data pcbd) {
     VpiEdgeCbScheduler *cb_sched =
-        reinterpret_cast<VpiEdgeCbScheduler*>(pcbd->user_data);
+        reinterpret_cast<VpiEdgeCbScheduler *>(pcbd->user_data);
     return cb_sched->process_edge_cbs(pcbd->value->value.str[0]);
 }
 
@@ -325,15 +327,13 @@ int VpiEdgeCbScheduler::track_edges() {
     s_vpi_value vpi_value;
     vpi_time.type = vpiSuppressTime;
     vpi_value.format = vpiBinStrVal;
-    s_cb_data edge_cb_data = {
-        .reason = cbValueChange,
-        .cb_rtn = &VpiEdgeCbScheduler::value_change_cb,
-        .obj = signal_obj->get_handle<vpiHandle>(),
-        .time = &vpi_time,
-        .value = &vpi_value,
-        .index = 0,
-        .user_data = (char *) this
-    };
+    s_cb_data edge_cb_data = {.reason = cbValueChange,
+                              .cb_rtn = &VpiEdgeCbScheduler::value_change_cb,
+                              .obj = signal_obj->get_handle<vpiHandle>(),
+                              .time = &vpi_time,
+                              .value = &vpi_value,
+                              .index = 0,
+                              .user_data = (char *)this};
 
     edge_cb_hdl = vpi_register_cb(&edge_cb_data);
 

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -43,7 +43,6 @@ from typing import (
     Generic,
     List,
     Optional,
-    Type,
     TypeVar,
     Union,
     cast,


### PR DESCRIPTION
Callbacks on a gpi signal change for a specific edge transition. This allows for an efficient implementation of ClockCycles that avoids going back and forth between python and simulator at each edge.

Useful for better performance when doing things such as
await ClockCycles(clk, 100)

It also provides a solution to https://github.com/cocotb/cocotb/issues/2208
