### PR TITLE
Fix link to contributing.html in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Cocotb Contribution Guidelines
 
 cocotb welcomes contributions from anyone!
-Please have a look at the [Development & Community](https://docs.cocotb.org/contributing.html) section of the cocotb documentation for an in-depth contribution guide.
+Please have a look at the [Development & Community](https://docs.cocotb.org/en/latest/contributing.html) section of the cocotb documentation for an in-depth contribution guide.


### PR DESCRIPTION
Reported in https://github.com/cocotb/cocotb/pull/4225#issue-2595051231

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
