### PR TITLE
Add back resolve x

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -133,6 +133,27 @@ Cocotb
 
     ``TRACE`` is used for internal low-level logging and produces very verbose logs.
 
+.. envvar:: COCOTB_RESOLVE_X
+
+    Defines how to resolve bits with a value of ``X``, ``Z``, ``U``, ``W``, or ``-`` when being converted to integer.
+    Valid settings are:
+
+    ``VALUE_ERROR``
+       Raise a :exc:`ValueError` exception.
+    ``ZEROS``
+       Resolve to ``0``.
+    ``ONES``
+       Resolve to ``1``.
+    ``RANDOM``
+       Randomly resolve to a ``0`` or a ``1``.
+
+    Set to ``VALUE_ERROR`` by default.
+
+    .. warning::
+
+        This exists for backwards-compatability reasons.
+        Using any value besides ``VALUE_ERROR`` is *not* recommended.
+
 .. envvar:: LIBPYTHON_LOC
 
     The absolute path to the Python library associated with the current Python installation;

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -134,6 +134,10 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
     :members:
     :inherited-members:
 
+.. autoclass:: cocotb.types.logic_array.ResolveX
+
+.. autodata:: cocotb.types.logic_array.RESOLVE_X
+
 
 Triggers
 ========

--- a/docs/source/newsfragments/4298.feature.1.rst
+++ b/docs/source/newsfragments/4298.feature.1.rst
@@ -1,0 +1,1 @@
+Added :attr:`cocotb.types.logic_array.RESOLVE_X` which controls the default resolution behavior of ``X``, ``Z``, ``U``, ``W``, and ``-`` values in :class:`.LogicArray`\ s whenever they are converted to integers using :class:`int` casts, :meth:`.LogicArray.to_unsigned` or :meth:`.LogicArray.to_signed` without pasing an argument for the ``resolve`` parameter.

--- a/docs/source/newsfragments/4298.feature.rst
+++ b/docs/source/newsfragments/4298.feature.rst
@@ -1,0 +1,1 @@
+Adding support for resolving ``X``, ``Z``, ``U``, ``W``, and ``-`` values to :meth:`.LogicArray.to_unsigned` and :meth:`.LogicArray.to_signed`.

--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -98,3 +98,13 @@ else:
             res = self._method(instance)
             instance.__dict__[self._method.__name__] = res
             return res
+
+
+# inheriting from (str, Enum) was broken in 3.12 and StrEnum must be used
+if sys.version_info >= (3, 12):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass

--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -100,8 +100,8 @@ else:
             return res
 
 
-# inheriting from (str, Enum) was broken in 3.12 and StrEnum must be used
-if sys.version_info >= (3, 12):
+# inheriting from (str, Enum) was broken in 3.11 and StrEnum must be used
+if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
     from enum import Enum

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -347,9 +347,9 @@ class LogicArray(ArrayLike[Logic]):
             # May convert list to str before converting to int.
             try:
                 self._value_as_int = int(self._get_str(), 2)
-            except ValueError as e:
+            except ValueError:
                 if resolve == "error":
