### PR TITLE
Improve trigger coverage

### DIFF
--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -9,6 +9,7 @@ import re
 from collections import deque
 from random import randint
 
+import pytest
 from common import _check_traceback
 
 import cocotb
@@ -217,3 +218,24 @@ async def test_recursive_combine(_):
 
     assert end_time - start_time == 30
     assert done == {10, 20, 30}
+
+
+@cocotb.test
+async def test_concurrency_trigger_repr(_):
+    e = Event()
+    assert re.match(r"<Event at \w+>", repr(e))
+    e = Event(name="my_event")
+    assert re.match(r"<Event for my_event at \w+>", repr(e))
+    w = e.wait()
+    assert re.match(r"<<Event for my_event at \w+>\.wait\(\) at \w+>", repr(w))
+
+
+@cocotb.test()
+async def test_invalid_trigger_types(dut):
+    o = object()
+
+    with pytest.raises(TypeError):
+        await First(Timer(1), o)
+
+    with pytest.raises(TypeError):
+        await Combine(Timer(1), o)

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -262,6 +262,14 @@ async def test_nulltrigger_reschedule(dut):
 
 
 @cocotb.test()
+async def test_nulltrigger_repr(_):
+    n = NullTrigger()
+    assert re.match(r"<NullTrigger at \w+>", repr(n))
+    n = NullTrigger(name="my_nulltrigger")
+    assert re.match(r"<NullTrigger for my_nulltrigger at \w+>", repr(n))
+
+
+@cocotb.test()
 async def test_event_set_schedule(dut):
     """
     Test that Event.set() doesn't cause an immediate reschedule.
@@ -843,6 +851,7 @@ async def test_get_task_from_join(_) -> None:
     j = await t.join()
     assert isinstance(j, Join)
     assert j.task is t
+    assert re.match(r"Join\(<Task \d+>\)", repr(j))
 
     t = cocotb.start_soon(noop())
     j = await Join(t)


### PR DESCRIPTION
Cleanup `Lock` to use same path for acquiring when not locked and also when released and there is a Task pending.
Add tests for missing trigger coverage.