### PR TITLE
Remove `TriggerException`

### DIFF
--- a/docs/source/newsfragments/4024.removal.rst
+++ b/docs/source/newsfragments/4024.removal.rst
@@ -1,0 +1,1 @@
+``cocotb.triggers.TriggerException`` was removed. :exc:`RuntimeError` is thrown in its place.

--- a/docs/source/newsfragments/4024.removal.rst
+++ b/docs/source/newsfragments/4024.removal.rst
@@ -1,1 +1,1 @@
-``cocotb.triggers.TriggerException`` was removed. :exc:`RuntimeError` is thrown in its place.
+The undocumented ``cocotb.triggers._TriggerException``, thrown when a trigger failed to register, was removed. :exc:`RuntimeError` is thrown in its place.

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -72,10 +72,6 @@ def _pointer_str(obj: object) -> str:
     return full_repr.rsplit(" ", 1)[1][:-1]
 
 
-class _TriggerException(Exception):
-    pass
-
-
 Self = TypeVar("Self", bound="Trigger")
 
 
@@ -251,7 +247,7 @@ class Timer(GPITrigger):
                 self._sim_steps, callback, self
             )
             if self._cbhdl is None:
-                raise _TriggerException(f"Unable set up {str(self)} Trigger")
+                raise RuntimeError(f"Unable set up {str(self)} Trigger")
         super()._prime(callback)
 
     def __repr__(self) -> str:
@@ -286,7 +282,7 @@ class ReadOnly(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass)
         if self._cbhdl is None:
             self._cbhdl = simulator.register_readonly_callback(callback, self)
             if self._cbhdl is None:
-                raise _TriggerException(f"Unable set up {str(self)} Trigger")
+                raise RuntimeError(f"Unable set up {str(self)} Trigger")
         super()._prime(callback)
 
     def __repr__(self) -> str:
@@ -304,7 +300,7 @@ class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass
         if self._cbhdl is None:
             self._cbhdl = simulator.register_rwsynch_callback(callback, self)
             if self._cbhdl is None:
-                raise _TriggerException(f"Unable set up {str(self)} Trigger")
+                raise RuntimeError(f"Unable set up {str(self)} Trigger")
         super()._prime(callback)
 
     def __repr__(self) -> str:
@@ -322,7 +318,7 @@ class NextTimeStep(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetacl
         if self._cbhdl is None:
             self._cbhdl = simulator.register_nextstep_callback(callback, self)
             if self._cbhdl is None:
-                raise _TriggerException(f"Unable set up {str(self)} Trigger")
+                raise RuntimeError(f"Unable set up {str(self)} Trigger")
         super()._prime(callback)
 
     def __repr__(self) -> str:
@@ -344,7 +340,7 @@ class _EdgeBase(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass
                 self.signal._handle, callback, type(self)._edge_type, self
             )
             if self._cbhdl is None:
-                raise _TriggerException(f"Unable set up {str(self)} Trigger")
+                raise RuntimeError(f"Unable set up {str(self)} Trigger")
         super()._prime(callback)
 
     def __repr__(self) -> str:

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -30,7 +30,6 @@ from cocotb.triggers import (
     RisingEdge,
     Timer,
 )
-from cocotb.triggers import _TriggerException as TriggerException
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 SIM_NAME = cocotb.SIM_NAME.lower()
@@ -136,14 +135,14 @@ async def do_test_afterdelay_in_readonly(dut, delay):
     exited = True
 
 
-# A TriggerException is expected to happen in this test, which indicates that
+# A RuntimeError is expected to happen in this test, which indicates that
 # ReadWrite after ReadOnly fails to register.
 # - Riviera and Questa (in Verilog) and Xcelium pass.
 # - Riviera and Questa (in VHDL) incorrectly allow registering ReadWrite
 #   after ReadOnly.
 # - Xcelium passes (VHDL and Verilog).
 @cocotb.test(
-    expect_error=TriggerException
+    expect_error=RuntimeError
     if (
         (LANGUAGE in ["verilog"] and SIM_NAME.startswith(("riviera", "modelsim")))
         or SIM_NAME.startswith("xmsim")


### PR DESCRIPTION
This was not documented, but was a necessary part of the public API as if a trigger failed to register, the user saw this exception. We can use the less specific `RuntimeError` as I don't think this error is really recoverable, so there is no reason to differentiate it from other types of exceptions.