### PR TITLE
Extended CI for stable/1.9

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -132,7 +132,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.11.3",
+        "sim-version": "r1.12.2",  # The latest release version.
         "os": "ubuntu-latest",
         "python-version": "3.8",
         "group": "ci",

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -235,7 +235,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "questa",
-        "sim-version": "siemens/questa/2023.4",
+        "sim-version": "siemens/questa/2024.2",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -244,7 +244,7 @@ ENVS = [
     {
         "lang": "vhdl and fli",
         "sim": "questa",
-        "sim-version": "siemens/questa/2023.4",
+        "sim-version": "siemens/questa/2024.2",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -253,7 +253,7 @@ ENVS = [
     {
         "lang": "vhdl and vhpi",
         "sim": "questa",
-        "sim-version": "siemens/questa/2023.4",
+        "sim-version": "siemens/questa/2024.2",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -301,7 +301,7 @@ ENVS = [
 
 # Questa: test more versions as part of the extended tests.
 questa_versions_novhpi = ("2021.2", "2021.3", "2021.4", "2022.1", "2022.2")
-questa_versions_vhpi = ("2022.3", "2022.4", "2023.1", "2023.2")
+questa_versions_vhpi = ("2022.3", "2022.4", "2023.1", "2023.2", "2023.4", "2024.1")
 
 for version in questa_versions_novhpi + questa_versions_vhpi:
     ENVS += [

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -282,7 +282,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "xcelium",
-        "sim-version": "cadence/xcelium/2309",
+        "sim-version": "cadence/xcelium/2403",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -291,7 +291,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "xcelium",
-        "sim-version": "cadence/xcelium/2309",
+        "sim-version": "cadence/xcelium/2403",
         "os": "ubuntu-20.04",
         "self-hosted": True,
         "python-version": "3.8",
@@ -362,6 +362,30 @@ for version in riviera_versions:
             "lang": "vhdl",
             "sim": "riviera",
             "sim-version": f"aldec/rivierapro/{version}",
+            "os": "ubuntu-20.04",
+            "self-hosted": True,
+            "python-version": "3.8",
+            "group": "extended",
+        },
+    ]
+
+# Xcelium: test more versions as part of the extended tests.
+xcelium_versions = ("2309",)
+for version in xcelium_versions:
+    ENVS += [
+        {
+            "lang": "verilog",
+            "sim": "xcelium",
+            "sim-version": f"cadence/xcelium/{version}",
+            "os": "ubuntu-20.04",
+            "self-hosted": True,
+            "python-version": "3.8",
+            "group": "extended",
+        },
+        {
+            "lang": "vhdl",
+            "sim": "xcelium",
+            "sim-version": f"cadence/xcelium/{version}",
             "os": "ubuntu-20.04",
             "self-hosted": True,
             "python-version": "3.8",

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Run tests against an extended set of simulator (versions).
+
+name: Test extended tool versions
+
+on:
+  # Run every Sunday at 2am (UTC).
+  schedule:
+    - cron: '0 2 * * 0'
+  # Allow triggering a CI run from the web UI.
+  workflow_dispatch:
+
+jobs:
+  test_dev:
+    name: Regression Tests
+    uses: ./.github/workflows/regression-tests.yml
+    with:
+      nox_session_test_sim: dev_test_sim
+      nox_session_test_nosim: dev_test_nosim
+      group: extended
+      max_parallel: 15

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -27,6 +27,11 @@ on:
         type: string
         default: "ci"
         description: Group of environments to run the tests against. Leave empty to run them all.
+      max_parallel:
+        required: false
+        type: number
+        default: 0
+        description: Maximum number of parallel matrix jobs
 
 jobs:
 
@@ -58,6 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.generate_envs.outputs.envs) }}
+      max-parallel: ${{ inputs.max_parallel }}
 
     steps:
     - uses: actions/checkout@v4

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -41,18 +41,23 @@ def total_object_count():
     if SIM_NAME.startswith("modelsim") and os.environ["VHDL_GPI_INTERFACE"] == "vhpi":
         return 66959
 
-    # Questa 2023.1 onwards (FLI) do not discover the following objects, which
-    # are instantiated four times:
-    # - inst_generic_sp_ram.clk (<class 'cocotb.handle.ModifiableObject'>)
-    # - inst_generic_sp_ram.rst (<class 'cocotb.handle.ModifiableObject'>)
-    # - inst_generic_sp_ram.wen (<class 'cocotb.handle.ModifiableObject'>)
-    # - inst_generic_sp_ram.en (<class 'cocotb.handle.ModifiableObject'>)
-    if (
-        SIM_NAME.startswith("modelsim")
-        and QuestaVersion(SIM_VERSION) >= QuestaVersion("2023.1")
-        and os.environ["VHDL_GPI_INTERFACE"] == "fli"
-    ):
-        return 34569 - 4 * 4
+    if SIM_NAME.startswith("modelsim") and os.environ["VHDL_GPI_INTERFACE"] == "fli":
+        # Questa 2024.1 onwards (FLI) do not discover the following objects, which
+        # are instantiated four times:
+        # - inst_generic_sp_ram.clk (<class 'cocotb.handle.ModifiableObject'>)
+        # - inst_generic_sp_ram.rst (<class 'cocotb.handle.ModifiableObject'>)
+        # - inst_generic_sp_ram.wen (<class 'cocotb.handle.ModifiableObject'>)
+        if QuestaVersion(SIM_VERSION) >= QuestaVersion("2024.1"):
+            return 34569 - 4 * 3
+
+        # Questa 2023.1 onwards (FLI) do not discover the following objects, which
+        # are instantiated four times:
+        # - inst_generic_sp_ram.clk (<class 'cocotb.handle.ModifiableObject'>)
+        # - inst_generic_sp_ram.rst (<class 'cocotb.handle.ModifiableObject'>)
+        # - inst_generic_sp_ram.wen (<class 'cocotb.handle.ModifiableObject'>)
+        # - inst_generic_sp_ram.en (<class 'cocotb.handle.ModifiableObject'>)
+        if QuestaVersion(SIM_VERSION) >= QuestaVersion("2023.1"):
+            return 34569 - 4 * 4
 
     if SIM_NAME.startswith(
         (


### PR DESCRIPTION
Backport more changes to update (extended) CI for stable/1.9, in line with what we have in master.

- **Fix test assumptions for Questa 2024**
- **CI: Update to Questa 2024.2**
- **CI: Run against Xcelium 2403**
- **CI: Update NVC to latest release 1.12.2 (#3988)**
- **CI: Run extended tests once a week**
