### PR TITLE
Docs: re-order Python Code Library Reference page

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -23,39 +23,69 @@ Python Test Runner
 .. warning::
     Python runners and associated APIs are an experimental feature and subject to change.
 
-.. automodule:: cocotb_tools.runner
-    :members:
-    :member-order: bysource
+.. currentmodule:: cocotb_tools.runner
+
+.. module:: cocotb_tools.runner
     :synopsis: Build HDL and run cocotb tests.
 
+.. autofunction:: get_runner
 
-Test Results
-============
-
-The exceptions in this module can be raised at any point by any code and will terminate the test.
-
-.. automodule:: cocotb.result
+.. autoclass:: Runner
     :members:
-    :member-order: bysource
-    :synopsis: Exceptions and functions for simulation result handling.
+
+.. autoclass:: VHDL
+
+.. autoclass:: Verilog
+
+Simulator Runners
+-----------------
+
+.. autoclass:: Icarus
+
+.. autoclass:: Verilator
+
+.. autoclass:: Riviera
+
+.. autoclass:: Questa
+
+.. autoclass:: Xcelium
+
+.. autoclass:: Ghdl
+
+.. autoclass:: Nvc
+
+Results
+-------
+
+.. autofunction:: get_results
+
+.. autofunction:: check_results_file
+
+File Utilities
+--------------
+
+.. autofunction:: get_abs_path
+
+.. autofunction:: get_abs_paths
+
+.. autofunction:: outdated
+
+.. autoclass:: UnknownFileExtension
 
 
 .. _writing-tests:
 
-Writing and Generating tests
+Writing and Generating Tests
 ============================
 
 .. autofunction:: cocotb.test
-
-.. autofunction:: cocotb.external
-
-.. autofunction:: cocotb.function
 
 .. autofunction:: cocotb.parameterize
 
 .. autoclass:: cocotb.regression.TestFactory
     :members:
     :member-order: bysource
+
 
 Interacting with the Simulator
 ==============================
@@ -182,15 +212,25 @@ The following are internal classes used within ``cocotb``.
     :member-order: bysource
     :private-members:
 
-Testbench Structure
-===================
 
-Clock
------
+Test Utilities
+==============
+
+Clock Driver
+------------
 
 .. autoclass:: cocotb.clock.Clock
     :members:
     :member-order: bysource
+
+
+Asynchronous Queues
+-------------------
+
+.. automodule:: cocotb.queue
+    :members:
+    :member-order: bysource
+    :synopsis: Asynchronous queues.
 
 
 Simulation Time Utilities
@@ -201,10 +241,11 @@ Simulation Time Utilities
     :member-order: bysource
     :synopsis: Various utilities for dealing with simulation time.
 
+
 .. _logging-reference-section:
 
 Logging
--------
+=======
 
 .. module:: cocotb.logging
     :synopsis: Classes for logging messages from cocotb during simulation.
@@ -269,6 +310,7 @@ Assignment Methods
 
 .. autoclass:: Release
 
+
 Other Handle Methods
 --------------------
 
@@ -285,16 +327,9 @@ Other Handle Methods
    Return a list of the sub-handles of *handle*,
    that is, the instances, signals, constants etc. of a certain hierarchy level in the DUT.
 
+
 Miscellaneous
 =============
-
-Asynchronous Queues
--------------------
-
-.. automodule:: cocotb.queue
-    :members:
-    :member-order: bysource
-    :synopsis: Asynchronous queues.
 
 Other Runtime Information
 -------------------------
@@ -319,6 +354,7 @@ Other Runtime Information
 
 .. _combine-results:
 
+
 The ``combine_results`` script
 ------------------------------
 
@@ -330,6 +366,7 @@ Use ``python -m cocotb_tools.combine_results`` to call the script.
     :prog: combine_results
 
 .. _cocotb-config:
+
 
 The ``cocotb-config`` script
 ----------------------------
@@ -365,8 +402,8 @@ The Regression Manager
     :members:
     :member-order: bysource
 
-The ``cocotb.simulator`` module
--------------------------------
+The ``cocotb.simulator`` module (Internals)
+-------------------------------------------
 
 This module is a Python wrapper to libgpi.
 It should not be considered public API, but is documented here for developers

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -223,7 +223,7 @@ class Scheduler:
         The scheduler treats Tests specially.
         If a Test finishes or a Task ends with an Exception, the scheduler is put into a `terminating` state.
         All currently queued Tasks are cancelled and all pending Triggers are unprimed.
-        This is currently spread out between :meth:`_handle_termination`, :meth:`_test_completed`, and :meth:`_cleanup`.
+        This is currently spread out between :meth:`_handle_termination` and :meth:`_cleanup`.
         In that mix of functions, the :attr:`_test_complete_cb` callback is called to inform whomever (the regression_manager) the test finished.
         The scheduler also is responsible for starting the next Test in the Normal phase by priming a ``Timer(1)`` with the second half of test completion handling.
 
