### PR TITLE
Cache calls to `get_sim_time`

### DIFF
--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -55,6 +55,7 @@ from cocotb.triggers import (
     Trigger,
     _Join,
 )
+from cocotb.utils import _get_sim_time
 
 # Sadly the Python standard logging module is very slow so it's better not to
 # make any calls by testing a boolean flag first
@@ -262,6 +263,11 @@ class Scheduler:
         and start the unstarted event loop.
         """
         with profiling_context:
+            # Invalidate get_sim_time cache
+            # Must be first as it affects all logging calls.
+            # TODO: move to GPITrigger
+            _get_sim_time.cache_clear()
+
             # TODO: move state tracking to global variable
             # and handle this via some kind of trigger-specific Python callback
             if trigger is self._read_write:

--- a/src/cocotb/_write_scheduler.py
+++ b/src/cocotb/_write_scheduler.py
@@ -74,7 +74,7 @@ else:
         if cocotb.sim_phase == cocotb.SimPhase.READ_WRITE:
             write_func(*args)
         elif cocotb.sim_phase == cocotb.SimPhase.READ_ONLY:
-            raise Exception(
+            raise RuntimeError(
                 f"Write to object {handle._name} was scheduled during a read-only sync phase."
             )
         else:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -72,7 +72,7 @@ from cocotb._xunit_reporter import XUnitReporter
 from cocotb.result import TestSuccess
 from cocotb.task import Task, _RunningTest
 from cocotb.triggers import SimTimeoutError, Timer, Trigger
-from cocotb.utils import get_sim_time
+from cocotb.utils import _get_sim_time, get_sim_time
 
 _pdb_on_exception = "COCOTB_PDB_ON_EXCEPTION" in os.environ
 
@@ -455,9 +455,15 @@ class RegressionManager:
 
     def _schedule_next_test(self, trigger: Optional[Trigger] = None) -> None:
         if trigger is not None:
-            # TODO move to Trigger object
+            # Invalidate get_sim_time cache
+            # Must be first as it affects all logging calls.
+            # TODO move to GPITrigger
+            _get_sim_time.cache_clear()
+
+            # TODO move to Timer object
             cocotb.sim_phase = cocotb.SimPhase.NORMAL
             trigger._cleanup()
+
         cocotb._write_scheduler.start_write_scheduler()
 
         self._test_task._add_done_callback(

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -48,6 +48,12 @@ def _get_simulator_precision() -> int:
     return _get_simulator_precision()
 
 
+@lru_cache(maxsize=None)
+def _get_sim_time() -> int:
+    timeh, timel = simulator.get_sim_time()
+    return timeh << 32 | timel
+
+
 # Simulator helper functions
 def get_sim_time(units: str = "step") -> int:
     """Retrieve the simulation time from the simulator.
@@ -69,14 +75,12 @@ def get_sim_time(units: str = "step") -> int:
     .. versionchanged:: 1.6.0
         Support ``'step'`` as the the *units* argument to mean "simulator time step".
     """
-    timeh, timel = simulator.get_sim_time()
+    steps = _get_sim_time()
 
-    result = timeh << 32 | timel
-
-    if units != "step":
-        result = get_time_from_sim_steps(result, units)
-
-    return result
+    if units == "step":
+        return steps
+    else:
+        return get_time_from_sim_steps(steps, units)
 
 
 @overload


### PR DESCRIPTION
This function is called on every logging call and Timer creation. It only changes value whenever control is returned to the simulator. So we cache the call and invalidate whenever a GPITrigger fires.

Also tidied up some test in test_timing_triggers because they were failing. Tests no longer assume fs precision and a couple out of date tests below are cleaned up.
