### PR TITLE
gpi_embed: set the program name to PYTHON_BIN

### DIFF
--- a/docs/source/newsfragments/4293.change.rst
+++ b/docs/source/newsfragments/4293.change.rst
@@ -1,0 +1,1 @@
+Python interpreter embedding is now more robust. Setting ``PYTHONHOME`` is no longer required, so simulator usage of Python scripts should no longer fail.

--- a/docs/source/newsfragments/4293.change.rst
+++ b/docs/source/newsfragments/4293.change.rst
@@ -1,1 +1,1 @@
-Python interpreter embedding is now more robust. Setting ``PYTHONHOME`` is no longer required, so simulator usage of Python scripts should no longer fail.
+Python interpreter embedding is now more robust when using Python 3.8+. Setting ``PYTHONHOME`` is no longer required, so simulator usage of Python scripts should no longer fail.

--- a/src/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/src/cocotb/share/lib/embed/gpi_embed.cpp
@@ -196,7 +196,7 @@ extern "C" COCOTB_EXPORT void _embed_init_python(void) {
     } else if (wcscmp(interpreter_path, sys_executable) != 0) {
         // LCOV_EXCL_START
         LOG_ERROR("Unexpected sys.executable value (expected '%ls', got '%ls')",
-                  sys_executable, interpreter_path);
+                  interpreter_path, sys_executable);
         return;
         // LCOV_EXCL_STOP
     }

--- a/src/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/src/cocotb/share/lib/embed/gpi_embed.cpp
@@ -64,9 +64,9 @@ static PyObject *pEventFn = NULL;
 static int get_interpreter_path(wchar_t *path, size_t path_size) {
     const char *path_c = getenv("PYGPI_PYTHON_BIN");
     if (!path_c) {
-        LOG_INFO(
-            "Did not detect Python virtual environment. "
-            "Using system-wide Python interpreter");
+        LOG_ERROR(
+            "PYGPI_PYTHON_BIN variable not set. Can't initialize Python "
+            "interpreter!");
         return -1;
     }
 

--- a/src/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/src/cocotb/share/lib/embed/gpi_embed.cpp
@@ -185,19 +185,16 @@ extern "C" COCOTB_EXPORT void _embed_init_python(void) {
     if (sys_executable_obj == NULL) {
         // LCOV_EXCL_START
         LOG_ERROR("Failed to load sys.executable");
-        return;
         // LCOV_EXCL_STOP
     } else if (PyUnicode_AsWideChar(sys_executable_obj, sys_executable,
                                     sizeof(sys_executable)) == -1) {
         // LCOV_EXCL_START
         LOG_ERROR("Failed to convert sys.executable to wide string");
-        return;
         // LCOV_EXCL_STOP
     } else if (wcscmp(interpreter_path, sys_executable) != 0) {
         // LCOV_EXCL_START
         LOG_ERROR("Unexpected sys.executable value (expected '%ls', got '%ls')",
                   interpreter_path, sys_executable);
-        return;
         // LCOV_EXCL_STOP
     }
 

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -50,24 +50,15 @@ else ifneq (, $(findstring MSYS, $(OS)))
 endif
 export OS
 
-# Detects if Python is running in a virtual environment
-# https://docs.python.org/3/library/venv.html
-IS_VENV=$(shell $(shell cocotb-config --python-bin) -c 'import sys; print(sys.prefix != sys.base_prefix)')
-
 # this ensures we use the same python as the one cocotb was installed into
 PYTHON_BIN ?= $(shell cocotb-config --python-bin)
+export PYTHON_BIN
 
 include $(shell cocotb-config --makefiles)/Makefile.deprecations
 
 PYTHON_ARCH := $(shell $(PYTHON_BIN) -c 'from platform import architecture; print(architecture()[0])')
 ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)
     $(error Unknown Python architecture: $(PYTHON_ARCH))
-endif
-
-# Changing PYTHONHOME confuses virtual environments, so only set it when not using a venv
-ifeq ($(IS_VENV),False)
-    # Set PYTHONHOME to properly populate sys.path in embedded python interpreter
-    export PYTHONHOME := $(shell $(PYTHON_BIN) -c 'import sys; print(sys.prefix)')
 endif
 
 ifeq ($(OS),Msys)

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -52,7 +52,7 @@ export OS
 
 # this ensures we use the same python as the one cocotb was installed into
 PYTHON_BIN ?= $(shell cocotb-config --python-bin)
-export PYTHON_BIN
+export PYGPI_PYTHON_BIN := $(PYTHON_BIN)
 
 include $(shell cocotb-config --makefiles)/Makefile.deprecations
 

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -162,7 +162,7 @@ class Runner(ABC):
 
         self.env["PATH"] += os.pathsep + str(cocotb_tools.config.libs_dir)
         self.env["PYTHONPATH"] = os.pathsep.join(sys.path)
-        self.env["PYTHONHOME"] = sys.prefix
+        self.env["PYGPI_PYTHON_BIN"] = sys.executable
         self.env["COCOTB_TOPLEVEL"] = self.sim_hdl_toplevel
         self.env["COCOTB_TEST_MODULES"] = self.test_module
         self.env["TOPLEVEL_LANG"] = self.hdl_toplevel_lang


### PR DESCRIPTION
See #4091.

This patch removes all special virtual environment handling, and instead of setting `PYTHONHOME`, it just sets the program name. Additionally, it uses the new Python Initialization API on >=3.8.

The previous code was setting `PYTHONHOME` to `sys.prefix`, which is wrong on, it should be `sys.base_prefix`. The home value sets the initial values of `base_prefix` and `base_exec_prefix`, which are searched for the standard library, this isn't what we want to do here. We want make sure that when running in a virtual environment, it is activated, which depends only on the executable path.

If `Py_SetProgramName` is indeed broken on Windows, then we could use the workaround I mentioned in the issue.

This also fixes the incorrect virtual env detection message, which relies on `VIRTUAL_ENV` being set, which is not guaranteed.