### PR TITLE
Add legacy `.buff` property to `LogicArray`

### DIFF
--- a/docs/source/newsfragments/3944.removal.rst
+++ b/docs/source/newsfragments/3944.removal.rst
@@ -1,1 +1,1 @@
-:attr:`LogicArray.buff <cocotb.types.LogicArray.buff>` has been deprecated. Use :meth:`LogicArray.to_unsigned() <cocotb.types.LogicArray.to_unsigned>` in combination with :meth:`int.to_bytes` as such ``v.to_unsigned().to_bytes(ceil(len(v) / 8), byteorder="big")`` instead.
+:attr:`LogicArray.buff <cocotb.types.LogicArray.buff>` has been deprecated. Use :meth:`LogicArray.to_unsigned() <cocotb.types.LogicArray.to_unsigned>` in combination with :meth:`int.to_bytes` instead. For example: ``v.to_unsigned().to_bytes(ceil(len(v) / 8), byteorder="big")``.

--- a/docs/source/newsfragments/3944.removal.rst
+++ b/docs/source/newsfragments/3944.removal.rst
@@ -1,0 +1,1 @@
+:attr:`LogicArray.buff <cocotb.types.LogicArray.buff>` has been deprecated. Use :meth:`LogicArray.to_unsigned() <cocotb.types.LogicArray.to_unsigned>` in combination with :meth:`int.to_bytes` as such ``v.to_unsigned().to_bytes(ceil(len(v) / 8), byteorder="big")`` instead.

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import typing
 import warnings
+from math import ceil
 
 from cocotb._deprecation import deprecated
 from cocotb.types import ArrayLike
@@ -346,6 +347,23 @@ class LogicArray(ArrayLike[Logic]):
         .. deprecated:: 2.0
         """
         return self.to_signed()
+
+    @property
+    @deprecated(
+        '`.buff` property is deprecated. Use `v.to_unsigned().to_bytes(ceil(len(v) / 8), byteorder="big")` instead.'
+    )
+    def buff(self) -> bytes:
+        """Converts the value to :class:`bytes` by interpreting it as an unsigned integer in big-endian byteorder.
+
+        The object is first converted to an :class:`int` as in :meth:`to_unsigned`.
+        Then the object is converted to :class:`bytes` by converting the resulting integer value as in :meth:`int.to_bytes`.
+        This assumes big-endian byteorder and the minimal number of bytes necessary to hold any value of the current object.
+
+        Returns: A :class:`bytes` object equivalent to the value.
+
+        .. deprecated:: 2.0
+        """
+        return self.to_unsigned().to_bytes(ceil(len(self) / 8), byteorder="big")
 
     def to_unsigned(self) -> int:
         """Convert the value to an :class:`int` by interpreting it using unsigned representation.

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -353,7 +353,7 @@ class LogicArray(ArrayLike[Logic]):
         '`.buff` property is deprecated. Use `v.to_unsigned().to_bytes(ceil(len(v) / 8), byteorder="big")` instead.'
     )
     def buff(self) -> bytes:
-        """Converts the value to :class:`bytes` by interpreting it as an unsigned integer in big-endian byteorder.
+        """Convert the value to :class:`bytes` by interpreting it as an unsigned integer in big-endian byteorder.
 
         The object is first converted to an :class:`int` as in :meth:`to_unsigned`.
         Then the object is converted to :class:`bytes` by converting the resulting integer value as in :meth:`int.to_bytes`.

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -353,11 +353,11 @@ class LogicArray(ArrayLike[Logic]):
         '`.buff` property is deprecated. Use `v.to_unsigned().to_bytes(ceil(len(v) / 8), byteorder="big")` instead.'
     )
     def buff(self) -> bytes:
-        """Convert the value to :class:`bytes` by interpreting it as an unsigned integer in big-endian byteorder.
+        """Convert the value to :class:`bytes` by interpreting it as an unsigned integer in big-endian byte order.
 
         The object is first converted to an :class:`int` as in :meth:`to_unsigned`.
         Then the object is converted to :class:`bytes` by converting the resulting integer value as in :meth:`int.to_bytes`.
-        This assumes big-endian byteorder and the minimal number of bytes necessary to hold any value of the current object.
+        This assumes big-endian byte order and the minimal number of bytes necessary to hold any value of the current object.
 
         Returns: A :class:`bytes` object equivalent to the value.
 

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -2,6 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
+
 from cocotb.types import Logic, LogicArray, Range
 
 
@@ -64,23 +65,19 @@ def test_logic_array_properties():
 
 def test_logic_array_properties_deprecated():
     with pytest.warns(DeprecationWarning):
-        assert LogicArray(0).integer == 0
+        assert LogicArray("0").integer == 0
     with pytest.warns(DeprecationWarning):
-        assert LogicArray(0).signed_integer == 0
+        assert LogicArray("0").signed_integer == 0
     with pytest.warns(DeprecationWarning):
-        assert LogicArray(0).binstr == "0"
+        assert LogicArray("0").binstr == "0"
     with pytest.warns(DeprecationWarning):
-        assert LogicArray(10).integer == 10
+        assert LogicArray("1010").integer == 10
     with pytest.warns(DeprecationWarning):
-        assert LogicArray(10).signed_integer == -6
+        assert LogicArray("1010").signed_integer == -6
     with pytest.warns(DeprecationWarning):
-        assert LogicArray(10).binstr == "1010"
+        assert LogicArray("1010").binstr == "1010"
     with pytest.warns(DeprecationWarning):
-        assert LogicArray(-6).integer == 10
-    with pytest.warns(DeprecationWarning):
-        assert LogicArray(-6).signed_integer == -6
-    with pytest.warns(DeprecationWarning):
-        assert LogicArray(-6).binstr == "1010"
+        assert LogicArray("01000001" + "00101111").buff == b"\x41\x2f"
 
 
 def test_logic_array_setattr():


### PR DESCRIPTION
This turns out to be used quite a bit in some codebases. We can assume big-endian only since we only support these deprecated interfaces for the sole purpose of calling them on the result of `handle.value`, which in cocotb < 2.0 [always defaulted to](https://github.com/cocotb/cocotb/blob/05a50946ffafad7659a2f0683cd2a23ab7e12f5d/cocotb/handle.py#L909) [big endian byteorder](https://github.com/cocotb/cocotb/blob/05a50946ffafad7659a2f0683cd2a23ab7e12f5d/cocotb/binary.py#L140).