### PR TITLE
CI: Gate log dumping in backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -52,9 +52,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Info log
-        if: ${{ success() }}
+        if: ${{ fromJSON(steps.check_labels.outputs.matched) > 0 && success() }}
         run: cat ~/.backport/backport.info.log
 
       - name: Debug log
-        if: ${{ failure() }}
+        if: ${{ fromJSON(steps.check_labels.outputs.matched) > 0 && failure() }}
         run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
The log dumping tasks weren't gated by the label check, leading to cases
where no logs were available and the `cat` failed.

Recent example: https://github.com/cocotb/cocotb/actions/runs/10457916201/job/28958603739?pr=4107
