### PR TITLE
Use EXTRA_ARGS correctly in Makefile.verilator

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.verilator
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.verilator
@@ -48,11 +48,11 @@ ifeq ($(VERILATOR_SIM_DEBUG), 1)
 endif
 
 ifeq ($(VERILATOR_TRACE),1)
-  EXTRA_ARGS += --trace --trace-structs
+  COMPILE_ARGS += --trace --trace-structs
   SIM_ARGS += --trace
 endif
 
-EXTRA_ARGS += --timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)
+COMPILE_ARGS += --timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)
 
 COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o Vtop -LDFLAGS "-Wl,-rpath,$(shell cocotb-config --lib-dir) -L$(shell cocotb-config --lib-dir) -lcocotbvpi_verilator"
 
@@ -73,7 +73,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/Vtop $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)
 
 	COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) COCOTB_TESTCASE=$(call deprecate,TESTCASE,COCOTB_TESTCASE) COCOTB_TEST_FILTER=$(COCOTB_TEST_FILTER) COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(SIM_CMD_PREFIX) $< $(SIM_ARGS) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(DEBUG) $(SIM_CMD_SUFFIX)
+        $(SIM_CMD_PREFIX) $< $(SIM_ARGS) $(EXTRA_ARGS) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(DEBUG) $(SIM_CMD_SUFFIX)
 
 	$(call check_for_results_file)
 


### PR DESCRIPTION
EXTRA_ARGS, per the documentation, are flags that are passed to both the compilation and the simulation steps when running a test.
