### PR TITLE
Move cleanup and test score to before wait on `Timer(1)`

### DIFF
--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -58,7 +58,7 @@ from cocotb.logging import _filter_from_c, _log_from_c  # isort: skip # noqa: F4
 log: py_logging.Logger
 """The default cocotb logger."""
 
-_scheduler: Scheduler
+_scheduler_inst: Scheduler
 """The global scheduler instance."""
 
 regression_manager: RegressionManager
@@ -136,7 +136,7 @@ def start_soon(coro: Union[Task, Coroutine]) -> Task:
 
     .. versionadded:: 1.6.0
     """
-    return _scheduler.start_soon(coro)
+    return _scheduler_inst.start_soon(coro)
 
 
 async def start(coro: Union[Task, Coroutine]) -> Task:
@@ -156,7 +156,7 @@ async def start(coro: Union[Task, Coroutine]) -> Task:
 
     .. versionadded:: 1.6.0
     """
-    task = _scheduler.start_soon(coro)
+    task = _scheduler_inst.start_soon(coro)
     await cocotb.triggers.NullTrigger()
     return task
 
@@ -175,7 +175,7 @@ def create_task(coro: Union[Task, Coroutine]) -> Task:
 
     .. versionadded:: 1.6.0
     """
-    return cocotb._scheduler.create_task(coro)
+    return cocotb._scheduler_inst.create_task(coro)
 
 
 def _initialise_testbench(argv_):  # pragma: no cover
@@ -233,8 +233,8 @@ def _initialise_testbench_(argv_):
     _setup_regression_manager()
 
     # setup global scheduler system
-    global _scheduler
-    _scheduler = Scheduler(test_complete_cb=regression_manager._test_complete)
+    global _scheduler_inst
+    _scheduler_inst = Scheduler(test_complete_cb=regression_manager._test_complete)
 
     # start Regression Manager
     regression_manager.start_regression()
@@ -273,9 +273,9 @@ def _sim_event(message: str) -> None:
     # We simply return here as the simulator will exit
     # so no cleanup is needed
     msg = f"Failing test at simulator request before test run completion: {message}"
-    if _scheduler is not None:
-        _scheduler.log.error(msg)
-        _scheduler._finish_scheduler(SimFailure(msg))
+    if _scheduler_inst is not None:
+        _scheduler_inst.log.error(msg)
+        _scheduler_inst._finish_scheduler(SimFailure(msg))
     else:
         log.error(msg)
         _stop_user_coverage()

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -818,10 +818,6 @@ class Scheduler:
         finally:
             self._current_task = None
 
-    def _finish_test(self, exc):
-        self._abort_test(exc)
-        self._check_termination()
-
     def _abort_test(self, exc):
         """Force this test to end early, without executing any cleanup.
 

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -230,7 +230,7 @@ class Scheduler:
         The scheduler treats Tests specially.
         If a Test finishes or a Task ends with an Exception, the scheduler is put into a `terminating` state.
         All currently queued Tasks are cancelled and all pending Triggers are unprimed.
-        This is currently spread out between :meth:`_check_termination`, :meth:`_test_completed`, and :meth:`_cleanup`.
+        This is currently spread out between :meth:`_handle_termination`, :meth:`_test_completed`, and :meth:`_cleanup`.
         In that mix of functions, the :attr:`_test_complete_cb` callback is called to inform whomever (the regression_manager) the test finished.
         The scheduler also is responsible for starting the next Test in the Normal phase by priming a ``Timer(1)`` with the second half of test completion handling.
 
@@ -310,7 +310,7 @@ class Scheduler:
                 func(*args)
             self._writes_pending.clear()
 
-    def _check_termination(self) -> None:
+    def _handle_termination(self) -> None:
         """
         Handle a termination that causes us to move onto the next test.
         """
@@ -368,7 +368,7 @@ class Scheduler:
             self._test_complete_cb()
 
             # if it did, make sure we handle the test completing
