### PR TITLE
Test writes in `ReadWrite`

### DIFF
--- a/src/cocotb/_conf.py
+++ b/src/cocotb/_conf.py
@@ -1,6 +1,0 @@
-# Copyright cocotb contributors
-# Licensed under the Revised BSD License, see LICENSE for details.
-# SPDX-License-Identifier: BSD-3-Clause
-import os
-
-trust_inertial = bool(int(os.environ.get("COCOTB_TRUST_INERTIAL_WRITES", "0")))

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -33,8 +33,8 @@ from fractions import Fraction
 from logging import Logger
 from typing import Union
 
-import cocotb._conf
 from cocotb._py_compat import cached_property
+from cocotb._write_scheduler import trust_inertial
 from cocotb.simulator import clock_create
 from cocotb.triggers import Event, Timer
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
@@ -138,7 +138,7 @@ class Clock:
                 f"Invalid clock impl {impl!r}, must be one of: {valid_impls_str}"
             )
         if impl == "auto":
-            impl = "gpi" if cocotb._conf.trust_inertial else "py"
+            impl = "gpi" if trust_inertial else "py"
         self.impl = impl
 
     async def start(self, start_high: bool = True) -> None:

--- a/src/cocotb_tools/combine_results.py
+++ b/src/cocotb_tools/combine_results.py
@@ -32,7 +32,7 @@ def _get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-i",
         "--input-filename",
-        default="results.xml",
+        default=r"results.*\.xml",
         help="A regular expression to match input filenames.",
     )
     parser.add_argument(

--- a/tests/test_cases/test_inertial_writes/Makefile
+++ b/tests/test_cases/test_inertial_writes/Makefile
@@ -4,8 +4,8 @@
 
 .PHONY: override_tests
 override_tests:
-	$(MAKE) COCOTB_TRUST_INERTIAL_WRITES=0 sim
-	$(MAKE) COCOTB_TRUST_INERTIAL_WRITES=1 sim
+	$(MAKE) COCOTB_TRUST_INERTIAL_WRITES=0 sim COCOTB_RESULTS_FILE=results_no_trust.xml
+	$(MAKE) COCOTB_TRUST_INERTIAL_WRITES=1 sim COCOTB_RESULTS_FILE=results_trust.xml
 
 MODULE := inertial_writes_tests
 

--- a/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
+++ b/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
@@ -4,7 +4,7 @@
 import os
 
 import cocotb
-from cocotb._conf import trust_inertial
+from cocotb._write_scheduler import trust_inertial
 from cocotb.clock import Clock
 from cocotb.triggers import (
     ReadOnly,


### PR DESCRIPTION
We noticed an issue with our fork of the Verilator main loop and this reproducer seemed valuable to stick in the regression. It might catch a couple misbehaving sims as well...