### PR TITLE
stable/1.9: Suggest installing cocotb 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The current stable version of cocotb requires:
 [GHDL](https://docs.cocotb.org/en/stable/simulator_support.html#ghdl) or
 [other simulator](https://docs.cocotb.org/en/stable/simulator_support.html))
 
-After installing these dependencies, the latest stable version of cocotb can be installed with pip.
+After installing these dependencies, the latest stable version 1.x of cocotb can be installed with pip.
 
 ```command
-pip install cocotb
+pip install 'cocotb == 1.*'
 ```
 
 For more details on installation, including prerequisites,


### PR DESCRIPTION
For the stable/1.9 branch, suggest installing cocotb 1.x in the README,
which is shown on PyPi as well.
