### PR TITLE
CI: Update to Questa 2024.2

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -273,7 +273,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "questa",
-        "sim-version": "siemens/questa/2023.4",
+        "sim-version": "siemens/questa/2024.2",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -282,7 +282,7 @@ ENVS = [
     {
         "lang": "vhdl and fli",
         "sim": "questa",
-        "sim-version": "siemens/questa/2023.4",
+        "sim-version": "siemens/questa/2024.2",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -291,7 +291,7 @@ ENVS = [
     {
         "lang": "vhdl and vhpi",
         "sim": "questa",
-        "sim-version": "siemens/questa/2023.4",
+        "sim-version": "siemens/questa/2024.2",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -339,7 +339,7 @@ ENVS = [
 
 # Questa: test more versions as part of the extended tests.
 questa_versions_novhpi = ("2021.2", "2021.3", "2021.4", "2022.1", "2022.2")
-questa_versions_vhpi = ("2022.3", "2022.4", "2023.1", "2023.2")
+questa_versions_vhpi = ("2022.3", "2022.4", "2023.1", "2023.2", "2023.4", "2024.1")
 
 for version in questa_versions_novhpi + questa_versions_vhpi:
     ENVS += [

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -41,18 +41,23 @@ def total_object_count():
     if SIM_NAME.startswith("modelsim") and os.environ["VHDL_GPI_INTERFACE"] == "vhpi":
         return 68127
 
-    # Questa 2023.1 onwards (FLI) do not discover the following objects, which
-    # are instantiated four times:
-    # - inst_generic_sp_ram.clk (<class 'cocotb.handle.LogicObject'>)
-    # - inst_generic_sp_ram.rst (<class 'cocotb.handle.LogicObject'>)
-    # - inst_generic_sp_ram.wen (<class 'cocotb.handle.LogicObject'>)
-    # - inst_generic_sp_ram.en (<class 'cocotb.handle.LogicObject'>)
-    if (
-        SIM_NAME.startswith("modelsim")
-        and QuestaVersion(SIM_VERSION) >= QuestaVersion("2023.1")
-        and os.environ["VHDL_GPI_INTERFACE"] == "fli"
-    ):
-        return 35153 - 4 * 4
+    if SIM_NAME.startswith("modelsim") and os.environ["VHDL_GPI_INTERFACE"] == "fli":
+        # Questa 2024.1 onwards (FLI) do not discover the following objects, which
+        # are instantiated four times:
+        # - inst_generic_sp_ram.clk (<class 'cocotb.handle.LogicObject'>)
+        # - inst_generic_sp_ram.rst (<class 'cocotb.handle.LogicObject'>)
+        # - inst_generic_sp_ram.wen (<class 'cocotb.handle.LogicObject'>)
+        if QuestaVersion(SIM_VERSION) >= QuestaVersion("2024.1"):
+            return 35153 - 4 * 3
+
+        # Questa 2023.1 onwards (FLI) do not discover the following objects, which
+        # are instantiated four times:
+        # - inst_generic_sp_ram.clk (<class 'cocotb.handle.LogicObject'>)
+        # - inst_generic_sp_ram.rst (<class 'cocotb.handle.LogicObject'>)
+        # - inst_generic_sp_ram.wen (<class 'cocotb.handle.LogicObject'>)
+        # - inst_generic_sp_ram.en (<class 'cocotb.handle.LogicObject'>)
+        if QuestaVersion(SIM_VERSION) >= QuestaVersion("2023.1"):
+            return 35153 - 4 * 4
 
     if SIM_NAME.startswith(
         (


### PR DESCRIPTION
As usual, use the latest release version in CI and move the previously
used version to the extended tests.
