### PR TITLE
Replace deprecated VCS options

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.vcs
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.vcs
@@ -79,7 +79,7 @@ $(SIM_BUILD)/simv: $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(CUSTOM_COMPILE_DEPS
 	COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) \
 	$(CMD) -top $(COCOTB_TOPLEVEL) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) -debug_access+r+w-memcbk -debug_region+cell +vpi -P pli.tab -sverilog \
 	-timescale=$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) -debug -load $(shell cocotb-config --lib-name-path vpi vcs) $(COMPILE_ARGS) $(VERILOG_SOURCES)
+	$(EXTRA_ARGS) -debug_acc+pp+f+dmptf -debug_region+cell+encrypt -load $(shell cocotb-config --lib-name-path vpi vcs) $(COMPILE_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)


### PR DESCRIPTION
VCS requires users to replace `-debug` option as shown belowed.

```
Warning-[DEBUG_DEP] Option will be deprecated
  The option '-debug' will be deprecated in a future release.  Please use
  '-debug_acc+pp+f+dmptf -debug_region+cell+encrypt' instead.
```