### PR TITLE
Fix isort config

### DIFF
--- a/examples/analog_model/test_analog_model.py
+++ b/examples/analog_model/test_analog_model.py
@@ -1,8 +1,9 @@
 # This file is public domain, it can be freely copied without restrictions.
 # SPDX-License-Identifier: CC0-1.0
 
-import cocotb
 from afe import AFE
+
+import cocotb
 from cocotb.clock import Clock
 from cocotb.queue import Queue
 from cocotb.triggers import Edge, RisingEdge, Timer

--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from random import getrandbits
 from typing import Any, Dict, List
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.clock import Clock
 from cocotb.handle import SimHandleBase
 from cocotb.queue import Queue

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -5,8 +5,9 @@ import os
 import sys
 from pathlib import Path
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_tools.runner import get_runner

--- a/examples/mixed_signal/tests/test_regulator_plot.py
+++ b/examples/mixed_signal/tests/test_regulator_plot.py
@@ -3,8 +3,9 @@
 
 import math
 
-import cocotb
 import matplotlib.pyplot as plt
+
+import cocotb
 from cocotb.triggers import Timer
 
 

--- a/examples/mixed_signal/tests/test_rescap.py
+++ b/examples/mixed_signal/tests/test_rescap.py
@@ -4,8 +4,9 @@
 from collections import defaultdict, namedtuple
 from itertools import cycle
 
-import cocotb
 import matplotlib.pyplot as plt
+
+import cocotb
 from cocotb.triggers import Timer
 from cocotb.utils import get_sim_time
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,16 @@ ignore = [
     "F811",
 ]
 
+[tool.ruff.lint.isort]
+known-first-party = [
+    "cocotb",
+    "cocotb_tools",
+    "pygpi",
+]
+known-third-party = [
+    "pytest",
+]
+
 [tool.cibuildwheel]
 # Build for supported platforms only.
 # Even though we only support 64 bit operating systems, we still support 32 bit

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -2,6 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
+
 from cocotb.types import Array, Range
 
 

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import pytest
+
 from cocotb_tools.runner import get_runner
 
 pytestmark = pytest.mark.simulator_required

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -2,6 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
+
 from cocotb.types import Logic
 
 

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -2,6 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
+
 from cocotb.types import Logic, LogicArray, Range
 
 

--- a/tests/pytest/test_logs.py
+++ b/tests/pytest/test_logs.py
@@ -7,11 +7,7 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import cocotb
 import pytest
-from cocotb.clock import Clock
-from cocotb.triggers import ClockCycles
-from cocotb_tools.runner import get_runner
 from test_cocotb import (
     compile_args,
     gpi_interfaces,
@@ -22,6 +18,11 @@ from test_cocotb import (
     sources,
     tests_dir,
 )
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles
+from cocotb_tools.runner import get_runner
 
 sys.path.insert(0, str(Path(tests_dir) / "pytest"))
 test_module = Path(__file__).stem

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 import pytest
-from cocotb_tools.runner import get_runner
 from test_cocotb import (
     compile_args,
     gpi_interfaces,
@@ -19,6 +18,8 @@ from test_cocotb import (
     sources,
     tests_dir,
 )
+
+from cocotb_tools.runner import get_runner
 
 pytestmark = pytest.mark.simulator_required
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))

--- a/tests/pytest/test_parameterize.py
+++ b/tests/pytest/test_parameterize.py
@@ -4,8 +4,9 @@
 
 from enum import Enum
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.decorators import _repr, _reprs
 
 

--- a/tests/pytest/test_plusargs.py
+++ b/tests/pytest/test_plusargs.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
+
 from cocotb_tools.runner import get_runner
 
 pytestmark = pytest.mark.simulator_required

--- a/tests/pytest/test_range.py
+++ b/tests/pytest/test_range.py
@@ -2,6 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
+
 from cocotb.types import Range
 
 

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -5,9 +5,10 @@
 import os
 import sys
 
-import cocotb
 import find_libpython
 import pytest
+
+import cocotb
 from cocotb.triggers import Timer
 from cocotb_tools.runner import get_runner
 

--- a/tests/pytest/test_timescale.py
+++ b/tests/pytest/test_timescale.py
@@ -3,8 +3,6 @@ import sys
 import tempfile
 
 import pytest
