### PR TITLE
Change timeouts in CI

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -126,6 +126,7 @@ jobs:
         sudo make install
     - name: Set up Icarus (Windows - source)
       if: startsWith(matrix.os, 'windows') && matrix.sim == 'icarus'
+      timeout-minutes: 5
       run: |
         conda install -c msys2 m2-base m2-make m2-autoconf m2-flex m2-bison m2-gperf m2w64-toolchain
         git clone https://github.com/steveicarus/iverilog.git
@@ -211,7 +212,6 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       id: windowstesting
       continue-on-error: ${{matrix.may-fail || false}}
-      timeout-minutes: 20
       # Virtual environments don't work on Windows with cocotb. Avoid using them
       # in nox testing.
       run: |
@@ -236,7 +236,7 @@ jobs:
       id: unixtesting
       if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
       continue-on-error: ${{matrix.may-fail || false}}
-      timeout-minutes: 30
+      timeout-minutes: 40
       run: |
         if [ "${{matrix.self-hosted}}" == "true" ]; then
           module load "${{ matrix.sim-version }}"


### PR DESCRIPTION
Remove timeout on Windows testing. I haven't seen issues with that in a while. Add timeout to Windows Icarus build since those often hang indefinitely, but if it finishes, it takes less than 5 minutes. And bump timeout on Linux testing because old Riviera version in the extended CI are just *barely* not finishing in time.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
