### PR TITLE
The Refactor

### DIFF
--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -34,7 +34,6 @@ import sys
 import time
 import warnings
 from collections.abc import Coroutine
-from enum import auto
 from types import SimpleNamespace
 from typing import Any, Dict, List, Union, cast
 
@@ -43,7 +42,6 @@ import cocotb.handle
 import cocotb.task
 import cocotb.triggers
 from cocotb._scheduler import Scheduler
-from cocotb._utils import DocEnum
 from cocotb.logging import default_config
 from cocotb.regression import RegressionManager, RegressionMode
 from cocotb.result import TestSuccess
@@ -118,18 +116,6 @@ and in parameters to :class:`.TestFactory`\ s.
 
 is_simulation: bool = False
 """``True`` if cocotb was loaded in a simulation."""
-
-
-class SimPhase(DocEnum):
-    """A phase of the time step."""
-
-    NORMAL = (auto(), "In the Beginning Of Time Step or a Value Change phase.")
-    READ_WRITE = (auto(), "In a ReadWrite phase.")
-    READ_ONLY = (auto(), "In a ReadOnly phase.")
-
-
-sim_phase: SimPhase = SimPhase.NORMAL
-"""The current phase of the time step."""
 
 
 def _setup_logging() -> None:

--- a/src/cocotb/_exceptions.py
+++ b/src/cocotb/_exceptions.py
@@ -4,4 +4,4 @@
 
 
 class InternalError(BaseException):
-    """An error internal to scheduler. If you see this, report a bug!"""
+    """An error in the cocotb runtime. If you see this, report a bug!"""

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -27,12 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Task scheduler.
-
-FIXME: We have a problem here. If a task schedules a read-only but we
-also have pending writes we have to schedule the ReadWrite callback before
-the ReadOnly (and this is invalid, at least in Modelsim).
-"""
 
 import logging
 import os
@@ -210,9 +204,6 @@ class Scheduler:
     """
 
     # Singleton events, recycled to avoid spurious object creation
-    _next_time_step = NextTimeStep()
-    _read_write = ReadWrite()
-    _read_only = ReadOnly()
     _none_outcome = _outcomes.Value(None)
 
     def __init__(self, test_complete_cb: Callable[[], None]) -> None:
@@ -221,12 +212,6 @@ class Scheduler:
         self.log = logging.getLogger("cocotb.scheduler")
         if _debug:
             self.log.setLevel(logging.DEBUG)
-
-        # A dictionary of pending tasks for each trigger,
-        # indexed by trigger
-        self._trigger2tasks: Dict[Trigger, list[Task]] = (
-            _py_compat.insertion_ordered_dict()
-        )
 
         self._scheduled_tasks: OrderedDict[Task[Any], _outcomes.Outcome] = OrderedDict()
         self._pending_threads = []
@@ -252,31 +237,6 @@ class Scheduler:
 
         # call complete cb, may schedule another test
         self._test_complete_cb()
-
-    def _sim_react(self, trigger: Trigger) -> None:
-        """Called when a :class:`~cocotb.triggers.GPITrigger` fires.
-
-        This is often the entry point into Python from the simulator,
-        so this function is in charge of enabling profiling.
-        It must also track the current simulator time phase,
-        and start the unstarted event loop.
-        """
-        with profiling_context:
-            # TODO: move state tracking to global variable
-            # and handle this via some kind of trigger-specific Python callback
-            if trigger is self._read_write:
-                cocotb.sim_phase = cocotb.SimPhase.READ_WRITE
-            elif trigger is self._read_only:
-                cocotb.sim_phase = cocotb.SimPhase.READ_ONLY
-            else:
-                cocotb.sim_phase = cocotb.SimPhase.NORMAL
-
-            # apply inertial writes if ReadWrite
-            if trigger is self._read_write:
-                cocotb._write_scheduler.apply_scheduled_writes()
-
-            self._react(trigger)
-            self._event_loop()
 
     def _react(self, trigger: Trigger) -> None:
         """Called when a :class:`~cocotb.triggers.Trigger` fires.

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -32,22 +32,13 @@ import logging
 import os
 import threading
 from collections import OrderedDict
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
-import cocotb
-import cocotb._write_scheduler
-from cocotb import _outcomes, _py_compat
+from cocotb import _outcomes
 from cocotb._exceptions import InternalError
-from cocotb._profiling import profiling_context
 from cocotb.task import Task
 from cocotb.triggers import (
     Event,
-    GPITrigger,
-    NextTimeStep,
-    ReadOnly,
-    ReadWrite,
-    Trigger,
-    _Join,
 )
 
 # Sadly the Python standard logging module is very slow so it's better not to
@@ -238,48 +229,6 @@ class Scheduler:
         # call complete cb, may schedule another test
         self._test_complete_cb()
 
-    def _react(self, trigger: Trigger) -> None:
-        """Called when a :class:`~cocotb.triggers.Trigger` fires.
-
-        Finds all Tasks waiting on the Trigger that fired and queues them.
-        """
-        if _debug:
-            self.log.debug(f"Trigger fired: {trigger}")
-
-        # find all tasks waiting on trigger that fired
-        try:
-            scheduling = self._trigger2tasks.pop(trigger)
-        except KeyError:
-            # GPI triggers should only be ever pending if there is an
-            # associated task waiting on that trigger, otherwise it would
-            # have been unprimed already
-            if isinstance(trigger, GPITrigger):
-                self.log.critical(f"No tasks waiting on trigger that fired: {trigger}")
-                trigger.log.info("I'm the culprit")
-            # For Python triggers this isn't actually an error - we might do
-            # event.set() without knowing whether any tasks are actually
-            # waiting on this event, for example
-            elif _debug:
-                self.log.debug(f"No tasks waiting on trigger that fired: {trigger}")
-            return
-
-        if _debug:
-            debugstr = "\n\t".join([str(task) for task in scheduling])
-            if len(scheduling) > 0:
-                debugstr = "\n\t" + debugstr
-            self.log.debug(
-                f"{len(scheduling)} pending tasks for trigger {trigger}{debugstr}"
-            )
-
-        # queue all tasks to wake up
-        for task in scheduling:
-            # unset trigger
-            task._trigger = None
-            self._schedule_task(task)
-
-        # cleanup trigger
-        trigger._cleanup()
-
     def _event_loop(self) -> None:
         """Run the main event loop.
 