-from cocotb.utils import _get_log_time_scale
-from cocotb_tools.runner import get_runner
 from test_cocotb import (
     compile_args,
     gpi_interfaces,
@@ -16,6 +14,9 @@ from test_cocotb import (
     sources,
     tests_dir,
 )
+
+from cocotb.utils import _get_log_time_scale
+from cocotb_tools.runner import get_runner
 
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
 

--- a/tests/pytest/test_vhdl_libraries_multiple.py
+++ b/tests/pytest/test_vhdl_libraries_multiple.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
+
 from cocotb_tools.runner import get_runner
 
 pytestmark = pytest.mark.simulator_required

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -3,11 +3,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-import cocotb
 import pytest
-from cocotb.clock import Clock
-from cocotb.triggers import ClockCycles
-from cocotb_tools.runner import get_runner
 from test_cocotb import (
     compile_args,
     gpi_interfaces,
@@ -18,6 +14,11 @@ from test_cocotb import (
     sources,
     tests_dir,
 )
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles
+from cocotb_tools.runner import get_runner
 
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
 test_module = os.path.basename(os.path.splitext(__file__)[0])

--- a/tests/test_cases/test_cocotb/pytest_assertion_rewriting.py
+++ b/tests/test_cases/test_cocotb/pytest_assertion_rewriting.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Tests relating to pytest integration"""
 
-import cocotb
 import pytest
+
+import cocotb
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_async_coroutines.py
+++ b/tests/test_cases/test_cocotb/test_async_coroutines.py
@@ -5,12 +5,13 @@
 Test function and substitutability of async coroutines
 """
 
-import cocotb
 import pytest
+from common import MyException
+
+import cocotb
 from cocotb._outcomes import Error, Value
 from cocotb.task import Task
 from cocotb.triggers import Timer
-from common import MyException
 
 
 class produce:

--- a/tests/test_cases/test_cocotb/test_clock.py
+++ b/tests/test_cases/test_cocotb/test_clock.py
@@ -10,8 +10,9 @@ import fractions
 import os
 from math import isclose
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.clock import Clock
 from cocotb.simulator import get_precision
 from cocotb.triggers import RisingEdge, Timer

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -9,10 +9,11 @@ import re
 from collections import deque
 from random import randint
 
+from common import _check_traceback
+
 import cocotb
 from cocotb.triggers import Combine, Event, First, Timer
 from cocotb.utils import get_sim_time
-from common import _check_traceback
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -4,8 +4,9 @@
 import os
 import warnings
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.regression import TestFactory
 from cocotb.triggers import Timer
 

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -12,8 +12,9 @@ Tests for edge triggers
 
 import os
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb._sim_versions import RivieraVersion
 from cocotb.clock import Clock
 from cocotb.result import SimTimeoutError

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -9,8 +9,9 @@ import logging
 import os
 import random
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.handle import _Limits
 from cocotb.triggers import Timer
 from cocotb.types import Logic, LogicArray

--- a/tests/test_cases/test_cocotb/test_logging.py
+++ b/tests/test_cases/test_cocotb/test_logging.py
@@ -8,9 +8,10 @@ Tests for the cocotb logger
 import logging
 import os
 
+import pytest
+
 import cocotb
 import cocotb.logging
-import pytest
 
 
 class StrCallCounter:

--- a/tests/test_cases/test_cocotb/test_queues.py
+++ b/tests/test_cases/test_cocotb/test_queues.py
@@ -5,8 +5,9 @@
 Tests relating to cocotb.queue.Queue, cocotb.queue.LifoQueue, cocotb.queue.PriorityQueue
 """
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.queue import LifoQueue, PriorityQueue, Queue, QueueEmpty, QueueFull
 from cocotb.triggers import Combine, NullTrigger
 

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -15,8 +15,10 @@ import re
 from asyncio import CancelledError, InvalidStateError
 from typing import Any, Awaitable, Coroutine
 
-import cocotb
 import pytest
+from common import MyException
+
+import cocotb
 from cocotb.clock import Clock
 from cocotb.task import Task
 from cocotb.triggers import (
@@ -30,7 +32,6 @@ from cocotb.triggers import (
     Timer,
     Trigger,
 )
-from common import MyException
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 

--- a/tests/test_cases/test_cocotb/test_start_soon.py
+++ b/tests/test_cases/test_cocotb/test_start_soon.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import warnings
 
-import cocotb
 from common import MyException
+
+import cocotb
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -5,8 +5,9 @@
 Tests for synchronization primitives like Lock and Event
 """
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.triggers import Lock, Timer, _InternalEvent
 from cocotb.utils import get_sim_time
 

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -11,10 +11,11 @@ Tests of cocotb.test functionality
 
 from collections.abc import Coroutine
 
-import cocotb
 import pytest
-from cocotb.triggers import NullTrigger, Timer
 from common import MyBaseException, MyException
+
+import cocotb
+from cocotb.triggers import NullTrigger, Timer
 
 
 @cocotb.test(expect_error=NameError)

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -16,8 +16,9 @@ import warnings
 from decimal import Decimal
 from fractions import Fraction
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.clock import Clock
 from cocotb.simulator import get_precision
 from cocotb.triggers import (

--- a/tests/test_cases/test_cocotb/test_utils.py
+++ b/tests/test_cases/test_cocotb/test_utils.py
@@ -1,8 +1,9 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-import cocotb
 import pytest
+
+import cocotb
 from cocotb import utils
 
 

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -27,8 +27,9 @@
 
 import os
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb._sim_versions import IcarusVersion, VerilatorVersion
 from cocotb.handle import (
     ArrayObject,

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -33,8 +33,9 @@ Also used a regression test of cocotb capabilities
 
 import threading
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.clock import Clock
 from cocotb.decorators import external
 from cocotb.triggers import ReadOnly, RisingEdge, Timer

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -25,8 +25,9 @@
 
 import logging
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.handle import EnumObject, HierarchyObject, IntegerObject, LogicObject
 
 

--- a/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
+++ b/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
@@ -4,8 +4,9 @@
 
 import os
 
-import cocotb
 import pytest
+
+import cocotb
 from cocotb.triggers import Timer
 
 is_questa_vhpi = (


### PR DESCRIPTION
We manually list out first-party and third-party packages so that isort keeps cocotb and external packages in separate import sections. `pre-commit run -a` was run afterwards. This should address the errant lint failure mentioned [here](https://github.com/cocotb/cocotb/pull/3944#issuecomment-2169121047).
