### PR TITLE
Disable bool cast on handles

### DIFF
--- a/docs/source/newsfragments/4296.change.rst
+++ b/docs/source/newsfragments/4296.change.rst
@@ -1,0 +1,1 @@
+``bool`` casts of :class:`cocotb.handle.SimHandleBase` subclasses will now fail, to prevent silent failures caused by the change in behavior to ``bool(handle)``. Instead use ``None`` to represent a lack of handle and ``handle is not None`` instead of the bool cast.

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -38,6 +38,7 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    NoReturn,
     Optional,
     Sequence,
     Tuple,
@@ -171,6 +172,11 @@ class SimHandleBase(ABC):
             if deffile:
                 desc += " (at " + deffile + ")"
         return type(self).__qualname__ + "(" + desc + ")"
+
+    def __bool__(self) -> NoReturn:
+        raise TypeError(
+            "This object cannot be cast to bool or used in conditionals. Use `obj is not None` check in conditionals."
+        )
 
 
 class RangeableObjectMixin(SimHandleBase):


### PR DESCRIPTION
In 1.X some handles had __bool__ casts defined as `bool(handle.value)`. This behavior is now changed and can cause silent failures. This prevents those suprises. Users should explicitly use `handle is not None` check if they wish to check to see if a handle object is present in a variable or not; and should use `bool(handle.value)` checks for the 1.X behavior.

This was changed in 1.5.0, so it's been behaving differently for a while now. I'm hoping this might help people shake out issues they've been silently not realizing for a while now.