### PR TITLE
Riviera-PRO: Always exit the compilation step

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -156,6 +156,7 @@ ifeq ($(COCOTB_USER_COVERAGE),1)
 	@echo "acdb report -cov $(COVERAGE_TYPES) -db $(RTL_LIBRARY).acdb -html -o coverage/acdb_report.html" >> $@
 	@echo "acdb report -cov $(COVERAGE_TYPES) -db $(RTL_LIBRARY).acdb -txt -o coverage/acdb_report.txt" >> $@
 endif
+	@echo "exit" >> $@
 endif
 
 # Note it's the redirection of the output rather than the 'do' command


### PR DESCRIPTION
Previously, we always redirected the output of Riviera-PRO in Makefiles,
which caused Riviera to unconditionally quit the compilation step. We
no longer do that, so we need to be explicit.

See also https://github.com/cocotb/cocotb/pull/3495 for the equivalent
change in the runner.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
