### PR TITLE
Move Python interpreter initialization to new 3.8+ pattern

### DIFF
--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -56,18 +56,13 @@ IS_VENV=$(shell $(shell cocotb-config --python-bin) -c 'import sys; print(sys.pr
 
 # this ensures we use the same python as the one cocotb was installed into
 PYTHON_BIN ?= $(shell cocotb-config --python-bin)
+export PYGPI_PYTHON_BIN := $(PYTHON_BIN)
 
 include $(shell cocotb-config --makefiles)/Makefile.deprecations
 
 PYTHON_ARCH := $(shell $(PYTHON_BIN) -c 'from platform import architecture; print(architecture()[0])')
 ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)
     $(error Unknown Python architecture: $(PYTHON_ARCH))
-endif
-
-# Changing PYTHONHOME confuses virtual environments, so only set it when not using a venv
-ifeq ($(IS_VENV),False)
-    # Set PYTHONHOME to properly populate sys.path in embedded python interpreter
-    export PYTHONHOME := $(shell $(PYTHON_BIN) -c 'import sys; print(sys.prefix)')
 endif
 
 ifeq ($(OS),Msys)

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -162,7 +162,7 @@ class Runner(ABC):
 
         self.env["PATH"] += os.pathsep + str(cocotb_tools.config.libs_dir)
         self.env["PYTHONPATH"] = os.pathsep.join(sys.path)
-        self.env["PYTHONHOME"] = sys.prefix
+        self.env["PYGPI_PYTHON_BIN"] = sys.executable
         self.env["COCOTB_TOPLEVEL"] = self.sim_hdl_toplevel
         self.env["COCOTB_TEST_MODULES"] = self.test_module
         self.env["TOPLEVEL_LANG"] = self.hdl_toplevel_lang


### PR DESCRIPTION
This is expected to not work with Python 3.6 or 3.7. Related to #4091. Changes Python interpreter initialization to use the new Python 3.8+ initialization sequence. This allows us to set the program name to the Python executable in a way that works consistently in all operating systems and means we no longer have to set PYTHONHOME. Not setting PYTHONHOME also allows us to avoid issues with Xcelium and potentially VCS caused by setting that variable.