### PR TITLE
Add Surfer to simulator support docs

### DIFF
--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -48,7 +48,7 @@ See also https://github.com/steveicarus/iverilog/issues/323.
 Waveforms
 ---------
 
-Icarus Verilog can produce waveform traces in the FST format, the native format of GTKWave.
+Icarus Verilog can produce waveform traces in the FST format.
 FST traces are much smaller and more efficient to write than VCD.
 They can be viewed with GTKWave or with `Surfer <https://surfer-project.org/>`_.
 
@@ -128,7 +128,7 @@ To get waveforms in VCD format, add Verilator's trace option(s) to the
 To set the same options on the command line, use ``EXTRA_ARGS="--trace --trace-structs" make ...``.
 A VCD file named ``dump.vcd`` will be generated in the current directory.
 
-Verilator can produce waveform traces in the FST format, the native format of GTKWave.
+Verilator can produce waveform traces in the FST format.
 FST traces are much smaller and more efficient to write.
 They can be viewed with GTKWave or with `Surfer <https://surfer-project.org/>`_.
 

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -49,7 +49,8 @@ Waveforms
 ---------
 
 Icarus Verilog can produce waveform traces in the FST format, the native format of GTKWave.
-FST traces are much smaller and more efficient to write than VCD, but requires the use of GTKWave.
+FST traces are much smaller and more efficient to write than VCD.
+They can be viewed with GTKWave or with `Surfer <https://surfer-project.org/>`_.
 
 To enable FST tracing, set :make:var:`WAVES` to ``1``.
 
@@ -128,7 +129,8 @@ To set the same options on the command line, use ``EXTRA_ARGS="--trace --trace-s
 A VCD file named ``dump.vcd`` will be generated in the current directory.
 
 Verilator can produce waveform traces in the FST format, the native format of GTKWave.
-FST traces are much smaller and more efficient to write, but require the use of GTKWave.
+FST traces are much smaller and more efficient to write.
+They can be viewed with GTKWave or with `Surfer <https://surfer-project.org/>`_.
 
 To enable FST tracing, add ``--trace-fst`` to :make:var:`EXTRA_ARGS` as shown below.
 


### PR DESCRIPTION
This PR adds a reference to the Surfer waveform viewer to the [Simulator Support](https://docs.cocotb.org/en/stable/simulator_support.html#waveforms) documentation.

Until recently, GTKWave was the only waveform viewer capable of showing FST files.
Surfer is a new waveform viewer that focuses on extensibility and a snappy interface, and it also supports FST files.


