### PR TITLE
CI: Update to Riviera-PRO 2024.04

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -292,7 +292,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "riviera",
-        "sim-version": "aldec/rivierapro/2023.10",
+        "sim-version": "aldec/rivierapro/2024.04",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -301,7 +301,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "riviera",
-        "sim-version": "aldec/rivierapro/2023.10",
+        "sim-version": "aldec/rivierapro/2024.04",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -367,7 +367,15 @@ for version in questa_versions_vhpi:
     ]
 
 # Riviera-PRO: test more versions as part of the extended tests.
-riviera_versions = ("2019.10", "2020.04", "2020.10", "2021.04", "2021.10", "2022.04")
+riviera_versions = (
+    "2019.10",
+    "2020.04",
+    "2020.10",
+    "2021.04",
+    "2021.10",
+    "2022.04",
+    "2023.10",
+)
 for version in riviera_versions:
     ENVS += [
         {

--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -235,6 +235,7 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiUnionVar:
         case vpiUnionNet:
             if (vpi_get(vpiPacked, new_hdl)) {
+                LOG_DEBUG("VPI: Found packed struct/union data type");
                 new_obj = new VpiSignalObjHdl(this, new_hdl,
                                               GPI_PACKED_STRUCTURE, false);
                 break;

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -38,7 +38,7 @@ COCOTB?=$(PWD)/../../..
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/sample_module/sample_module.sv
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    VHDL_SOURCES =  $(COCOTB)/tests/designs/sample_module/sample_module_pack.vhdl $(COCOTB)/tests/designs/sample_module/sample_module_1.vhdl $(COCOTB)/tests/designs/sample_module/sample_module.vhdl
+    VHDL_SOURCES =  $(COCOTB)/tests/designs/sample_module/sample_module_package.vhdl $(COCOTB)/tests/designs/sample_module/sample_module_1.vhdl $(COCOTB)/tests/designs/sample_module/sample_module.vhdl
 
     ifneq ($(filter $(SIM),ius xcelium),)
         COMPILE_ARGS += -v93

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -38,7 +38,7 @@ typedef struct
 {
     logic a_in;
     logic b_out;
-} test_if;
+} test_struct_unpacked;
 `endif // `ifndef VERILATOR
 
 typedef struct packed
@@ -46,7 +46,7 @@ typedef struct packed
     logic val_a;
     logic val_b;
     logic value;
-} test_struct;
+} test_struct_packed;
 
 
 `endif
@@ -80,9 +80,9 @@ module sample_module #(
     output real                                 stream_out_real,
     output integer                              stream_out_int,
     `ifndef VERILATOR
-    input  test_if                              inout_if,
+    input  test_struct_unpacked                 inout_if,
     `endif
-    input  test_struct                          my_struct,
+    input  test_struct_packed                   my_struct,
     input  string                               stream_in_string,
 `endif
     input  [7:0]                                stream_in_data,
@@ -142,7 +142,7 @@ end
 `endif //  `ifndef _VCP
 
 `ifndef VERILATOR
-test_if struct_var;
+test_struct_unpacked struct_var;
 `endif
 `endif //  `ifndef __ICARUS__
 

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -35,7 +35,7 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 library work;
-use work.sample_module_pack.all;
+use work.sample_module_package.all;
 
 entity sample_module is
     port (
@@ -53,7 +53,7 @@ entity sample_module is
         stream_in_string                : in    string(1 to 64);
         stream_in_bool                  : in    boolean;
 
-        inout_if                        : in    test_if;
+        inout_if                        : in    test_record;
 
         stream_out_data_comb            : out   std_ulogic_vector(7 downto 0);
         stream_out_data_registered      : out   std_ulogic_vector(7 downto 0);

--- a/tests/designs/sample_module/sample_module_package.vhdl
+++ b/tests/designs/sample_module/sample_module_package.vhdl
@@ -32,14 +32,14 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-package sample_module_pack is
+package sample_module_package is
 
-    type test_if is record
+    type test_record is record
         a_in  : std_logic;
         b_out : std_logic;
-    end record test_if;
+    end record test_record;
 
-end package sample_module_pack;
+end package sample_module_package;
 
-package body sample_module_pack is
-end package body sample_module_pack;
+package body sample_module_package is
+end package body sample_module_package;

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -39,7 +39,9 @@ if hdl_toplevel_lang == "verilog":
     gpi_interfaces = ["vpi"]
 else:
     sources = [
-        os.path.join(tests_dir, "designs", "sample_module", "sample_module_pack.vhdl"),
+        os.path.join(
+            tests_dir, "designs", "sample_module", "sample_module_package.vhdl"
+        ),
         os.path.join(tests_dir, "designs", "sample_module", "sample_module_1.vhdl"),
         os.path.join(tests_dir, "designs", "sample_module", "sample_module.vhdl"),
     ]

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -150,7 +150,7 @@ async def test_ndim_array_indexes(dut):
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
 # Verilator doesn't support structs (gh-1275)
-# Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
+# Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587, gh-3933)
 @cocotb.test(
     expect_error=AttributeError
     if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl", "verilator"))

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -161,8 +161,8 @@ async def test_ndim_array_indexes(dut):
     )
     else ()
 )