@@ -329,49 +278,8 @@ class Scheduler:
         if task in self._scheduled_tasks:
             self._scheduled_tasks.pop(task)
 
-        # Unprime the trigger this task is waiting on
-        trigger = task._trigger
-        if trigger is not None:
-            task._trigger = None
-            if task in self._trigger2tasks.setdefault(trigger, []):
-                self._trigger2tasks[trigger].remove(task)
-            if not self._trigger2tasks[trigger]:
-                trigger._unprime()
-                del self._trigger2tasks[trigger]
-
         if self._terminate:
             return
-
-        elif _Join(task) in self._trigger2tasks:
-            self._react(_Join(task))
-
-    def _schedule_task_upon(self, task: Task[Any], trigger: Trigger) -> None:
-        """Schedule `task` to be resumed when `trigger` fires."""
-        # TODO Move this all into Task
-        task._trigger = trigger
-        task._state = Task._State.PENDING
-
-        trigger_tasks = self._trigger2tasks.setdefault(trigger, [])
-        trigger_tasks.append(task)
-
-        if not trigger._primed:
-            if trigger_tasks != [task]:
-                # should never happen
-                raise InternalError("More than one task waiting on an unprimed trigger")
-
-            try:
-                # TODO maybe associate the react method with the trigger object so
-                # we don't have to do a type check here.
-                if isinstance(trigger, GPITrigger):
-                    trigger._prime(self._sim_react)
-                else:
-                    trigger._prime(self._react)
-            except Exception as e:
-                # discard the trigger we associated, it will never fire
-                self._trigger2tasks.pop(trigger)
-
-                # replace it with a new trigger that throws back the exception
-                self._schedule_task(task, outcome=_outcomes.Error(e))
 
     def _schedule_task(
         self, task: Task[Any], outcome: _outcomes.Outcome[Any] = _none_outcome
@@ -465,42 +373,6 @@ class Scheduler:
 
         return wrapper()
 
-    # This collection of functions parses a trigger out of the object
-    # that was yielded by a task, converting `list` -> `Waitable`,
-    # `Waitable` -> `Task`, `Task` -> `Trigger`.
-    # Doing them as separate functions allows us to avoid repeating unnecessary
-    # `isinstance` checks.
-
-    def _trigger_from_started_task(self, result: Task) -> Trigger:
-        if _debug:
-            self.log.debug(f"Joining to already running task: {result}")
-        return _Join(result)
-
-    def _trigger_from_unstarted_task(self, result: Task) -> Trigger:
-        self._schedule_task(result)
-        if _debug:
-            self.log.debug(f"Scheduling unstarted task: {result!r}")
-        return _Join(result)
-
-    def _trigger_from_any(self, result) -> Trigger:
-        """Convert a yielded object into a Trigger instance"""
-        # note: the order of these can significantly impact performance
-
-        if isinstance(result, Trigger):
-            return result
-
-        # TODO move this into Task
-        if isinstance(result, Task):
-            if result._state is Task._State.UNSTARTED:
-                return self._trigger_from_unstarted_task(result)
-            else:
-                return self._trigger_from_started_task(result)
-
-        raise TypeError(
-            f"Coroutine yielded an object of type {type(result)}, which the scheduler can't "
-            f"handle: {result!r}\n"
-        )
-
     def _resume_task(self, task: Task, outcome: _outcomes.Outcome[Any]) -> None:
         """Resume *task* with *outcome*.
 
@@ -520,28 +392,6 @@ class Scheduler:
             self._current_task = task
 
             result = task._advance(outcome=outcome)
-
-            if task.done():
-                if _debug:
-                    self.log.debug(f"{task} completed with {task._outcome}")
-                assert result is None
-                self._unschedule(task)
-
-            # Don't handle the result if we're shutting down
-            if self._terminate:
-                return
-
-            if not task.done():
-                if _debug:
-                    self.log.debug(f"{task!r} yielded {result} ({cocotb.sim_phase})")
-                try:
-                    result = self._trigger_from_any(result)
-                except TypeError as exc:
-                    # restart this task with an exception object telling it that
-                    # it wasn't allowed to yield that
-                    self._schedule_task(task, _outcomes.Error(exc))
-                else:
-                    self._schedule_task_upon(task, result)
 
             # We do not return from here until pending threads have completed, but only
             # from the main thread, this seems like it could be problematic in cases
@@ -570,19 +420,6 @@ class Scheduler:
 
         Unprime all pending triggers and kill off any tasks, stop all externals.
         """
-        # copy since we modify this in kill
-        items = list((k, list(v)) for k, v in self._trigger2tasks.items())
-
-        # reversing seems to fix gh-928, although the order is still somewhat
-        # arbitrary.
-        for _, waiting in items[::-1]:
-            for task in waiting:
-                if _debug:
-                    self.log.debug(f"Killing {task}")
-                task.kill()
-            # we don't unprime trigger here since removing all tasks waiting on
-            # the trigger should cause it to be unprimed in _unschedule
-        assert not self._trigger2tasks
 
         # Kill any queued coroutines.
         # We use a while loop because task.kill() calls _unschedule(), which will remove the task from _pending_tasks.

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -1272,3 +1272,21 @@ class TestFactory(Generic[F]):
 
             glbs["__cocotb_tests__"].append(test)
             glbs[test.name] = test
+
+
+class _RunningTest(Task[None]):
+    """
+    The result of calling a :class:`cocotb.test` decorated object.
+
+    All this class does is change ``__name__`` to show "Test" instead of "Task".
+
+    .. versionchanged:: 1.8.0
+        Moved to the ``cocotb.task`` module.
+    """
+
+    _name: str = "Test"
+
+    def __init__(self, inst: Coroutine[Any, Any, None], name: str) -> None:
+        super().__init__(inst)
+        self.__name__ = f"{type(self)._name} {name}"
+        self.__qualname__ = self.__name__

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -8,7 +8,18 @@ import os
 import warnings
 from asyncio import CancelledError, InvalidStateError
 from enum import auto
-from typing import Any, Callable, Coroutine, Generator, Generic, List, Optional, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Generator,
+    Generic,
+    List,
+    Optional,
+    Set,
+    TypeVar,
+    Union,
+)
 
 import cocotb
 import cocotb.triggers
