### PR TITLE
Move `SimTimeoutError` to `cocotb.triggers`

### DIFF
--- a/docs/source/newsfragments/4039.change.rst
+++ b/docs/source/newsfragments/4039.change.rst
@@ -1,0 +1,1 @@
+Moved :class:`~cocotb.triggers.SimTimeoutError` from ``cocotb.result`` to :mod:`cocotb.triggers`.

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -70,7 +70,7 @@ from cocotb._xunit_reporter import XUnitReporter
 from cocotb.result import SimFailure, TestSuccess
 from cocotb.sim_time_utils import get_sim_time
 from cocotb.task import Task, _RunningTest
-from cocotb.triggers import Timer, Trigger
+from cocotb.triggers import SimTimeoutError, Timer, Trigger
 
 _pdb_on_exception = "COCOTB_PDB_ON_EXCEPTION" in os.environ
 
@@ -112,7 +112,7 @@ class Test:
             Defaults to ``func.__doc__`` (the docstring of the test function).
 
         timeout_time:
-            Simulation time duration before the test is forced to fail with a :exc:`~cocotb.result. SimTimeoutError`.
+            Simulation time duration before the test is forced to fail with a :exc:`~cocotb.triggers.SimTimeoutError`.
 
         timeout_unit:
             Units of ``timeout_time``, accepts any units that :class:`~cocotb.triggers.Timer` does.
@@ -159,7 +159,7 @@ class Test:
                     res = await cocotb.triggers.with_timeout(
                         running_co, self.timeout_time, self.timeout_unit
                     )
-                except cocotb.result.SimTimeoutError:
+                except SimTimeoutError:
                     running_co.kill()
                     raise
                 else:

--- a/src/cocotb/result.py
+++ b/src/cocotb/result.py
@@ -36,7 +36,3 @@ class SimFailure(BaseException):
     Not intended to be thrown by the user.
     Exists to be used to mark tests that are expected to error due to simulation failure.
     """
-
-
-class SimTimeoutError(TimeoutError):
-    """Exception thrown when a timeout, in terms of simulation time, occurs."""

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -56,7 +56,6 @@ from cocotb._outcomes import Error, Outcome, Value
 from cocotb._py_compat import cached_property
 from cocotb._utils import ParameterizedSingletonMetaclass, remove_traceback_frames
 from cocotb.handle import LogicObject, ValueObjectBase
-from cocotb.result import SimTimeoutError
 from cocotb.sim_time_utils import get_sim_steps, get_time_from_sim_steps
 
 T = TypeVar("T")
@@ -994,6 +993,10 @@ async def with_timeout(
 ) -> T: ...
 
 
+class SimTimeoutError(TimeoutError):
+    """Exception thrown when a timeout, in terms of simulation time, occurs."""
+
+
 async def with_timeout(
     trigger: Union[
         Trigger, Waitable[Any], cocotb.task.Task[Any], Coroutine[Any, Any, Any]
@@ -1009,26 +1012,26 @@ async def with_timeout(
     the caller blocks until the callee completes,
     and the callee's result is returned to the caller.
     If timeout occurs, the callee is killed
-    and :exc:`~cocotb.result.SimTimeoutError` is raised.
+    and :exc:`SimTimeoutError` is raised.
 
     When an unstarted :class:`~cocotb.coroutine`\ is passed,
     the callee coroutine is started,
     the caller blocks until the callee completes,
     and the callee's result is returned to the caller.
     If timeout occurs, the callee `continues to run`
-    and :exc:`~cocotb.result.SimTimeoutError` is raised.
+    and :exc:`SimTimeoutError` is raised.
 
     When a :term:`task` is passed,
     the caller blocks until the callee completes
     and the callee's result is returned to the caller.
     If timeout occurs, the callee `continues to run`
-    and :exc:`~cocotb.result.SimTimeoutError` is raised.
+    and :exc:`SimTimeoutError` is raised.
 
     If a :class:`~cocotb.triggers.Trigger` or :class:`~cocotb.triggers.Waitable` is passed,
     the caller blocks until the trigger fires,
     and the trigger is returned to the caller.
     If timeout occurs, the trigger is cancelled
-    and :exc:`~cocotb.result.SimTimeoutError` is raised.
+    and :exc:`SimTimeoutError` is raised.
 
     Usage:
 
@@ -1052,7 +1055,7 @@ async def with_timeout(
         First trigger that completed if timeout did not occur.
 
     Raises:
-        :exc:`~cocotb.result.SimTimeoutError`: If timeout occurs.
+        :exc:`SimTimeoutError`: If timeout occurs.
 
     .. versionadded:: 1.3
 

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -18,7 +18,6 @@ import pytest
 import cocotb
 from cocotb._sim_versions import RivieraVersion
 from cocotb.clock import Clock
-from cocotb.result import SimTimeoutError
 from cocotb.triggers import (
     ClockCycles,
     Combine,
@@ -27,6 +26,7 @@ from cocotb.triggers import (
     First,
     ReadOnly,
     RisingEdge,
+    SimTimeoutError,
     Timer,
     with_timeout,
 )

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -15,7 +15,7 @@ import pytest
 from common import MyBaseException, MyException
 
 import cocotb
-from cocotb.triggers import NullTrigger, Timer
+from cocotb.triggers import NullTrigger, SimTimeoutError, Timer
 
 
 @cocotb.test(expect_error=NameError)
@@ -52,9 +52,7 @@ async def test_expect_exception_list(dut):
     raise MyException()
 
 
-@cocotb.test(
-    expect_error=cocotb.result.SimTimeoutError, timeout_time=1, timeout_unit="ns"
-)
+@cocotb.test(expect_error=SimTimeoutError, timeout_time=1, timeout_unit="ns")
 async def test_timeout_testdec_fail(dut):
     await Timer(10, "ns")
 
@@ -70,7 +68,7 @@ async def test_timeout_testdec_simultaneous(dut):
         await cocotb.triggers.with_timeout(
             Timer(1, "ns"), timeout_time=1, timeout_unit="ns"
         )
-    except cocotb.result.SimTimeoutError:
+    except SimTimeoutError:
         pass
     else:
         assert False, "Expected a Timeout"

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -28,7 +28,9 @@ from cocotb.triggers import (
     ReadOnly,
     ReadWrite,
     RisingEdge,
+    SimTimeoutError,
     Timer,
+    with_timeout,
 )
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
@@ -214,17 +216,13 @@ async def example_coro():
 
 @cocotb.test()
 async def test_timeout_func_coro_fail(dut):
-    with pytest.raises(cocotb.result.SimTimeoutError):
-        await cocotb.triggers.with_timeout(
-            example_coro(), timeout_time=1, timeout_unit="ns"
-        )
+    with pytest.raises(SimTimeoutError):
+        await with_timeout(example_coro(), timeout_time=1, timeout_unit="ns")
 
 
 @cocotb.test()
 async def test_timeout_func_coro_pass(dut):
-    res = await cocotb.triggers.with_timeout(
-        example_coro(), timeout_time=100, timeout_unit="ns"
-    )
+    res = await with_timeout(example_coro(), timeout_time=100, timeout_unit="ns")
     assert res == 1
 
 
@@ -235,15 +233,13 @@ async def example():
 
 @cocotb.test()
 async def test_timeout_func_fail(dut):
-    with pytest.raises(cocotb.result.SimTimeoutError):
-        await cocotb.triggers.with_timeout(example(), timeout_time=1, timeout_unit="ns")
+    with pytest.raises(SimTimeoutError):
+        await with_timeout(example(), timeout_time=1, timeout_unit="ns")
 
 
 @cocotb.test()
 async def test_timeout_func_pass(dut):
-    res = await cocotb.triggers.with_timeout(
-        example(), timeout_time=100, timeout_unit="ns"
-    )
+    res = await with_timeout(example(), timeout_time=100, timeout_unit="ns")
     assert res == 1
 
 
@@ -320,18 +316,18 @@ async def test_timer_round_mode(_):
 
     # test with_timeout round_mode
     with pytest.raises(ValueError):
-        await cocotb.triggers.with_timeout(
+        await with_timeout(
             Timer(1, "step"), timeout_time=2.5, timeout_unit="step", round_mode="error"
         )
-    await cocotb.triggers.with_timeout(
+    await with_timeout(
         Timer(1, "step"), timeout_time=2, timeout_unit="step", round_mode="error"
     )
-    await cocotb.triggers.with_timeout(
+    await with_timeout(
         Timer(1, "step"), timeout_time=2.5, timeout_unit="step", round_mode="floor"
     )
-    await cocotb.triggers.with_timeout(
+    await with_timeout(
         Timer(1, "step"), timeout_time=2.5, timeout_unit="step", round_mode="ceil"
     )
-    await cocotb.triggers.with_timeout(
+    await with_timeout(
         Timer(1, "step"), timeout_time=2.5, timeout_unit="step", round_mode="round"
     )

--- a/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
+++ b/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
@@ -6,8 +6,14 @@ import os
 import cocotb
 from cocotb._conf import trust_inertial
 from cocotb.clock import Clock
-from cocotb.result import SimTimeoutError
-from cocotb.triggers import ReadOnly, ReadWrite, RisingEdge, Timer, with_timeout
+from cocotb.triggers import (
+    ReadOnly,
+    ReadWrite,
+    RisingEdge,
+    SimTimeoutError,
+    Timer,
+    with_timeout,
+)
 
 SIM_NAME = cocotb.SIM_NAME.lower()
 vhdl = os.environ.get("TOPLEVEL_LANG", "verilog").lower() == "vhdl"


### PR DESCRIPTION
A part of the effort to remove `cocotb.result` (this would be the only thing left in that package and arguably it doesn't belong there).