### PR TITLE
Increase timeout to allow slow Mac OS tests to finish

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -51,7 +51,7 @@ jobs:
 
     name: ${{matrix.name}}
     runs-on: ${{matrix.runs-on}}
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     env:
       SIM: ${{matrix.sim}}


### PR DESCRIPTION
The Verilator + Mac OS CI tests have been failing recently due to timeout. They get 98% of the way done fairly consistently, so we only really need to bump this a bit, but I added some buffer in case building Verilator gets much longer.

The issue seems to be the link step (not including the rest of the compilation) takes ~15 minutes. I don't really understand why, there's plenty of memory available so it shouldn't be swapping, and the CPUs themselves are ~2x slower (based on regression time) not 3+x slower. Oh well...