### PR TITLE
CI: Move Verilator on macos to experimental bucket

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -223,7 +223,7 @@ ENVS = [
         "sim-version": "stable",
         "os": "macos-13",
         "python-version": "3.8",
-        "group": "ci",
+        "group": "experimental",
     },
     # Icarus windows from source
     {


### PR DESCRIPTION
We cannot tightly control the version of Verilator being used in our
CI testing, which led to Verilator 5.026 breaking CI on macOS due to an
upstream issue (https://github.com/verilator/verilator/issues/5190).

Move this test to the experimental bucket until it's stable again.
