### PR TITLE
Logic array `int` constructor + various fixes

### DIFF
--- a/docs/source/newsfragments/4142.feature.1.rst
+++ b/docs/source/newsfragments/4142.feature.1.rst
@@ -1,0 +1,1 @@
+:class:`~cocotb.types.Array` can take :class:`int` as the second positional argument or ``width`` keyword argument as shorthand for passing ``Range(0, "to", width-1)`` as ``range``.

--- a/docs/source/newsfragments/4142.feature.rst
+++ b/docs/source/newsfragments/4142.feature.rst
@@ -1,0 +1,1 @@
+:class:`~cocotb.types.LogicArray` can take :class:`int` as the second positional argument or ``width`` keyword argument as shorthand for passing ``Range(width-1, "downto", 0)`` as ``range``.

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -115,7 +115,7 @@ class ArrayLike(ABC, Generic[T]):
         for v in self:
             if v == value:
                 count += 1
-        return 0
+        return count
 
 
 from .array import Array  # noqa: E402 F401

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -34,7 +34,10 @@ class ArrayLike(ABC, Generic[T]):
     @range.setter
     @abstractmethod
     def range(self, new_range: Range) -> None:
-        """Set a new indexing scheme on the array. Must be the same size."""
+        """Set a new indexing scheme on the array.
+
+        Must be the same size.
+        """
 
     def __len__(self) -> int:
         return len(self.range)
@@ -79,11 +82,17 @@ class ArrayLike(ABC, Generic[T]):
         start: Optional[int] = None,
         stop: Optional[int] = None,
     ) -> int:
-        """
-        Return index of first occurrence of *value*.
+        """Find first occurence of value.
 
-        Raises :exc:`IndexError` if the value is not found.
-        Search only within *start* and *stop* if given.
+        Args:
+            value: Value to search for.
+            start: Index to start search at.
+            stop: Index to stop search at.
+
+        Returns: Index of first occurence of *value*.
+
+        Raises:
+            ValueError: If the value is not present.
         """
         if start is None:
             start = self.left
@@ -95,7 +104,13 @@ class ArrayLike(ABC, Generic[T]):
         raise IndexError(f"{value!r} not in array")
 
     def count(self, value: T) -> int:
-        """Return number of occurrences of *value*."""
+        """Return number of occurrences of value.
+
+        Args:
+            value: Value to search for.
+
+        Returns: Number of occurences of *value*.
+        """
         count: int = 0
         for v in self:
             if v == value:

--- a/src/cocotb/types/array.py
+++ b/src/cocotb/types/array.py
@@ -259,10 +259,6 @@ class Array(ArrayLike[T]):
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self._value!r}, {self._range!r})"
 
-    def count(self, value: T) -> int:
-        """Return number of occurrences of *value*."""
-        return self._value.count(value)
-
     def _translate_index(self, item: int) -> int:
         try:
             return self._range.index(item)

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -571,10 +571,6 @@ class LogicArray(ArrayLike[Logic]):
         else:
             return NotImplemented
 
-    def count(self, value: Logic) -> int:
-        """Return number of occurrences of *value*."""
-        return self._get_array().count(value)
-
     @property
     @deprecated("`.binstr` property is deprecated. Use `str(value)` instead.")
     def binstr(self) -> str:

--- a/src/cocotb/types/range.py
+++ b/src/cocotb/types/range.py
@@ -177,7 +177,7 @@ class Range(Sequence[int]):
         # doesn't support start and stop, and the version in Sequence is slow, but does
         # support start and stop.
         # Range is immutable, so caching this is fine.
-        return super().index(value, start, stop)
+        return super().index(value, start, stop)  # type: ignore[arg-type]  # Sequence.index can take None for stop
 
 
 def _guess_step(left: int, right: int) -> int:

--- a/src/cocotb/types/range.py
+++ b/src/cocotb/types/range.py
@@ -67,16 +67,13 @@ class Range(Sequence[int]):
     """
 
     @overload
