### PR TITLE
Don't force `vpiNoDelay` when writing strings

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/vpi/VpiSignal.cpp
@@ -202,16 +202,18 @@ int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s,
 
     switch (action) {
         case GPI_DEPOSIT:
+#if defined(MODELSIM) || defined(IUS)
+            // Xcelium and Questa do not like setting string variables using
+            // vpiInertialDelay.
             if (vpiStringVar ==
                 vpi_get(vpiType, GpiObjHdl::get_handle<vpiHandle>())) {
-                // assigning to a vpiStringVar only seems to work with
-                // vpiNoDelay
                 vpi_put_flag = vpiNoDelay;
             } else {
-                // Use Inertial delay to schedule an event, thus behaving like a
-                // verilog testbench
                 vpi_put_flag = vpiInertialDelay;
             }
+#else
+            vpi_put_flag = vpiInertialDelay;
+#endif
             break;
         case GPI_FORCE:
             vpi_put_flag = vpiForceFlag;


### PR DESCRIPTION
Removes special case logic for assigning strings in VPI. Previously if assigning a string with `GPI_DEPOSIT`, it was assigned with `vpiNoDelay`. The comment says

> // assigning to a vpiStringVar only seems to work with
                // vpiNoDelay

But doesn't say what simulator or version, or what error they were seeing. This is now causing a behavioral issue, so I'm investigating removing it.