### PR TITLE
Fix multiple VHDL libraries in Pytest + NVC

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1035,7 +1035,7 @@ class Nvc(Runner):
                 )
 
         cmds = [
-            ["nvc", f"--work={self.hdl_library}"]
+            ["nvc", f"--work={self.hdl_library}", "-L", str(self.build_dir)]
             + [arg for arg in self.build_args if type(arg) in (str, VHDL)]
             + ["-a"]
             + [str(source) for source in self.sources if is_vhdl_source(source)]
@@ -1046,7 +1046,7 @@ class Nvc(Runner):
 
     def _test_command(self) -> List[_Command]:
         cmds = [
-            ["nvc", f"--work={self.hdl_toplevel_library}"]
+            ["nvc", f"--work={self.hdl_toplevel_library}", "-L", str(self.build_dir)]
             + self.build_args
             + ["-e", self.sim_hdl_toplevel, "--no-save", "--jit"]
             + self._get_parameter_options(self.parameters)

--- a/tests/pytest/test_vhdl_libraries_multiple.py
+++ b/tests/pytest/test_vhdl_libraries_multiple.py
@@ -25,8 +25,8 @@ sys.path.insert(0, str(src_path))
     reason="Skipping test since only VHDL is supported",
 )
 @pytest.mark.skipif(
-    os.getenv("SIM", "ghdl") not in ["ghdl", "questa", "riviera"],
-    reason="Skipping test since only GHDL, Questa/ModelSim, and Riviera are supported",
+    os.getenv("SIM", "ghdl") not in ["ghdl", "nvc", "questa", "riviera"],
+    reason="Skipping test since only GHDL, NVC, Questa/ModelSim, and Riviera are supported",
 )
 def test_toplevel_library():
     vhdl_gpi_interfaces = os.getenv("VHDL_GPI_INTERFACE", None)


### PR DESCRIPTION
Hi,

when running the `tests/pytest/test_vhdl_libraries_multiple.py` test case with NVC, it fails with the following error message: `test_vhdl_libraries_multiple.py ** Error: library ELIB not found`

This is because NVC does not search for libraries in `build_dir`.

This PR

* Activates this test case for NVC
* Fixes the issue by adding `-L <build_dir>` to the NVC arguments.

(I can add a bugfix newsfragment after review if requested.)

Thank you!
Markus

@nickg: As usual, I'd like to hear your opinion :) Thank you!