@@ -285,31 +296,17 @@ class Task(Generic[ResultType]):
         self._done_callbacks.append(callback)
 
     def __await__(self) -> Generator[Any, Any, ResultType]:
-        # It's tempting to use `return (yield from self._coro)` here,
-        # which bypasses the scheduler. Unfortunately, this means that
-        # we can't keep track of the result or state of the coroutine,
-        # things which we expose in our public API. If you want the
-        # efficiency of bypassing the scheduler, remove the `@coroutine`
-        # decorator from your `async` functions.
-
-        # Hand the coroutine back to the scheduler trampoline.
         yield self
         return self.result()
 
 
-class _RunningTest(Task[None]):
-    """
-    The result of calling a :class:`cocotb.test` decorated object.
+_all_tasks: Set[Task[Any]] = set()
+_current_task: Union[Task[Any], None] = None
 
-    All this class does is change ``__name__`` to show "Test" instead of "Task".
 
-    .. versionchanged:: 1.8.0
-        Moved to the ``cocotb.task`` module.
-    """
+def all_tasks() -> Set[Task[Any]]:
+    return _all_tasks
 
-    _name: str = "Test"
 
-    def __init__(self, inst: Coroutine[Any, Any, None], name: str) -> None:
-        super().__init__(inst)
-        self.__name__ = f"{type(self)._name} {name}"
-        self.__qualname__ = self.__name__
+def current_task() -> Union[Task[Any], None]:
+    return _current_task

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -88,6 +88,8 @@ class Task(Generic[ResultType]):
 
         self._task_id = self._id_count
         type(self)._id_count += 1
+        _all_tasks.add(self)
+
         self.__name__ = f"{type(self)._name} {self._task_id}"
         self.__qualname__ = self.__name__
 
@@ -310,3 +312,95 @@ def all_tasks() -> Set[Task[Any]]:
 
 def current_task() -> Union[Task[Any], None]:
     return _current_task