-            self._check_termination()
+            self._handle_termination()
 
     def _sim_react(self, trigger: Trigger) -> None:
         """Called when a :class:`~cocotb.triggers.GPITrigger` fires.
@@ -469,7 +469,7 @@ class Scheduler:
                 self._pending_events.pop(0).set()
 
         # no more pending tasks
-        self._check_termination()
+        self._handle_termination()
         if _debug:
             self.log.debug("All tasks scheduled, handing control back to simulator")
 

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -310,27 +310,31 @@ class Scheduler:
                 func(*args)
             self._writes_pending.clear()
 
-    def _check_termination(self):
-        """Handle a termination that causes us to move onto the next test."""
-        if self._terminate:
-            if _debug:
-                self.log.debug("Test terminating, scheduling Timer")
+    def _check_termination(self) -> None:
+        """
+        Handle a termination that causes us to move onto the next test.
+        """
+        if not self._terminate:
+            return
 
-            if self._write_task is not None:
-                self._write_task.kill()
-                self._write_task = None
+        if _debug:
+            self.log.debug("Test terminating, scheduling Timer")
 
-            for t in self._trigger2tasks:
-                t._unprime()
+        if self._write_task is not None:
+            self._write_task.kill()
+            self._write_task = None
 
-            if self._timer1._primed:
-                self._timer1._unprime()
+        for t in self._trigger2tasks:
+            t._unprime()
 
-            self._timer1._prime(self._test_completed)
-            self._trigger2tasks = _py_compat.insertion_ordered_dict()
-            self._terminate = False
-            self._write_calls.clear()
-            self._writes_pending.clear()
+        if self._timer1._primed:
+            self._timer1._unprime()
+
+        self._timer1._prime(self._test_completed)
+        self._trigger2tasks = _py_compat.insertion_ordered_dict()
+        self._terminate = False
+        self._write_calls.clear()
+        self._writes_pending.clear()
 
     def _test_completed(self, trigger=None):
         """Called after a test and its cleanup have completed."""

--- a/src/cocotb/decorators.py
+++ b/src/cocotb/decorators.py
@@ -80,7 +80,7 @@ def function(func: Callable[..., Coroutine[Any, Any, Result]]) -> Callable[..., 
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        return cocotb._scheduler._queue_function(func(*args, **kwargs))
+        return cocotb._scheduler_inst._queue_function(func(*args, **kwargs))
 
     return wrapper
 
@@ -107,7 +107,7 @@ def external(func: Callable[..., Result]) -> Callable[..., Coroutine[Any, Any, R
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        return cocotb._scheduler._run_in_executor(func, *args, **kwargs)
+        return cocotb._scheduler_inst._run_in_executor(func, *args, **kwargs)
 
     return wrapper
 

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -69,7 +69,7 @@ else:
     def _inertial_write(
         handle: "ValueObjectBase[Any, Any]", f: Callable[..., None], args: Any
     ) -> None:
-        cocotb._scheduler._schedule_write(handle, f, args)
+        cocotb._scheduler_inst._schedule_write(handle, f, args)
 
 
 class _Limits(enum.IntEnum):

--- a/src/cocotb/ipython_support.py
+++ b/src/cocotb/ipython_support.py
@@ -25,7 +25,7 @@ class SimTimePrompt(Prompts):
 
 def _runner(shell, x):
     """Handler for async functions"""
-    ret = cocotb._scheduler._queue_function(x)
+    ret = cocotb._scheduler_inst._queue_function(x)
     shell.prompts._show_time = shell.execution_count
     return ret
 

--- a/src/cocotb/queue.py
+++ b/src/cocotb/queue.py
@@ -105,7 +105,7 @@ class Queue(Generic[T]):
         """
         while self.full():
             event = Event(f"{type(self).__name__} put")
-            self._putters.append((event, cocotb._scheduler._current_task))
+            self._putters.append((event, cocotb._scheduler_inst._current_task))
             await event.wait()
         self.put_nowait(item)
 
