### PR TITLE
Build with Verilator in parallel

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -10,6 +10,7 @@
 # TODO: support custom dependencies
 
 import logging
+import multiprocessing
 import os
 import re
 import shlex
@@ -1300,6 +1301,8 @@ class Verilator(Runner):
         cmds.append(
             [
                 "make",
+                "-j",
+                f"{multiprocessing.cpu_count()}"
                 "-C",
                 str(self.build_dir),
                 "-f",

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1302,7 +1302,7 @@ class Verilator(Runner):
             [
                 "make",
                 "-j",
-                f"{multiprocessing.cpu_count()}"
+                f"{multiprocessing.cpu_count()}",
                 "-C",
                 str(self.build_dir),
                 "-f",


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

Minor update: use the `-j` flag in the call to Verilator's Makefile to speed up the build process (basic profiling indicated ~3x speedup for a single source file, likely scaling to high speedup for more source files)

I also use specific `CFLAGS` in the call to `verilator` in my installation to obtain a little more speedup on build; however, I'm unsure if these would be welcome, and may require more testing to make sure they're not specific to just `g++`
