### PR TITLE
Fix memory leak of Python callbacks

### DIFF
--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -317,8 +317,8 @@ class Scheduler:
             task._trigger = None
             self._queue(task)
 
-        # This trigger isn't needed any more
-        trigger._unprime()
+        # cleanup trigger
+        trigger._cleanup()
 
     def _event_loop(self) -> None:
         """Run the main event loop.

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -455,7 +455,7 @@ class RegressionManager:
         if trigger is not None:
             # TODO move to Trigger object
             cocotb.sim_phase = cocotb.SimPhase.NORMAL
-            trigger._unprime()
+            trigger._cleanup()
         cocotb._write_scheduler.start_write_scheduler()
 
         self._test_task._add_done_callback(

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -614,6 +614,10 @@ void gpi_deregister_callback(gpi_cb_hdl cb_hdl) {
     cb_hdl->m_impl->deregister_callback(cb_hdl);
 }
 
+void *gpi_get_callback_data(gpi_cb_hdl cb_hdl) {
+    return cb_hdl->get_user_data();
+}
+
 const char *GpiImplInterface::get_name_c() { return m_name.c_str(); }
 
 const string &GpiImplInterface::get_name_s() { return m_name; }

--- a/src/cocotb/share/lib/gpi/gpi_priv.h
+++ b/src/cocotb/share/lib/gpi/gpi_priv.h
@@ -186,6 +186,7 @@ class GPI_EXPORT GpiCbHdl : public GpiHdl {
     gpi_cb_state_e get_call_state();
 
     int set_user_data(int (*function)(void *), void *cb_data);
+    void *get_user_data() noexcept { return m_cb_data; };
 
     virtual ~GpiCbHdl();
 

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -764,6 +764,11 @@ static PyObject *stop_simulator(PyObject *, PyObject *) {
 }
 
 static PyObject *deregister(gpi_hdl_Object<gpi_cb_hdl> *self, PyObject *) {
+    // cleanup uncalled callback
+    auto cb = static_cast<PythonCallback *>(gpi_get_callback_data(self->hdl));
+    delete cb;
+
+    // deregister from interface
     gpi_deregister_callback(self->hdl);
 
     Py_RETURN_NONE;

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -114,6 +114,9 @@ class Trigger(Awaitable["Trigger"]):
             Do not call this directly within a :term:`task`. It is intended to be used
             only by the scheduler.
         """
+        self._cleanup()
+
+    def _cleanup(self) -> None:
         self._primed = False
 
     def __del__(self) -> None:
@@ -144,8 +147,11 @@ class GPITrigger(Trigger):
         """Disable a primed trigger, can be re-primed."""
         if self._cbhdl is not None:
             self._cbhdl.deregister()
+        return super()._unprime()
+
+    def _cleanup(self) -> None:
         self._cbhdl = None
-        super()._unprime()
+        return super()._cleanup()
 
 
 class Timer(GPITrigger):


### PR DESCRIPTION
This leak occurs when a trigger is deregistered before it fires. The callback is cleaned up if it did fire. The `trigger._unprime` method had to be split up so that triggers that fired weren't attempted to be deregistered (`trigger._unprime`) more than once. Fired triggers just run `trigger._cleanup`.