### PR TITLE
Fix sim phase tracking bug in scheduler

### DIFF
--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -266,9 +266,9 @@ class Scheduler:
             # and handle this via some kind of trigger-specific Python callback
             if trigger is self._read_write:
                 cocotb.sim_phase = cocotb.SimPhase.READ_WRITE
-            if trigger is self._read_only:
+            elif trigger is self._read_only:
                 cocotb.sim_phase = cocotb.SimPhase.READ_ONLY
-            elif isinstance(trigger, GPITrigger):
+            else:
                 cocotb.sim_phase = cocotb.SimPhase.NORMAL
 
             # apply inertial writes if ReadWrite

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -368,3 +368,17 @@ async def test_readonly_in_readwrite(dut):
     assert get_sim_time() == curr_time
     await ReadOnly()
     assert get_sim_time() == curr_time
+
+
+@cocotb.test
+async def test_sim_phase(dut) -> None:
+    assert cocotb.sim_phase is cocotb.SimPhase.NORMAL
+    await ReadWrite()
+    assert cocotb.sim_phase is cocotb.SimPhase.READ_WRITE
+    cocotb.start_soon(Clock(dut.clk, 10, "ns").start())
+    await Timer(10, "ns")
+    assert cocotb.sim_phase is cocotb.SimPhase.NORMAL
+    await ReadOnly()
+    assert cocotb.sim_phase is cocotb.SimPhase.READ_ONLY
+    await RisingEdge(dut.clk)
+    assert cocotb.sim_phase is cocotb.SimPhase.NORMAL


### PR DESCRIPTION
Should have been an `elif` on the second condition which cause all ReadWrite phase to be overwritten with Normal.