### PR TITLE
Reintroduce and deprecate `Event.data`

### DIFF
--- a/docs/source/newsfragments/3980.removal.rst
+++ b/docs/source/newsfragments/3980.removal.rst
@@ -1,0 +1,1 @@
+Deprecated the undocumented ``data`` attribute on :class:`~cocotb.triggers.Event` and corresponding argument to :meth:`.Event.set`.

--- a/docs/source/newsfragments/4079.removal.rst
+++ b/docs/source/newsfragments/4079.removal.rst
@@ -1,1 +1,0 @@
-Removed the undocumented *data* attribute on :class:`~cocotb.triggers.Event` and on the corresponding :meth:`.Event.set`.

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -28,6 +28,7 @@
 """A collection of triggers which a testbench can ``await``."""
 
 import logging
+import warnings
 from abc import abstractmethod
 from decimal import Decimal
 from fractions import Fraction
@@ -500,6 +501,23 @@ class Event:
         self._pending_events: List[_Event] = []
         self.name: Optional[str] = name
         self._fired: bool = False
+        self._data: Any = None
+
+    @property
+    @deprecated("The data field will be removed in a future release.")
+    def data(self) -> Any:
+        """The data associated with the Event.
+
+        .. deprecated:: 2.0
+            The data field will be removed in a future release.
+            Use a separate variable to store the data instead.
+        """
+        return self._data
+
+    @data.setter
+    @deprecated("The data field will be removed in a future release.")
+    def data(self, new_data: Any) -> None:
+        self._data = new_data
 
     def _prime_trigger(
         self, trigger: _Event, callback: Callable[[Trigger], None]
@@ -509,9 +527,15 @@ class Event:
     def _unprime_trigger(self, trigger: _Event) -> None:
         self._pending_events.remove(trigger)
 
-    def set(self) -> None:
+    def set(self, data: Optional[Any] = None) -> None:
         """Set the Event and unblock all Tasks blocked on this Event."""
         self._fired = True
+        if data is not None:
+            warnings.warn(
+                "The data field will be removed in a future release.",
+                DeprecationWarning,
+            )
+        self._data = data
 
         pending_events, self._pending_events = self._pending_events, []
         for event in pending_events:

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -8,7 +8,7 @@ import pytest
 
 import cocotb
 from cocotb.regression import TestFactory
-from cocotb.triggers import Join, Timer
+from cocotb.triggers import Event, Join, Timer
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 
@@ -96,3 +96,20 @@ async def test_task_join_deprecated(_) -> None:
     t = cocotb.start_soon(noop())
     with pytest.warns(DeprecationWarning, match=r"task.join\(\)"):
         await t.join()
+
+
+@cocotb.test
+async def test_event_data_deprecated(_) -> None:
+    e = Event()
+
+    with pytest.warns(DeprecationWarning):
+        e.data = 12
+
+    with pytest.warns(DeprecationWarning):
+        assert e.data == 12
+
+    with pytest.warns(DeprecationWarning):
+        e.set(42)
+
+    with pytest.warns(DeprecationWarning):
+        assert e.data == 42


### PR DESCRIPTION
Closes #3980.

Reintroduce and deprecate the `data` field in `cocotb.triggers.Event` and the corresponding argument to `Event.set` that was removed in #4079. This is in the way of a 2.0 release, but it's definitely something we don't want to support going forward (`asyncio` API compatibility).
