### PR TITLE
Allow `KeyboardInterrupt` and `SystemExit` to bubble up

### DIFF
--- a/docs/source/newsfragments/4330.change.rst
+++ b/docs/source/newsfragments/4330.change.rst
@@ -1,0 +1,1 @@
+:exc:`KeyboardInterrupt` and :exc:`SystemExit` are no longer handled by the scheduler, allowing them to end the simulation immediately.

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -446,6 +446,10 @@ class Scheduler:
             # This function runs in the scheduler thread
             try:
                 _outcome = _outcomes.Value(await task)
+            except (KeyboardInterrupt, SystemExit):
+                # Allow these to bubble up to the execution root to fail the sim immediately.
+                # This follows asyncio's behavior.
+                raise
             except BaseException as e:
                 _outcome = _outcomes.Error(e)
             event.outcome = _outcome

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -512,8 +512,6 @@ class RegressionManager:
             outcome = self._test_task._outcome
         try:
             outcome.get()
-        except (KeyboardInterrupt, SystemExit):
-            raise
         except BaseException as e:
             result = remove_traceback_frames(e, ["_test_complete", "get"])
         else:

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -157,6 +157,10 @@ class Task(Generic[ResultType]):
         except StopIteration as e:
             self._outcome = Value(e.value)
             self._state = Task._State.FINISHED
+        except (KeyboardInterrupt, SystemExit):
+            # Allow these to bubble up to the execution root to fail the sim immediately.
+            # This follows asyncio's behavior.
+            raise
         except BaseException as e:
             self._outcome = Error(remove_traceback_frames(e, ["_advance", "send"]))
             self._state = Task._State.FINISHED

--- a/tests/test_cases/test_kill_sim/Makefile
+++ b/tests/test_cases/test_kill_sim/Makefile
@@ -1,0 +1,21 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+COCOTB_TEST_MODULES := kill_sim_tests
+
+.PHONY: tests
+tests:
+	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_sys_exit
+	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_task_sys_exit
+	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_keyboard_interrupt
+	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_task_keyboard_interrupt
+
+.PHONY: test_kill_sim
+test_kill_sim:
+	$(RM) -f test_failed
+	-$(MAKE) sim
+	test ! -f $(COCOTB_RESULTS_FILE)
+	test ! -f test_failed
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_kill_sim/kill_sim_tests.py
+++ b/tests/test_cases/test_kill_sim/kill_sim_tests.py
@@ -1,0 +1,42 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import sys
+from typing import Any
+
+import cocotb
+
+
+def make_failure_file() -> None:
+    open("test_failed", "w").close()
+
+
+@cocotb.test
+async def test_sys_exit(_: Any) -> None:
+    sys.exit(1)
+    make_failure_file()
+
+
+@cocotb.test
+async def test_task_sys_exit(_: Any) -> None:
+    async def coro():
+        sys.exit(1)
+
+    await cocotb.start_soon(coro())
+    make_failure_file()
+
+
+@cocotb.test
+async def test_keyboard_interrupt(_: Any) -> None:
+    raise KeyboardInterrupt  # Analogous to Ctrl-C
+    make_failure_file()
+
+
+@cocotb.test
+async def test_task_keyboard_interrupt(_: Any) -> None:
+    async def coro():
+        raise KeyboardInterrupt  # Analogous to Ctrl-C
+
+    await cocotb.start_soon(coro())
+    make_failure_file()


### PR DESCRIPTION
Fixes #3880 in an alternative way. Currently these are "handled" as part of the Task and Test classes, but in both cases what's meant is "die now", not "handle me and maybe keep running tests". asyncio follows the same approach by special casing these two exception types.

- [x] Add tests
- [x] Add newsfrag