### PR TITLE
1.9.1 backports part1

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.verilator
+++ b/cocotb/share/makefiles/simulators/Makefile.verilator
@@ -49,6 +49,7 @@ endif
 
 ifeq ($(VERILATOR_TRACE),1)
   EXTRA_ARGS += --trace --trace-structs
+  SIM_ARGS += --trace
 endif
 
 EXTRA_ARGS += --timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)
@@ -70,7 +71,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/Vtop $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)
 
 	MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(SIM_CMD_PREFIX) $< $(PLUSARGS) $(SIM_CMD_SUFFIX)
+        $(SIM_CMD_PREFIX) $< $(SIM_ARGS) $(PLUSARGS) $(SIM_CMD_SUFFIX)
 
 	$(call check_for_results_file)
 

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -672,6 +672,7 @@ def get_ext():
 
     if sys.platform == "darwin":
         cfg_vars["LDSHARED"] = cfg_vars["LDSHARED"].replace("-bundle", "-dynamiclib")
+        cfg_vars["LDCXXSHARED"] = cfg_vars["LDSHARED"].replace("-bundle", "-dynamiclib")
 
     share_lib_dir = os.path.relpath(os.path.join(cocotb_share_dir, "lib"))
     include_dirs = [

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -85,7 +85,7 @@ Installation of cocotb
 
     .. parsed-literal::
 
-        pip install cocotb =~ |version|
+        pip install "cocotb~=|version|"
 
 .. only:: not is_release_build
 
@@ -117,8 +117,5 @@ If you want to install the **development version** of cocotb,
 
 After installation, you should be able to execute :command:`cocotb-config`.
 If it is not found, you need to append its location to the :envvar:`PATH` environment variable.
-This may happen when you use the ``--user`` option to :command:`pip`,
-in which case the location is documented :ref:`here<python:inst-alt-install-user>`.
-
 
 For more installation options, please see `our Wiki <https://github.com/cocotb/cocotb/wiki/Tier-2-Setup-Instructions>`_.

--- a/documentation/source/install_devel.rst
+++ b/documentation/source/install_devel.rst
@@ -80,4 +80,3 @@ The development version of cocotb can be installed by running
 
 After installation, you should be able to execute ``cocotb-config``.
 If it is not found, you need to append its location to the ``PATH`` environment variable.
-This may happen when you use the ``--user`` option to ``pip``, in which case the location is documented :ref:`here<python:inst-alt-install-user>`.

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -27,7 +27,7 @@ In order to use this simulator, set :make:var:`SIM` to ``icarus``:
 
 .. note::
 
-    A working installation of `Icarus Verilog <http://iverilog.icarus.com/>`_ is required.
+    A working installation of `Icarus Verilog <https://github.com/steveicarus/iverilog>`_ is required.
     You can find installation instructions `in the Icarus Verilog Installation Guide <https://iverilog.fandom.com/wiki/Installation_Guide>`_.
 
 .. _sim-icarus-accessing-bits:

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,14 +113,23 @@ def build_cocotb_for_dev_test(session: nox.Session, *, editable: bool) -> None:
     """
 
     env = session.env.copy()
-    env["CFLAGS"] = "-Werror -Wno-deprecated-declarations -g --coverage"
-    env["CXXFLAGS"] = "-Werror"
+    flags = " ".join(
+        [
+            "-Werror",
+            "-Wno-error=deprecated-declarations",
+            "-Wsuggest-override",
+            "-g",
+            "--coverage",
+        ]
+    )
+    env["CFLAGS"] = flags
+    env["CXXFLAGS"] = flags
     env["LDFLAGS"] = "--coverage"
 
     if editable:
-        session.run("pip", "install", "-e", ".", env=env)
+        session.run("pip", "install", "-v", "-e", ".", env=env)
     else:
-        session.run("pip", "install", ".", env=env)
+        session.run("pip", "install", "-v", ".", env=env)
 
 
 #


### PR DESCRIPTION
Pretty much the same as https://github.com/cocotb/cocotb/pull/4098, just with cherry-pick commit hashes included and a clean cherry-pick for the documentation fixes.

I did the cherry-picks interactively to fix the conflicts we're getting due to the modified directory structure between stable/1.9 and master.

- **Support SIM_ARGS in Verilator Makefile**
- **Update build following change to setuptools/distutils (#4095)**
- **Fix some documentation issues**
