### PR TITLE
Add support for VHDL libraries in Riviera-PRO Makefile

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -322,7 +322,7 @@ The following variables are makefile variables, not environment variables.
 
 .. make:var:: VHDL_SOURCES_<lib>
 
-      A list of the VHDL source files to include in the VHDL library *lib* (currently for GHDL/ModelSim/Questa/Xcelium/Incisive only).
+      A list of the VHDL source files to include in the VHDL library *lib* (currently for GHDL/ModelSim/Questa/Xcelium/Incisive/Riviera-PRO only).
 
 .. make:var:: VHDL_LIB_ORDER
 

--- a/docs/source/newsfragments/3922.feature.rst
+++ b/docs/source/newsfragments/3922.feature.rst
@@ -1,0 +1,1 @@
+Riviera-PRO now support compilation into (multiple) VHDL libraries ``lib`` using ``VHDL_SOURCES_<lib>``.

--- a/docs/source/newsfragments/3922.feature.rst
+++ b/docs/source/newsfragments/3922.feature.rst
@@ -1,1 +1,1 @@
-Riviera-PRO now support compilation into (multiple) VHDL libraries ``lib`` using ``VHDL_SOURCES_<lib>``.
+Riviera-PRO now support compilation into (multiple) VHDL libraries using :make:var:`VHDL_SOURCES_<lib>`.

--- a/docs/source/newsfragments/3922.feature.rst
+++ b/docs/source/newsfragments/3922.feature.rst
@@ -1,1 +1,1 @@
-Riviera-PRO now support compilation into (multiple) VHDL libraries using :make:var:`VHDL_SOURCES_<lib>`.
+Riviera-PRO now supports compilation into (multiple) VHDL libraries using :make:var:`VHDL_SOURCES_<lib>`.

--- a/src/cocotb_tools/makefiles/Makefile.sim
+++ b/src/cocotb_tools/makefiles/Makefile.sim
@@ -57,8 +57,8 @@ SIM                       Selects which simulator Makefile to use
 WAVES                     Enable wave traces dump for Riviera-PRO and Questa
 VERILOG_SOURCES           A list of the Verilog source files to include
 VHDL_SOURCES              A list of the VHDL source files to include
-VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/NVC/ModelSim/Questa/Xcelium/Incisive only)
-VHDL_LIB_ORDER            Compilation order of VHDL libraries (needed for NVC/ModelSim/Questa/Xcelium/Incisive)
+VHDL_SOURCES_<lib>        VHDL source files to include in *lib* (GHDL/NVC/ModelSim/Questa/Xcelium/Incisive/Riviera-PRO only)
+VHDL_LIB_ORDER            Compilation order of VHDL libraries (needed for NVC/ModelSim/Questa/Xcelium/Incisive/Riviera-PRO)
 SIM_CMD_PREFIX            Prefix for simulation command invocations
 COMPILE_ARGS              Arguments to pass to compile (analysis) stage of simulation
 SIM_ARGS                  Arguments to pass to execution of compiled simulation

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -126,8 +126,9 @@ $(SIM_BUILD)/runsim.tcl : $(VERILOG_SOURCES) $(VHDL_SOURCES) | $(SIM_BUILD)
 	@echo "@if [string length [array get env LICENSE_QUEUE]] {" >> $@
 	@echo " set LICENSE_QUEUE $$::env(LICENSE_QUEUE)" >> $@
 	@echo "}" >> $@
-	@echo "alib $(RTL_LIBRARY)" >> $@
-	@echo "set worklib $(RTL_LIBRARY)" >> $@
+	@echo "if [file exists $(SIM_BUILD)/$(RTL_LIBRARY)] {adel -lib $(SIM_BUILD)/$(RTL_LIBRARY) -all}" >> $@;
+	@echo "alib $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
+	@echo "amap $(RTL_LIBRARY) $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@;
 ifneq ($(VHDL_SOURCES),)
 	@echo "acom -work $(RTL_LIBRARY) $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -129,6 +129,7 @@ $(SIM_BUILD)/runsim.tcl : $(VERILOG_SOURCES) $(VHDL_SOURCES) | $(SIM_BUILD)
 	@echo "if [file exists $(SIM_BUILD)/$(RTL_LIBRARY)] {adel -lib $(SIM_BUILD)/$(RTL_LIBRARY) -all}" >> $@;
 	@echo "alib $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
 	@echo "amap $(RTL_LIBRARY) $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@;
+	@echo "set worklib $(RTL_LIBRARY)" >> $@;
 ifneq ($(VHDL_SOURCES),)
 	@echo "acom -work $(RTL_LIBRARY) $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -69,7 +69,7 @@ ASIM_ARGS += $(SIM_ARGS)
 # Plusargs need to be passed to ASIM command not vsimsa
 ASIM_ARGS += $(PLUSARGS)
 
