### PR TITLE
Change Verilator expectation of ReadWrite in ReadWrite

### DIFF
--- a/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
+++ b/tests/test_cases/test_inertial_writes/inertial_writes_tests.py
@@ -144,11 +144,11 @@ async def test_writes_in_read_write(dut):
 if simulator_test:
     expect_fail = False
 elif not trust_inertial and (
-    SIM_NAME.startswith(("icarus", "xmsim", "verilator"))
+    SIM_NAME.startswith(("icarus", "xmsim"))
     or (SIM_NAME.startswith("modelsim") and intf in ("vpi", "fli"))
     or (SIM_NAME.startswith("riviera") and intf == "vpi")
 ):
-    # Icarus, Xcelium, Questa VPI, Questa FLI, Riviera VPI, and Verilator allow the user
+    # Icarus, Xcelium, Questa VPI, Questa FLI, and Riviera VPI allow the user
     # to keep scheduling ReadWrite phases.
     expect_fail = False
 elif trust_inertial:


### PR DESCRIPTION
This should fix the CI. #4114 was merged with a passing CI, but this CI run was only done before #3861 was merged, which changed what the test expectation should be.

Until https://github.com/verilator/verilator/pull/5399 can be used to check if there are ReadWrite callbacks available Verilator will have to be the odd one out when it comes to repeated ReadWrite scheduling. Considering this doesn't work at all in VHPI sims, I don't think of this as a guarantee so ultimately we aren't regressing on guaranteed behavior.

#4115 also fixes this issue because writes in a ReadWrite are applied immediately, leading to the condition where Verilator knows there's another eval that is needed.