### PR TITLE
Apply writes in ReadWrite phase immediately

### DIFF
--- a/docs/source/newsfragments/4115.change.rst
+++ b/docs/source/newsfragments/4115.change.rst
@@ -1,0 +1,1 @@
+Writes performed following an ``await`` on :class:`~cocotb.triggers.ReadWrite` will be applied immediately (but inertially) and not scheduled for the next ``ReadWrite``.

--- a/src/cocotb/_write_scheduler.py
+++ b/src/cocotb/_write_scheduler.py
@@ -71,12 +71,14 @@ else:
         args: Sequence[Any],
     ) -> None:
         """Queue *write_func* to be called on the next ``ReadWrite`` trigger."""
-        if cocotb.sim_phase == cocotb.SimPhase.READ_ONLY:
+        if cocotb.sim_phase == cocotb.SimPhase.READ_WRITE:
+            write_func(*args)
+        elif cocotb.sim_phase == cocotb.SimPhase.READ_ONLY:
             raise Exception(
                 f"Write to object {handle._name} was scheduled during a read-only sync phase."
             )
-
-        if handle in _write_calls:
-            del _write_calls[handle]
-        _write_calls[handle] = (write_func, args)
-        _writes_pending.set()
+        else:
+            if handle in _write_calls:
+                del _write_calls[handle]
+            _write_calls[handle] = (write_func, args)
+            _writes_pending.set()

--- a/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
+++ b/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
@@ -141,23 +141,7 @@ async def test_writes_in_read_write(dut):
     assert dut.stream_in_data.value == 1
 
 
-if simulator_test:
-    expect_fail = False
-elif not trust_inertial and (
-    SIM_NAME.startswith(("icarus", "xmsim"))
-    or (SIM_NAME.startswith("modelsim") and intf in ("vpi", "fli"))
-    or (SIM_NAME.startswith("riviera") and intf == "vpi")
-):
-    # Icarus, Xcelium, Questa VPI, Questa FLI, and Riviera VPI allow the user
-    # to keep scheduling ReadWrite phases.
-    expect_fail = False
-elif trust_inertial:
-    expect_fail = False
-else:
-    expect_fail = True
-
-
-@cocotb.test(expect_fail=expect_fail)
+@cocotb.test
 async def test_writes_in_last_read_write(dut):
     cocotb.start_soon(Clock(dut.clk, 10, "ns").start())
     dut.stream_in_data.value = 0


### PR DESCRIPTION
Depends on #4114 and #4118. Closes #3966.

This change may increase performance by decreasing the number of cycles needed to complete a time step.
Previously, any write during the ReadWrite phase was queued up for the *next* ReadWrite phase. Waiting for the next one to apply more writes will only end up taking two more eval cycles which could be done in one.
All invariants should still hold even when collapsing what was previously two cycles into one:
* all writes during ReadWrite should read-back in the next ReadWrite or ReadOnly stage
* all writes are still inertial so you won't be able to read-back what you just wrote
* writes applied immediately in the ReadWrite stage follow application of scheduled writes applied in the ReadWrite stage (the writes maintain order)
* any HDL changes downstream of a value changed by either scheduled writes or immediate writes won't be visible until the next ReadWrite or ReadOnly

Things that will change:
* writes to the same signal in successive ReadWrites will be no longer be *seen* in HDL as a glitch as the immediate write will overwrite the applied scheduled write in 0 "time" / delta cycles.

Additionally, while all the VPI implementations (and Questa's FLI) allow the user to schedule infinitely more ReadWrite stages in a time step, every VHPI implementation does *not* allow you to do this, so writes scheduled in a ReadWrite phase where no writes were applied will invoke UB (typically apply writes on the next time step, whoops...).

Finally, in COCOTB_TRUST_INERTIAL_WRITES=1 mode, inertial writes done in ReadWrite in GHDL and NVC already behave this way and it seems to cause no issues.

- [X] newsfragment