### PR TITLE
Explicitly track Task state

### DIFF
--- a/docs/source/newsfragments/4149.removal.rst
+++ b/docs/source/newsfragments/4149.removal.rst
@@ -1,0 +1,1 @@
+Removed ``Task.has_started()``.

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -178,7 +178,7 @@ def start_soon(
     """
     task = create_task(coro)
     task._add_done_callback(_task_done_callback)
-    cocotb._scheduler_inst._queue(task)
+    cocotb._scheduler_inst._schedule_task(task)
     return task
 
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -973,10 +973,8 @@ class RegressionManager:
         """
         if self._test_outcome is not None:  # pragma: no cover
             raise InternalError("Outcome already has a value, but is being set again.")
-        outcome = Error(exc)
-        self._test_outcome = outcome
-        self._test_task._do_done_callbacks()
-        cocotb._scheduler_inst._unschedule(self._test_task)
+        self._test_outcome = Error(exc)
+        self._test_task.kill()
 
     @staticmethod
     def _safe_divide(a: float, b: float) -> float:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -463,7 +463,7 @@ class RegressionManager:
         self._test_task._add_done_callback(
             lambda _: cocotb._scheduler_inst.shutdown_soon()
         )
-        cocotb._scheduler_inst._queue(self._test_task)
+        cocotb._scheduler_inst._schedule_task(self._test_task)
         cocotb._scheduler_inst._event_loop()
 
     def _tear_down(self) -> None:


### PR DESCRIPTION
* Refactors `_task_done_callback` to not raise exceptions and thus require stripping parts of the traceback.
   * Properly handles cancelled tasks.
* Refactors Task to explicitly handle the current state.
   * Introduces new "scheduled" state for when a Task is currently in the `Scheduler._pending_tasks` queue.
   * Properly handles calling `Task.kill()` and `Task.cancel` on cancelled Tasks (used to check for `_outcome`, now checks for `Task.done()`).

Closes #3975.

I wanted to get rid of `has_started`. This required replacement with another variable that is actually useful (i.e. it tracks whether it's queued or not). This led to a revamp of Task state tracking. The revamp also realized a few uncaught bugs in the Task state logic regarding cancelling already cancelled or finished tasks, and setting outcome (as if the Task had finished) when the Task was cancelled. The latter bug mentioned required changing the `_task_done_exception` as there was no `_outcome` to `get` even though the Task was finished when it was cancelled; hence the first commit.

### TODO
- [x] Document state?
- [x] Newsfragment