### PR TITLE
Call immediately if done_callback is added to finished Task

### DIFF
--- a/docs/source/newsfragments/4041.feature.rst
+++ b/docs/source/newsfragments/4041.feature.rst
@@ -1,1 +1,0 @@
-Added :meth:`.Task.add_done_callback` and :meth:`.Task.remove_done_callback` to support running user-supplied callbacks when :class:`~cocotb.task.Task`\ s become "done".

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -242,34 +242,18 @@ class Task(Generic[ResultType]):
         else:
             return None
 
-    def add_done_callback(self, callback: Callable[["Task[ResultType]"], Any]) -> None:
+    def _add_done_callback(self, callback: Callable[["Task[ResultType]"], Any]) -> None:
         """Add *callback* to the list of callbacks to be run once the Task becomes "done".
 
         Args:
             callback: The callback to run once "done".
+
+        .. note::
+            If the task is already done, calling this function will call the callback immediately.
         """
+        if self.done():
+            callback(self)
         self._done_callbacks.append(callback)
-
-    def remove_done_callback(
-        self, callback: Callable[["Task[ResultType]"], Any]
-    ) -> int:
-        """Remove a callback added by a call to :meth:`add_done_callback`.
-
-        Args:
-            callback: The callback to remove from the callback list.
-
-        Returns:
-            The number of callbacks removed.
-            Typically ``1``, unless a callback was added more than once or never added.
-        """
-        count = 0
-        while True:
-            try:
-                self._done_callbacks.remove(callback)
-            except ValueError:
-                return count
-            else:
-                count += 1
 
     def __await__(self) -> Generator[Any, Any, ResultType]:
         # It's tempting to use `return (yield from self._coro)` here,


### PR DESCRIPTION
If a done callback is added to a Task using `add_done_callback`, and the Task is already done, the callback is never called. asyncio on the other handle schedules the callback to run in the call to `add_done_callback`. We don't have a way to schedule callbacks in this way, so we just callback immediately.

- [x] Make this API private and delete newsfragment.