### PR TITLE
Improve `Array` and `LogicArray` indexing performance

### DIFF
--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -25,7 +25,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import collections.abc
 import enum
 import logging
 import re
@@ -836,10 +835,6 @@ class ArrayObject(
             [ValueObjectBase[Any, Any], Callable[..., None], Sequence[Any]], None
         ],
     ) -> None:
-        if not isinstance(value, (collections.abc.Sequence, Array)):
-            raise TypeError(
-                f"Assigning non-list value to object {self._name} of type {type(self)}"
-            )
         if len(value) != len(self):
             raise ValueError(
                 "Assigning list of length %d to object %s of length %d"

--- a/src/cocotb/types/range.py
+++ b/src/cocotb/types/range.py
@@ -2,7 +2,9 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 from functools import lru_cache
-from typing import Iterator, Sequence, Union, overload
+from typing import Iterator, Optional, Sequence, Union, overload
+
+from cocotb._utils import cached_method
 
 
 class Range(Sequence[int]):
@@ -168,6 +170,14 @@ class Range(Sequence[int]):
 
     def __repr__(self) -> str:
         return f"{type(self).__qualname__}({self.left!r}, {self.direction!r}, {self.right!r})"
+
+    @cached_method
+    def index(self, value: int, start: int = 0, stop: Optional[int] = None) -> int:
+        # Using a cached version of collections.abc.Sequence.index because range.index
+        # doesn't support start and stop, and the version in Sequence is slow, but does
+        # support start and stop.
+        # Range is immutable, so caching this is fine.
+        return super().index(value, start, stop)
 
 
 def _guess_step(left: int, right: int) -> int:


### PR DESCRIPTION
* Adds `@cached_method` that works like `@cached_property` and avoids issues with using `@lru_cache(maxsize=None)` on methods.
* Uses `@cached_method` to cache the `_translate_index()` method on `Array` and `LogicArray`, which use the apparently slow implementation of `Range.index()` inherited from `collections.abc.Sequence`.
* Uses `@cached_method` to correct invalid uses of `@lru_cache(maxsize=None)` in handle.py.

This make matrix_multiplier test somewhere between 15-20% faster.