### PR TITLE
Remove `cocotb.result.SimFailure`

### DIFF
--- a/docs/source/newsfragments/3938.removal.rst
+++ b/docs/source/newsfragments/3938.removal.rst
@@ -1,0 +1,1 @@
+``cocotb.result.SimFailure`` has been removed. It's replaced with the *_expect_sim_failure* argument to :func:`cocotb.test`. Users are not intended to use this functionality.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -398,7 +398,7 @@ Bugfixes
 --------
 
 - Tests which fail at initialization, for instance due to no ``yield`` being present, are no longer silently ignored. (:pr:`1253`)
-- Tests that were not run because predecessors threw :class:`cocotb.result.SimFailure`, and caused the simulator to exit, are now recorded with an outcome of :class:`cocotb.result.SimFailure`.
+- Tests that were not run because predecessors threw ``cocotb.result.SimFailure``, and caused the simulator to exit, are now recorded with an outcome of ``cocotb.result.SimFailure``.
   Previously, these tests were ignored. (:pr:`1279`)
 - Makefiles now correctly fail if the simulation crashes before a ``results.xml`` file can be written. (:pr:`1314`)
 - Logging of non-string messages with colored log output is now working. (:pr:`1410`)

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -280,16 +280,12 @@ def _stop_library_coverage() -> None:
         _library_coverage.save()  # pragma: no cover
 
 
-def _sim_event(message: str) -> None:
+def _sim_event(msg: str) -> None:
     """Function that can be called externally to signal an event."""
-    from cocotb.result import SimFailure
-
     # We simply return here as the simulator will exit
     # so no cleanup is needed
-    msg = f"Failing test at simulator request before test run completion: {message}"
-    if _scheduler_inst is not None:
-        _scheduler_inst.log.error(msg)
-        _scheduler_inst._finish_scheduler(SimFailure(msg))
+    if regression_manager is not None:
+        regression_manager._fail_simulation(msg)
     else:
         log.error(msg)
         _stop_user_coverage()

--- a/src/cocotb/decorators.py
+++ b/src/cocotb/decorators.py
@@ -155,6 +155,7 @@ class _Parameterized(Generic[F]):
         expect_error: Union[Type[Exception], Sequence[Type[Exception]]] = (),
         skip: bool = False,
         stage: int = 0,
+        _expect_sim_failure: bool = False,
     ) -> Iterable[Test]:
         test_func_name = self.test_function.__qualname__ if name is None else name
 
@@ -201,6 +202,7 @@ class _Parameterized(Generic[F]):
                 expect_error=expect_error,
                 skip=skip,
                 stage=stage,
+                _expect_sim_failure=_expect_sim_failure,
             )
 
 
@@ -248,6 +250,7 @@ def test(
     skip: bool = False,
     stage: int = 0,
     name: Optional[str] = None,
+    _expect_sim_failure: bool = False,
 ) -> Callable[[Union[F, _Parameterized[F]]], F]: ...
 
 
@@ -261,6 +264,7 @@ def test(
     skip: bool = False,
     stage: int = 0,
     name: Optional[str] = None,
+    _expect_sim_failure: bool = False,
 ) -> Callable[[Union[F, _Parameterized[F]]], F]:
     """
     Decorator to register a Callable which returns a Coroutine as a test.
@@ -379,6 +383,7 @@ def test(
                     expect_error=expect_error,
                     skip=skip,
                     stage=stage,
+                    _expect_sim_failure=_expect_sim_failure,
                 ),
             )
             return test_func
@@ -394,6 +399,7 @@ def test(
                     expect_error=expect_error,
                     skip=skip,
                     stage=stage,
+                    _expect_sim_failure=_expect_sim_failure,
                 ),
             )
             return f

--- a/src/cocotb/result.py
+++ b/src/cocotb/result.py
@@ -28,11 +28,3 @@
 
 class TestSuccess(BaseException):
     """Exception to be thrown by the user to end a test early, forcing a PASS."""
-
-
-class SimFailure(BaseException):
-    """Exception showing that the simulator exited unsuccessfully.
-
-    Not intended to be thrown by the user.
-    Exists to be used to mark tests that are expected to error due to simulation failure.
-    """

--- a/tests/test_cases/issue_1279/issue_1279.py
+++ b/tests/test_cases/issue_1279/issue_1279.py
@@ -1,5 +1,5 @@
 """
