### PR TITLE
Use Verilator coverage filename.

### DIFF
--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -188,7 +188,8 @@ int main(int argc, char** argv) {
 // VM_COVERAGE is a define which is set if Verilator is
 // instructed to collect coverage (when compiling the simulation)
 #if VM_COVERAGE
-    VerilatedCov::write("coverage.dat");
+    VerilatedCov::write();  // Uses +verilator+coverage+file+<filename>,
+                            // defaults to coverage.dat
 #endif
 
     return 0;


### PR DESCRIPTION
Make cocotb compatible to the `+verilator+coverage+file+<filename>` Simulation Runtime Arguments of verilator.

See: https://verilator.org/guide/latest/exe_sim.html?highlight=coverage#cmdoption-arg-verilator-coverage-file-filename

Supported since verilator v5.022.
(Since https://github.com/verilator/verilator/commit/1a9250278825f383efe8d6ef15b55c477e6723e5)
