### PR TITLE
Move profiling out of scheduler

### DIFF
--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -37,6 +37,7 @@ from enum import auto
 from types import SimpleNamespace
 from typing import Any, Dict, List, Union, cast
 
+import cocotb._profiling
 import cocotb.handle
 import cocotb.task
 import cocotb.triggers
@@ -294,6 +295,7 @@ def _sim_event(msg: str) -> None:
         regression_manager._fail_simulation(msg)
     else:
         log.error(msg)
+        cocotb._profiling.finalize()
         _stop_user_coverage()
         _stop_library_coverage()
 

--- a/src/cocotb/_profiling.py
+++ b/src/cocotb/_profiling.py
@@ -1,0 +1,42 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+# Debug mode controlled by environment variables
+import cProfile
+import os
+import pstats
+from typing import Union
+
+from cocotb._py_compat import nullcontext
+
+_profile: Union[cProfile.Profile, None]
+
+
+class _profiling_context:
+    """Context manager that profiles its contents"""
+
+    def __enter__(self):
+        _profile.enable()
+
+    def __exit__(self, *excinfo):
+        _profile.disable()
+
+
+if "COCOTB_ENABLE_PROFILING" in os.environ:
+    _profile = cProfile.Profile()
+
+    def finalize() -> None:
+        ps = pstats.Stats(_profile).sort_stats("cumulative")
+        ps.dump_stats("cocotb.pstat")
+
+    profiling_context = _profiling_context()
+
+else:
+    _profile = None
+
+    def finalize() -> None:
+        pass
+
+    profiling_context = nullcontext()

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -46,6 +46,7 @@ from typing import Any, Callable, Dict, Union
 import cocotb
 import cocotb._write_scheduler
 from cocotb import _outcomes, _py_compat
+from cocotb._profiling import profiling_context
 from cocotb._utils import remove_traceback_frames
 from cocotb.result import TestSuccess
 from cocotb.task import Task
@@ -59,14 +60,6 @@ from cocotb.triggers import (
     Trigger,
 )
 
-# Debug mode controlled by environment variables
-_profiling = "COCOTB_ENABLE_PROFILING" in os.environ
-if _profiling:
-    import cProfile
-    import pstats
-
-    _profile = cProfile.Profile()
-
 # Sadly the Python standard logging module is very slow so it's better not to
 # make any calls by testing a boolean flag first
 _debug = "COCOTB_SCHEDULER_DEBUG" in os.environ
@@ -74,16 +67,6 @@ _debug = "COCOTB_SCHEDULER_DEBUG" in os.environ
 
 class InternalError(BaseException):
     """An error internal to scheduler. If you see this, report a bug!"""
-
-
-class profiling_context:
-    """Context manager that profiles its contents"""
-
-    def __enter__(self):
-        _profile.enable()
-
-    def __exit__(self, *excinfo):
-        _profile.disable()
 
 
 class external_state:
@@ -283,11 +266,6 @@ class Scheduler:
         self._terminate = False
         self._test = None
 
-        # dump profiling
-        if _profiling:
-            ps = pstats.Stats(_profile).sort_stats("cumulative")
-            ps.dump_stats("test_profile.pstat")
-
         # call complete cb, may schedule another test
         self._test_complete_cb()
 
@@ -299,12 +277,7 @@ class Scheduler:
         It must also track the current simulator time phase,
         and start the unstarted event loop.
         """
-        if _profiling:
-            ctx = profiling_context()
-        else:
-            ctx = _py_compat.nullcontext()
-
-        with ctx:
+        with profiling_context:
             # TODO: move state tracking to global variable
             # and handle this via some kind of trigger-specific Python callback
             if trigger is self._read_write:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -475,9 +475,9 @@ class RegressionManager:
 
         # Setup simulator finalization
         simulator.stop_simulator()
+        cocotb._profiling.finalize()
         cocotb._stop_user_coverage()
         cocotb._stop_library_coverage()
-        cocotb._profiling.finalize()
 
     def _test_complete(self) -> None:
         """Callback given to the scheduler, to be called when the current test completes.

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -57,6 +57,7 @@ from typing import (
 )
 
 import cocotb
+import cocotb._profiling
 import cocotb._scheduler
 import cocotb._write_scheduler
 from cocotb import _ANSI, simulator
@@ -476,6 +477,7 @@ class RegressionManager:
         simulator.stop_simulator()
         cocotb._stop_user_coverage()
         cocotb._stop_library_coverage()
+        cocotb._profiling.finalize()
 
     def _test_complete(self) -> None:
         """Callback given to the scheduler, to be called when the current test completes.


### PR DESCRIPTION
Depends on #4055.

Moves profiling out of scheduler and into a global registration system. This is another step towards moving things out of the scheduler in such a way to allow for moving triggers out of the scheduler altogether.