### PR TITLE
Improve TypeError exception message for edge triggers

### DIFF
--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -376,7 +376,9 @@ class RisingEdge(_EdgeBase):
     @classmethod
     def __singleton_key__(cls, signal: LogicObject) -> LogicObject:
         if not (isinstance(signal, LogicObject) and len(signal) == 1):
-            raise TypeError("")
+            raise TypeError(
+                f"{cls.__qualname__} requires a 1-bit LogicObject. Got {signal!r} of length {len(signal)}"
+            )
         return signal
 
 
@@ -401,7 +403,9 @@ class FallingEdge(_EdgeBase):
     @classmethod
     def __singleton_key__(cls, signal: LogicObject) -> LogicObject:
         if not (isinstance(signal, LogicObject) and len(signal) == 1):
-            raise TypeError("")
+            raise TypeError(
+                f"{cls.__qualname__} requires a 1-bit LogicObject. Got {signal!r} of length {len(signal)}"
+            )
         return signal
 
 
@@ -422,7 +426,9 @@ class Edge(_EdgeBase):
         cls, signal: ValueObjectBase[Any, Any]
     ) -> ValueObjectBase[Any, Any]:
         if not isinstance(signal, ValueObjectBase):
-            raise TypeError("")
+            raise TypeError(
+                f"{cls.__qualname__} requires an object derived from ValueObjectBase which can change value. Got {signal!r} of length {len(signal)}"
+            )
         return signal
 
 


### PR DESCRIPTION
Before, you would have to carefully look at the traceback to see where the problem was.

Before:
```
Traceback (most recent call last):
  File "/home/marlon/git/cocotb/tests/test_cases/test_cocotb/test_edge_triggers.py", line 285, in test_edge_on_vector
    await RisingEdge(dut.stream_in_data)
  File "/home/marlon/git/cocotb/src/cocotb/utils.py", line 243, in __call__
    key = cls.__singleton_key__(*args, **kwargs)
  File "/home/marlon/git/cocotb/src/cocotb/triggers.py", line 379, in __singleton_key__
    raise TypeError("")
TypeError
```
After:
```
Traceback (most recent call last):
  File "/home/marlon/git/cocotb/tests/test_cases/test_cocotb/test_edge_triggers.py", line 285, in test_edge_on_vector
    await RisingEdge(dut.stream_in_data)
  File "/home/marlon/git/cocotb/src/cocotb/utils.py", line 243, in __call__
    key = cls.__singleton_key__(*args, **kwargs)
  File "/home/marlon/git/cocotb/src/cocotb/triggers.py", line 379, in __singleton_key__
    raise TypeError(f"{cls.__qualname__} requires a 1-bit LogicObject. Got {signal!r} of length {len(signal)}")
TypeError: RisingEdge requires a 1-bit LogicObject. Got LogicObject(sample_module.stream_in_data) of length 8
```