### PR TITLE
Fixes to `BinaryValue.__eq__`

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -569,13 +569,16 @@ class BinaryValue:
         if isinstance(other, (BinaryValue, LogicArray)):
             return self.binstr == other.binstr
         elif isinstance(other, int):
-            return self.integer == other
+            try:
+                return self.integer == other
+            except ValueError:
+                return False
         elif isinstance(other, str):
             return self.binstr == other
         elif isinstance(other, Logic):
             return self.binstr == str(other)
         else:
-            return False
+            return NotImplemented
 
     def __int__(self):
         return self.integer


### PR DESCRIPTION
Calling `bv.integer` may cause a ValueError if COCOTB_RESOLVE_X=VALUE_ERROR. So we catch that case and return False. Also, for unhandled types we should be returning NotImplemented instead of False to allow the other type a chance to do the equality.

