### PR TITLE
Replacing the no longer supported option '+acc+1' with '-debug_access+r+w-memcbk -debug_region+cell'

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.vcs
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.vcs
@@ -77,7 +77,7 @@ $(SIM_BUILD)/pli.tab : | $(SIM_BUILD)
 $(SIM_BUILD)/simv: $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	cd $(SIM_BUILD) && \
 	COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) \
-	$(CMD) -top $(COCOTB_TOPLEVEL) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) +acc+1 +vpi -P pli.tab -sverilog \
+	$(CMD) -top $(COCOTB_TOPLEVEL) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) -debug_access+r+w-memcbk -debug_region+cell +vpi -P pli.tab -sverilog \
 	-timescale=$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
 	$(EXTRA_ARGS) -debug -load $(shell cocotb-config --lib-name-path vpi vcs) $(COMPILE_ARGS) $(VERILOG_SOURCES)
 


### PR DESCRIPTION
In the vcs Version V-2023.12-SP1-1_Full64, I encountered the following error while building the project:

```
Error-[OBSOLETE_OPTION_PLUSACC] Obsolete option '+acc' used
The specified option '+acc+1' is no longer supported.
Please use '-debug_access+r+w-memcbk -debug_region+cell' instead.
```

```
make[1]: *** [/tmp/venv/lib64/python3.6/site-packages/cocotb/share/makefiles/simulators/Makefile.vcs:78: sim_build/simv] Error 255
```

I replaced the option `+acc+1` with the suggested option from vcs. I verified the solution on versions Version T-2022.06-1_Full64 and Version V-2023.12-SP1-1_Full64.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
