### PR TITLE
Remove unused and incorrect unreachable() impl

### DIFF
--- a/src/cocotb/share/include/cocotb_utils.h
+++ b/src/cocotb/share/include/cocotb_utils.h
@@ -90,11 +90,4 @@ constexpr Deferable<F> make_deferable(F f) {
 #define DEFER(statement) \
     auto DEFER0(_defer, __COUNTER__) = make_deferable([&]() { statement; });
 
-#if __cplusplus >= 202302L
-#include <utility>
-using unreachable = std::unreachable;
-#else
-extern "C" [[noreturn]] void unreachable();
-#endif
-
 #endif /* COCOTB_UTILS_H_ */

--- a/src/cocotb/share/lib/utils/cocotb_utils.cpp
+++ b/src/cocotb/share/lib/utils/cocotb_utils.cpp
@@ -98,11 +98,3 @@ extern "C" void *utils_dyn_sym(void *handle, const char *sym_name) {
 #endif
     return entry_point;
 }
-
-#if __cplusplus < 202302L
-extern "C" [[noreturn]] void unreachable() {
-    LOG_CRITICAL("Reached unreachable code!");
-    // TODO platform-specific stacktrace?
-    exit(1);
-}
-#endif


### PR DESCRIPTION
For C++23 the syntax should have been the below. The current syntax fails to compile. 
```c++
using std::unreachable;
```

And for the C++ <23 impl it does the incorrect thing and calls exit. Invoking `std::unreachable` is UB and is primarily for optimization. I mistaken thought it was comparable to `unreachable` from Zig or other C/C++ frameworks.