### PR TITLE
Prevent transitions from ReadOnly to ReadWrite or ReadOnly

### DIFF
--- a/docs/source/newsfragments/4208.change.rst
+++ b/docs/source/newsfragments/4208.change.rst
@@ -1,1 +1,1 @@
-Attempting to await on either the :class:`~cocotb.triggers.ReadWrite` or :class:`~cocotb.triggers.ReadOnly` trigger while in the ReadOnly state now raises a :exc:`RuntimeError`.
+Attempting to await on either the :class:`~cocotb.triggers.ReadWrite` or :class:`~cocotb.triggers.ReadOnly` trigger while in the ReadOnly phase now raises a :exc:`RuntimeError`.

--- a/docs/source/newsfragments/4208.change.rst
+++ b/docs/source/newsfragments/4208.change.rst
@@ -1,0 +1,1 @@
+Attempting to await on either the :class:`~cocotb.triggers.ReadWrite` or :class:`~cocotb.triggers.ReadOnly` trigger while in the ReadOnly state now raises a :exc:`RuntimeError`.

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -282,7 +282,7 @@ class ReadOnly(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass)
     def _prime(self, callback: Callable[[Trigger], None]) -> None:
         if cocotb.sim_phase is cocotb.SimPhase.READ_ONLY:
             raise RuntimeError(
-                "Attempted illegal transition: awaiting ReadOnly in ReadOnly state"
+                "Attempted illegal transition: awaiting ReadOnly in ReadOnly phase"
             )
         if self._cbhdl is None:
             self._cbhdl = simulator.register_readonly_callback(callback, self)
@@ -304,7 +304,7 @@ class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass
     def _prime(self, callback: Callable[[Trigger], None]) -> None:
         if cocotb.sim_phase is cocotb.SimPhase.READ_ONLY:
             raise RuntimeError(
-                "Attempted illegal transition: awaiting ReadWrite in ReadOnly state"
+                "Attempted illegal transition: awaiting ReadWrite in ReadOnly phase"
             )
         if self._cbhdl is None:
             self._cbhdl = simulator.register_rwsynch_callback(callback, self)

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -280,6 +280,10 @@ class ReadOnly(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass)
         return None
 
     def _prime(self, callback: Callable[[Trigger], None]) -> None:
+        if cocotb.sim_phase is cocotb.SimPhase.READ_ONLY:
+            raise RuntimeError(
+                "Attempted illegal transition: awaiting ReadOnly in ReadOnly state"
+            )
         if self._cbhdl is None:
             self._cbhdl = simulator.register_readonly_callback(callback, self)
             if self._cbhdl is None:
@@ -298,6 +302,10 @@ class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass
         return None
 
     def _prime(self, callback: Callable[[Trigger], None]) -> None:
+        if cocotb.sim_phase is cocotb.SimPhase.READ_ONLY:
+            raise RuntimeError(
+                "Attempted illegal transition: awaiting ReadWrite in ReadOnly state"
+            )
         if self._cbhdl is None:
             self._cbhdl = simulator.register_rwsynch_callback(callback, self)
             if self._cbhdl is None:


### PR DESCRIPTION
Transitioning from ReadOnly to ReadWrite or ReadOnly are not legal, this checks prevents that from occuring by raising a `RuntimeError` when it is attempted. Closes #1245. Closes #2222.