### PR TITLE
Emit TypeError if invalid type used when constructing Logic

### DIFF
--- a/src/cocotb/types/logic.py
+++ b/src/cocotb/types/logic.py
@@ -106,7 +106,8 @@ class Logic:
         value: value to construct into a :class:`Logic`.
 
     Raises:
-        ValueError: if the value cannot be constructed into a :class:`Logic`.
+        ValueError: If the value if of the correct type, but cannot be constructed into a :class:`Logic`.
+        TypeError: If the value is of a type that can't be constructed into a :class:`Logic`.
     """
 
     _repr: int
@@ -145,6 +146,10 @@ class Logic:
     ) -> "Logic":
         if isinstance(value, Logic):
             return value
+        elif value is not None and not isinstance(value, (str, int)):
+            raise TypeError(
+                f"Expected str, bool, or int, not {type(value).__qualname__}"
+            )
         return cls._map_literal(value)
 
     def __and__(self, other: "Logic") -> "Logic":

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -44,9 +44,12 @@ def test_logic_conversions():
     l = Logic("-")
     assert Logic(Logic("-")) == l
 
-    for value in ("j", 2, object()):
-        with pytest.raises(ValueError):
-            Logic(value)
+    with pytest.raises(ValueError):
+        Logic("j")
+    with pytest.raises(ValueError):
+        Logic(2)
+    with pytest.raises(TypeError):
+        Logic(object())
 
 
 def test_logic_equality():

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -32,6 +32,8 @@ def test_logic_array_iterable_construction():
     with pytest.raises(OverflowError):
         LogicArray([1, 0, 1, 0], Range(1, "downto", 0))
     with pytest.raises(ValueError):
+        LogicArray(["l", "o", "l"])
+    with pytest.raises(TypeError):
         LogicArray([object()])
 
 


### PR DESCRIPTION
This is more in line with idiomatic Python where `TypeError` is used if an argument is of the wrong type and `ValueError` is used if the type is correct, but the value is invalid for some reason.