### PR TITLE
VPI: Queue callback objects instead of simulator pointers.

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -720,9 +720,11 @@ static int32_t handle_vpi_callback_(GpiCbHdl *cb_hdl) {
     gpi_to_user();
 
     if (!cb_hdl) {
+        // LCOV_EXCL_START
         LOG_CRITICAL("VPI: Callback data corrupted: ABORTING");
         gpi_embed_end();
         return -1;
+        // LCOV_EXCL_STOP
     }
 
     gpi_cb_state_e old_state = cb_hdl->get_call_state();

--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -28,7 +28,10 @@
 #include "VpiImpl.h"
 
 #include <cstring>
+#ifndef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
+#include <algorithm>
 #include <queue>
+#endif
 
 #include "_vendor/vpi/vpi_user.h"
 
@@ -37,6 +40,10 @@ extern "C" {
 static VpiCbHdl *sim_init_cb;
 static VpiCbHdl *sim_finish_cb;
 static VpiImpl *vpi_table;
+
+#ifndef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
+static std::deque<GpiCbHdl *> cb_queue;
+#endif
 }
 
 #define CASE_STR(_X) \
@@ -672,6 +679,13 @@ GpiCbHdl *VpiImpl::register_nexttime_callback(int (*function)(void *),
 }
 
 int VpiImpl::deregister_callback(GpiCbHdl *gpi_hdl) {
+#ifndef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
+    auto it = std::find(cb_queue.begin(), cb_queue.end(), gpi_hdl);
+    if (it != cb_queue.end()) {
+        cb_queue.erase(it);
+    }
+#endif
+
     return gpi_hdl->cleanup_callback();
 }
 
@@ -702,12 +716,8 @@ const char *VpiImpl::get_type_delimiter(GpiObjHdl *obj_hdl) {
 
 extern "C" {
 
-static int32_t handle_vpi_callback_(p_cb_data cb_data) {
+static int32_t handle_vpi_callback_(GpiCbHdl *cb_hdl) {
     gpi_to_user();
-
-    int rv = 0;
-
-    VpiCbHdl *cb_hdl = (VpiCbHdl *)cb_data->user_data;
 
     if (!cb_hdl) {
         LOG_CRITICAL("VPI: Callback data corrupted: ABORTING");
@@ -738,36 +748,35 @@ static int32_t handle_vpi_callback_(p_cb_data cb_data) {
 
     gpi_to_simulator();
 
-    return rv;
+    return 0;
 }
-
-#ifdef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
-int32_t handle_vpi_callback(p_cb_data cb_data) {
-    return handle_vpi_callback_(cb_data);
-}
-#else
-static std::queue<p_cb_data> cbs;
-static bool reacting = false;
 
 // Main re-entry point for callbacks from simulator
 int32_t handle_vpi_callback(p_cb_data cb_data) {
+#ifdef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
+    VpiCbHdl *cb_hdl = (VpiCbHdl *)cb_data->user_data;
+    return handle_vpi_callback_(cb_hdl);
+#else
     // must push things into a queue because Icaurus (gh-4067), Xcelium
     // (gh-4013), and Questa (gh-4105) react to value changes on signals that
     // are set with vpiNoDelay immediately, and not after the current callback
     // has ended, causing re-entrancy.
-    cbs.push(cb_data);
+    static bool reacting = false;
+    VpiCbHdl *cb_hdl = (VpiCbHdl *)cb_data->user_data;
     if (reacting) {
+        cb_queue.push_back(cb_hdl);
         return 0;
     }
     reacting = true;
-    while (!cbs.empty()) {
-        handle_vpi_callback_(cbs.front());
-        cbs.pop();
+    int32_t ret = handle_vpi_callback_(cb_hdl);
+    while (!cb_queue.empty()) {
+        handle_vpi_callback_(cb_queue.front());
+        cb_queue.pop_front();
     }
     reacting = false;
-    return 0;
-}
+    return ret;
 #endif
+}
 
 static void register_impl() {
     vpi_table = new VpiImpl("VPI");

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -424,7 +424,8 @@ async def test_immediate_reentrace(dut):
         await Edge(dut.mybits_uninitialized)
         seen += 1
         dut.mybit.setimmediatevalue(0)
-        nested.cancel()
+        with pytest.warns(FutureWarning):
+            nested.cancel()
 
     cocotb.start_soon(watch())
     await Timer(1, "ns")

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -13,7 +13,7 @@ import pytest
 
 import cocotb
 from cocotb.handle import LogicObject, StringObject, _Limits
-from cocotb.triggers import Edge, Timer
+from cocotb.triggers import Edge, FallingEdge, Timer
 from cocotb.types import Logic, LogicArray
 
 SIM_NAME = cocotb.SIM_NAME.lower()
@@ -413,10 +413,18 @@ async def test_immediate_reentrace(dut):
     await Timer(1, "ns")
     seen = 0
 
+    async def nested_watch():
+        await FallingEdge(dut.mybit)
+        raise RuntimeError("Should have been cancelled")
+
+    nested = cocotb.start_soon(nested_watch())
+
     async def watch():
-        nonlocal seen
+        nonlocal seen, nested
         await Edge(dut.mybits_uninitialized)
         seen += 1
+        dut.mybit.setimmediatevalue(0)
+        nested.cancel()
 
     cocotb.start_soon(watch())
     await Timer(1, "ns")


### PR DESCRIPTION
We observed a number of segfaults with xcelium, due to the fact that a nested callback will enqueue the p_cb_data from the simulator and return, and when processed later from the queue the s_cb_data pointed at can be overwritten with other data, in particular the user_data pointer used to get back the CB object.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
