### PR TITLE
Instruct users to install a 1.x version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ The current stable version of cocotb requires:
 [GHDL](https://docs.cocotb.org/en/stable/simulator_support.html#ghdl) or
 [other simulator](https://docs.cocotb.org/en/stable/simulator_support.html))
 
-After installing these dependencies, the latest stable version of cocotb can be installed with pip.
+After installing these dependencies, the latest stable 1.x-backwards-compatible version of cocotb can be installed with pip.
 
 ```command
-pip install cocotb
+pip install 'cocotb<2.0'
 ```
 
 For more details on installation, including prerequisites,

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -78,11 +78,15 @@ The installation instructions vary depending on your operating system:
 Installation of cocotb
 ======================
 
-The **stable version** of cocotb can be installed by running
+The **stable, 1.x-backwards-compatible version** of cocotb can be installed by running
 
 .. code-block:: bash
 
-    pip install cocotb
+    pip install 'cocotb<2.0'
+
+The "<2.0" part of the command makes sure you will get a 1.x version of cocotb.
+This is because the upcoming 2.0 release of cocotb will contain breaking changes,
+and you should make a conscious decision to switch to it.
 
 .. note::
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
