### PR TITLE
Remove dead code paths from scheduler

### DIFF
--- a/tests/test_cases/test_cocotb/test_async_generators.py
+++ b/tests/test_cases/test_cocotb/test_async_generators.py
@@ -2,7 +2,10 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import pytest
+
 import cocotb
+from cocotb.task import Task
 
 
 async def whoops_async_generator():
@@ -10,11 +13,33 @@ async def whoops_async_generator():
     yield cocotb.triggers.Timer(1)
 
 
-@cocotb.test()
-async def test_forking_accidental_async_generator(dut):
-    try:
+@cocotb.test
+async def test_forking_accidental_async_generator(_) -> None:
+    with pytest.raises(TypeError) as e:
         cocotb.start_soon(whoops_async_generator())
-    except TypeError as e:
-        assert "async generator" in str(e)
-    else:
-        assert False, "should have thrown"
+
+    assert "async generator" in str(e)
+
+
+@cocotb.test
+async def test_constructing_accidental_async_generator(_) -> None:
+    with pytest.raises(TypeError) as e:
+        Task(whoops_async_generator())
+
+    assert "async generator" in str(e)
+
+
+@cocotb.test
+async def test_creating_accidental_async_generator(_) -> None:
+    with pytest.raises(TypeError) as e:
+        cocotb.create_task(whoops_async_generator())
+
+    assert "async generator" in str(e)
+
+
+@cocotb.test
+async def test_awaiting_accidental_async_generator(_) -> None:
+    with pytest.raises(TypeError):
+        await whoops_async_generator()
+
+    # Python handles this so we don't want to presume what the error message is


### PR DESCRIPTION
Since removing the `yield` syntax there is no way for the scheduler to ever see an async generator object, Waitable, or unstarted function. Python's await statement calls the `__await__` function and the aforementioned objects either handle these types or TypeError. So not our problem anymore.
