### PR TITLE
Add robustness on as_tcl_value() function

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -49,12 +49,13 @@ _space_re = re.compile(r"([\s])", re.ASCII)
 
 
 def _as_tcl_value(value: str) -> str:
-    # add '\' before special characters and spaces
-    value = _magic_re.sub(r"\\\1", value)
-    value = value.replace("\n", r"\n")
-    value = _space_re.sub(r"\\\1", value)
-    if value[0] == '"':
-        value = "\\" + value
+    if len(value):
+        # add '\' before special characters and spaces
+        value = _magic_re.sub(r"\\\1", value)
+        value = value.replace("\n", r"\n")
+        value = _space_re.sub(r"\\\1", value)
+        if value[0] == '"':
+            value = "\\" + value
 
     return value
 

--- a/tests/test_cases/test_as_tcl_value/Makefile
+++ b/tests/test_cases/test_as_tcl_value/Makefile
@@ -1,0 +1,19 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
+include ../../designs/sample_module/Makefile
+COCOTB_TEST_MODULES:=test_as_tcl_value
+
+endif

--- a/tests/test_cases/test_as_tcl_value/test_as_tcl_value.py
+++ b/tests/test_cases/test_as_tcl_value/test_as_tcl_value.py
@@ -1,0 +1,10 @@
+import cocotb
+from cocotb.runner import as_tcl_value
+
+@cocotb.test()
+async def test_empty_string(dut):
+  assert as_tcl_value("") == ""
+
+@cocotb.test()
+async def test_special_char(dut):
+  assert as_tcl_value("Test \n end\ttest\r") == "Test\\ \\n\\ end\\\ttest\\\r"


### PR DESCRIPTION
Simple check on input's length before trying to access it.
As feeding a blank string would result in:

```
if value[0] == '"':
          ~~~~~^^^
IndexError: string index out of range
```

Could you please double-check the test case, as I'm not sure that I've understood the function's expected behaviour?

I didn't understand how I could get the PR ID before pushing the PR, so I didn't create a news fragment.
Sorry :(

PS : the link in [CONTRIBUTING.md](https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md) returns 404