### PR TITLE
Add done_callback interface to `Task`s

### DIFF
--- a/docs/source/newsfragments/4041.feature.rst
+++ b/docs/source/newsfragments/4041.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`.Task.add_done_callback` and :meth:`.Task.remove_done_callback` to support running user-supplied callbacks when :class:`~cocotb.task.Task`\ s become "done".


### PR DESCRIPTION
Adds `add_done_callback` and `remove_done_callback` as seen in asyncio's Tasks with the hopes they may be used in the future for instrumenting test end behaviors rather than baking them into the scheduler, but also as a potentially useful feature for users.