### PR TITLE
Add (deprecated) `__bool__` cast for LogicArray

### DIFF
--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -803,6 +803,14 @@ class LogicArray(ArrayLike[Logic]):
     def __invert__(self) -> "LogicArray":
         return LogicArray(~v for v in self)
 
+    def __bool__(self) -> bool:
+        warnings.warn(
+            "The behavior of bool casts and using LogicArray in conditionals may change in the future. "
+            """Use explicit comparisons (e.g. `LogicArray() == "11"`) instead""",
+            FutureWarning,
+        )
+        return any(v in (Logic("H"), Logic("1")) for v in self)
+
 
 def _make_range(
     range: Union[Range, int, None], width: Union[int, None]

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -1,6 +1,8 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
+import warnings
+
 import pytest
 
 from cocotb.types import Logic, LogicArray, Range
@@ -396,3 +398,13 @@ def test_null_vector():
         assert null_vector == 0
     assert null_vector == ""
     assert null_vector == []
+
+
+def test_bool_cast():
+    with pytest.warns(FutureWarning):
+        assert LogicArray("0110")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action="ignore", category=FutureWarning)
+        assert not LogicArray("0000")
+        assert LogicArray("01XZ")
+        assert LogicArray("XZ01")


### PR DESCRIPTION
This was done for backwards compatibility using the same semantics as BinaryValue.

There are many possible reasonable implementations of value checking:
* all values == logical 1 `all(v == 1 for v in value)`
* any value == logical 1 `any(v == 1 for v in value)`
* `or` reduction of value == logical 1 `reduce(or_, value) == 1`

We should refuse the temptation to guess (as Verilog has done) and have users *explicitly* mention the behavior they are looking for, so this was deprecated.

Not advertising this as a feature with a newsfragment since we don't want users to necessary use it.