### PR TITLE
Deprecate `Join()` and `task.join()`

### DIFF
--- a/docs/source/newsfragments/3931.change.rst
+++ b/docs/source/newsfragments/3931.change.rst
@@ -1,1 +1,0 @@
-Awaiting :meth:`Task.join() <cocotb.task.Task.join>` now returns the :class:`~cocotb.triggers.Join` trigger, not the result of the :class:`~cocotb.task.Task`. To wait for the task to complete and yield the result of the task, await the task directly: ``await task``.

--- a/docs/source/newsfragments/3931.feature.rst
+++ b/docs/source/newsfragments/3931.feature.rst
@@ -1,1 +1,0 @@
-Added :attr:`Join.task <cocotb.triggers.Join.task>` to get the joined task.

--- a/docs/source/newsfragments/3931.removal.rst
+++ b/docs/source/newsfragments/3931.removal.rst
@@ -1,1 +1,1 @@
-``cocotb.triggers.Join.retval`` was removed. Use :attr:`Join.task <cocotb.triggers.Join.task>` to get the joined task and :meth:`Task.result() <cocotb.task.Task.result>` to get its result.
+``cocotb.triggers.Join.retval`` was removed.

--- a/docs/source/newsfragments/4084.removal.1.rst
+++ b/docs/source/newsfragments/4084.removal.1.rst
@@ -1,0 +1,1 @@
+:meth:`.Task.join` was deprecated, use the :class:`~cocotb.task.Task` being joined directly wherever ``task.join()`` was previously used.

--- a/docs/source/newsfragments/4084.removal.rst
+++ b/docs/source/newsfragments/4084.removal.rst
@@ -1,0 +1,1 @@
+:class:`~cocotb.triggers.Join` was deprecated, use the :class:`~cocotb.task.Task` being joined directly wherever ``Join(task)`` was previously used.

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -53,11 +53,11 @@ from cocotb.task import Task
 from cocotb.triggers import (
     Event,
     GPITrigger,
-    Join,
     NextTimeStep,
     ReadOnly,
     ReadWrite,
     Trigger,
+    _Join,
 )
 
 # Sadly the Python standard logging module is very slow so it's better not to
@@ -401,8 +401,8 @@ class Scheduler:
 
             self._terminate = True
 
-        elif Join(task) in self._trigger2tasks:
-            self._react(Join(task))
+        elif _Join(task) in self._trigger2tasks:
+            self._react(_Join(task))
         else:
             try:
                 # throws an error if the background task errored
@@ -594,13 +594,13 @@ class Scheduler:
     def _trigger_from_started_task(self, result: Task) -> Trigger:
         if _debug:
             self.log.debug(f"Joining to already running task: {result}")
-        return result.join()
+        return _Join(result)
 
     def _trigger_from_unstarted_task(self, result: Task) -> Trigger:
         self._queue(result)
         if _debug:
             self.log.debug(f"Scheduling unstarted task: {result!r}")
-        return result.join()
+        return _Join(result)
 
     def _trigger_from_any(self, result) -> Trigger:
         """Convert a yielded object into a Trigger instance"""

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Coroutine, Generator, Generic, List, Optional,
 
 import cocotb
 import cocotb.triggers
+from cocotb._deprecation import deprecated
 from cocotb._outcomes import Error, Outcome, Value
 from cocotb._py_compat import cached_property
 from cocotb._utils import extract_coro_stack, remove_traceback_frames
@@ -164,7 +165,10 @@ class Task(Generic[ResultType]):
             for callback in self._done_callbacks:
                 callback(self)
 
-    def join(self) -> "cocotb.triggers.Join[ResultType]":
+    @deprecated(
+        "Using `task` directly is prefered to `task.join()` in all situations where the latter could be used.`"
+    )
+    def join(self) -> "cocotb.triggers._Join[ResultType]":
         """Wait for the task to complete.
 
         Returns:
@@ -176,13 +180,11 @@ class Task(Generic[ResultType]):
             await my_task.join()
             # "my_task" is done here
 
-        .. versionchanged:: 2.0
+        .. deprecated:: 2.0
 
-            :keyword:`await`\ ing a task using this no longer returns the result of the task, but returns the trigger.
-            To get the result, use :meth:`result` of the completed task,
-            or simply ``await task`` to get the old behavior.
+            Using ``task`` directly is prefered to ``task.join()`` in all situations where the latter could be used.
         """
-        return cocotb.triggers.Join(self)
+        return cocotb.triggers._Join(self)
 
     def has_started(self) -> bool:
         """Return ``True`` if the Task has started executing."""

--- a/tests/test_cases/test_async_bridge/test_async_bridge.py
+++ b/tests/test_cases/test_async_bridge/test_async_bridge.py
@@ -331,7 +331,7 @@ async def test_resume_from_weird_thread_fails(dut):
     assert not func_started, "Function should never have started"
     assert raised, "No exception was raised to warn the user"
 
