### PR TITLE
Use Verilator coverage filename.

### DIFF
--- a/cocotb/share/lib/verilator/verilator.cpp
+++ b/cocotb/share/lib/verilator/verilator.cpp
@@ -188,7 +188,8 @@ int main(int argc, char** argv) {
 // VM_COVERAGE is a define which is set if Verilator is
 // instructed to collect coverage (when compiling the simulation)
 #if VM_COVERAGE
-    VerilatedCov::write("coverage.dat");
+    VerilatedCov::write();  // Uses +verilator+coverage+file+<filename>,
+                            // defaults to coverage.dat
 #endif
 
     return 0;


### PR DESCRIPTION
allow specification of a coverage filename (make coverage merge of different tests easier)
would be nice to see that change already in cocotb-1.9.0.
backport: #4032
