### PR TITLE
Transition `ReadWrite`, `ReadOnly`, and `NextTimeStep` to regular Singletons

### DIFF
--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -281,3 +281,30 @@ else:
 
             setattr(instance, self._method.__name__, lookup)
             return lookup
+
+
+_T = TypeVar("_T", bound=type)
+_Value = TypeVar("_Value", bound=object)
+
+
+def singleton(orig_cls: _T) -> _T:
+    """Class decorator which turns a type into a Singleton type."""
+    orig_new = orig_cls.__new__
+    orig_init = orig_cls.__init__
+    instance = None
+
+    @wraps(orig_cls.__new__)
+    def __new__(cls: Type[_Value], *args: Any, **kwargs: Any) -> _Value:
+        nonlocal instance
+        if instance is None:
+            instance = orig_new(cls, *args, **kwargs)
+            orig_init(instance, *args, **kwargs)
+        return instance
+
+    @wraps(orig_cls.__init__)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    orig_cls.__new__ = __new__
+    orig_cls.__init__ = __init__
+    return orig_cls


### PR DESCRIPTION
Timing Triggers like ReadWrite, ReadOnly, NextTimeStep can have full program lifetime, so there were transitioned to typical singletons. A singleton class decorator was introduced to make this easier.