-async def test_struct(dut):
-    """Test setting and getting values of structs."""
+async def test_struct_unpacked(dut):
+    """Test setting and getting values of unpacked structs."""
     cocotb.start_soon(Clock(dut.clk, 1000, "ns").start())
     dut.inout_if.a_in.value = 1
     await Timer(1000, "ns")

--- a/tests/test_cases/test_packed_union/test_packed_union.py
+++ b/tests/test_cases/test_packed_union/test_packed_union.py
@@ -10,13 +10,14 @@ from cocotb._sim_versions import RivieraVersion
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 
 
-# Riviera-PRO 2022.10 (VPI) and newer does not discover dut.t correctly (gh-3587)
+# Riviera-PRO 2022.10-2023.10 (VPI) do not discover dut.t correctly (gh-3587)
 @cocotb.test(
     expect_error=Exception
     if cocotb.SIM_NAME.lower().startswith(("verilator", "icarus", "ghdl"))
     or (
         cocotb.SIM_NAME.lower().startswith("riviera")
         and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
+        and RivieraVersion(cocotb.SIM_VERSION) < RivieraVersion("2024.04")
         and LANGUAGE == "verilog"
     )
     else (AttributeError)

--- a/tests/test_cases/test_struct/test_struct.py
+++ b/tests/test_cases/test_struct/test_struct.py
@@ -53,7 +53,7 @@ async def test_packed_struct_setting(dut):
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
 # Verilator doesn't support structs (gh-1275)
-# Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
+# Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587, gh-3933)
 @cocotb.test(
     expect_error=AttributeError
     if SIM_NAME.startswith(("icarus", "ghdl", "verilator"))
@@ -100,7 +100,7 @@ async def test_struct_iteration(dut):
         tlog.info(f"Found {member._path}")
         count += 1
 
-    # Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
+    # Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587, gh-3933)
     rv_2022_10_plus = RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
     if SIM_NAME.startswith("riviera") and rv_2022_10_plus and LANGUAGE == "verilog":
         assert count == 0

--- a/tests/test_cases/test_struct/test_struct.py
+++ b/tests/test_cases/test_struct/test_struct.py
@@ -32,11 +32,17 @@ async def test_packed_struct_format(dut):
     )
 
 
+# Riviera-PRO 2024.04 crashes on this testcase (gh-3936)
+sim_ver = RivieraVersion(cocotb.SIM_VERSION)
+is_riviera_2024_04 = sim_ver >= "2024.04" and sim_ver < "2024.05"
+
+
 @cocotb.test(
-    expect_error=AttributeError
-    if SIM_NAME.startswith(("icarus", "ghdl", "nvc"))
-    else (),
+    expect_error=(
+        AttributeError if SIM_NAME.startswith(("icarus", "ghdl", "nvc")) else ()
+    ),
     expect_fail=SIM_NAME.startswith(("modelsim", "riviera")),
+    skip=(SIM_NAME.startswith("riviera") and is_riviera_2024_04),
 )
 async def test_packed_struct_setting(dut):
     """Test getting and setting setting the value of an entire struct"""


### PR DESCRIPTION
Update CI to Riviera-PRO 2024.04 and remove test waivers for fixed issues:

- https://github.com/cocotb/cocotb/issues/3587
- https://github.com/cocotb/cocotb/issues/3467 (no waiver was added, the problem was only showing up locally for me)


Commits:
- **CI: Update Riviera-PRO to 2024.04**
- **Riviera-PRO: Update test expectations for 2024.04**

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