@@ -126,7 +126,7 @@ class Queue(Generic[T]):
         """
         while self.empty():
             event = Event(f"{type(self).__name__} get")
-            self._getters.append((event, cocotb._scheduler._current_task))
+            self._getters.append((event, cocotb._scheduler_inst._current_task))
             await event.wait()
         return self.get_nowait()
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -430,7 +430,7 @@ class RegressionManager:
             else:
                 self._test_start_sim_time = get_sim_time("ns")
                 self._test_start_time = time.time()
-                return cocotb._scheduler._add_test(self._test_task)
+                return cocotb._scheduler_inst._add_test(self._test_task)
 
         return self._tear_down()
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -91,7 +91,7 @@ class Task(Generic[ResultType]):
     def __repr__(self) -> str:
         coro_stack = self._get_coro_stack()
 
-        if cocotb._scheduler._current_task is self:
+        if cocotb._scheduler_inst._current_task is self:
             fmt = "<{name} running coro={coro}()>"
         elif self.done():
             fmt = "<{name} finished coro={coro}() outcome={outcome}>"
@@ -149,7 +149,7 @@ class Task(Generic[ResultType]):
             self.log.debug("kill() called on coroutine")
         # todo: probably better to throw an exception for anyone waiting on the coroutine
         self._outcome = Value(None)
-        cocotb._scheduler._unschedule(self)
+        cocotb._scheduler_inst._unschedule(self)
 
         # Close coroutine so there is no RuntimeWarning that it was never awaited
         if not self.has_started():

--- a/tests/designs/plusargs_module/tb_top.vhd
+++ b/tests/designs/plusargs_module/tb_top.vhd
@@ -13,5 +13,6 @@ begin
     begin
         wait for 10 ns;
         dummy_sig <= '1';
+        wait;
     end process;
 end architecture;

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -496,7 +496,7 @@ async def test_test_repr(_):
     """Test RunningTest.__repr__"""
     log = logging.getLogger("cocotb.test")
 
-    current_test = cocotb._scheduler._test
+    current_test = cocotb._scheduler_inst._test
     log.info(repr(current_test))
     assert re.match(
         r"<Test test_test_repr running coro=test_test_repr\(\)>", repr(current_test)
@@ -514,7 +514,7 @@ class TestClassRepr(Coroutine):
     async def check_repr(self, dut):
         log = logging.getLogger("cocotb.test")
 
-        current_test = cocotb._scheduler._test
+        current_test = cocotb._scheduler_inst._test
         log.info(repr(current_test))
         assert re.match(
             r"<Test TestClassRepr running coro=TestClassRepr\(\)>", repr(current_test)
@@ -561,7 +561,7 @@ async def test_start_soon_scheduling(dut):
         log = logging.getLogger("cocotb.test")
         log.debug("react_wrapper start")
         assert coro_scheduled is False
-        cocotb._scheduler._sim_react(trigger)
+        cocotb._scheduler_inst._sim_react(trigger)
         assert coro_scheduled is True
         log.debug("react_wrapper end")
 
@@ -691,7 +691,7 @@ async def test_start_scheduling(dut):
         log = logging.getLogger("cocotb.test")
         log.debug("react_wrapper start")
         sim_resumed = False
-        cocotb._scheduler._sim_react(trigger)
+        cocotb._scheduler_inst._sim_react(trigger)
         sim_resumed = True
         log.debug("react_wrapper end")
 

--- a/tests/test_cases/test_one_empty_test/Makefile
+++ b/tests/test_cases/test_one_empty_test/Makefile
@@ -1,0 +1,7 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+include ../../designs/sample_module/Makefile
+
+MODULE = test_one_empty_test

--- a/tests/test_cases/test_one_empty_test/test_one_empty_test.py
+++ b/tests/test_cases/test_one_empty_test/test_one_empty_test.py
@@ -1,0 +1,10 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import cocotb
+
+
+@cocotb.test
+async def test(_):
+    pass


### PR DESCRIPTION
Moves the cleanup and test score to before the wait on `Timer(1)` to start the next test.

~~This is a WIP. The issue is that we can't start the test with `Timer(1)` because when it attempts to start the unstarted task, it uses `Trigger._outcome` which is *usually* the trigger; but coroutines can only be started with `None`. I'm going to change `Trigger` to remove the `_outcome` and only ever send it `None`, as mentioned [here](https://github.com/cocotb/cocotb/pull/3931#issuecomment-2159465269), and have the `__await__` function return any value that's pertinent.~~ Fixed.