-    await task.join()
+    await task
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -48,8 +48,8 @@ async def test_unfired_first_triggers(dut):
     await wait_for_firsts()
 
     # make sure the other tasks finish
-    await fire_task.join()
-    await e1_task.join()
+    await fire_task
+    await e1_task
 
 
 @cocotb.test()
@@ -74,7 +74,7 @@ async def test_nested_first(dut):
 
     fire_task = cocotb.start_soon(fire_events())
     await wait_for_nested_first()
-    await fire_task.join()
+    await fire_task
 
 
 @cocotb.test()
@@ -126,7 +126,7 @@ async def test_combine(dut):
 
     tasks = [await cocotb.start(coro(dly)) for dly in [10, 30, 20]]
 
-    await Combine(*(t.join() for t in tasks))
+    await Combine(*tasks)
 
 
 @cocotb.test()
@@ -139,7 +139,7 @@ async def test_fork_combine(dut):
 
     tasks = [cocotb.start_soon(coro(dly)) for dly in [10, 30, 20]]
 
-    await Combine(*(t.join() for t in tasks))
+    await Combine(*tasks)
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -8,7 +8,7 @@ import pytest
 
 import cocotb
 from cocotb.regression import TestFactory
-from cocotb.triggers import Timer
+from cocotb.triggers import Join, Timer
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 
@@ -76,3 +76,23 @@ async def test_string_handle_casts_deprecated(dut):
     await Timer(1, "ns")
     with pytest.warns(DeprecationWarning):
         str(dut.stream_in_string)
+
+
+@cocotb.test
+async def test_join_trigger_deprecated(_) -> None:
+    async def noop():
+        pass
+
+    t = cocotb.start_soon(noop())
+    with pytest.warns(DeprecationWarning, match=r"Join\(task\)"):
+        await Join(t)
+
+
+@cocotb.test
+async def test_task_join_deprecated(_) -> None:
+    async def noop():
+        pass
+
+    t = cocotb.start_soon(noop())
+    with pytest.warns(DeprecationWarning, match=r"task.join\(\)"):
+        await t.join()

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -66,7 +66,7 @@ async def test_rising_edge(dut):
     await Timer(10, "ns")
     dut.clk.value = 1
     fail_timer = Timer(1000, "ns")
-    result = await First(fail_timer, test.join())
+    result = await First(fail_timer, test)
     assert result is not fail_timer, "Test timed out"
 
 
@@ -79,7 +79,7 @@ async def test_falling_edge(dut):
     await Timer(10, "ns")
     dut.clk.value = 0
     fail_timer = Timer(1000, "ns")
-    result = await First(fail_timer, test.join())
+    result = await First(fail_timer, test)
     assert result is not fail_timer, "Test timed out"
 
 
@@ -250,8 +250,8 @@ async def test_clock_cycles_forked(dut):
 
     a = cocotb.start_soon(wait_ten())
     b = cocotb.start_soon(wait_ten())
-    await a.join()
-    await b.join()
+    await a
+    await b
 
 
 @cocotb.test(

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -26,7 +26,6 @@ from cocotb.triggers import (
     Combine,
     Event,
     First,
-    Join,
     NullTrigger,
     ReadOnly,
     RisingEdge,
@@ -41,7 +40,7 @@ test_flag = False
 
 async def clock_yield(task):
     global test_flag
-    await task.join()
+    await task
     test_flag = True
 
 
@@ -823,23 +822,6 @@ async def test_multiple_concurrent_test_fails(_) -> None:
     cocotb.start_soon(call_error(thing))
     cocotb.start_soon(call_error(thing))
     await Timer(10, "ns")
-
-
-@cocotb.test
-async def test_get_task_from_join(_) -> None:
-    async def noop():
-        pass
-
-    t = cocotb.start_soon(noop())
-    j = await t.join()
-    assert isinstance(j, Join)
-    assert j.task is t
-    assert re.match(r"Join\(<Task \d+>\)", repr(j))
-
-    t = cocotb.start_soon(noop())
-    j = await Join(t)
-    assert isinstance(j, Join)
-    assert j.task is t
 
 
 @cocotb.test

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -78,4 +78,4 @@ async def dual_iteration(dut):
     loop_one = cocotb.start_soon(iteration_loop(dut))
     loop_two = cocotb.start_soon(iteration_loop(dut))
 
-    await First(loop_one.join(), loop_two.join())
+    await First(loop_one, loop_two)


### PR DESCRIPTION
This reintroduces old behavior of `Join(task)` and `task.join()`. The change was causing tests which previously failed to continue because when using `Join(task)` or `task.join()` instead of just `task` it prevented exception propagation. It also deprecates the `Join` trigger and `task.join()`.

In asyncio, which we are trying to align with, Tasks are Futures (known in cocotb as Triggers). There is no separate Future object for each Trigger firing. So Tasks are passed directly where any Future is expected. Similarly, cocotb currently supports passing Tasks directly wherever Triggers are expected. Removing Join from the public API forces users to pass Tasks directly instead of Join triggers which should align their code with the asyncio-like model we are converging on.