### PR TITLE
Correct broken import in `cocotb/__init__.py`

### DIFF
--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -40,10 +40,10 @@ from typing import Any, Dict, List, Union, cast
 import cocotb.handle
 import cocotb.triggers
 from cocotb._scheduler import Scheduler
+from cocotb._utils import DocEnum
 from cocotb.logging import default_config
 from cocotb.regression import RegressionManager, RegressionMode
 from cocotb.task import Task
-from cocotb.utils import DocEnum
 
 from ._version import __version__
 


### PR DESCRIPTION
#4022 included the addition of `from cocotb.utils import DocEnum`, and #4023 moved `DocEnum` to `cocotb._utils`. This wasn't caught because the CI for #4023 was not re-run after the merge of #4022.