+
+    # if task.done():
+    #     if _debug:
+    #         self.log.debug(f"{task} completed with {task._outcome}")
+    #     assert result is None
+    #     self._unschedule(task)
+
+    # # Don't handle the result if we're shutting down
+    # if self._terminate:
+    #     return
+
+    # if not task.done():
+    #     if _debug:
+    #         self.log.debug(f"{task!r} yielded {result} ({cocotb.sim_phase})")
+    #     try:
+    #         result = self._trigger_from_any(result)
+    #     except TypeError as exc:
+    #         # restart this task with an exception object telling it that
+    #         # it wasn't allowed to yield that
+    #         self._schedule_task(task, _outcomes.Error(exc))
+    #     else:
+    #         self._schedule_task_upon(task, result)
+
+    # def _react(self, trigger: Trigger) -> None:
+    #     """Called when a :class:`~cocotb.triggers.Trigger` fires.
+
+    #     Finds all Tasks waiting on the Trigger that fired and queues them.
+    #     """
+    #     if _debug:
+    #         self.log.debug(f"Trigger fired: {trigger}")
+
+    #     # find all tasks waiting on trigger that fired
+    #     try:
+    #         scheduling = self._trigger2tasks.pop(trigger)
+    #     except KeyError:
+    #         # GPI triggers should only be ever pending if there is an
+    #         # associated task waiting on that trigger, otherwise it would
+    #         # have been unprimed already
+    #         if isinstance(trigger, GPITrigger):
+    #             self.log.critical(f"No tasks waiting on trigger that fired: {trigger}")
+    #             trigger.log.info("I'm the culprit")
+    #         # For Python triggers this isn't actually an error - we might do
+    #         # event.set() without knowing whether any tasks are actually
+    #         # waiting on this event, for example
+    #         elif _debug:
+    #             self.log.debug(f"No tasks waiting on trigger that fired: {trigger}")
+    #         return
+
+    #     if _debug:
+    #         debugstr = "\n\t".join([str(task) for task in scheduling])
+    #         if len(scheduling) > 0:
+    #             debugstr = "\n\t" + debugstr
+    #         self.log.debug(
+    #             f"{len(scheduling)} pending tasks for trigger {trigger}{debugstr}"
+    #         )
+
+    #     # queue all tasks to wake up
+    #     for task in scheduling:
+    #         # unset trigger
+    #         task._trigger = None
+    #         self._schedule_task(task)
+
+    #     # cleanup trigger
+    #     trigger._cleanup()
+
+    # def _schedule_task_upon(self, task: Task[Any], trigger: Trigger) -> None:
+    #     """Schedule `task` to be resumed when `trigger` fires."""
+    #     # TODO Move this all into Task
+    #     task._trigger = trigger
+    #     task._state = Task._State.PENDING
+
+    #     trigger_tasks = self._trigger2tasks.setdefault(trigger, [])
+    #     trigger_tasks.append(task)
+
+    #     if not trigger._primed:
+    #         if trigger_tasks != [task]:
+    #             # should never happen
+    #             raise InternalError("More than one task waiting on an unprimed trigger")
+
+    #         try:
+    #             # TODO maybe associate the react method with the trigger object so
+    #             # we don't have to do a type check here.
+    #             if isinstance(trigger, GPITrigger):
+    #                 trigger._prime(self._sim_react)
+    #             else:
+    #                 trigger._prime(self._react)
+    #         except Exception as e:
+    #             # discard the trigger we associated, it will never fire
+    #             self._trigger2tasks.pop(trigger)
+
+    #             # replace it with a new trigger that throws back the exception
+    #             self._schedule_task(task, outcome=_outcomes.Error(e))

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -29,6 +29,7 @@
 
 import logging
 from abc import abstractmethod
