### PR TITLE
Guard VHDL-specific option in Xcelium Python runner.

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1366,9 +1366,10 @@ class Xcelium(Runner):
             verbosity_opts += ["-plinowarn"]
 
         vhpi_opts = []
-        # Xcelium 23.09.004 fixes cocotb issue #1076 as long as the
-        # following define is set.
-        vhpi_opts.append("-NEW_VHPI_PROPAGATE_DELAY")
+        if self.vhdl_sources or any(is_vhdl_source(src) for src in self.sources):
+            # Xcelium 23.09.004 fixes cocotb issue #1076 as long as the
+            # following define is set.
+            vhpi_opts.append("-NEW_VHPI_PROPAGATE_DELAY")
 
         cmds = [
             ["xrun"]
@@ -1444,9 +1445,10 @@ class Xcelium(Runner):
             input_tcl = ["-input", "@run; exit;"]
 
         vhpi_opts = []
-        # Xcelium 23.09.004 fixes cocotb issue #1076 as long as the
-        # following define is set.
-        vhpi_opts.append("-NEW_VHPI_PROPAGATE_DELAY")
+        if self.vhdl_sources or any(is_vhdl_source(src) for src in self.sources):
+            # Xcelium 23.09.004 fixes cocotb issue #1076 as long as the
+            # following define is set.
+            vhpi_opts.append("-NEW_VHPI_PROPAGATE_DELAY")
 
         cmds = [["mkdir", "-p", tmpdir]]
         cmds += [

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -48,6 +48,8 @@ def test_cocotb_parallel(seed):
 
     runner.build_args = compile_args
     runner.sources = sources
+    runner.verilog_sources = []
+    runner.vhdl_sources = []
 
     runner.test(
         seed=seed,

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -47,6 +47,7 @@ def test_cocotb_parallel(seed):
     runner = get_runner(sim)
 
     runner.build_args = compile_args
+    runner.sources = sources
 
     runner.test(
         seed=seed,


### PR DESCRIPTION
Closes #4059. Guards addition of `-NEW_VHPI_PROPAGATE_DELAY` on whether VHDL sources are present.

