### PR TITLE
Scheduler refactor

### DIFF
--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -522,7 +522,12 @@ class Scheduler:
                 raise InternalError("More than one task waiting on an unprimed trigger")
 
             try:
-                trigger._prime(self._react)
+                # TODO maybe associate the react method with the trigger object so
+                # we don't have to do a type check here.
+                if isinstance(trigger, GPITrigger):
+                    trigger._prime(self._gpi_react)
+                else:
+                    trigger._prime(self._react)
             except Exception as e:
                 # discard the trigger we associated, it will never fire
                 self._trigger2tasks.pop(trigger)

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -150,6 +150,10 @@ class Task(Generic[T]):
         self._outcome = Value(None)
         cocotb._scheduler._unschedule(self)
 
+        # Close coroutine so there is no RuntimeWarning that it was never awaited
+        if not self.has_started():
+            self._coro.close()
+
     def join(self) -> "cocotb.triggers.Join":
         """Return a trigger that will fire when the wrapped coroutine exits."""
         return cocotb.triggers.Join(self)

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -524,7 +524,7 @@ async def test_start_soon_scheduling(dut):
         log = logging.getLogger("cocotb.test")
         log.debug("react_wrapper start")
         assert coro_scheduled is False
-        cocotb._scheduler._react(trigger)
+        cocotb._scheduler._gpi_react(trigger)
         assert coro_scheduled is True
         log.debug("react_wrapper end")
 
@@ -654,7 +654,7 @@ async def test_start_scheduling(dut):
         log = logging.getLogger("cocotb.test")
         log.debug("react_wrapper start")
         sim_resumed = False
-        cocotb._scheduler._react(trigger)
+        cocotb._scheduler._gpi_react(trigger)
         sim_resumed = True
         log.debug("react_wrapper end")
 

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -524,7 +524,7 @@ async def test_start_soon_scheduling(dut):
         log = logging.getLogger("cocotb.test")
         log.debug("react_wrapper start")
         assert coro_scheduled is False
-        cocotb._scheduler._gpi_react(trigger)
+        cocotb._scheduler._sim_react(trigger)
         assert coro_scheduled is True
         log.debug("react_wrapper end")
 
@@ -654,7 +654,7 @@ async def test_start_scheduling(dut):
         log = logging.getLogger("cocotb.test")
         log.debug("react_wrapper start")
         sim_resumed = False
-        cocotb._scheduler._gpi_react(trigger)
+        cocotb._scheduler._sim_react(trigger)
         sim_resumed = True
         log.debug("react_wrapper end")
 


### PR DESCRIPTION
Removed `pending_triggers` and `scheduling` queues in the scheduler. Made `pending_tasks` *the* task queue. Whenever triggers fires they now immediately add the tasks waiting upon them to the `pending_tasks` queue alongside the outcome the scheduler should inject into the task.

Also cleaned up state tracking a bit by using an Enum.

Separated react method into one for GPITriggers and the other for Python Triggers.

- [x] potential speed optimization by using a data structure other than list for the pending_tasks queue. We currently need an O(n) lookup loop in Python.