### PR TITLE
Highlight catastrophic failure on CI

### DIFF
--- a/src/cocotb_tools/combine_results.py
+++ b/src/cocotb_tools/combine_results.py
@@ -59,6 +59,11 @@ def main() -> int:
     args = parser.parse_args()
     rc = 0
 
+    if not os.path.isfile("results.xml"):
+        print(f"ERROR: results.xml was not written by the simulation!")
+        rc = 1
+        return rc
+
     result = ET.Element("testsuites", name=args.output_testsuites_name)
 
     input_pattern = re.compile(args.input_filename)


### PR DESCRIPTION
CI runs that have a catastrophic failure due to a dependency conflict and do not run are not being reported as failure, #4333.

Some modules are failure due the the fundamental changes between cocotb 1.9 and 2.0

In CI, the ability to catch these types of bugs early is really handy and one of the main reasons to add this.

Adding a test for the presence of the results.xml file and just exit 1 with failure.