### PR TITLE
GpiClk: clock implemented on the simulator side.

### DIFF
--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -81,9 +81,11 @@ imitate a callback.
 class GpiObjHdl;
 class GpiCbHdl;
 class GpiIterator;
+class GpiClk;
 typedef GpiObjHdl *gpi_sim_hdl;
 typedef GpiCbHdl *gpi_cb_hdl;
 typedef GpiIterator *gpi_iterator_hdl;
+typedef GpiClk *gpi_clk_hdl;
 #else
 /* In C, we declare some incomplete struct types that we never complete.
  * The names of these are irrelevant, but for simplicity they match the C++
@@ -92,9 +94,11 @@ typedef GpiIterator *gpi_iterator_hdl;
 struct GpiObjHdl;
 struct GpiCbHdl;
 struct GpiIterator;
+struct GpiClk;
 typedef struct GpiObjHdl *gpi_sim_hdl;
 typedef struct GpiCbHdl *gpi_cb_hdl;
 typedef struct GpiIterator *gpi_iterator_hdl;
+typedef struct GpiClk *gpi_clk_hdl;
 #endif
 
 #ifdef __cplusplus
@@ -258,6 +262,13 @@ GPI_EXPORT void gpi_deregister_callback(gpi_cb_hdl gpi_hdl);
 // implementations of GPI we provide a convenience function to extract the
 // callback data
 GPI_EXPORT void *gpi_get_callback_data(gpi_cb_hdl gpi_hdl);
+
+// Simulation clock functions
+GPI_EXPORT gpi_clk_hdl gpi_clock_create(gpi_sim_hdl clk_signal_hdl);
+GPI_EXPORT int gpi_clock_start(gpi_clk_hdl clk, uint64_t period_steps,
+                               uint64_t high_steps, uint64_t phase_steps);
+GPI_EXPORT int gpi_clock_stop(gpi_clk_hdl clk);
+GPI_EXPORT void gpi_clock_delete(gpi_clk_hdl clk);
 
 #ifdef __cplusplus
 }

--- a/src/cocotb/share/lib/gpi/gpi_priv.h
+++ b/src/cocotb/share/lib/gpi/gpi_priv.h
@@ -53,7 +53,6 @@ typedef enum gpi_cb_state {
 class GpiCbHdl;
 class GpiImplInterface;
 class GpiIterator;
-class GpiCbHdl;
 
 /* Base GPI class others are derived from */
 class GPI_EXPORT GpiHdl {
@@ -167,6 +166,32 @@ class GPI_EXPORT GpiSignalObjHdl : public GpiObjHdl {
 
     virtual GpiCbHdl *register_value_change_callback(
         int edge, int (*gpi_function)(void *), void *gpi_cb_data) = 0;
+};
+
+/* GPI Clock */
+// This object implements a simulator-side clock using GPI.
+class GPI_EXPORT GpiClk : public GpiHdl {
+  public:
+    GpiClk(GpiSignalObjHdl *clk_sig) : GpiHdl(clk_sig->m_impl, clk_sig) {}
+
+    ~GpiClk();
+
+    int start(uint64_t period_steps, uint64_t high_steps, uint64_t phase_steps);
+
+    int stop();
+
+    bool is_running() const { return clk_toggle_cb_hdl != nullptr; }
+
+  protected:
+    GpiCbHdl *clk_toggle_cb_hdl = nullptr;
+
+    uint64_t period = 0;
+    uint64_t t_high = 0;
+
+    int clk_val = 0;
+
+    int toggle();
+    static int toggle_cb(void *gpi_clk);
 };
 
 /* GPI Callback handle */


### PR DESCRIPTION
These changes implement #89. It passes many tests, however to fully work it needs #3874 first for proper cleanup in all cases (as noted in the original issue).

I don't fully understand what's needed from #2108, or if things have progressed in the meantime and that's no longer needed. One difference is that there the clock would run necessarily before any timed callback, whereas here it's implemented with timed callbacks, so the order relative to other CBs at the same time is not guaranteed. However, the current clocks in python also work via Timer and have the same limitation, so maybe it doesn't matter.

One notable difference with using this (and previous PRs' implementations for what I can tell) is that the toggling happens immediately, and not during ReadWrite. @ktbarrett pointed out that if using inertial writes the behavior should be identical, so one option is to use GpiClk automatically only if inertial writes are configured.

One reason in favor of still doing this in all cases (assuming tests pass) is that it's good for performance: the clock toggles before eval() is called, usually reducing the number of eval calls by one (although #3861 should fix that in most cases). And an HDL clock implementation is already different from the python clock in this regard, so if things are written in a way that is agnostic to where the clock is generated, it should also work with this.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
