### PR TITLE
Pass the python bin path to the embedder library

### DIFF
--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -50,24 +50,15 @@ else ifneq (, $(findstring MSYS, $(OS)))
 endif
 export OS
 
-# Detects if Python is running in a virtual environment
-# https://docs.python.org/3/library/venv.html
-IS_VENV=$(shell $(shell cocotb-config --python-bin) -c 'import sys; print(sys.prefix != sys.base_prefix)')
-
 # this ensures we use the same python as the one cocotb was installed into
 PYTHON_BIN ?= $(shell cocotb-config --python-bin)
+export PYGPI_PYTHON_BIN := $(PYTHON_BIN)
 
 include $(shell cocotb-config --makefiles)/Makefile.deprecations
 
 PYTHON_ARCH := $(shell $(PYTHON_BIN) -c 'from platform import architecture; print(architecture()[0])')
 ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)
     $(error Unknown Python architecture: $(PYTHON_ARCH))
-endif
-
-# Changing PYTHONHOME confuses virtual environments, so only set it when not using a venv
-ifeq ($(IS_VENV),False)
-    # Set PYTHONHOME to properly populate sys.path in embedded python interpreter
-    export PYTHONHOME := $(shell $(PYTHON_BIN) -c 'import sys; print(sys.prefix)')
 endif
 
 ifeq ($(OS),Msys)

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -149,7 +149,7 @@ class Runner(ABC):
 
         self.env["PATH"] += os.pathsep + str(cocotb_tools.config.libs_dir)
         self.env["PYTHONPATH"] = os.pathsep.join(sys.path)
-        self.env["PYTHONHOME"] = sys.prefix
+        self.env["PYGPI_PYTHON_BIN"] = sys.executable
         self.env["COCOTB_TOPLEVEL"] = self.sim_hdl_toplevel
         self.env["COCOTB_TEST_MODULES"] = self.test_module
         self.env["TOPLEVEL_LANG"] = self.hdl_toplevel_lang


### PR DESCRIPTION
Some virtual environment managers, like pipx, don't set VIRTUAL_ENV, and *always* passing the Python binary seems to avoid problems with poorly configured Python environments. PYTHONHOME doesn't need to be set, it's actually seems to be ignored by initialization if we set an appropriate binary name.

Closes #3643 and #4065.