+from collections import OrderedDict
 from decimal import Decimal
 from fractions import Fraction
 from typing import (
@@ -74,50 +75,70 @@ def _pointer_str(obj: object) -> str:
 Self = TypeVar("Self", bound="Trigger")
 
 
-class Trigger(Awaitable["Trigger"]):
-    """Base class to derive from."""
+class _CallbackHandle:
+    """TODO"""
 
-    @abstractmethod
+    # TODO Add state tracking?
+
+    def __init__(self, func: Callable[[], None], trigger: "Trigger") -> None:
+        self._func = func
+        self._trigger = trigger
+
+    def cancel(self) -> None:
+        self._trigger._deregister(self)
+
+    def _run(self) -> None:
+        self._func()
+
+
+class Trigger(Awaitable["Trigger"]):
+    """TODO"""
+
     def __init__(self) -> None:
-        self._primed = False
+        self._cb_handles: OrderedDict[_CallbackHandle, None] = OrderedDict()
 
     @cached_property
     def log(self) -> logging.Logger:
         """A :class:`logging.Logger` for the trigger."""
         return logging.getLogger(f"cocotb.{type(self).__qualname__}.0x{id(self):x}")
 
-    def _prime(self, callback: Callable[["Trigger"], None]) -> None:
-        """Set a callback to be invoked when the trigger fires.
+    @abstractmethod
+    def _prime(self) -> None: ...
 
-        The callback will be invoked with a single argument, `self`.
+    @abstractmethod
+    def _unprime(self) -> None: ...
 
-        Sub-classes must override this, but should end by calling the base class
-        method.
+    def _register(self, cb: Callable[[], None]) -> _CallbackHandle:
+        """Registers the given callback to be called when the Trigger 'fires'.
 
-        .. warning::
-            Do not call this directly within a :term:`task`. It is intended to be used
-            only by the scheduler.
+        Calls :meth:`_prime` to register the underlying Trigger mechanism if a callback is added.
+
+        Returns:
+            A cancellable handle to the given callback.
         """
-        self._primed = True
+        res = _CallbackHandle(cb, self)
+        if not self._cb_handles:
+            self._prime()
+        self._cb_handles[res] = None
+        return res
 
-    def _unprime(self) -> None:
-        """Remove the callback, and perform cleanup if necessary.
+    def _deregister(self, cb_handle: _CallbackHandle) -> None:
+        """Prevents the given callback from being called once the Trigger fires.
 
-        After being un-primed, a Trigger may be re-primed again in the future.
-        Calling `_unprime` multiple times is allowed, subsequent calls should be
-        a no-op.
+        Calls :meth:`_unprime` to deregister the underlying Trigger mechanism if all callbacks are removed.
 
-        Sub-classes may override this, but should end by calling the base class
-        method.
-
-        .. warning::
-            Do not call this directly within a :term:`task`. It is intended to be used
-            only by the scheduler.
+        Args:
+            cb_handle: The Handle to the callback previously registered.
         """
-        self._cleanup()
+        self._cb_handles.pop(cb_handle)
+        if not self._cb_handles:
+            self._unprime()
 
-    def _cleanup(self) -> None:
-        self._primed = False
+    def _fire(self) -> None:
+        """Calls all registered callbacks when the Trigger 'fires'."""
+        while self._cb_handles:
+            cb_handle, _ = self._cb_handles.popitem(last=False)
+            cb_handle._run()
 
     def __await__(self: Self) -> Generator[Any, Any, Self]:
         yield self
@@ -125,29 +146,7 @@ class Trigger(Awaitable["Trigger"]):
 
 
 class GPITrigger(Trigger):
-    """Base Trigger class for GPI triggers.
-
-    Consumes simulation time.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-
-        # Required to ensure documentation can build
-        # if simulator is not None:
-        #    self.cbhdl = simulator.create_callback(self)
-        # else:
-        self._cbhdl: Optional[simulator.gpi_cb_hdl] = None
-
-    def _unprime(self) -> None:
-        """Disable a primed trigger, can be re-primed."""
-        if self._cbhdl is not None:
-            self._cbhdl.deregister()
-        return super()._unprime()
-
-    def _cleanup(self) -> None:
-        self._cbhdl = None
-        return super()._cleanup()
+    """TODO"""
 
 
 class Timer(GPITrigger):
@@ -241,15 +240,27 @@ class Timer(GPITrigger):
         if self._sim_steps == 0:
             self._sim_steps = 1
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
-        """Register for a timed callback."""
+        self._cbhdl: Union[simulator.gpi_cb_hdl, None] = None
+
+    def _prime(self) -> None:
+        assert self._cbhdl is None
+        self._cbhdl = simulator.register_timed_callback(
+            self._sim_steps, self._fire, self
+        )
         if self._cbhdl is None:
-            self._cbhdl = simulator.register_timed_callback(
-                self._sim_steps, callback, self
-            )
-            if self._cbhdl is None:
-                raise RuntimeError(f"Unable set up {str(self)} Trigger")
-        super()._prime(callback)
+            raise RuntimeError(f"Unable set up {str(self)} Trigger")
+
+    def _unprime(self) -> None:
+        assert self._cbhdl is not None
+        self._cbhdl.deregister()
+        self._cbhdl = None
+
+    def _fire(self) -> None:
+        # start profiling
+        # set global state
+        super()._fire()
+        self._cbhdl = None
+        # end profiling
 
     def __repr__(self) -> str:
         return "<{} of {:1.2f}ps at {}>".format(
@@ -1111,3 +1122,35 @@ async def with_timeout(
         raise SimTimeoutError
     else:
         return res
+
+    # def _sim_react(self, trigger: Trigger) -> None:
+    #     """Called when a :class:`~cocotb.triggers.GPITrigger` fires.
+
+    #     This is often the entry point into Python from the simulator,
+    #     so this function is in charge of enabling profiling.
+    #     It must also track the current simulator time phase,
+    #     and start the unstarted event loop.
+    #     """
+    #     with profiling_context:
+    #         # TODO: move state tracking to global variable
+    #         # and handle this via some kind of trigger-specific Python callback
+    #         if trigger is self._read_write:
+    #             cocotb.sim_phase = cocotb.SimPhase.READ_WRITE
+    #         elif trigger is self._read_only:
+    #             cocotb.sim_phase = cocotb.SimPhase.READ_ONLY
+    #         else:
+    #             cocotb.sim_phase = cocotb.SimPhase.NORMAL
+
+    #         # apply inertial writes if ReadWrite
+    #         if trigger is self._read_write:
+    #             cocotb._write_scheduler.apply_scheduled_writes()
+
+    #         self._react(trigger)
+    #         self._event_loop()
+
+
+_current_gpi_trigger: Union[GPITrigger, None] = None
+
+
+def current_gpi_trigger() -> Union[GPITrigger, None]:
+    return _current_gpi_trigger

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -55,6 +55,7 @@ import cocotb.task
 from cocotb import simulator
 from cocotb._deprecation import deprecated
 from cocotb._outcomes import Error, Outcome, Value
+from cocotb._profiling import profiling_context
 from cocotb._py_compat import cached_property
 from cocotb._utils import ParameterizedSingletonMetaclass, remove_traceback_frames
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
@@ -76,7 +77,7 @@ Self = TypeVar("Self", bound="Trigger")
 
 
 class _CallbackHandle:
-    """TODO"""
+    """A cancellable handle to a callback registered with a Trigger."""
 
     # TODO Add state tracking?
 
@@ -87,12 +88,12 @@ class _CallbackHandle:
     def cancel(self) -> None:
         self._trigger._deregister(self)
 
-    def _run(self) -> None:
-        self._func()
-
 
 class Trigger(Awaitable["Trigger"]):
-    """TODO"""
+    """Represents a future event which can fire.
+
+    :class:`~cocotb.task.Task` can wait on a Trigger which blocks that Task until the Trigger "fires."
+    """
 
     def __init__(self) -> None:
         self._cb_handles: OrderedDict[_CallbackHandle, None] = OrderedDict()
@@ -103,10 +104,19 @@ class Trigger(Awaitable["Trigger"]):
         return logging.getLogger(f"cocotb.{type(self).__qualname__}.0x{id(self):x}")
 
     @abstractmethod
-    def _prime(self) -> None: ...
+    def _prime(self) -> None:
+        """Setup the underlying trigger mechanism.
+
+        This should set ther underlying trigger mechanism to call :meth:`_fire`.
+        """
 
     @abstractmethod
-    def _unprime(self) -> None: ...
+    def _unprime(self) -> None:
+        """Disable and cleanup the underlying trigger mechanism before it fires."""
+
+    def _cleanup(self) -> None:
+        """Cleanup the underlying trigger mechanism after it fires."""
+        pass
 
     def _register(self, cb: Callable[[], None]) -> _CallbackHandle:
         """Registers the given callback to be called when the Trigger 'fires'.
@@ -117,9 +127,10 @@ class Trigger(Awaitable["Trigger"]):
             A cancellable handle to the given callback.
         """
         res = _CallbackHandle(cb, self)
+        self._cb_handles[res] = None
+        # _prime must come after adding to _cb_handles incase _prime calls _react
         if not self._cb_handles:
             self._prime()
-        self._cb_handles[res] = None
         return res
 
     def _deregister(self, cb_handle: _CallbackHandle) -> None:
@@ -134,11 +145,12 @@ class Trigger(Awaitable["Trigger"]):
         if not self._cb_handles:
             self._unprime()
 
-    def _fire(self) -> None:
+    def _react(self) -> None:
         """Calls all registered callbacks when the Trigger 'fires'."""
         while self._cb_handles:
             cb_handle, _ = self._cb_handles.popitem(last=False)
-            cb_handle._run()
+            cb_handle._func()
+        self._cleanup()
 
     def __await__(self: Self) -> Generator[Any, Any, Self]:
         yield self
@@ -147,6 +159,25 @@ class Trigger(Awaitable["Trigger"]):
 
 class GPITrigger(Trigger):
     """TODO"""
+
+    def __init__(self) -> None:
+        self._cbhdl: Union[simulator.gpi_cb_hdl, None] = None
+
+    def _react(self) -> None:
+        with profiling_context:
+            global _current_gpi_trigger
+            _current_gpi_trigger = self
+            Trigger._react()
+            cocotb._scheduler_inst._event_loop()
+
+    # _prime in subclasses should set up _cbhdl vaiable with GPI callback handle
+
+    def _unprime(self) -> None:
+        self._cbhdl.deregister()
+        self._cbhdl = None
+
+    def _cleanup(self) -> None:
+        self._cbhdl = None
 
 
 class Timer(GPITrigger):
@@ -240,27 +271,10 @@ class Timer(GPITrigger):
         if self._sim_steps == 0:
             self._sim_steps = 1
 
-        self._cbhdl: Union[simulator.gpi_cb_hdl, None] = None
-
     def _prime(self) -> None:
-        assert self._cbhdl is None
-        self._cbhdl = simulator.register_timed_callback(
-            self._sim_steps, self._fire, self
-        )
+        self._cbhdl = simulator.register_timed_callback(self._sim_steps, self._react)
         if self._cbhdl is None:
             raise RuntimeError(f"Unable set up {str(self)} Trigger")
-
-    def _unprime(self) -> None:
-        assert self._cbhdl is not None
-        self._cbhdl.deregister()
-        self._cbhdl = None
-
-    def _fire(self) -> None:
-        # start profiling
-        # set global state
-        super()._fire()
-        self._cbhdl = None
-        # end profiling
 
     def __repr__(self) -> str:
         return "<{} of {:1.2f}ps at {}>".format(
@@ -290,19 +304,20 @@ class ReadOnly(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass)
     def __singleton_key__(cls) -> None:
         return None
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self) -> None:
+        self._cbhdl = simulator.register_readonly_callback(self._react)
+        if self._cbhdl is None:
+            raise RuntimeError(f"Unable set up {str(self)} Trigger")
+
+    def __repr__(self) -> str:
+        return f"{type(self).__qualname__}()"
+
+    def __await__(self) -> Generator[Any, Any, Self]:
         if cocotb.sim_phase is cocotb.SimPhase.READ_ONLY:
             raise RuntimeError(
                 "Attempted illegal transition: awaiting ReadOnly in ReadOnly phase"
             )
-        if self._cbhdl is None:
-            self._cbhdl = simulator.register_readonly_callback(callback, self)
-            if self._cbhdl is None:
-                raise RuntimeError(f"Unable set up {str(self)} Trigger")
-        super()._prime(callback)
-
-    def __repr__(self) -> str:
-        return f"{type(self).__qualname__}()"
+        return (yield from super().__await__())
 
 
 class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass):
