### PR TITLE
Fix Riviera-PRO makefile 

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -112,7 +112,7 @@ define make_lib
   echo "if [file exists $(SIM_BUILD)/$(LIB)] {adel -lib $(SIM_BUILD)/$(LIB) -all}" >> $@;
   echo "alib $(SIM_BUILD)/$(LIB)" >> $@;
   echo "amap $(LIB) $(SIM_BUILD)/$(LIB)" >> $@;
-  echo "acom -work $(LIB) $(VCOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES_$(LIB)))" >> $@;
+  echo "acom -work $(LIB) $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES_$(LIB)))" >> $@;
 endef
 
 # Create a TCL script based on the list of $(VERILOG_SOURCES)


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

Closes #4026 

- Fix the incorrect referral to VCOM_ARGS in the Riviera-PRO Makefile
- Allow using Questa-specific args in Riviera-Pro Makefile (as most Questa commands can be used with Riviera-Pro via aliases)