### PR TITLE
Merge RTL_LIBRARY and TOPLEVEL_LIBRARY

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -504,13 +504,8 @@ The following variables are makefile variables, not environment variables.
 .. make:var:: TOPLEVEL_LIBRARY
 
     The name of the library that contains the :envvar:`COCOTB_TOPLEVEL` module/entity.
-    Defaults to the :make:var:`RTL_LIBRARY`.
-    Only supported by the Siemens EDA Questa simulator.
-
-.. make:var:: RTL_LIBRARY
-
-    The name of the library that contains :make:var:`VHDL_SOURCES` and :make:var:`VERILOG_SOURCES`.
     Only supported by the Aldec Riviera-PRO, Aldec Active-HDL, and Siemens EDA Questa simulators.
+
 
 
 Library Build Process

--- a/docs/source/newsfragments/4189.removal.rst
+++ b/docs/source/newsfragments/4189.removal.rst
@@ -1,0 +1,1 @@
+The ``RTL_LIBRARY`` and :envvar:`TOPLEVEL_LIBRARY` Makefile variables were merged into :envvar:`TOPLEVEL_LIBRARY`. Update all uses of ``RTL_LIBRARY``.

--- a/src/cocotb_tools/makefiles/simulators/Makefile.activehdl
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.activehdl
@@ -22,7 +22,13 @@ ALOG_ARGS += $(COMPILE_ARGS)
 ACOM_ARGS += $(COMPILE_ARGS)
 ASIM_ARGS += $(SIM_ARGS)
 
-RTL_LIBRARY ?= work
+ifdef RTL_LIBRARY
+    $(warning Using RTL_LIBRARY is deprecated, please use TOPLEVEL_LIBRARY instead.)
+    TOPLEVEL_LIBRARY ?= $(RTL_LIBRARY)
+else
+    TOPLEVEL_LIBRARY ?= work
+endif
+
 ALOG_ARGS += -dbg
 ACOM_ARGS += -dbg
 
@@ -46,8 +52,8 @@ endif
 
 # Create a DO script (Tcl-like but not fully compatible) based on the list of $(VERILOG_SOURCES)
 $(SIM_BUILD)/runsim.do : $(VERILOG_SOURCES) $(VHDL_SOURCES) | $(SIM_BUILD)
-	@echo "alib $(RTL_LIBRARY)" > $@
-	@echo "set worklib $(RTL_LIBRARY)" >> $@
+	@echo "alib $(TOPLEVEL_LIBRARY)" > $@
+	@echo "set worklib $(TOPLEVEL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)
 	@echo "acom $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif

--- a/src/cocotb_tools/makefiles/simulators/Makefile.questa
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.questa
@@ -42,9 +42,12 @@ ifeq (, $(CMD))
     $(error Unable to locate command >$(CMD_BIN)<)
 endif
 
-RTL_LIBRARY ?= work
-
-TOPLEVEL_LIBRARY ?= $(RTL_LIBRARY)
+ifdef RTL_LIBRARY
+    $(warning Using RTL_LIBRARY is deprecated, please use TOPLEVEL_LIBRARY instead.)
+    TOPLEVEL_LIBRARY ?= $(RTL_LIBRARY)
+else
+    TOPLEVEL_LIBRARY ?= work
+endif
 COCOTB_TOPLEVEL := "$(TOPLEVEL_LIBRARY).$(COCOTB_TOPLEVEL)"
 
 ifndef VLOG_ARGS
@@ -127,14 +130,14 @@ $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEP
 	@echo "}" >> $@
 	@echo "vmap -c" >> $@
 	$(foreach LIB, $(VHDL_LIB_ORDER), $(make_lib))
-	@echo "if [file exists $(SIM_BUILD)/$(RTL_LIBRARY)] {vdel -lib $(SIM_BUILD)/$(RTL_LIBRARY) -all}" >> $@
-	@echo "vlib $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
-	@echo "vmap $(RTL_LIBRARY) $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
+	@echo "if [file exists $(SIM_BUILD)/$(TOPLEVEL_LIBRARY)] {vdel -lib $(SIM_BUILD)/$(TOPLEVEL_LIBRARY) -all}" >> $@
+	@echo "vlib $(SIM_BUILD)/$(TOPLEVEL_LIBRARY)" >> $@
+	@echo "vmap $(TOPLEVEL_LIBRARY) $(SIM_BUILD)/$(TOPLEVEL_LIBRARY)" >> $@
 ifneq ($(VHDL_SOURCES),)
-	@echo "vcom -work $(RTL_LIBRARY) $(VCOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
+	@echo "vcom -work $(TOPLEVEL_LIBRARY) $(VCOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif
 ifneq ($(VERILOG_SOURCES),)
