### PR TITLE
Fix attempt to remove non-existing element in Lock._unprime_lock()

### DIFF
--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -672,7 +672,8 @@ class Lock(AsyncContextManager[None]):
             self._pending_primed.append(lock)
 
     def _unprime_lock(self, lock: _Lock) -> None:
-        self._pending_primed.remove(lock)
+        if lock in self._pending_primed:
+            self._pending_primed.remove(lock)
 
     def acquire(self) -> Trigger:
         """Produce a trigger which fires when the lock is acquired."""


### PR DESCRIPTION
When running cocotb tests the following errors are printed (e.g. in test_synchronization_primitives.test_trigger_lock test):

```
Exception ignored in: <function Trigger.__del__ at 0x7fffd6c50fe0>
Traceback (most recent call last):
  File ".../cocotb/src/cocotb/triggers.py", line 124, in __del__
    self._unprime()
  File ".../cocotb/src/cocotb/triggers.py", line 616, in _unprime
    self._parent._unprime_lock(self)
  File ".../cocotb/src/cocotb/triggers.py", line 676, in _unprime_lock
    self._pending_primed.remove(lock)
ValueError: list.remove(x): x not in list
```

The reason why tests do not fail is that python ignores all exceptions raised in __del__ method:
https://docs.python.org/3/reference/datamodel.html#object.__del__.

The mechanism of the failure is as follows:

- callers always call both _prime_lock() and _unprime_lock()
- depending on _locked attribute, _prime_lock() may not populate _pending_primed list
- however, _unprime_lock attempts to remove item from _unprime_lock unconditionally.

The fix is simply to address this mismatch of conditionality.

Unfortunately it is not possible to write a unit test for this specific method of failure.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
