### PR TITLE
Remove runner.check_results_file from documentation

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -61,8 +61,6 @@ Results
 
 .. autofunction:: get_results
 
-.. autofunction:: check_results_file
-
 File Utilities
 --------------
 


### PR DESCRIPTION
PR #4235 removed `check_results_file` from `runner.py` but left the
reference to it in the documentation. Remove it from the docs as well.