@@ -304,9 +304,9 @@ class Scheduler:
         Handle a termination that causes us to move onto the next test.
         """
         if self._test is None:
-            raise InternalError("_test_completed called with no active test")
+            raise InternalError("_handle_termination called with no active test")
         elif self._test._outcome is None:
-            raise InternalError("_test_completed called with an incomplete test")
+            raise InternalError("_handle_termination called with an incomplete test")
         elif _debug:
             self.log.debug("Test terminating...")
 

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -913,7 +913,7 @@ static PyMethodDef SimulatorMethods[] = {
      PyDoc_STR("package_iterate(/)\n"
                "--\n\n"
                "package_iterate() -> cocotb.simulator.gpi_iterator_hdl\n"
-               "Get an iterator handle to loop over all packages."
+               "Get an iterator handle to loop over all packages.\n"
                "\n"
                ".. versionadded:: 2.0")},
     {"register_timed_callback", register_timed_callback, METH_VARARGS,

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -68,11 +68,11 @@ def _shlex_join(split_command: Iterable[str]) -> str:
 
 
 class VHDL(str):
-    """Tags source files and build arguments to :meth:`~cocotb_tools.runner.Simulator.build` as VHDL-specific."""
+    """Tags source files and build arguments to :meth:`Runner.build() <cocotb_tools.runner.Runner.build>` as VHDL-specific."""
 
 
 class Verilog(str):
-    """Tags source files and build arguments to :meth:`~cocotb_tools.runner.Simulator.build` as Verilog-specific."""
+    """Tags source files and build arguments to :meth:`Runner.build() <cocotb_tools.runner.Runner.build>` as Verilog-specific."""
 
 
 class Runner(ABC):
@@ -571,6 +571,10 @@ _verilog_extensions_s = ", ".join(f"`{c}`" for c in _verilog_extensions)
 
 
 class UnknownFileExtension(ValueError):
+    """Raised when a source file type cannot be determined from the file extension.
+
+    See :meth:`Runner.build() <cocotb_tools.runner.Runner.build>` for details on supported standard file extensions and the use of :class:`VHDL` and :class:`Verilog` for specifying file type."""
+
     def __init__(self, source: PathLike) -> None:
         super().__init__(
             f"Can't determine if {source} is a VHDL or Verilog file. "
@@ -600,11 +604,11 @@ def is_verilog_source(source: PathLike) -> bool:
 class Icarus(Runner):
     """Implementation of :class:`Runner` for Icarus.
 
-    * ``hdl_toplevel`` argument to :meth:`build` is *required*.
-    * ``waves`` argument *must* be given to :meth:`build` if used.
-    * ``timescale`` argument to :meth:`build` must be given to support dumping the command file.
-    * Does not support the ``gui`` argument to :meth:`test`.
-    * Does not support the ``pre_cmd`` argument to :meth:`test`.
+    * ``hdl_toplevel`` argument to :meth:`.build` is *required*.
+    * ``waves`` argument *must* be given to :meth:`.build` if used.
+    * ``timescale`` argument to :meth:`.build` must be given to support dumping the command file.
+    * Does not support the ``gui`` argument to :meth:`.test`.
+    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}
@@ -735,7 +739,7 @@ class Icarus(Runner):
 class Questa(Runner):
     """Implementation of :class:`Runner` for Questa.
 
-    * Does not support the ``timescale`` argument to :meth:`build` or :meth:`test`.
+    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["fli", "vhpi"]}
@@ -869,9 +873,9 @@ class Questa(Runner):
 class Ghdl(Runner):
     """Implementation of :class:`Runner` for GHDL.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`test`.
-    * Does not support the ``gui`` argument to :meth:`test`.
-    * Does not support the ``waves`` argument to :meth:`build` or :meth:`test`.
+    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    * Does not support the ``gui`` argument to :meth:`.test`.
+    * Does not support the ``waves`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"vhdl": ["vpi"]}
@@ -986,12 +990,12 @@ class Ghdl(Runner):
 
 
 class Nvc(Runner):
-    """Implementation of :class:`Runner` for GHDL.
+    """Implementation of :class:`Runner` for NVC.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`test`.
-    * Does not support the ``gui`` argument to :meth:`test`.
-    * Does not support the ``waves`` argument to :meth:`build` or :meth:`test`.
-    * Does not support the ``timescale`` argument to :meth:`build` or :meth:`test`.
+    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    * Does not support the ``gui`` argument to :meth:`.test`.
+    * Does not support the ``waves`` argument to :meth:`.build` or :meth:`.test`.
+    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"vhdl": ["vhpi"]}
@@ -1056,11 +1060,11 @@ class Nvc(Runner):
 
 
 class Riviera(Runner):
-    """Implementation of :class:`Runner` for GHDL.
+    """Implementation of :class:`Runner` for Riviera-PRO.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`test`.
-    * Does not support the ``gui`` argument to :meth:`test`.
-    * Does not support the ``timescale`` argument to :meth:`build` or :meth:`test`.
+    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    * Does not support the ``gui`` argument to :meth:`.test`.
+    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["vhpi"]}
@@ -1203,10 +1207,10 @@ class Riviera(Runner):
 
 
 class Verilator(Runner):
-    """Implementation of :class:`Runner` for GHDL.
+    """Implementation of :class:`Runner` for Verilator.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`test`.
-    * Does not support the ``gui`` argument to :meth:`test`.
+    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    * Does not support the ``gui`` argument to :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}
@@ -1316,10 +1320,10 @@ class Verilator(Runner):
 
 
 class Xcelium(Runner):
-    """Implementation of :class:`Runner` for GHDL.
+    """Implementation of :class:`Runner` for Xcelium.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`test`.
-    * Does not support the ``timescale`` argument to :meth:`build` or :meth:`test`.
+    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["vhpi"]}


### PR DESCRIPTION
Fix the `package_iterate()` docstring and re-order the Python reference page a bit.