### PR TITLE
Remove support for `Timer(0)`

### DIFF
--- a/docs/source/newsfragments/3937.removal.rst
+++ b/docs/source/newsfragments/3937.removal.rst
@@ -1,0 +1,1 @@
+Support for passing ``0`` as the *time* argument to :class:`~cocotb.triggers.Timer` has been removed. If a rounding operation causes the value to become ``0``, we change it to 1 simulation time step.

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -12,7 +12,6 @@ Tests related to timing triggers
 """
 
 import os
-import warnings
 from decimal import Decimal
 from fractions import Fraction
 
@@ -272,20 +271,13 @@ async def test_singleton_isinstance(dut):
     assert isinstance(ReadWrite(), ReadWrite)
 
 
-@cocotb.test()
-async def test_neg_timer(dut):
+@cocotb.test
+async def test_neg_timer(_):
     """Test negative timer values are forbidden"""
     with pytest.raises(ValueError):
         Timer(-42)  # no need to even `await`, constructing it is an error
-    # handle 0 special case
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
+    with pytest.raises(ValueError):
         Timer(0)
-        assert (
-            "Timer setup with value 0, which might exhibit undefined behavior in some simulators"
-            in str(w[-1].message)
-        )
-        assert issubclass(w[-1].category, RuntimeWarning)
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -280,6 +280,13 @@ async def test_neg_timer(_):
         Timer(0)
 
 
+@cocotb.test
+async def test_timer_rounds_to_0(_) -> None:
+    steps = get_sim_time("step")
+    await Timer(0.1, "step", round_mode="round")
+    assert get_sim_time("step") == steps + 1
+
+
 @cocotb.test()
 async def test_timer_round_mode(_):
     # test invalid round_mode specifier


### PR DESCRIPTION
Previously we issued a warning, but it was always an invalid operation that only sometimes worked in simulators.

If we round to 0 steps, we fix it up after the fact to 1. This is valid since this only occurs when using a rounding mode, and by using a rounding mode the user agrees to whatever reasonable time value we "round" to.

- [x] Add test for when rounding to 0 occurs