### PR TITLE
LogicArray changes

### DIFF
--- a/docs/source/newsfragments/4093.removal.1.rst
+++ b/docs/source/newsfragments/4093.removal.1.rst
@@ -1,0 +1,1 @@
+Constructing a :class:`~cocotb.types.LogicArray` from an :class:`int` now only accepts integer literals (unsigned). Use :meth:`.LogicArray.from_signed` to convert negative integers into :class:`~cocotb.types.LogicArray`\ s using two's complement representation.

--- a/docs/source/newsfragments/4093.removal.rst
+++ b/docs/source/newsfragments/4093.removal.rst
@@ -1,0 +1,1 @@
+When constructing a :class:`~cocotb.types.LogicArray` from a :class:`int`, the *range* argument is now required.

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -22,7 +22,7 @@ async def dff_simple_test(dut):
     # verilator does not support 4-state signals
     # see https://veripool.org/guide/latest/languages.html#unknown-states
     initial = (
-        LogicArray(0)
+        LogicArray("0")
         if cocotb.SIM_NAME.lower().startswith("verilator")
         else (
             LogicArray("U") if LANGUAGE.lower().startswith("vhdl") else LogicArray("X")

--- a/src/cocotb/types/array.py
+++ b/src/cocotb/types/array.py
@@ -122,11 +122,6 @@ class Array(ArrayLike[T]):
         TypeError: When invalid argument types are used.
     """
 
-    __slots__ = (
-        "_value",
-        "_range",
-    )
-
     def __init__(self, value: Iterable[T], range: Optional[Range] = None):
         self._value = list(value)
         if range is None:

--- a/src/cocotb/types/array.py
+++ b/src/cocotb/types/array.py
@@ -1,12 +1,12 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-import typing
+from typing import Iterable, Iterator, Optional, TypeVar, Union, cast, overload
 
 from cocotb.types import ArrayLike
 from cocotb.types.range import Range
 
-T = typing.TypeVar("T")
+T = TypeVar("T")
 
 
 class Array(ArrayLike[T]):
@@ -127,7 +127,7 @@ class Array(ArrayLike[T]):
         "_range",
     )
 
-    def __init__(self, value: typing.Iterable[T], range: typing.Optional[Range] = None):
+    def __init__(self, value: Iterable[T], range: Optional[Range] = None):
         self._value = list(value)
         if range is None:
             self._range = Range(0, "to", len(self._value) - 1)
@@ -154,10 +154,10 @@ class Array(ArrayLike[T]):
             )
         self._range = new_range
 
-    def __iter__(self) -> typing.Iterator[T]:
+    def __iter__(self) -> Iterator[T]:
         return iter(self._value)
 
-    def __reversed__(self) -> typing.Iterator[T]:
+    def __reversed__(self) -> Iterator[T]:
         return reversed(self._value)
 
     def __contains__(self, item: object) -> bool:
@@ -171,15 +171,13 @@ class Array(ArrayLike[T]):
         else:
             return NotImplemented
 
-    @typing.overload
+    @overload
     def __getitem__(self, item: int) -> T: ...
 
-    @typing.overload
+    @overload
     def __getitem__(self, item: slice) -> "Array[T]": ...
 
-    def __getitem__(
-        self, item: typing.Union[int, slice]
-    ) -> typing.Union[T, "Array[T]"]:
+    def __getitem__(self, item: Union[int, slice]) -> Union[T, "Array[T]"]:
         if isinstance(item, int):
             idx = self._translate_index(item)
             return self._value[idx]
@@ -199,18 +197,18 @@ class Array(ArrayLike[T]):
             return Array(value=value, range=range)
         raise TypeError(f"indexes must be ints or slices, not {type(item).__name__}")
 
-    @typing.overload
+    @overload
     def __setitem__(self, item: int, value: T) -> None: ...
 
-    @typing.overload
-    def __setitem__(self, item: slice, value: typing.Iterable[T]) -> None: ...
+    @overload
+    def __setitem__(self, item: slice, value: Iterable[T]) -> None: ...
 
     def __setitem__(
-        self, item: typing.Union[int, slice], value: typing.Union[T, typing.Iterable[T]]
+        self, item: Union[int, slice], value: Union[T, Iterable[T]]
     ) -> None:
         if isinstance(item, int):
             idx = self._translate_index(item)
-            self._value[idx] = typing.cast(T, value)
+            self._value[idx] = cast(T, value)
         elif isinstance(item, slice):
             start = item.start if item.start is not None else self.left
             stop = item.stop if item.stop is not None else self.right
@@ -222,7 +220,7 @@ class Array(ArrayLike[T]):
                 raise IndexError(
                     f"slice [{start}:{stop}] direction does not match array direction [{self.left}:{self.right}]"
                 )
-            value = list(typing.cast(typing.Iterable[T], value))
+            value = list(cast(Iterable[T], value))
             if len(value) != (stop_i - start_i + 1):
                 raise ValueError(
                     f"value of length {len(value)!r} will not fit in slice [{start}:{stop}]"

--- a/src/cocotb/types/logic.py
+++ b/src/cocotb/types/logic.py
@@ -1,11 +1,11 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-import typing
 from functools import lru_cache
+from typing import Dict, Optional, Set, Type, Union
 
-LogicLiteralT = typing.Union[str, int, bool]
-LogicConstructibleT = typing.Union[LogicLiteralT, "Logic"]
+LogicLiteralT = Union[str, int, bool]
+LogicConstructibleT = Union[LogicLiteralT, "Logic"]
 
 
 _U = 0
@@ -18,7 +18,7 @@ _L = 6
 _H = 7
 _D = 8
 
-_literal_repr: typing.Dict[LogicLiteralT, int] = {
+_literal_repr: Dict[LogicLiteralT, int] = {
     # unassigned
     "U": _U,
     "u": _U,
@@ -49,7 +49,7 @@ _literal_repr: typing.Dict[LogicLiteralT, int] = {
     "-": _D,
 }
 
-_str_literals: typing.Set[str] = {k for k in _literal_repr.keys() if isinstance(k, str)}
+_str_literals: Set[str] = {k for k in _literal_repr.keys() if isinstance(k, str)}
 
 
 class Logic:
@@ -94,7 +94,7 @@ class Logic:
 
     .. code-block:: python3
 
-        >>> def full_adder(a: Logic, b: Logic, carry: Logic) -> typing.Tuple[Logic, Logic]:
+        >>> def full_adder(a: Logic, b: Logic, carry: Logic) -> Tuple[Logic, Logic]:
         ...     res = a ^ b ^ carry
         ...     carry_out = (a & b) | (b & carry) | (a & carry)
         ...     return res, carry_out
@@ -115,7 +115,7 @@ class Logic:
 
     @classmethod
     @lru_cache(maxsize=None)
-    def _get_object(cls: typing.Type["Logic"], _repr: int) -> "Logic":
+    def _get_object(cls: Type["Logic"], _repr: int) -> "Logic":
         """Return the Logic object associated with the repr, enforcing singleton."""
         self = object.__new__(cls)
         self._repr = _repr
@@ -124,8 +124,8 @@ class Logic:
     @classmethod
     @lru_cache(maxsize=None)
     def _map_literal(
-        cls: typing.Type["Logic"],
-        value: typing.Optional[LogicLiteralT] = None,
+        cls: Type["Logic"],
+        value: Optional[LogicLiteralT] = None,
     ) -> "Logic":
         """Convert and cache all literals."""
         if value is None:
@@ -142,8 +142,8 @@ class Logic:
         return obj
 
     def __new__(
-        cls: typing.Type["Logic"],
-        value: typing.Optional[LogicConstructibleT] = None,
+        cls: Type["Logic"],
+        value: Optional[LogicConstructibleT] = None,
     ) -> "Logic":
         if isinstance(value, Logic):
             return value

--- a/src/cocotb/types/logic.py
+++ b/src/cocotb/types/logic.py
@@ -109,8 +109,6 @@ class Logic:
         ValueError: if the value cannot be constructed into a :class:`Logic`.
     """
 
-    __slots__ = ("_repr",)
-
     _repr: int
 
     @classmethod

--- a/src/cocotb/types/logic.py
+++ b/src/cocotb/types/logic.py
@@ -49,6 +49,8 @@ _literal_repr: typing.Dict[LogicLiteralT, int] = {
     "-": _D,
 }
 
+_str_literals: typing.Set[str] = {k for k in _literal_repr.keys() if isinstance(k, str)}
+
 
 class Logic:
     r"""

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -167,7 +167,7 @@ class LogicArray(ArrayLike[Logic]):
         self._value_as_int = None
         self._value_as_str = None
         if isinstance(value, str):
-            if any(v not in _str_literals for v in value):
+            if not (set(value) <= _str_literals):
                 raise ValueError("Invalid str literal")
             self._value_as_str = value.upper()
             if range is not None:

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -1,6 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
+import warnings
 from math import ceil
 from typing import Iterable, Iterator, List, Optional, Union, cast, overload
 
@@ -424,6 +425,9 @@ class LogicArray(ArrayLike[Logic]):
 
         Returns: An :class:`int` equivalent to the value by interpreting it using unsigned representation.
         """
+        if len(self) == 0:
+            warnings.warn("Converting a LogicArray of length 0 to integer")
+            return 0
         return self._get_int()
 
     def to_signed(self) -> int:
@@ -435,6 +439,9 @@ class LogicArray(ArrayLike[Logic]):
 
         Returns: An :class:`int` equivalent to the value by interpreting it using two's complement representation.
         """
+        if len(self) == 0:
+            warnings.warn("Converting a LogicArray of length 0 to integer")
+            return 0
         value = self._get_int()
         if value >= (1 << (len(self) - 1)):
             value -= 1 << len(self)
@@ -524,7 +531,7 @@ class LogicArray(ArrayLike[Logic]):
         return self._get_str()
 
     def __int__(self) -> int:
-        return self._get_int()
+        return self.to_unsigned()
 
     def __and__(self, other: "LogicArray") -> "LogicArray":
         if not isinstance(other, LogicArray):

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -2,7 +2,6 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import typing
-import warnings
 from math import ceil
 
 from cocotb._deprecation import deprecated
@@ -142,16 +141,9 @@ class LogicArray(ArrayLike[Logic]):
         range: typing.Optional[Range] = None,
     ) -> "LogicArray":
         if isinstance(value, int):
-            warnings.warn(
-                "Constructing a LogicArray from an integer is deprecated. "
-                "Use `LogicArray.from_signed(value)` or `LogicArray.from_unsigned(value)` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if value < 0:
-                return cls.from_signed(value, range=range)
-            else:
-                return cls.from_unsigned(value, range=range)
+            if range is None:
+                raise TypeError("Missing required argument 'range'")
+            return cls.from_unsigned(value, range=range)
 
         self = super().__new__(cls)
 
@@ -198,7 +190,7 @@ class LogicArray(ArrayLike[Logic]):
             OverflowError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
         """
         if value < 0:
-            raise OverflowError(f"{value} not in bounds for an unsigned integer.")
+            raise ValueError(f"{value} not in bounds for an unsigned integer.")
 
         bitlen = max(1, int.bit_length(value))
         if bitlen > len(range):

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -1,8 +1,8 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-import typing
 from math import ceil
+from typing import Iterable, Iterator, List, Optional, Union, cast, overload
 
 from cocotb._deprecation import deprecated
 from cocotb.types import ArrayLike
@@ -123,33 +123,33 @@ class LogicArray(ArrayLike[Logic]):
     # implementations are faster for particular operations.
     # Each implementation can be present, or None if the implementation has not been
     # computed or has been invalidated by a mutating operation.
-    _value_as_array: typing.Union[typing.List[Logic], None]
-    _value_as_int: typing.Union[int, None]
-    _value_as_str: typing.Union[str, None]
+    _value_as_array: Union[List[Logic], None]
+    _value_as_int: Union[int, None]
+    _value_as_str: Union[str, None]
     _range: Range
 
-    @typing.overload
+    @overload
     def __init__(
         self,
         value: str,
-        range: typing.Optional[Range] = None,
+        range: Optional[Range] = None,
     ) -> None: ...
 
-    @typing.overload
+    @overload
     def __init__(
         self,
-        value: typing.Iterable[LogicConstructibleT],
-        range: typing.Optional[Range] = None,
+        value: Iterable[LogicConstructibleT],
+        range: Optional[Range] = None,
     ) -> None: ...
 
-    @typing.overload
+    @overload
     def __init__(
         self,
         value: int,
         range: Range,
     ) -> None: ...
 
-    @typing.overload
+    @overload
     def __init__(
         self,
         value: None,
@@ -158,10 +158,8 @@ class LogicArray(ArrayLike[Logic]):
 
     def __init__(
         self,
-        value: typing.Union[
-            int, str, typing.Iterable[LogicConstructibleT], None
-        ] = None,
-        range: typing.Optional[Range] = None,
+        value: Union[int, str, Iterable[LogicConstructibleT], None] = None,
+        range: Optional[Range] = None,
     ) -> None:
         self._value_as_array = None
         self._value_as_int = None
@@ -206,7 +204,7 @@ class LogicArray(ArrayLike[Logic]):
             else:
                 self._range = Range(len(self._value_as_array) - 1, "downto", 0)
 
-    def _get_array(self) -> typing.List[Logic]:
+    def _get_array(self) -> List[Logic]:
         if self._value_as_array is None:
             # May convert int to str before to converting to array.
             self._value_as_array = [Logic(v) for v in self._get_str()]
@@ -218,8 +216,7 @@ class LogicArray(ArrayLike[Logic]):
                 self._value_as_str = format(self._value_as_int, f"0{len(self)}b")
             else:
                 self._value_as_str = "".join(
-                    str(v)
-                    for v in typing.cast(typing.List[Logic], self._value_as_array)
+                    str(v) for v in cast(List[Logic], self._value_as_array)
                 )
         return self._value_as_str
 
@@ -291,10 +288,10 @@ class LogicArray(ArrayLike[Logic]):
             )
         self._range = new_range
 
-    def __iter__(self) -> typing.Iterator[Logic]:
+    def __iter__(self) -> Iterator[Logic]:
         return iter(self._get_array())
 
-    def __reversed__(self) -> typing.Iterator[Logic]:
+    def __reversed__(self) -> Iterator[Logic]:
         return reversed(self._get_array())
 
     def __contains__(self, item: object) -> bool:
@@ -443,15 +440,13 @@ class LogicArray(ArrayLike[Logic]):
             value -= 1 << len(self)
         return value
 
-    @typing.overload
+    @overload
     def __getitem__(self, item: int) -> Logic: ...
 
-    @typing.overload
+    @overload
     def __getitem__(self, item: slice) -> "LogicArray": ...
 
-    def __getitem__(
-        self, item: typing.Union[int, slice]
-    ) -> typing.Union[Logic, "LogicArray"]:
+    def __getitem__(self, item: Union[int, slice]) -> Union[Logic, "LogicArray"]:
         array = self._get_array()
         if isinstance(item, int):
             idx = self._translate_index(item)
@@ -472,18 +467,18 @@ class LogicArray(ArrayLike[Logic]):
             return LogicArray(value=value, range=range)
         raise TypeError(f"indexes must be ints or slices, not {type(item).__name__}")
 
-    @typing.overload
+    @overload
     def __setitem__(self, item: int, value: LogicConstructibleT) -> None: ...
 
-    @typing.overload
+    @overload
     def __setitem__(
-        self, item: slice, value: typing.Iterable[LogicConstructibleT]
+        self, item: slice, value: Iterable[LogicConstructibleT]
     ) -> None: ...
 
     def __setitem__(
         self,
-        item: typing.Union[int, slice],
-        value: typing.Union[LogicConstructibleT, typing.Iterable[LogicConstructibleT]],
+        item: Union[int, slice],
+        value: Union[LogicConstructibleT, Iterable[LogicConstructibleT]],
     ) -> None:
         array = self._get_array()
         # invalid other impls
@@ -491,7 +486,7 @@ class LogicArray(ArrayLike[Logic]):
         self._value_as_int = None
         if isinstance(item, int):
             idx = self._translate_index(item)
-            array[idx] = Logic(typing.cast(LogicConstructibleT, value))
+            array[idx] = Logic(cast(LogicConstructibleT, value))
         elif isinstance(item, slice):
             start = item.start if item.start is not None else self.left
             stop = item.stop if item.stop is not None else self.right
@@ -504,8 +499,7 @@ class LogicArray(ArrayLike[Logic]):
                     f"slice [{start}:{stop}] direction does not match array direction [{self.left}:{self.right}]"
                 )
             value_as_logics = [
-                Logic(v)
-                for v in typing.cast(typing.Iterable[LogicConstructibleT], value)
+                Logic(v) for v in cast(Iterable[LogicConstructibleT], value)
             ]
             if len(value_as_logics) != (stop_i - start_i + 1):
                 raise ValueError(

--- a/src/cocotb/types/range.py
+++ b/src/cocotb/types/range.py
@@ -90,11 +90,11 @@ class Range(Sequence[int]):
         if isinstance(direction, int) and right is None:
             step = _guess_step(left, direction)
             stop = direction + step
-        elif direction is None and isinstance(right, int):
-            step = _guess_step(left, right)
-            stop = right + step
         elif isinstance(direction, str) and isinstance(right, int):
             step = _direction_to_step(direction)
+            stop = right + step
+        elif direction is None and isinstance(right, int):
+            step = _guess_step(left, right)
             stop = right + step
         else:
             raise TypeError("invalid arguments")

--- a/src/cocotb/types/range.py
+++ b/src/cocotb/types/range.py
@@ -1,6 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
+from functools import lru_cache
 from typing import Iterator, Sequence, Union, overload
 
 
@@ -177,6 +178,7 @@ def _guess_step(left: int, right: int) -> int:
     return -1
 
 
+@lru_cache(maxsize=None)
 def _direction_to_step(direction: str) -> int:
     direction = direction.lower()
     if direction == "to":

--- a/src/cocotb/types/range.py
+++ b/src/cocotb/types/range.py
@@ -1,10 +1,10 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-import typing
+from typing import Iterator, Sequence, Union, overload
 
 
-class Range(typing.Sequence[int]):
+class Range(Sequence[int]):
     r"""
     Variant of :class:`range` with inclusive right bound.
 
@@ -65,23 +65,23 @@ class Range(typing.Sequence[int]):
 
     __slots__ = ("_range",)
 
-    @typing.overload
+    @overload
     def __init__(self, left: int, direction: int) -> None:
         pass  # pragma: no cover
 
-    @typing.overload
+    @overload
     def __init__(self, left: int, direction: str, right: int) -> None:
         pass  # pragma: no cover
 
-    @typing.overload
+    @overload
     def __init__(self, left: int, *, right: int) -> None:
         pass  # pragma: no cover
 
     def __init__(
         self,
         left: int,
-        direction: typing.Union[int, str, None] = None,
-        right: typing.Union[int, None] = None,
+        direction: Union[int, str, None] = None,
+        right: Union[int, None] = None,
     ) -> None:
         start = left
         stop: int
@@ -130,15 +130,15 @@ class Range(typing.Sequence[int]):
     def __len__(self) -> int:
         return len(self._range)
 
-    @typing.overload
+    @overload
     def __getitem__(self, item: int) -> int:
         pass  # pragma: no cover
 
-    @typing.overload
+    @overload
     def __getitem__(self, item: slice) -> "Range":
         pass  # pragma: no cover
 
-    def __getitem__(self, item: typing.Union[int, slice]) -> typing.Union[int, "Range"]:
+    def __getitem__(self, item: Union[int, slice]) -> Union[int, "Range"]:
         if isinstance(item, int):
             return self._range[item]
         elif isinstance(item, slice):
@@ -150,10 +150,10 @@ class Range(typing.Sequence[int]):
     def __contains__(self, item: object) -> bool:
         return item in self._range
 
-    def __iter__(self) -> typing.Iterator[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(self._range)
 
-    def __reversed__(self) -> typing.Iterator[int]:
+    def __reversed__(self) -> Iterator[int]:
         return reversed(self._range)
 
     def __eq__(self, other: object) -> bool:

--- a/src/cocotb/types/range.py
+++ b/src/cocotb/types/range.py
@@ -64,8 +64,6 @@ class Range(Sequence[int]):
         right: rightmost bound of range (inclusive)
     """
 
-    __slots__ = ("_range",)
-
     @overload
     def __init__(self, left: int, direction: int) -> None:
         pass  # pragma: no cover

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -21,7 +21,7 @@ def test_logic_array_constructor():
     with pytest.raises(OverflowError):
         LogicArray("101010", Range(0, "to", 0))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         LogicArray()
 
     assert LogicArray(10, Range(5, "downto", 0)) == LogicArray("001010")

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -27,12 +27,8 @@ def test_logic_array_constructor():
 
 def test_logic_array_constructor_deprecated():
     with pytest.warns(DeprecationWarning):
-        assert LogicArray(0xA7) == LogicArray("10100111")
-    with pytest.warns(DeprecationWarning):
         assert LogicArray(10, Range(5, "downto", 0)) == LogicArray("001010")
 
-    with pytest.warns(DeprecationWarning):
-        assert LogicArray(-1) == LogicArray("1")
     with pytest.warns(DeprecationWarning):
         assert LogicArray(-2, Range(5, "downto", 0)) == LogicArray("111110")
 
@@ -45,15 +41,13 @@ def test_logic_array_constructor_deprecated():
 
 
 def test_logic_array_int_conversion():
-    assert LogicArray.from_unsigned(0xA7) == LogicArray("10100111")
     assert LogicArray.from_unsigned(10, Range(5, "downto", 0)) == LogicArray("001010")
-    with pytest.raises(OverflowError):
-        LogicArray.from_unsigned(-10)
+
     with pytest.raises(OverflowError):
         LogicArray.from_unsigned(10, Range(1, "to", 3))
 
-    assert LogicArray.from_signed(-1) == LogicArray("1")
     assert LogicArray.from_signed(-2, Range(5, "downto", 0)) == LogicArray("111110")
+
     with pytest.raises(OverflowError):
         LogicArray.from_signed(-45, Range(1, "to", 3))
 

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -24,20 +24,13 @@ def test_logic_array_constructor():
     with pytest.raises(ValueError):
         LogicArray()
 
-
-def test_logic_array_constructor_deprecated():
-    with pytest.warns(DeprecationWarning):
-        assert LogicArray(10, Range(5, "downto", 0)) == LogicArray("001010")
-
-    with pytest.warns(DeprecationWarning):
-        assert LogicArray(-2, Range(5, "downto", 0)) == LogicArray("111110")
+    assert LogicArray(10, Range(5, "downto", 0)) == LogicArray("001010")
 
     with pytest.raises(OverflowError):
-        with pytest.warns(DeprecationWarning):
-            LogicArray(10, Range(1, "to", 3))
-    with pytest.raises(OverflowError):
-        with pytest.warns(DeprecationWarning):
-            LogicArray(-45, Range(1, "to", 3))
+        LogicArray(10, Range(1, "to", 3))
+
+    with pytest.raises(ValueError):
+        LogicArray(-10, Range(7, "downto", 0))
 
 
 def test_logic_array_int_conversion():
@@ -45,6 +38,9 @@ def test_logic_array_int_conversion():
 
     with pytest.raises(OverflowError):
         LogicArray.from_unsigned(10, Range(1, "to", 3))
+
+    with pytest.raises(ValueError):
+        LogicArray.from_unsigned(-10, Range(7, "downto", 0))
 
     assert LogicArray.from_signed(-2, Range(5, "downto", 0)) == LogicArray("111110")
 

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -253,3 +253,45 @@ def test_changing_range():
         a.range = range(10)
     with pytest.raises(ValueError):
         a.range = Range(7, "downto", 0)
+
+
+def test_null_vector():
+    null_range = Range(-1, "downto", 0)
+    assert len(null_range) == 0
+
+    # test construction doesn't fail
+    LogicArray("")
+    LogicArray("", null_range)
+    LogicArray([])
+    LogicArray([], null_range)
+    with pytest.raises(OverflowError):
+        LogicArray(0, null_range)
+    LogicArray(range=null_range)
+    with pytest.raises(OverflowError):
+        LogicArray.from_unsigned(0, null_range)
+    with pytest.raises(OverflowError):
+        LogicArray.from_signed(0, null_range)
+
+    null_vector = LogicArray("")
+
+    # test attributes
+    assert len(null_vector) == 0
+    assert list(null_vector) == []
+    assert str(null_vector) == ""
+    with pytest.warns(UserWarning):
+        assert int(null_vector) == 0
+    with pytest.warns(UserWarning):
+        assert null_vector.to_signed() == 0
+    with pytest.warns(UserWarning):
+        assert null_vector.to_unsigned() == 0
+
+    # test comparison
+    assert null_vector == LogicArray("")
+    assert null_vector == LogicArray("", null_range)
+    assert null_vector == LogicArray([])
+    assert null_vector == LogicArray([], null_range)
+    assert null_vector == LogicArray(range=null_range)
+    with pytest.warns(UserWarning):
+        assert null_vector == 0
+    assert null_vector == ""
+    assert null_vector == []

--- a/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
+++ b/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
@@ -32,8 +32,8 @@ async def test_long_signal(dut):
     else ()
 )
 async def test_read_zero_signal(dut):
-    """Read a zero vector. It should always read 0."""
-    assert dut.Cntrl_out.value == 0, "Failed to readback dut.Cntrl_out"
+    """Read a zero vector. It should always read an empty LogicArray."""
+    assert dut.Cntrl_out.value == "", "Failed to readback dut.Cntrl_out"
 
 
 @cocotb.test(
@@ -48,7 +48,7 @@ async def test_write_zero_signal_with_0(dut):
     """Write a zero vector with 0."""
     dut.Cntrl_out.value = 0x0
     await Timer(1, "ns")
-    assert dut.Cntrl_out.value == 0, "Failed to readback dut.Cntrl_out"
+    assert dut.Cntrl_out.value == "", "Failed to readback dut.Cntrl_out"
 
 
 @cocotb.test(


### PR DESCRIPTION
Removes some features that were of little value, required guessing, or that were deprecated (those can go in 1.9). The idea is that `LogicArray` has 3 different "literal" syntaxes: integer literals (`0b1010101`), string literals (`"01011010"`), and array/tuple literals (`[1, 0, 1, 0]`). These can be used in construction and comparison. Perhaps they will make it to the other operations someday.

Improves performance in the most common operations: construction from binstr and comparison to integer. Construction time is halfed and comparison is 10x'd.

```
#Before
> python -m timeit -s "from cocotb.types import LogicArray, Range" "LogicArray('10101010')"
100000 loops, best of 5: 2.82 usec per loop

> python -m timeit -s "from cocotb.types import LogicArray, Range" -s "a = LogicArray('10101010')" "a == 123"
200000 loops, best of 5: 1.54 usec per loop

# After
> python -m timeit -s "from cocotb.types import LogicArray, Range" "LogicArray('10101010')"
200000 loops, best of 5: 1.19 usec per loop

> python -m timeit -s "from cocotb.types import LogicArray, Range" -s "a = LogicArray('10101010')" "a == 123"
2000000 loops, best of 5: 171 nsec per loop
```