-	@echo "vlog -work $(RTL_LIBRARY) -sv $(VLOG_ARGS) $(EXTRA_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
+	@echo "vlog -work $(TOPLEVEL_LIBRARY) -sv $(VLOG_ARGS) $(EXTRA_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
 endif
 ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -69,7 +69,12 @@ ASIM_ARGS += $(SIM_ARGS)
 # Plusargs need to be passed to ASIM command not vsimsa
 ASIM_ARGS += $(call deprecate,PLUSARGS,COCOTB_PLUSARGS)
 
-RTL_LIBRARY ?= work
+ifdef RTL_LIBRARY
+    $(warning Using RTL_LIBRARY is deprecated, please use TOPLEVEL_LIBRARY instead.)
+    TOPLEVEL_LIBRARY ?= $(RTL_LIBRARY)
+else
+    TOPLEVEL_LIBRARY ?= work
+endif
 
 # Pass the VPI library to the Verilog compilation to get extended checking.
 ALOG_ARGS += -pli $(shell cocotb-config --lib-name-path vpi riviera)
@@ -126,15 +131,15 @@ $(SIM_BUILD)/runsim.tcl : $(VERILOG_SOURCES) $(VHDL_SOURCES) | $(SIM_BUILD)
 	@echo "@if [string length [array get env LICENSE_QUEUE]] {" >> $@
 	@echo " set LICENSE_QUEUE $$::env(LICENSE_QUEUE)" >> $@
 	@echo "}" >> $@
-	@echo "if [file exists $(SIM_BUILD)/$(RTL_LIBRARY)] {adel -lib $(SIM_BUILD)/$(RTL_LIBRARY) -all}" >> $@;
-	@echo "alib $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@
-	@echo "amap $(RTL_LIBRARY) $(SIM_BUILD)/$(RTL_LIBRARY)" >> $@;
-	@echo "set worklib $(RTL_LIBRARY)" >> $@;
+	@echo "if [file exists $(SIM_BUILD)/$(TOPLEVEL_LIBRARY)] {adel -lib $(SIM_BUILD)/$(TOPLEVEL_LIBRARYRTL_LIBRARY) -all}" >> $@;
+	@echo "alib $(SIM_BUILD)/$(TOPLEVEL_LIBRARY)" >> $@
+	@echo "amap $(TOPLEVEL_LIBRARY) $(SIM_BUILD)/$(TOPLEVEL_LIBRARY)" >> $@;
+	@echo "set worklib $(TOPLEVEL_LIBRARY)" >> $@;
 ifneq ($(VHDL_SOURCES),)
-	@echo "acom -work $(RTL_LIBRARY) $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
+	@echo "acom -work $(TOPLEVEL_LIBRARY) $(ACOM_ARGS) $(call to_tcl_path,$(VHDL_SOURCES))" >> $@
 endif
 ifneq ($(VERILOG_SOURCES),)
-	@echo "alog -work $(RTL_LIBRARY) $(ALOG_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
+	@echo "alog -work $(TOPLEVEL_LIBRARY) $(ALOG_ARGS) $(call to_tcl_path,$(VERILOG_SOURCES))" >> $@
 endif
 ifdef SCRIPT_FILE
 	@echo "do $(SCRIPT_FILE)" >> $@
@@ -153,8 +158,8 @@ else
 	@echo "run -all" >> $@
 	@echo "endsim" >> $@
 ifeq ($(COCOTB_USER_COVERAGE),1)
-	@echo "acdb report -cov $(COVERAGE_TYPES) -db $(RTL_LIBRARY).acdb -html -o coverage/acdb_report.html" >> $@
-	@echo "acdb report -cov $(COVERAGE_TYPES) -db $(RTL_LIBRARY).acdb -txt -o coverage/acdb_report.txt" >> $@
+	@echo "acdb report -cov $(COVERAGE_TYPES) -db $(TOPLEVEL_LIBRARY).acdb -html -o coverage/acdb_report.html" >> $@
+	@echo "acdb report -cov $(COVERAGE_TYPES) -db $(TOPLEVEL_LIBRARY).acdb -txt -o coverage/acdb_report.txt" >> $@
 endif
 	@echo "exit" >> $@
 endif

--- a/tests/test_cases/test_toplevel_library/Makefile
+++ b/tests/test_cases/test_toplevel_library/Makefile
@@ -6,9 +6,7 @@ ifeq ($(SIM),questa)
 
 PROJ_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-VHDL_SOURCES_mylib := $(PROJ_DIR)/mylib.vhd
-VHDL_LIB_ORDER := mylib
-
+VHDL_SOURCES := $(PROJ_DIR)/mylib.vhd
 COCOTB_TOPLEVEL := myentity
 TOPLEVEL_LIBRARY := mylib
 TOPLEVEL_LANG := vhdl


### PR DESCRIPTION
These were doing the same thing, so I merged them and left the removed variable as a deprecated default initializer for the one that remains.