### PR TITLE
[stable/1.9] Backport PR #4151: Enable Python 3.13 builds

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -69,15 +69,24 @@ ENVS = [
         "python-version": "3.12",
         "group": "ci",
     },
-    # A single test for the upcoming Python version.
     {
         "lang": "verilog",
         "sim": "icarus",
         "sim-version": "apt",
         "os": "ubuntu-20.04",
-        "python-version": "3.13.0-alpha - 3.13.0",
-        "group": "experimental",
+        "python-version": "3.13",
+        "group": "ci",
     },
+    # A single test for the upcoming Python version.
+    # TODO: Enable once Python 3.14 development starts.
+    # {
+    #     "lang": "verilog",
+    #     "sim": "icarus",
+    #     "sim-version": "apt",
+    #     "os": "ubuntu-20.04",
+    #     "python-version": "3.14.0-alpha - 3.14.0",
+    #     "group": "experimental",
+    # },
     # Test Icarus on Ubuntu
     {
         "lang": "verilog",

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -87,6 +87,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python-version}}
+        allow-prereleases: true
     - name: Set up Anaconda ${{matrix.python-version}} (Windows)
       if: startsWith(matrix.os, 'windows')
       uses: conda-incubator/setup-miniconda@v2

--- a/documentation/source/newsfragments/4151.feature.rst
+++ b/documentation/source/newsfragments/4151.feature.rst
@@ -1,0 +1,1 @@
+Python 3.13 is now supported.

--- a/documentation/source/platform_support.rst
+++ b/documentation/source/platform_support.rst
@@ -28,6 +28,7 @@ The following versions of Python (CPython), and all associated patch releases (e
 * Python 3.10
 * Python 3.11
 * Python 3.12
+* Python 3.13
 
 Supported Linux Distributions and Versions
 ==========================================

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ dev_deps = [
 ]
 
 # Version of the cibuildwheel package used to build wheels.
-cibuildwheel_version = "2.17.0"
+cibuildwheel_version = "2.20.0"
 
 #
 # Helpers for use within this file.

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: BSD License",
         "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
         "Framework :: cocotb",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `stable/1.9`:
 - [Enable Python 3.13 builds](https://github.com/cocotb/cocotb/pull/4151)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)