-    def __init__(self, left: int, direction: int) -> None:
-        pass  # pragma: no cover
+    def __init__(self, left: int, direction: int) -> None: ...
 
     @overload
-    def __init__(self, left: int, direction: str, right: int) -> None:
-        pass  # pragma: no cover
+    def __init__(self, left: int, direction: str, right: int) -> None: ...
 
     @overload
-    def __init__(self, left: int, *, right: int) -> None:
-        pass  # pragma: no cover
+    def __init__(self, left: int, *, right: int) -> None: ...
 
     def __init__(
         self,
@@ -110,22 +107,22 @@ class Range(Sequence[int]):
         )
 
     def to_range(self) -> range:
-        """Convert :class:`Range` to :class:`range`."""
+        """Convert Range to :class:`range`."""
         return self._range
 
     @property
     def left(self) -> int:
-        """Leftmost value in a range."""
+        """Leftmost value in a Range."""
         return self._range.start
 
     @property
     def direction(self) -> str:
-        """``'to'`` if values are meant to be ascending, ``'downto'`` otherwise."""
+        """``'to'`` if Range is ascending, ``'downto'`` otherwise."""
         return _step_to_direction(self._range.step)
 
     @property
     def right(self) -> int:
-        """Rightmost value in a range."""
+        """Rightmost value in a Range."""
         return self._range.stop - self._range.step
 
     def __len__(self) -> int:

--- a/src/cocotb/types/range.py
+++ b/src/cocotb/types/range.py
@@ -2,7 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 from functools import lru_cache
-from typing import Iterator, Optional, Sequence, Union, overload
+from typing import Iterator, Sequence, Union, overload
 
 from cocotb._utils import cached_method
 
@@ -165,19 +165,10 @@ class Range(Sequence[int]):
     def __hash__(self) -> int:
         return hash(self._range)
 
-    def count(self, item: int) -> int:
-        return self._range.count(item)
-
     def __repr__(self) -> str:
         return f"{type(self).__qualname__}({self.left!r}, {self.direction!r}, {self.right!r})"
 
-    @cached_method
-    def index(self, value: int, start: int = 0, stop: Optional[int] = None) -> int:
-        # Using a cached version of collections.abc.Sequence.index because range.index
-        # doesn't support start and stop, and the version in Sequence is slow, but does
-        # support start and stop.
-        # Range is immutable, so caching this is fine.
-        return super().index(value, start, stop)  # type: ignore[arg-type]  # Sequence.index can take None for stop
+    index = cached_method(Sequence.index)
 
 
 def _guess_step(left: int, right: int) -> int:

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -19,8 +19,13 @@ def test_both_construction():
     assert a.direction == "to"
     assert a.right == 1
 
-    with pytest.raises(ValueError):
-        Array("1234", Range(0, 1))
+    Array("1234", 4)
+    Array("1234", range=Range(-2, 1))
+    Array("1234", width=4)
+
+
+def test_range_int_construction():
+    assert Array("1234", 4)
 
 
 def test_bad_construction():
@@ -34,6 +39,10 @@ def test_bad_construction():
         Array(value="1234", range=Range(0, 1))
     with pytest.raises(TypeError):
         Array(value="1234", range=object())
+    with pytest.raises(TypeError):
+        Array("1234", range(4))
+    with pytest.raises(TypeError):
+        Array("1234", Range(0, 3), width=4)
 
 
 def test_length():


### PR DESCRIPTION
The feature split from #4101 for supporting passing `int` as shorthand for Range. This makes the LogicArray constructor somewhat backwards compatible with BinaryValue which took a `BinaryValue(int, int)` overload.

The intent is for int to be able to be taken as the second positional argument, or as the 'width' keyword argument, while only Range can be passed to 'range' by keyword argument. The current implementation still allows the user to write `range=4`, but is considerably less logic than enforcing otherwise. Type hints *could* help, but we can't write positional-only argument before Python 3.8.

There's also various fixes to documentation, typing, code simplification. Some overloads were removed just so there's less duplicate documentation. Performance is of little concern to methods like `index` and `count`, which will probably never get used.