### PR TITLE
Don't unprime triggers in Trigger.__del__

### DIFF
--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -119,10 +119,6 @@ class Trigger(Awaitable["Trigger"]):
     def _cleanup(self) -> None:
         self._primed = False
 
-    def __del__(self) -> None:
-        # Ensure if a trigger drops out of scope we remove any pending callbacks
-        self._unprime()
-
     def __await__(self: Self) -> Generator[Any, Any, Self]:
         yield self
         return self


### PR DESCRIPTION
Follow on to #4176.

`Trigger.__del__` is run whenever a Trigger is finally removed, but the scheduler already calls `_cleanup` when a Trigger fires, or `_unprime` if a Trigger is cancelled, so this is unnecessary and probably causing issues we aren't seeing yet. AFAICT there's no way for a Trigger to become primed and then not either be handled by firing cleanup or premature cancellation for this code to need to be executed.