### PR TITLE
Make awaiting `Join` trigger not return `Task` result

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -137,8 +137,8 @@ Python Triggers
 
 .. autoclass:: cocotb.triggers.First
 
-.. autoclass:: cocotb.triggers.Join(coroutine)
-    :members: retval
+.. autoclass:: cocotb.triggers.Join
+    :members:
 
 
 Synchronization

--- a/docs/source/newsfragments/3931.change.rst
+++ b/docs/source/newsfragments/3931.change.rst
@@ -1,0 +1,1 @@
+Awaiting :meth:`Task.join() <cocotb.task.Task.join>` now returns the :class:`~cocotb.triggers.Join` trigger, not the result of the :class:`~cocotb.task.Task`. To wait for the task to complete and yield the result of the task, await the task directly: ``await task``.

--- a/docs/source/newsfragments/3931.feature.rst
+++ b/docs/source/newsfragments/3931.feature.rst
@@ -1,0 +1,1 @@
+Added :attr:`Join.task <cocotb.triggers.Join.task>` to get the joined task.

--- a/docs/source/newsfragments/3931.removal.rst
+++ b/docs/source/newsfragments/3931.removal.rst
@@ -1,0 +1,1 @@
+``cocotb.triggers.Join.retval`` was removed. Use :attr:`Join.task <cocotb.triggers.Join.task>` to get the joined task and :meth:`Task.result() <cocotb.task.Task.result>` to get its result.

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -128,7 +128,7 @@ class Trigger(Awaitable[None]):
 
     @property
     def _outcome(self) -> Outcome[Any]:
-        """The result that `await this_trigger` produces in a coroutine.
+        """The result that ``await this_trigger`` produces in a coroutine.
 
         The default is to produce the trigger itself, which is done for
         ease of use with :class:`~cocotb.triggers.First`.