-Test that once a SimFailure occurs, no further tests are run
+Test that once a simulation failure occurs, no further tests are run
 """
 
 import cocotb
@@ -7,8 +7,7 @@ import cocotb
 
 @cocotb.test(
     skip=cocotb.SIM_NAME.lower().startswith("riviera"),  # gh-1859
-    expect_error=cocotb.result.SimFailure,
-    stage=1,
+    _expect_sim_failure=True,
 )
 async def test_sim_failure_a(dut):
     # invoke a deadlock, as nothing is driving this clock
@@ -17,8 +16,7 @@ async def test_sim_failure_a(dut):
 
 @cocotb.test(
     skip=cocotb.SIM_NAME.lower().startswith("riviera"),  # gh-1859
-    expect_error=cocotb.result.SimFailure,
-    stage=2,
+    _expect_sim_failure=True,
 )
 async def test_sim_failure_b(dut):
     assert False, "This test should never run"

--- a/tests/test_cases/test_3316_b/test_3316_b.py
+++ b/tests/test_cases/test_3316_b/test_3316_b.py
@@ -6,7 +6,6 @@ import random
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.result import SimFailure
 from cocotb.triggers import RisingEdge
 
 
@@ -22,16 +21,11 @@ async def clk_in_coroutine(dut):
         await RisingEdge(dut.clk)
 
 
-@cocotb.test(expect_error=SimFailure)
+@cocotb.test(_expect_sim_failure=True)
 async def clk_in_hdl(dut):
-    try:
-        dut.d.value = 0
+    dut.d.value = 0
+    await RisingEdge(dut.clk)
+    for _ in range(3):
+        val = random.randint(0, 1)
+        dut.d.value = val
         await RisingEdge(dut.clk)
-        for _ in range(3):
-            val = random.randint(0, 1)
-            dut.d.value = val
-            await RisingEdge(dut.clk)
-    except SimFailure:
-        pass
-    else:
-        assert False, "Exception did not occur"

--- a/tests/test_cases/test_3316_d/test_3316_d.py
+++ b/tests/test_cases/test_3316_d/test_3316_d.py
@@ -6,7 +6,6 @@ import random
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.result import SimFailure
 from cocotb.triggers import RisingEdge
 
 
@@ -22,16 +21,11 @@ async def clk_in_coroutine(dut):
         await RisingEdge(dut.clk)
 
 
-@cocotb.test(expect_error=SimFailure)
+@cocotb.test(_expect_sim_failure=True)
 async def clk_in_hdl(dut):
-    try:
-        dut.d.value = 0
+    dut.d.value = 0
+    await RisingEdge(dut.clk)
+    for _ in range(3):
+        val = random.randint(0, 1)
+        dut.d.value = val
         await RisingEdge(dut.clk)
-        for _ in range(3):
-            val = random.randint(0, 1)
-            dut.d.value = val
-            await RisingEdge(dut.clk)
-    except SimFailure:
-        pass
-    else:
-        assert False, "Exception did not occur"

--- a/tests/test_cases/test_fatal/test_fatal.py
+++ b/tests/test_cases/test_fatal/test_fatal.py
@@ -4,12 +4,11 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import cocotb
-from cocotb.result import SimFailure
 from cocotb.triggers import Timer
 
 
 @cocotb.test(
-    expect_error=SimFailure, skip=cocotb.SIM_NAME.lower().startswith("riviera")
+    _expect_sim_failure=True, skip=cocotb.SIM_NAME.lower().startswith("riviera")
 )
 async def test_fatal(_):
     await Timer(100, "ns")


### PR DESCRIPTION
Closes #3788. Depends on #3941.

This PR ended up being more of a refactor of the RegressionManager than intended. 

This PR:
* Moves `SimFailure` to regression.py (to be removed once I refactor how tests end)
* Adds `_sim_expect_failure` flag to `cocotb.test` decorator to cover this use case.