@@ -312,19 +327,28 @@ class ReadWrite(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass
     def __singleton_key__(cls) -> None:
         return None
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self) -> None:
+        self._cbhdl = simulator.register_rwsynch_callback(self._react)
+        if self._cbhdl is None:
+            raise RuntimeError(f"Unable set up {str(self)} Trigger")
+
+    def _react(self) -> None:
+        with profiling_context:
+            global _current_gpi_trigger
+            _current_gpi_trigger = self
+            cocotb._write_scheduler.apply_scheduled_writes()
+            Trigger._react()
+            cocotb._scheduler_inst._event_loop()
+
+    def __repr__(self) -> str:
+        return f"{type(self).__qualname__}()"
+
+    def __await__(self) -> Generator[Any, Any, Self]:
         if cocotb.sim_phase is cocotb.SimPhase.READ_ONLY:
             raise RuntimeError(
                 "Attempted illegal transition: awaiting ReadWrite in ReadOnly phase"
             )
-        if self._cbhdl is None:
-            self._cbhdl = simulator.register_rwsynch_callback(callback, self)
-            if self._cbhdl is None:
-                raise RuntimeError(f"Unable set up {str(self)} Trigger")
-        super()._prime(callback)
-
-    def __repr__(self) -> str:
-        return f"{type(self).__qualname__}()"
+        return (yield from super().__await__())
 
 
 class NextTimeStep(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass):
