### PR TITLE
Extended CI: Only run 5 tests in parallel

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -21,4 +21,4 @@ jobs:
       nox_session_test_sim: dev_test_sim
       nox_session_test_nosim: dev_test_nosim
       group: extended
-      max_parallel: 15
+      max_parallel: 5


### PR DESCRIPTION
We only have 5 licenses of each proprietary simulator, avoid overloading
the system by running more tests in parallel that then fail due to
license exhaustion (we cannot control the interleaving of tests, i.e.,
we can't have 5 Cadence, 5 Synopsys, and 5 Aldec tests run in parallel
reliably, hence go the safe and slow route instead).
