### PR TITLE
Add test waivers for older tool versions

### DIFF
--- a/tests/test_cases/test_array_simple/test_array_simple.py
+++ b/tests/test_cases/test_array_simple/test_array_simple.py
@@ -8,7 +8,6 @@ import logging
 import os
 
 import cocotb
-from cocotb._sim_versions import RivieraVersion
 from cocotb.clock import Clock
 from cocotb.triggers import Timer
 
@@ -150,15 +149,11 @@ async def test_ndim_array_indexes(dut):
 # GHDL unable to access record signals (gh-2591)
 # Icarus doesn't support structs (gh-2592)
 # Verilator doesn't support structs (gh-1275)
-# Riviera-PRO 2022.10 and newer does not discover inout_if correctly over VPI (gh-3587, gh-3933)
+# Riviera-PRO does not discover inout_if correctly over VPI (gh-3587, gh-3933)
 @cocotb.test(
     expect_error=AttributeError
     if cocotb.SIM_NAME.lower().startswith(("icarus", "ghdl", "verilator"))
-    or (
-        cocotb.SIM_NAME.lower().startswith("riviera")
-        and RivieraVersion(cocotb.SIM_VERSION) >= RivieraVersion("2022.10")
-        and LANGUAGE == "verilog"
-    )
+    or (cocotb.SIM_NAME.lower().startswith("riviera") and LANGUAGE == "verilog")
     else ()
 )
 async def test_struct_unpacked(dut):

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -10,7 +10,19 @@ import cocotb
 from cocotb.handle import HierarchyObject, LogicObject
 
 
-@cocotb.test()
+# Riviera-PRO 2019.10 does not detect packages over GPI:
+#   AttributeError: 'types.SimpleNamespace' object has no attribute
+#   'cocotb_package_pkg_1'
+@cocotb.test(
+    expect_error=(
+        AttributeError
+        if (
+            cocotb.SIM_NAME.lower().startswith("riviera")
+            and cocotb.SIM_VERSION.startswith("2019.10")
+        )
+        else ()
+    )
+)
 async def test_package_access(_) -> None:
     """Test package parameter access"""
 


### PR DESCRIPTION
Make the extended tool version tests pass by adding more test waivers for older versions.

A passing test run is available at https://github.com/cocotb/cocotb/actions/runs/9794340911.

- **Update test expectations for older Riviera versions**
- **Add waivers for Release tests with Riviera-PRO/VHPI**
- **Riviera-PRO 2019.10 cannot access packages**
