### PR TITLE
Skip mixed_signal example if Spectre is unavailable

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -34,7 +34,11 @@ EXAMPLES := adder/tests \
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-        EXAMPLES += mixed_signal/tests
+        ifeq (, $(shell which spectre))
+            $(info Skipping example mixed_signal since Spectre is not available)
+        else
+            EXAMPLES += mixed_signal/tests
+        endif
     else
         $(info Skipping example mixed_signal since only Xcelium is supported)
     endif

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -34,7 +34,7 @@ EXAMPLES := adder/tests \
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     ifeq ($(SIM),$(filter $(SIM),ius xcelium))
-        ifeq (, $(shell which spectre))
+        ifeq (,$(shell which spectre))
             $(info Skipping example mixed_signal since Spectre is not available)
         else
             EXAMPLES += mixed_signal/tests


### PR DESCRIPTION
See the title.  `nox` is failing for me since I don't have Spectre installed.

This patch makes `nox` pass for me, but I'll have to check via GH Actions to see if `mixed_signal` is still running since I can't test that case locally.