@@ -334,12 +358,10 @@ class NextTimeStep(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetacl
     def __singleton_key__(cls) -> None:
         return None
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self) -> None:
+        self._cbhdl = simulator.register_nextstep_callback(self._react)
         if self._cbhdl is None:
-            self._cbhdl = simulator.register_nextstep_callback(callback, self)
-            if self._cbhdl is None:
-                raise RuntimeError(f"Unable set up {str(self)} Trigger")
-        super()._prime(callback)
+            raise RuntimeError(f"Unable set up {str(self)} Trigger")
 
     def __repr__(self) -> str:
         return f"{type(self).__qualname__}()"
@@ -354,14 +376,12 @@ class _EdgeBase(GPITrigger, metaclass=_ParameterizedSingletonGPITriggerMetaclass
         super().__init__()
         self.signal = signal
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self) -> None:
+        self._cbhdl = simulator.register_value_change_callback(
+            self.signal._handle, self._react, type(self)._edge_type
+        )
         if self._cbhdl is None:
-            self._cbhdl = simulator.register_value_change_callback(
-                self.signal._handle, callback, type(self)._edge_type, self
-            )
-            if self._cbhdl is None:
-                raise RuntimeError(f"Unable set up {str(self)} Trigger")
-        super()._prime(callback)
+            raise RuntimeError(f"Unable set up {str(self)} Trigger")
 
     def __repr__(self) -> str:
         return f"{type(self).__qualname__}({self.signal!r})"
@@ -459,18 +479,11 @@ class _Event(Trigger):
         super().__init__()
         self._parent = parent
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
-        if self._primed:
-            return
-        self._callback = callback
-        self._parent._prime_trigger(self, callback)
-        return super()._prime(callback)
+    def _prime(self) -> None:
+        self._parent._prime_trigger(self)
 
     def _unprime(self) -> None:
-        if not self._primed:
-            return
         self._parent._unprime_trigger(self)
-        return super()._unprime()
 
     def __repr__(self) -> str:
         return f"<{self._parent!r}.wait() at {_pointer_str(self)}>"
@@ -512,9 +525,7 @@ class Event:
         self.name: Optional[str] = name
         self._fired: bool = False
 
