### PR TITLE
Disable icarus waveform output when `WAVES` disabled

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.icarus
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.icarus
@@ -74,6 +74,9 @@ ifeq ($(WAVES), 1)
     VERILOG_SOURCES += $(SIM_BUILD)/cocotb_iverilog_dump.v
     COMPILE_ARGS += -s cocotb_iverilog_dump
     FST = -fst
+else
+    # Disable waveform output
+    FST = -none
 endif
 
 $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -683,6 +683,9 @@ class Icarus(Runner):
         plusargs = self.plusargs
         if self.waves:
             plusargs += ["-fst"]
+        else:
+            # Disable waveform output
+            plusargs += ["-none"]
 
         if self.pre_cmd is not None:
             raise ValueError("WARNING: pre_cmd is not implemented for Icarus Verilog.")


### PR DESCRIPTION
When `WAVES` was disabled a waveform in the default format (vcd) was produced. This PR passes `-none` to icarus to disable waveform output.
