### PR TITLE
stable/1.9 backports (part 7)

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -254,7 +254,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "riviera",
-        "sim-version": "aldec/rivierapro/2023.10",
+        "sim-version": "aldec/rivierapro/2024.04",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -263,7 +263,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "riviera",
-        "sim-version": "aldec/rivierapro/2023.10",
+        "sim-version": "aldec/rivierapro/2024.04",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -329,7 +329,15 @@ for version in questa_versions_vhpi:
     ]
 
 # Riviera-PRO: test more versions as part of the extended tests.
-riviera_versions = ("2019.10", "2020.04", "2020.10", "2021.04", "2021.10", "2022.04")
+riviera_versions = (
+    "2019.10",
+    "2020.04",
+    "2020.10",
+    "2021.04",
+    "2021.10",
+    "2022.04",
+    "2023.10",
+)
 for version in riviera_versions:
     ENVS += [
         {

--- a/cocotb/share/makefiles/simulators/Makefile.riviera
+++ b/cocotb/share/makefiles/simulators/Makefile.riviera
@@ -157,6 +157,7 @@ ifeq ($(COVERAGE),1)
 	@echo "acdb report -cov $(COVERAGE_TYPES) -db $(RTL_LIBRARY).acdb -html -o coverage/acdb_report.html" >> $@
 	@echo "acdb report -cov $(COVERAGE_TYPES) -db $(RTL_LIBRARY).acdb -txt -o coverage/acdb_report.txt" >> $@
 endif
+	@echo "exit" >> $@
 endif
 
 # Note it's the redirection of the output rather than the 'do' command

--- a/tests/test_cases/issue_330/issue_330.py
+++ b/tests/test_cases/issue_330/issue_330.py
@@ -11,13 +11,14 @@ SIM_NAME = cocotb.SIM_NAME.lower()
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
 # Verilator doesn't support structs (gh-1275)
-# Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
+# Riviera-PRO 2022.10-2023.10 do not discover dut.inout_if correctly over VPI (gh-3587)
 @cocotb.test(
     expect_error=AttributeError
     if SIM_NAME.startswith(("icarus", "ghdl", "verilator"))
     or (
         SIM_NAME.startswith("riviera")
         and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
+        and RivieraVersion(cocotb.SIM_VERSION) < RivieraVersion("2024.04")
         and cocotb.LANGUAGE == "verilog"
     )
     else ()
@@ -60,11 +61,14 @@ async def issue_330_iteration(dut):
         tlog.info("Found %s" % member._path)
         count += 1
 
-    # Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
-    rv_2022_10_plus = RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
+    # Riviera-PRO 2022.10-2023.10 do not discover dut.inout_if correctly over VPI (gh-3587)
+    riviera_broken_struct = (
+        RivieraVersion(cocotb.SIM_VERSION) >= "2022.10"
+        and RivieraVersion(cocotb.SIM_VERSION) < "2024.04"
+    )
     if (
         SIM_NAME.startswith("riviera")
-        and rv_2022_10_plus
+        and riviera_broken_struct
         and cocotb.LANGUAGE == "verilog"
     ):
         assert count == 0

--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -147,13 +147,14 @@ async def test_ndim_array_indexes(dut):
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
 # Verilator doesn't support structs (gh-1275)
-# Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587)
+# Riviera-PRO 2022.10-2023.10 do not discover dut.inout_if correctly over VPI (gh-3587)
 @cocotb.test(
     expect_error=AttributeError
     if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl", "verilator"))
     or (
         cocotb.SIM_NAME.lower().startswith("riviera")
         and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
+        and RivieraVersion(cocotb.SIM_VERSION) < RivieraVersion("2024.04")
         and cocotb.LANGUAGE == "verilog"
     )
     else ()

--- a/tests/test_cases/test_packed_union/test_packed_union.py
+++ b/tests/test_cases/test_packed_union/test_packed_union.py
@@ -6,13 +6,14 @@ import cocotb
 from cocotb._sim_versions import RivieraVersion
 
 
-# Riviera-PRO 2022.10 (VPI) and newer does not discover dut.t correctly (gh-3587)
+# Riviera-PRO 2022.10-2023.10 (VPI) do not discover dut.t correctly (gh-3587)
 @cocotb.test(
     expect_error=Exception
     if cocotb.SIM_NAME.lower().startswith(("verilator", "icarus", "ghdl"))
     or (
         cocotb.SIM_NAME.lower().startswith("riviera")
         and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
+        and RivieraVersion(cocotb.SIM_VERSION) < RivieraVersion("2024.04")
         and cocotb.LANGUAGE == "verilog"
     )
     else ()


### PR DESCRIPTION
Riviera updates.

- **Riviera-PRO: Always exit the compilation step**
- **Riviera-PRO: Update test expectations for 2024.04** (not a clean backport, but a variant of https://github.com/cocotb/cocotb/pull/3932/commits/2f9121a0cc098ed881bb61357623e875d1622209)
- **CI: Update Riviera-PRO to 2024.04**
