### PR TITLE
Vpi: remove vpiPort from iteration

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiIterator.cpp
+++ b/src/cocotb/share/lib/vpi/VpiIterator.cpp
@@ -35,7 +35,7 @@
 
 decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
     /* for reused lists */
-
+    // clang-format off
     // vpiInstance is the base class for module, program, interface, etc.
     std::vector<int32_t> instance_options = {
         vpiNet,
@@ -43,24 +43,36 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
         vpiReg,
         vpiRegArray,
     };
-
     std::vector<int32_t> module_options = {
         // vpiModule,            // Aldec SEGV on mixed language
         // vpiModuleArray,       // Aldec SEGV on mixed language
         // vpiIODecl,            // Don't care about these
-        vpiMemory, vpiIntegerVar, vpiRealVar, vpiRealNet, vpiStructVar,
-        vpiStructNet, vpiVariables, vpiNamedEvent, vpiNamedEventArray,
+        vpiMemory,
+        vpiIntegerVar,
+        vpiRealVar,
+        vpiRealNet,
+        vpiStructVar,
+        vpiStructNet,
+        vpiVariables,
+        vpiNamedEvent,
+        vpiNamedEventArray,
         vpiParameter,
         // vpiSpecParam,         // Don't care
         // vpiParamAssign,       // Aldec SEGV on mixed language
         // vpiDefParam,          // Don't care
-        vpiPrimitive, vpiPrimitiveArray,
+        vpiPrimitive,
+        vpiPrimitiveArray,
         // vpiContAssign,        // Don't care
-        vpiProcess,  // Don't care
-        vpiModPath, vpiTchk, vpiAttribute, vpiPort, vpiInternalScope,
+        vpiProcess,              // Don't care
+        vpiModPath,
+        vpiTchk,
+        vpiAttribute,
+        // vpiPort,              // Splits into high/lo signals; signals are still there under vpiReg/vpiNet
+        vpiInternalScope,
         // vpiInterface,         // Aldec SEGV on mixed language
         // vpiInterfaceArray,    // Aldec SEGV on mixed language
     };
+    // clang-format on
 
     // append base class vpiInstance members
     module_options.insert(module_options.begin(), instance_options.begin(),
@@ -106,10 +118,6 @@ decltype(VpiIterator::iterate_over) VpiIterator::iterate_over = [] {
         {vpiMemory,
          {
              vpiMemoryWord,
-         }},
-        {vpiPort,
-         {
-             vpiPortBit,
          }},
         {vpiGate,
          {

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -305,7 +305,7 @@ async def test_discover_all(dut):
         pass_total = 308
     elif LANGUAGE in ["verilog"] and cocotb.SIM_NAME.lower().startswith("riviera"):
         # Applies to Riviera-PRO 2019.10 and newer.
-        pass_total = 198
+        pass_total = 197
     elif LANGUAGE in ["vhdl"]:
         pass_total = 244
     else:


### PR DESCRIPTION
These aren't proper signals, and not handled by our python code. These split into high/low signals, rather than being signals themselves. The port signals are still accessible through the other iteration schemes.

I also reformatted these so we can view the git blame better in the future, I imagine we have some more that need to be removed.
> 
> In SystemVerilog's VPI (Verilog Procedural Interface), vpiPort is a property that refers to ports in modules or interfaces. It provides access to information about ports, such as connections and direction.
> 
> When dealing with module ports, vpiPort is used to navigate and interact with the connections. Some key properties and functions associated with vpiPort include:
> 
> vpiPortIndex: This returns the index of the port.
> vpiHighConn: This indicates the connection closer to the top module.
> vpiLowConn: This indicates the connection further from the top module.
> vpiPortType: Defines the type of the port, such as vpiInterfacePort, vpiModportPort, or vpiPort.
> For example, you can use vpiPort in combination with other VPI functions to traverse port connections in a design hierarchy, please refer to Section 37.14 of the SystemVerilog LRM on ports.
> 