-                    raise e
+                    raise
 
                 return int(
                     RE_UNRESOLVED.sub(RESOLVE_MAP[resolve], self._get_str()),

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -351,7 +351,7 @@ class LogicArray(ArrayLike[Logic]):
                 if resolve == "error":
                     raise e
 
-                self._value_as_int = int(
+                return int(
                     RE_UNRESOLVED.sub(RESOLVE_MAP[resolve], self._get_str()),
                     2,  # type: ignore
                 )

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class ResolveX(StrEnum):
-    """Resolution behaviors supported when converting a LogicArray to an integer.
+    """Resolution behaviors supported when converting a :class:`LogicArray` to an integer.
 
     The values ``L`` and ``H`` are always resolved to ``0`` and ``1`` respectively.
     These behaviors exist to resolve the Logic values ``X``, ``Z``, ``U``, ``W``, and ``-``
@@ -41,7 +41,7 @@ class ResolveX(StrEnum):
 
 # Must add documentation after the fact because Enum member creation is weird
 ResolveX.VALUE_ERROR.__doc__ = (
-    "Throws a ValueError if the LogicArray contains non-``0``/``1`` values."
+    "Throws a :exc:`ValueError` if the :class:`LogicArray` contains non-``0``/``1`` values."
 )
 ResolveX.ZEROS.__doc__ = "Resolves all non-``0``/``1`` values to ``0``."
 ResolveX.ONES.__doc__ = "Resolves all non-``0``/``1`` values to ``1``."
@@ -58,7 +58,7 @@ Defaults to :attr:`~ResolveX.VALUE_ERROR`.
 
 .. warning::
 
-    This exists for backwards-compatability reasons.
+    This exists for backwards-compatibility reasons.
     Using any value besides ``VALUE_ERROR`` is *not* recommended.
 """
 

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -17,7 +17,6 @@ from typing import (
 
 from cocotb._deprecation import deprecated
 from cocotb._py_compat import StrEnum
-from cocotb._utils import DocEnum
 from cocotb.types import ArrayLike
 from cocotb.types.logic import Logic, LogicConstructibleT, _str_literals
 from cocotb.types.range import Range
@@ -26,7 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Literal
 
 
-class ResolveX(DocEnum, StrEnum):
+class ResolveX(StrEnum):
     """Resolution behaviors supported when converting a LogicArray to an integer.
 
     The values ``L`` and ``H`` are always resolved to ``0`` and ``1`` respectively.
@@ -34,16 +33,21 @@ class ResolveX(DocEnum, StrEnum):
     to either ``0`` or ``1``.
     """
 
-    VALUE_ERROR = (
-        "error",
-        "Throws a ValueError if the LogicArray contains non-``0``/``1`` values.",
-    )
-    ZEROS = ("zeros", "Resolves all non-``0``/``1`` values to ``0``.")
-    ONES = ("ones", "Resolves all non-``0``/``1`` values to ``1``.")
-    RANDOM = (
-        "random",
-        "Resolves all non-``0``/``1`` values randomly to either ``0`` or ``1``.",
-    )
+    VALUE_ERROR = "error"
+    ZEROS = "zeros"
+    ONES = "ones"
+    RANDOM = "random"
+
+
+# Must add documentation after the fact because Enum member creation is weird
+ResolveX.VALUE_ERROR.__doc__ = (
+    "Throws a ValueError if the LogicArray contains non-``0``/``1`` values."
+)
+ResolveX.ZEROS.__doc__ = "Resolves all non-``0``/``1`` values to ``0``."
+ResolveX.ONES.__doc__ = "Resolves all non-``0``/``1`` values to ``1``."
+ResolveX.RANDOM.__doc__ = (
+    "Resolves all non-``0``/``1`` values randomly to either ``0`` or ``1``."
+)
 
 
 RESOLVE_X = ResolveX[os.getenv("COCOTB_RESOLVE_X", "VALUE_ERROR")]

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -40,9 +40,7 @@ class ResolveX(StrEnum):
 
 
 # Must add documentation after the fact because Enum member creation is weird
-ResolveX.VALUE_ERROR.__doc__ = (
-    "Throws a :exc:`ValueError` if the :class:`LogicArray` contains non-``0``/``1`` values."
-)
+ResolveX.VALUE_ERROR.__doc__ = "Throws a :exc:`ValueError` if the :class:`LogicArray` contains non-``0``/``1`` values."
 ResolveX.ZEROS.__doc__ = "Resolves all non-``0``/``1`` values to ``0``."
 ResolveX.ONES.__doc__ = "Resolves all non-``0``/``1`` values to ``1``."
 ResolveX.RANDOM.__doc__ = (

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -88,6 +88,7 @@ def _help_vars_text() -> str:
         COCOTB_ATTACH             Pause time value in seconds before the simulator start
         COCOTB_ENABLE_PROFILING   Performance analysis of the Python portion of cocotb
         COCOTB_LOG_LEVEL          Default logging level (default INFO)
+        COCOTB_RESOLVE_X          How to resolve X, Z, U, W, - on integer conversion
         LIBPYTHON_LOC             Absolute path to libpython
 
         Regression Manager

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -408,3 +408,46 @@ def test_bool_cast():
         assert not LogicArray("0000")
         assert LogicArray("01XZ")
         assert LogicArray("XZ01")
+
+
+def test_resolve_x():
+    a = LogicArray("UX01ZWLH-")
+
+    with pytest.raises(ValueError):
+        a.to_unsigned("error")
+    with pytest.raises(ValueError):
+        a.to_signed("error")
+    assert LogicArray("01LH").to_unsigned("error") == 0b0101
+
+    assert a.to_unsigned("ones") == 0b110111011
+
+    assert a.to_unsigned("zeros") == 0b000100010
+
+    rand_val = a.to_unsigned("random")
+    # check known bits only
+    assert (rand_val >> 1) & 1 == 1
+    assert (rand_val >> 2) & 1 == 0
+    assert (rand_val >> 5) & 1 == 1
+    assert (rand_val >> 6) & 1 == 0
+
+
+def test_resolve_default_behavior():
+    import cocotb.types.logic_array
+
+    a = LogicArray("01X")
+
+    cocotb.types.logic_array.RESOLVE_X = "error"
+    with pytest.raises(ValueError):
+        a.to_unsigned()
+
+    cocotb.types.logic_array.RESOLVE_X = "zeros"
+    assert a.to_unsigned() == 0b010
+
+    cocotb.types.logic_array.RESOLVE_X = "ones"
+    assert a.to_unsigned() == 0b011
+
+    cocotb.types.logic_array.RESOLVE_X = "random"
+    rand_val = a.to_unsigned()
+    # check known bits only
+    assert (rand_val >> 1) & 1 == 1
+    assert (rand_val >> 2) & 1 == 0


### PR DESCRIPTION
Adds back COCOTB_RESOLVE_X with the old values, while using low, high, random, and error for the user-passed literals.