### PR TITLE
Enable Python 3.13 builds

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -93,15 +93,24 @@ ENVS = [
         "python-version": "3.12",
         "group": "ci",
     },
-    # A single test for the upcoming Python version.
     {
         "lang": "verilog",
         "sim": "icarus",
         "sim-version": "apt",
         "os": "ubuntu-20.04",
-        "python-version": "3.13.0-alpha - 3.13.0",
-        "group": "experimental",
+        "python-version": "3.13",
+        "group": "ci",
     },
+    # A single test for the upcoming Python version.
+    # TODO: Enable once Python 3.14 development starts.
+    # {
+    #     "lang": "verilog",
+    #     "sim": "icarus",
+    #     "sim-version": "apt",
+    #     "os": "ubuntu-20.04",
+    #     "python-version": "3.14.0-alpha - 3.14.0",
+    #     "group": "experimental",
+    # },
     # Test Icarus on Ubuntu
     {
         "lang": "verilog",

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -89,6 +89,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python-version}}
+        allow-prereleases: true
     - name: Set up Anaconda ${{matrix.python-version}} (Windows)
       if: startsWith(matrix.os, 'windows')
       uses: conda-incubator/setup-miniconda@v3

--- a/docs/source/newsfragments/4151.feature.rst
+++ b/docs/source/newsfragments/4151.feature.rst
@@ -1,0 +1,1 @@
+Python 3.13 is now supported.

--- a/docs/source/platform_support.rst
+++ b/docs/source/platform_support.rst
@@ -28,6 +28,7 @@ The following versions of Python (CPython), and all associated patch releases (e
 * Python 3.10
 * Python 3.11
 * Python 3.12
+* Python 3.13
 
 Supported Linux Distributions and Versions
 ==========================================

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ dev_deps = [
 ]
 
 # Version of the cibuildwheel package used to build wheels.
-cibuildwheel_version = "2.17.0"
+cibuildwheel_version = "2.20.0"
 
 #
 # Helpers for use within this file.

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: BSD License",
         "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
         "Framework :: cocotb",


### PR DESCRIPTION
Update cibuildwheel to build wheels for Python 3.13, which now had its final release candidate and will not see any more changes to its ABI. Also update the CI configuration to build Python 3.13 by default for all builds, not only the experimental ones.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