-RTL_LIBRARY ?= $(SIM_BUILD)/work
+RTL_LIBRARY ?= work
 
 # Pass the VPI library to the Verilog compilation to get extended checking.
 ALOG_ARGS += -pli $(shell cocotb-config --lib-name-path vpi riviera)

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -127,6 +127,7 @@ $(SIM_BUILD)/runsim.tcl : $(VERILOG_SOURCES) $(VHDL_SOURCES) | $(SIM_BUILD)
 	@echo " set LICENSE_QUEUE $$::env(LICENSE_QUEUE)" >> $@
 	@echo "}" >> $@
 	@echo "alib $(RTL_LIBRARY)" >> $@
+	@echo "set worklib $(RTL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)
 	@echo "acom -work $(RTL_LIBRARY) $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -108,22 +108,30 @@ else
    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))
 endif
 
+define make_lib
+  echo "if [file exists $(SIM_BUILD)/$(LIB)] {adel -lib $(SIM_BUILD)/$(LIB) -all}" >> $@;
+  echo "alib $(SIM_BUILD)/$(LIB)" >> $@;
+  echo "amap $(LIB) $(SIM_BUILD)/$(LIB)" >> $@;
+  echo "acom -work $(LIB) $(VCOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES_$(LIB)))" >> $@;
+endef
+
 # Create a TCL script based on the list of $(VERILOG_SOURCES)
 $(SIM_BUILD)/runsim.tcl : $(VERILOG_SOURCES) $(VHDL_SOURCES) | $(SIM_BUILD)
 	@echo "onerror {" > $@
 	@echo "	puts [read [open sim.log r]]" >> $@
 	@echo "	quit -code 1" >> $@
 	@echo "}" >> $@
+	@echo "amap -c" >> $@
+	$(foreach LIB, $(VHDL_LIB_ORDER), $(make_lib))
 	@echo "@if [string length [array get env LICENSE_QUEUE]] {" >> $@
 	@echo " set LICENSE_QUEUE $$::env(LICENSE_QUEUE)" >> $@
 	@echo "}" >> $@
 	@echo "alib $(RTL_LIBRARY)" >> $@
-	@echo "set worklib $(RTL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)
-	@echo "acom $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
+	@echo "acom -work $(RTL_LIBRARY) $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif
 ifneq ($(VERILOG_SOURCES),)
-	@echo "alog $(ALOG_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
+	@echo "alog -work $(RTL_LIBRARY) $(ALOG_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
 endif
 ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@

--- a/tests/test_cases/test_vhdl_libraries/Makefile
+++ b/tests/test_cases/test_vhdl_libraries/Makefile
@@ -12,7 +12,7 @@ ifneq ($(filter $(SIM),xcelium),)
     COMPILE_ARGS += -v93
 endif
 
-ifneq ($(filter nvc questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
+ifneq ($(filter nvc questa modelsim xcelium ius riviera,$(shell echo $(SIM) | tr A-Z a-z)),)
     VHDL_LIB_ORDER := blib
 endif
 
@@ -20,9 +20,9 @@ ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),vhdl)
 all:
 	@echo "Skipping test since only VHDL is supported"
 clean::
-else ifeq ($(filter ghdl nvc questa modelsim xcelium ius,$(shell echo $(SIM) | tr A-Z a-z)),)
+else ifeq ($(filter ghdl nvc questa modelsim xcelium ius riviera,$(shell echo $(SIM) | tr A-Z a-z)),)
 all:
-	@echo "Skipping test since only GHDL, NVC, Questa/ModelSim, Xcelium and Incisive are supported"
+	@echo "Skipping test since only GHDL, NVC, Questa/ModelSim, Xcelium, Incisive and Riviera-PRO are supported"
 clean::
 else
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/test_cases/test_vhdl_libraries_multiple/Makefile
+++ b/tests/test_cases/test_vhdl_libraries_multiple/Makefile
@@ -17,7 +17,7 @@ ifneq ($(filter $(SIM),xcelium),)
     COMPILE_ARGS += -v93
 endif
 
-ifneq ($(filter nvc questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
+ifneq ($(filter nvc questa modelsim xcelium riviera,$(shell echo $(SIM) | tr A-Z a-z)),)
     VHDL_LIB_ORDER := elib dlib clib blib
 endif
 
@@ -25,9 +25,9 @@ ifneq ($(shell echo $(TOPLEVEL_LANG) | tr A-Z a-z),vhdl)
 all:
 	@echo "Skipping test since only VHDL is supported"
 clean::
-else ifeq ($(filter ghdl nvc questa modelsim xcelium,$(shell echo $(SIM) | tr A-Z a-z)),)
+else ifeq ($(filter ghdl nvc questa modelsim xcelium riviera,$(shell echo $(SIM) | tr A-Z a-z)),)
 all:
-	@echo "Skipping test since only GHDL, NVC, Questa/ModelSim and Xcelium are supported"
+	@echo "Skipping test since only GHDL, NVC, Questa/ModelSim, Xcelium and Riviera-PRO are supported"
 clean::
 else
 include $(shell cocotb-config --makefiles)/Makefile.sim


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

Closes #3921 

Add support for (multiple) VHDL libraries in Riviera-PRO simulator. Inspired by pull requests like https://github.com/cocotb/cocotb/pull/3599 and https://github.com/cocotb/cocotb/pull/2465.

Added test cases accordingly.