-    def _prime_trigger(
-        self, trigger: _Event, callback: Callable[[Trigger], None]
-    ) -> None:
+    def _prime_trigger(self, trigger: _Event) -> None:
         self._pending_events.append(trigger)
 
     def _unprime_trigger(self, trigger: _Event) -> None:
@@ -526,7 +537,7 @@ class Event:
 
         pending_events, self._pending_events = self._pending_events, []
         for event in pending_events:
-            event._callback(event)
+            event._react()
 
     def wait(self) -> Trigger:
         """Block the current Task until the Event is set.
@@ -573,32 +584,25 @@ class _InternalEvent(Trigger):
     def __init__(self, parent: object) -> None:
         super().__init__()
         self._parent = parent
-        self._callback: Optional[Callable[[Trigger], None]] = None
-        self.fired: bool = False
+        self._fired: bool = False
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
-        if self._callback is not None:
-            raise RuntimeError("This Trigger may only be awaited once")
-        self._callback = callback
-        super()._prime(callback)
-        if self.fired:
-            self._callback(self)
+    def _prime(self) -> None:
+        if self._fired:
+            self._react()
 
     def set(self) -> None:
         """Wake up coroutine blocked on this event."""
-        self.fired = True
-
-        if self._callback is not None:
-            self._callback(self)
+        self._fired = True
+        self._react()
 
     def is_set(self) -> bool:
         """Return true if event has been set."""
-        return self.fired
+        return self._fired
 
     def __await__(
         self: Self,
     ) -> Generator[Any, Any, Self]:
-        if self._primed:
+        if self._cb_handles:
             raise RuntimeError("Only one Task may await this Trigger")
         yield self
         return self
@@ -618,18 +622,11 @@ class _Lock(Trigger):
         super().__init__()
         self._parent = parent
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
-        if self._primed:
-            return
-        self._callback = callback
+    def _prime(self) -> None:
         self._parent._prime_lock(self)
-        return super()._prime(callback)
 
     def _unprime(self) -> None:
-        if not self._primed:
-            return
         self._parent._unprime_lock(self)
-        return super()._unprime()
 
     def __repr__(self) -> str:
         return f"<{self._parent!r}.acquire() at {_pointer_str(self)}>"
@@ -678,7 +675,7 @@ class Lock(AsyncContextManager[None]):
 
     def _acquire_and_fire(self, lock: _Lock) -> None:
         self._locked = True
-        lock._callback(lock)
+        lock._react()
 
     def _prime_lock(self, lock: _Lock) -> None:
         if not self._locked:
@@ -741,8 +738,11 @@ class NullTrigger(Trigger):
         super().__init__()
         self.name = name
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
-        callback(self)
+    def _prime(self) -> None:
+        self._react()
+
+    def _unprime(self) -> None:
+        pass
 
     def __repr__(self) -> str:
         if self.name is None:
@@ -767,11 +767,12 @@ class _Join(
         super().__init__()
         self._task = task
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self) -> None:
         if self._task.done():
-            callback(self)
-        else:
-            super()._prime(callback)
+            self._react()
+
+    def _unprime(self) -> None:
+        pass
 
     def __repr__(self) -> str:
         return f"Join({self._task!s})"
@@ -1122,31 +1123,6 @@ async def with_timeout(
         raise SimTimeoutError
     else:
         return res
-
-    # def _sim_react(self, trigger: Trigger) -> None:
-    #     """Called when a :class:`~cocotb.triggers.GPITrigger` fires.
-
-    #     This is often the entry point into Python from the simulator,
-    #     so this function is in charge of enabling profiling.
-    #     It must also track the current simulator time phase,
-    #     and start the unstarted event loop.
-    #     """
-    #     with profiling_context:
-    #         # TODO: move state tracking to global variable
-    #         # and handle this via some kind of trigger-specific Python callback
-    #         if trigger is self._read_write:
-    #             cocotb.sim_phase = cocotb.SimPhase.READ_WRITE
-    #         elif trigger is self._read_only:
-    #             cocotb.sim_phase = cocotb.SimPhase.READ_ONLY
-    #         else:
-    #             cocotb.sim_phase = cocotb.SimPhase.NORMAL
-
-    #         # apply inertial writes if ReadWrite
-    #         if trigger is self._read_write:
-    #             cocotb._write_scheduler.apply_scheduled_writes()
-
-    #         self._react(trigger)
-    #         self._event_loop()
 
 
 _current_gpi_trigger: Union[GPITrigger, None] = None


### PR DESCRIPTION
This PR reorganizes all the core components of cocotb: Triggers, Tasks, the Scheduler, and Regression Manager. The intent is to reorganize the code into a more flexible configuration for follow ons to support alternative Regression Managers, CancelledError, and support multiple kinds of Tasks for implementing TaskManagers. It will also reorganize the core components in a way that is more similar to asyncio, potentially allowing us to move to asyncio in the future to replace the Scheduler, Tasks, and base Trigger objects.

TODO
- [ ] Add more context to this PR