### PR TITLE
Allow user to specify elaboration arguments for NVC simulator.

### DIFF
--- a/docs/source/newsfragments/4267.feature.rst
+++ b/docs/source/newsfragments/4267.feature.rst
@@ -1,1 +1,1 @@
-Allow user to specify elaboration arguments for NVC simulator(useful to do coverage).
+Allow user to specify elaboration arguments for NVC (e.g. to enable coverage collection).

--- a/docs/source/newsfragments/4267.feature.rst
+++ b/docs/source/newsfragments/4267.feature.rst
@@ -1,0 +1,1 @@
+Allow user to specify elaboration arguments for NVC simulator(useful to do coverage).

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -331,6 +331,7 @@ class Runner(ABC):
                 If not set, run all testcases found in *test_module*.
                 Can be a comma-separated list.
             seed: A specific random seed to use.
+            elab_args: A list of elaboration arguments for the simulator.
             test_args: A list of extra arguments for the simulator.
             plusargs: 'plusargs' to set for the simulator.
             extra_env: Extra environment variables to set.

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -302,6 +302,7 @@ class Runner(ABC):
         gpi_interfaces: Optional[List[str]] = None,
         testcase: Optional[Union[str, Sequence[str]]] = None,
         seed: Optional[Union[str, int]] = None,
+        elab_args: Sequence[str] = [],
         test_args: Sequence[str] = [],
         plusargs: Sequence[str] = [],
         extra_env: Mapping[str, str] = {},
@@ -390,6 +391,7 @@ class Runner(ABC):
 
         self.pre_cmd = pre_cmd
 
+        self.elab_args = list(elab_args)
         self.test_args = list(test_args)
         self.plusargs = list(plusargs)
         self.env = dict(extra_env)
@@ -1065,6 +1067,7 @@ class Nvc(Runner):
             ["nvc", f"--work={self.hdl_toplevel_library}", "-L", str(self.build_dir)]
             + self.build_args
             + ["-e", self.sim_hdl_toplevel, "--no-save", "--jit"]
+            + self.elab_args
             + self._get_parameter_options(self.parameters)
             + ["-r"]
             + self.test_args


### PR DESCRIPTION
This was required to pass the appropriate options for doing coverage with the NVC simulator. Previously no elaboration arguments could be passed to NVC.