### PR TITLE
Change exception in task behavior

### DIFF
--- a/docs/source/newsfragments/4072.feature.rst
+++ b/docs/source/newsfragments/4072.feature.rst
@@ -1,0 +1,1 @@
+Added *fail_on_exception* parameter to :func:`cocotb.start_soon`, :func:`cocotb.start`, and :func:`cocotb.create_task` to control the behavior when a :class:`~cocotb.task.Task` finishes with an Exception.

--- a/src/cocotb/_exceptions.py
+++ b/src/cocotb/_exceptions.py
@@ -1,0 +1,7 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+class InternalError(BaseException):
+    """An error internal to scheduler. If you see this, report a bug!"""

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -45,6 +45,7 @@ from typing import Any, Callable, Dict, Union
 import cocotb
 import cocotb._write_scheduler
 from cocotb import _outcomes, _py_compat
+from cocotb._exceptions import InternalError
 from cocotb._profiling import profiling_context
 from cocotb._utils import remove_traceback_frames
 from cocotb.result import TestSuccess
@@ -62,10 +63,6 @@ from cocotb.triggers import (
 # Sadly the Python standard logging module is very slow so it's better not to
 # make any calls by testing a boolean flag first
 _debug = "COCOTB_SCHEDULER_DEBUG" in os.environ
-
-
-class InternalError(BaseException):
-    """An error internal to scheduler. If you see this, report a bug!"""
 
 
 class external_state:

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -142,8 +142,7 @@ class Task(Generic[ResultType]):
             self._outcome = Error(remove_traceback_frames(e, ["_advance", "send"]))
 
         if self.done():
-            for callback in self._done_callbacks:
-                callback(self)
+            self._do_done_callbacks()
 
     def kill(self) -> None:
         """Kill a coroutine."""
@@ -162,8 +161,11 @@ class Task(Generic[ResultType]):
             self._coro.close()
 
         if self.done():
-            for callback in self._done_callbacks:
-                callback(self)
+            self._do_done_callbacks()
+
+    def _do_done_callbacks(self) -> None:
+        for callback in self._done_callbacks:
+            callback(self)
 
     @deprecated(
         "Using `task` directly is prefered to `task.join()` in all situations where the latter could be used.`"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,7 +28,7 @@
 # Do not fail on DeprecationWarning caused by virtualenv, which might come from
 # the site module.
 # Do not fail on DeprecationWarning caused by attrs dropping 3.6 support
-export PYTHONWARNINGS = error,ignore::DeprecationWarning:site,always::FutureWarning:cocotb._scheduler,ignore::DeprecationWarning:attr
+export PYTHONWARNINGS = error,ignore::DeprecationWarning:site,ignore::DeprecationWarning:attr
 
 REGRESSIONS :=  $(shell ls test_cases/)
 

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -478,7 +478,7 @@ async def test_test_repr(_):
     """Test RunningTest.__repr__"""
     log = logging.getLogger("cocotb.test")
 
-    current_test = cocotb._scheduler_inst._test
+    current_test = cocotb.regression_manager._test_task
     log.info(repr(current_test))
     assert re.match(
         r"<Test test_test_repr running coro=test_test_repr\(\)>", repr(current_test)
@@ -496,7 +496,7 @@ class TestClassRepr(Coroutine):
     async def check_repr(self, dut):
         log = logging.getLogger("cocotb.test")
 
-        current_test = cocotb._scheduler_inst._test
+        current_test = cocotb.regression_manager._test_task
         log.info(repr(current_test))
         assert re.match(
             r"<Test TestClassRepr running coro=TestClassRepr\(\)>", repr(current_test)

--- a/tests/test_cases/test_forked_exception/Makefile
+++ b/tests/test_cases/test_forked_exception/Makefile
@@ -4,10 +4,4 @@
 
 MODULE := test_forked_exception
 
-# ensure the test runs, squash any error code, and ensure a failing test was reported
-.PHONY: override_for_this_test
-override_for_this_test:
-	-$(MAKE) all
-	@test ! -f $(COCOTB_RESULTS_FILE)
-
 include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_forked_exception/test_forked_exception.py
+++ b/tests/test_cases/test_forked_exception/test_forked_exception.py
@@ -8,12 +8,8 @@ The Makefile in this folder is specially set up to squash any error code due
 to a failing test and ensures the failing test is reported properly.
 """
 
-import warnings
-
 import cocotb
 from cocotb.triggers import Timer
-
-warnings.simplefilter("error", category=FutureWarning)
 
 
 class MyException(Exception): ...


### PR DESCRIPTION
Depends on #4071.

Add parameter to control exception in Task behavior.
    
`fail_on_exception` can be:
* NEVER: exceptions will be stored and never cause test failure.
* ALWAYS: exceptions will always cause test failure.
* LEGACY (default): the old behavior where it only failed the test if
  there was no one awaiting the failing task.
