### PR TITLE
Add `__index__` to LogicArray to support integer string casting

### DIFF
--- a/src/cocotb/types/logic.py
+++ b/src/cocotb/types/logic.py
@@ -246,3 +246,6 @@ class Logic:
         elif self._repr == _1:
             return 1
         raise ValueError(f"Cannot convert {self!r} to int")
+
+    def __index__(self) -> int:
+        return int(self)

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -122,6 +122,17 @@ class LogicArray(ArrayLike[Logic]):
         >>> la.to_bytes()
         b"\n"
 
+    You can also convert :class:`LogicArray`\ s to hexidecimal or binary strings using
+    the builtins :func:`hex:` and :func:`bin`, respectively.
+
+    .. code-block:: python3
+
+        >>> la = LogicArray("01111010")
+        >>> hex(la)
+        0x7a
+        >>> bin(la)
+        0b1111010
+
     :class:`LogicArray`\ s also support element-wise logical operations: ``&``, ``|``,
     ``^``, and ``~``.
 

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -122,7 +122,7 @@ class LogicArray(ArrayLike[Logic]):
         >>> la.to_bytes()
         b"\n"
 
-    You can also convert :class:`LogicArray`\ s to hexidecimal or binary strings using
+    You can also convert :class:`LogicArray`\ s to hexadecimal or binary strings using
     the builtins :func:`hex:` and :func:`bin`, respectively.
 
     .. code-block:: python3

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -767,6 +767,9 @@ class LogicArray(ArrayLike[Logic]):
     def __int__(self) -> int:
         return self.to_unsigned()
 
+    def __index__(self) -> int:
+        return int(self)
+
     def __and__(self, other: "LogicArray") -> "LogicArray":
         if not isinstance(other, LogicArray):
             return NotImplemented

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -82,6 +82,13 @@ def test_logic_str_conversions():
     assert str(Logic("Z")) == "Z"
 
 
+def test_logic_index_cast():
+    assert bin(Logic("0")) == "0b0"
+    assert bin(Logic("1")) == "0b1"
+    with pytest.raises(ValueError):
+        bin(Logic("X"))
+
+
 def test_logic_int_conversions():
     assert int(Logic("0")) == 0
     assert int(Logic("1")) == 1

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -219,6 +219,13 @@ def test_logic_array_literal_casts():
     assert int(LogicArray("0101010")) == 0b0101010
 
 
+def test_logic_array_index_casts():
+    assert bin(LogicArray("000101")) == "0b101"
+    assert hex(LogicArray("01111010")) == "0x7a"
+    with pytest.raises(ValueError):
+        bin(LogicArray("X010"))
+
+
 def test_equality():
     # fmt: off
     # cross product of all impls


### PR DESCRIPTION
Closes #4229. Allows the use of LogicArray directly in indexing `memory[my_logic_value]` and in integer string casts: `hex()`, `bin()`, etc.

- [x] Add test