### PR TITLE
Fix config_file for coverage

### DIFF
--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -362,7 +362,7 @@ def _start_user_coverage() -> None:
                     "Collecting coverage of user code. Coverage config file supplied."
                 )
                 # Allow the config file to handle all configuration
-                _user_coverage = coverage.coverage()
+                _user_coverage = coverage.coverage(config_file=config_filepath)
             _user_coverage.start()
 
 


### PR DESCRIPTION
The configuration file is given to the coverage initializer via an argument instead of it being read from the environment in the coverage module.

Fixes #3947 
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
