### PR TITLE
Use uv to build venvs, virtualenv as fallback

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,9 @@ import nox
 # Sessions run by default if nox is called without further arguments.
 nox.options.sessions = ["dev_test"]
 
+# Try to use "uv" to build venvs, with the nox default "virtualenv" as fallback
+nox.options.default_venv_backend = "uv|virtualenv"
+
 test_deps = ["pytest>=6"]
 coverage_deps = ["coverage[toml]>=5.0", "pytest-cov"]
 # gcovr 5.1 has an issue parsing some gcov files, so pin to 5.0. See
@@ -30,6 +33,7 @@ dev_deps = [
     "nox",
     "ruff",
     "clang-format",
+    "uv",
 ]
 
 # Version of the cibuildwheel package used to build wheels.


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