@@ -760,7 +760,7 @@ class Join(Trigger, Generic[T], metaclass=_ParameterizedSingletonGPITriggerMetac
 
     @property
     def task(self) -> cocotb.task.Task[T]:
-        """Returns the :class:`~cocotb.task.Task` being joined.
+        """Return the :class:`~cocotb.task.Task` being joined.
 
         .. versionadded:: 2.0
         """

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -747,7 +747,7 @@ class Join(Trigger, Generic[T], metaclass=_ParameterizedSingletonGPITriggerMetac
 
     .. note::
         Typically there is no reason to directly instantiate this trigger,
-        instead call ``task.join()``.
+        instead call :meth:`Task.join() <cocotb.task.Task.join>` on the task.
     """
 
     @classmethod

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -224,8 +224,7 @@ def _get_log_time_scale(units: str) -> int:
 class _ParameterizedSingletonMetaclass(ABCMeta):
     """A metaclass that allows class construction to reuse an existing instance.
 
-    We use this so that :class:`RisingEdge(sig) <cocotb.triggers.RisingEdge>` and :class:`Join(coroutine) <cocotb.triggers.Join>` always return
-    the same instance, rather than creating new copies.
+    We use this so that many triggers classes return the same object rather than make new ones.
     """
 
     __singleton_key__: Callable[..., Any]

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -125,7 +125,7 @@ async def test_fork_and_monitor(dut, period=1000, clocks=6):
     expect = clocks - 1
 
     while True:
-        result = await First(timer, task.join())
+        result = await First(timer, task)
         assert count <= expect, "Task didn't complete in expected time"
         if result is timer:
             dut._log.info("Count %d: Task still running" % count)

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -38,20 +38,20 @@ LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 test_flag = False
 
 
-async def clock_yield(generator):
+async def clock_yield(task):
     global test_flag
-    await Join(generator)
+    await task.join()
     test_flag = True
 
 
 @cocotb.test()
-async def test_coroutine_kill(dut):
-    """Test that killing a coroutine causes pending routine continue"""
-    clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
+async def test_task_kill(dut):
+    """Test that killing a task causes pending task continue"""
+    clk_task = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
     await Timer(100, "ns")
-    cocotb.start_soon(clock_yield(clk_gen))
+    cocotb.start_soon(clock_yield(clk_task))
     await Timer(100, "ns")
-    clk_gen.kill()
+    clk_task.kill()
     assert not test_flag
     await Timer(1000, "ns")
     assert test_flag
@@ -74,15 +74,16 @@ async def clock_two(dut):
 
 
 @cocotb.test()
-async def test_coroutine_close_down(dut):
+async def test_task_close_down(dut):
+    """Test tasks completing allows awaiting task to continue."""
     log = logging.getLogger("cocotb.test")
     cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
 
-    coro_one = cocotb.start_soon(clock_one(dut))
-    coro_two = cocotb.start_soon(clock_two(dut))
+    task_one = cocotb.start_soon(clock_one(dut))
+    task_two = cocotb.start_soon(clock_two(dut))
 
-    await Join(coro_one)
-    await Join(coro_two)
+    await task_one
+    await task_two
 
     log.info("Back from joins")
 
@@ -100,16 +101,16 @@ async def join_finished(dut):
         await Timer(1, "ns")
         return retval
 
-    coro = cocotb.start_soon(some_coro())
+    task = cocotb.start_soon(some_coro())
 
     retval = 1
-    x = await coro.join()
+    x = await task
     assert x == 1
 
     # joining the second time should give the same result.
     # we change retval here to prove it does not run again
     retval = 2
-    x = await coro.join()
+    x = await task
     assert x == 1
 
 
@@ -131,8 +132,8 @@ async def consistent_join(dut):
     long_wait = cocotb.start_soon(wait_for(dut.clk, 30))
 
     await wait_for(dut.clk, 20)
-    a = await short_wait.join()
-    b = await long_wait.join()
+    a = await short_wait
+    b = await long_wait
     assert a == b == 3
 
 
@@ -144,18 +145,6 @@ async def test_kill_twice(dut):
     clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
     await Timer(1, "ns")
     clk_gen.kill()
-    await Timer(1, "ns")
-    clk_gen.kill()
-
-
-@cocotb.test()
-async def test_join_identity(dut):
-    """
-    Test that Join() returns the same object each time
-    """
-    clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
-
-    assert Join(clk_gen) is Join(clk_gen)
     await Timer(1, "ns")
     clk_gen.kill()
 
@@ -377,13 +366,32 @@ async def test_task_repr(dut):
 
     coro_task = await cocotb.start(coroutine_outer())
 
+    # let coroutine_inner run up to the await COmbine
     coro_e.set(coro_task)
-
     await NullTrigger()
 
     log.info(repr(coro_task))
     assert re.match(
-        r"<Task \d+ pending coro=coroutine_inner\(\) trigger=Combine\(Join\(<Task \d+>\), Join\(<Task \d+>\)\)>",
+        (
+            r"<Task \d+ pending coro=coroutine_inner\(\) trigger=Combine\("
+            r"<Task \d+ created coro=coroutine_wait\(\)>, "
+            r"<Task \d+ created coro=coroutine_wait\(\)>"
+            r"\)>"
+        ),
+        repr(coro_task),
+    )
+
+    # wait for coroutine_waits to start
+    await NullTrigger()
+
+    log.info(repr(coro_task))
+    assert re.match(
+        (
+            r"<Task \d+ pending coro=coroutine_inner\(\) trigger=Combine\("
+            r"<Task \d+ pending coro=coroutine_wait\(\) trigger=<Timer of 1000.00ps at \w+>>, "
+            r"<Task \d+ pending coro=coroutine_wait\(\) trigger=<Timer of 1000.00ps at \w+>>"
+            r"\)>"
+        ),
         repr(coro_task),
     )
 
@@ -404,7 +412,27 @@ async def test_task_repr(dut):
 
     log.info(repr(coro_task))
     assert re.match(
-        r"<Task \d+ pending coro=coroutine_first\(\) trigger=First\(Join\(<Task \d+>\), <Timer of 2000.00ps at \w+>\)>",
+        (
+            r"<Task \d+ pending coro=coroutine_first\(\) trigger=First\("
+            r"<Task \d+ created coro=coroutine_wait\(\)>, "
+            r"<Timer of 2000.00ps at \w+>"
+            r"\)>"
+        ),
+        repr(coro_task),
+    )
+
+    # wait for coroutine_wait to start
+    await NullTrigger()  # start_soon on _wait_callback
+    await NullTrigger()  # awaiting Task in _wait_callback
+
+    log.info(repr(coro_task))
+    assert re.match(
+        (
+            r"<Task \d+ pending coro=coroutine_first\(\) trigger=First\("
+            r"<Task \d+ pending coro=coroutine_wait\(\) trigger=<Timer of 1000.00ps at \w+>>, "
+            r"<Timer of 2000.00ps at \w+>"
+            r"\)>"
+        ),
         repr(coro_task),
     )
 
@@ -804,3 +832,19 @@ async def test_multiple_concurrent_test_fails(_) -> None:
     cocotb.start_soon(call_error(thing))
     cocotb.start_soon(call_error(thing))
     await Timer(10, "ns")
+
+
+@cocotb.test
+async def test_get_task_from_join(_) -> None:
+    async def noop():
+        pass
+
+    t = cocotb.start_soon(noop())
+    j = await t.join()
+    assert isinstance(j, Join)
+    assert j.task is t
+
+    t = cocotb.start_soon(noop())
+    j = await Join(t)
+    assert isinstance(j, Join)
+    assert j.task is t

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -46,7 +46,7 @@ async def clock_yield(task):
 
 @cocotb.test()
 async def test_task_kill(dut):
-    """Test that killing a task causes pending task continue"""
+    """Test that killing a task causes pending task to continue"""
     clk_task = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
     await Timer(100, "ns")
     cocotb.start_soon(clock_yield(clk_task))
@@ -366,7 +366,7 @@ async def test_task_repr(dut):
 
     coro_task = await cocotb.start(coroutine_outer())
 
-    # let coroutine_inner run up to the await COmbine
+    # let coroutine_inner run up to the await Combine
     coro_e.set(coro_task)
     await NullTrigger()
 

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -22,7 +22,6 @@ from cocotb.clock import Clock
 from cocotb.simulator import get_precision
 from cocotb.triggers import (
     First,
-    Join,
     NextTimeStep,
     ReadOnly,
     ReadWrite,
@@ -160,8 +159,8 @@ async def test_readwrite_in_readonly(dut):
     global exited
     exited = False
     clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
-    coro = cocotb.start_soon(do_test_readwrite_in_readonly(dut))
-    await First(Join(coro), Timer(10_000, "ns"))
+    task = cocotb.start_soon(do_test_readwrite_in_readonly(dut))
+    await First(task, Timer(10_000, "ns"))
     clk_gen.kill()
     assert exited
 
@@ -172,8 +171,8 @@ async def test_cached_write_in_readonly(dut):
     global exited
     exited = False
     clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
-    coro = cocotb.start_soon(do_test_cached_write_in_readonly(dut))
-    await First(Join(coro), Timer(10_000, "ns"))
+    task = cocotb.start_soon(do_test_cached_write_in_readonly(dut))
+    await First(task, Timer(10_000, "ns"))
     clk_gen.kill()
     assert exited
 
@@ -184,8 +183,8 @@ async def test_afterdelay_in_readonly_valid(dut):
     global exited
     exited = False
     clk_gen = cocotb.start_soon(Clock(dut.clk, 100, "ns").start())
-    coro = cocotb.start_soon(do_test_afterdelay_in_readonly(dut, 1))
-    await First(Join(coro), Timer(100_000, "ns"))
+    task = cocotb.start_soon(do_test_afterdelay_in_readonly(dut, 1))
+    await First(task, Timer(100_000, "ns"))
     clk_gen.kill()
     assert exited
 

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -222,13 +222,13 @@ async def test_external_from_start_soon(dut):
     cocotb.start_soon(Clock(dut.clk, 100, units="ns").start())
 
     coro1 = cocotb.start_soon(run_function(dut))
-    value = await coro1.join()
+    value = await coro1
     assert value == 2
     dut._log.info("Back from join 1")
 
     value = 0
     coro2 = cocotb.start_soon(run_external(dut))
-    value = await coro2.join()
+    value = await coro2
     assert value == 2
     dut._log.info("Back from join 2")
 


### PR DESCRIPTION
Awaiting the Join trigger will not return the task's
result, the user can use `await task` for the same effect. This allows
the user to have some way of awaiting a task to finish *without* getting
the result, which is especially useful if the outcome is anticipated to
be an exception.