### PR TITLE
Make sim_phase a global variable

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -313,6 +313,8 @@ Other Runtime Information
 
 .. autodata:: cocotb.is_simulation
 
+.. autodata:: cocotb.sim_phase
+
 .. _combine-results:
 
 The ``combine_results`` script

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -315,6 +315,8 @@ Other Runtime Information
 
 .. autodata:: cocotb.sim_phase
 
+.. autoenum:: cocotb.SimPhase
+
 .. _combine-results:
 
 The ``combine_results`` script

--- a/docs/source/newsfragments/4022.feature.rst
+++ b/docs/source/newsfragments/4022.feature.rst
@@ -1,0 +1,1 @@
+Added :data:`cocotb.sim_phase` to allow the user to determine what phase of a time step they are in.

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -33,6 +33,7 @@ import sys
 import time
 import warnings
 from collections.abc import Coroutine
+from enum import auto
 from types import SimpleNamespace
 from typing import Any, Dict, List, Union, cast
 
@@ -42,6 +43,7 @@ from cocotb._scheduler import Scheduler
 from cocotb.logging import default_config
 from cocotb.regression import RegressionManager, RegressionMode
 from cocotb.task import Task
+from cocotb.utils import DocEnum
 
 from ._version import __version__
 
@@ -113,6 +115,18 @@ and in parameters to :class:`.TestFactory`\ s.
 
 is_simulation: bool = False
 """``True`` if cocotb was loaded in a simulation."""
+
+
+class SimPhase(DocEnum):
+    """A phase of the time step."""
+
+    NORMAL = (auto(), "In the Beginning Of Time Step or a Value Change phase.")
+    READ_WRITE = (auto(), "In a ReadWrite phase.")
+    READ_ONLY = (auto(), "In a ReadOnly phase.")
+
+
+sim_phase: SimPhase = SimPhase.NORMAL
+"""The current phase of the time step."""
 
 
 def _setup_logging() -> None:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -446,7 +446,8 @@ class RegressionManager:
 
     def _schedule_next_test(self, trigger: Optional[Trigger] = None) -> None:
         if trigger is not None:
-            cocotb._scheduler_inst._sim_phase = cocotb._scheduler.SimPhase.NORMAL
+            # TODO move to Trigger object
+            cocotb.sim_phase = cocotb.SimPhase.NORMAL
             trigger._unprime()
         cocotb._scheduler_inst._add_test(self._test_task)
 


### PR DESCRIPTION
This should allow users to determine *roughly* what state they are in, and should help us prevent issues in the future when we prevent illegal timing transitions.
