### PR TITLE
Random fixes

### DIFF
--- a/docs/source/newsfragments/4338.feature.rst
+++ b/docs/source/newsfragments/4338.feature.rst
@@ -1,0 +1,1 @@
+The Makefile flow no longer requires that :ref:`_cocotb-config` be located on the ``PATH``. Set :envvar:`PYTHON_BIN` if the wrong Python executable is used.

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -56,13 +56,10 @@ PYTHON_BIN_RES := $(shell cocotb-config --python-bin 2>>/dev/null; echo $$?)
 PYTHON_BIN_RC := $(lastword $(PYTHON_BIN_RES))
 PYTHON_BIN := $(strip $(subst $(PYTHON_BIN_RC)QQQQ,,$(PYTHON_BIN_RES)QQQQ))
 ifneq ($(PYTHON_BIN_RC),0)
-  PYTHON_BIN := python
-  PYGPI_PYTHON_BIN := $(shell $(PYTHON_BIN) -m cocotb_tools.config --python-bin)
-else
-  PYGPI_PYTHON_BIN := $(PYTHON_BIN)
+    PYTHON_BIN := python
 endif
 
-export PYGPI_PYTHON_BIN
+export PYGPI_PYTHON_BIN := $(shell $(PYTHON_BIN) -m cocotb_tools.config --python-bin)
 
 # Directory containing the cocotb Makefiles
 COCOTB_MAKEFILES_DIR := $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)
@@ -164,10 +161,6 @@ define check_lib_order
   fi;
 endef
 
-else
-    $(warning Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.)
-endif # COCOTB_MAKEFILE_INC_INCLUDED
-
 ifneq ($(filter $(SIM),nvc ghdl verilator),)
   COCOTB_TRUST_INERTIAL_WRITES ?= 1
 else
@@ -175,3 +168,7 @@ else
 endif
 
 export COCOTB_TRUST_INERTIAL_WRITES
+
+else
+    $(warning Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.)
+endif # COCOTB_MAKEFILE_INC_INCLUDED

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -51,10 +51,20 @@ endif
 export OS
 
 # this ensures we use the same python as the one cocotb was installed into
-PYTHON_BIN ?= $(shell cocotb-config --python-bin)
-export PYGPI_PYTHON_BIN := $(PYTHON_BIN)
+# attempts to use cocotb_config entry script to get that info, falls back to "python"
+PYTHON_BIN_RES := $(shell cocotb-config --python-bin 2>>/dev/null; echo $$?)
+PYTHON_BIN_RC := $(lastword $(PYTHON_BIN_RES))
+PYTHON_BIN := $(strip $(subst $(PYTHON_BIN_RC)QQQQ,,$(PYTHON_BIN_RES)QQQQ))
+ifneq ($(PYTHON_BIN_RC),0)
+  PYTHON_BIN := python
+  PYGPI_PYTHON_BIN := $(shell $(PYTHON_BIN) -m cocotb_tools.config --python-bin)
+else
+  PYGPI_PYTHON_BIN := $(PYTHON_BIN)
+endif
 
-include $(shell cocotb-config --makefiles)/Makefile.deprecations
+export PYGPI_PYTHON_BIN
+
+include $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)/Makefile.deprecations
 
 PYTHON_ARCH := $(shell $(PYTHON_BIN) -c 'from platform import architecture; print(architecture()[0])')
 ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)
@@ -124,7 +134,7 @@ ifndef LIBPYTHON_LOC
 
 # get the path to libpython and the return code from the script
 # adapted from https://stackoverflow.com/a/24658961/6614127
-FIND_LIBPYTHON_RES := $(shell cocotb-config --libpython; echo $$?)
+FIND_LIBPYTHON_RES := $(shell $(PYTHON_BIN) -m cocotb_tools.config --libpython; echo $$?)
 FIND_LIBPYTHON_RC := $(lastword $(FIND_LIBPYTHON_RES))
 LIBPYTHON_LOC := $(strip $(subst $(FIND_LIBPYTHON_RC)QQQQ,,$(FIND_LIBPYTHON_RES)QQQQ))
 

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -64,7 +64,10 @@ endif
 
 export PYGPI_PYTHON_BIN
 
-include $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)/Makefile.deprecations
+# Directory containing the cocotb Makefiles
+COCOTB_MAKEFILES_DIR := $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)
+
+include $(COCOTB_MAKEFILES_DIR)/Makefile.deprecations
 
 PYTHON_ARCH := $(shell $(PYTHON_BIN) -c 'from platform import architecture; print(architecture()[0])')
 ifeq ($(filter $(PYTHON_ARCH),64bit 32bit),)

--- a/src/cocotb_tools/makefiles/Makefile.sim
+++ b/src/cocotb_tools/makefiles/Makefile.sim
@@ -86,11 +86,14 @@ ifeq ($(MAKECMDGOALS),help)
     $(info $(help_makevars))
     # hack to get newlines in output, see https://stackoverflow.com/a/54539610
     # NOTE: the output of the command must not include a '%' sign, otherwise the formatting will break
-    help_envvars := $(subst %,${newline},$(shell cocotb-config --help-vars | tr \\n %))
+    help_envvars := $(subst %,${newline},$(shell $(PYTHON_BIN) -m cocotb.config --help-vars | tr \\n %))
     $(info ${help_envvars})
     # is there a cleaner way to exit here?
     $(error Stopping after printing help)
 endif
+
+PYTHON_BIN ?= python
+include $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)/Makefile.inc
 
 # Default to Icarus if no simulator is defined
 SIM ?= icarus
@@ -99,7 +102,7 @@ SIM ?= icarus
 SIM_LOWERCASE := $(shell echo $(SIM) | tr A-Z a-z)
 
 # Directory containing the cocotb Makfiles
-COCOTB_MAKEFILES_DIR := $(shell cocotb-config --makefiles)
+COCOTB_MAKEFILES_DIR := $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)
 
 include $(COCOTB_MAKEFILES_DIR)/Makefile.deprecations
 

--- a/src/cocotb_tools/makefiles/Makefile.sim
+++ b/src/cocotb_tools/makefiles/Makefile.sim
@@ -101,11 +101,6 @@ SIM ?= icarus
 # Maintain backwards compatibility by supporting upper and lower case SIM variable
 SIM_LOWERCASE := $(shell echo $(SIM) | tr A-Z a-z)
 
-# Directory containing the cocotb Makfiles
-COCOTB_MAKEFILES_DIR := $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)
-
-include $(COCOTB_MAKEFILES_DIR)/Makefile.deprecations
-
 HAVE_SIMULATOR = $(shell if [ -f $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.$(SIM_LOWERCASE) ]; then echo 1; else echo 0; fi;)
 AVAILABLE_SIMULATORS = $(patsubst .%,%,$(suffix $(wildcard $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.*)))
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.activehdl
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.activehdl
@@ -4,8 +4,6 @@
 
 # Common Makefile for the Aldec Active-HDL simulator
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 CMD_BIN := vsimsa
 
 ifdef ACTIVEHDL_BIN_DIR
@@ -35,16 +33,16 @@ ACOM_ARGS += -dbg
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
     # backslashes needed because we embed in `echo` below
-    GPI_ARGS = -pli \"$(shell cocotb-config --lib-name-path vpi activehdl)\"
+    GPI_ARGS = -pli \"$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi activehdl)\"
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi activehdl):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi activehdl):cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     # backslashes needed because we embed in `echo` below
-    GPI_ARGS = -loadvhpi \"$(shell cocotb-config --lib-name-path vhpi activehdl):vhpi_startup_routines_bootstrap\"
+    GPI_ARGS = -loadvhpi \"$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi activehdl):vhpi_startup_routines_bootstrap\"
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = $(shell cocotb-config --lib-name-path vpi activehdl):cocotbvpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi activehdl):cocotbvpi_entry_point
 endif
 else
    $(error A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG))

--- a/src/cocotb_tools/makefiles/simulators/Makefile.cvc
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.cvc
@@ -25,8 +25,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 ifneq ($(VHDL_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):
@@ -63,7 +61,7 @@ endif
 $(SIM_BUILD)/sim.vvp: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) \
 	COCOTB_TESTCASE=$(call deprecate,TESTCASE,COCOTB_TESTCASE) COCOTB_TEST_FILTER=$(COCOTB_TEST_FILTER) COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +loadvpi=$(shell cocotb-config --lib-name-path vpi cvc):vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+        $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +loadvpi=$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi cvc):vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 ifeq ($(CVC_ITERP),1)
@@ -80,7 +78,7 @@ ifeq ($(CVC_ITERP),1)
     debug:  $(CUSTOM_SIM_DEPS)
 	COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) \
         COCOTB_TESTCASE=$(call deprecate,TESTCASE,COCOTB_TESTCASE) COCOTB_TEST_FILTER=$(COCOTB_TEST_FILTER) COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(SIM_CMD_PREFIX) gdb --args $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +loadvpi=$(shell cocotb-config --lib-name-path vpi cvc):vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+        $(SIM_CMD_PREFIX) gdb --args $(CMD) $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +loadvpi=$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi cvc):vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 else
     debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) \

--- a/src/cocotb_tools/makefiles/simulators/Makefile.ghdl
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.ghdl
@@ -28,8 +28,6 @@
 
 TOPLEVEL_LANG ?= vhdl
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 ifneq ($(or $(filter-out $(TOPLEVEL_LANG),vhdl),$(VERILOG_SOURCES)),)
 
 $(COCOTB_RESULTS_FILE):
@@ -104,7 +102,7 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)
 
 	COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) COCOTB_TESTCASE=$(call deprecate,TESTCASE,COCOTB_TESTCASE) COCOTB_TEST_FILTER=$(COCOTB_TEST_FILTER) COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(SIM_CMD_PREFIX) $(CMD) -r $(GHDL_ARGS) $(GHDL_RUN_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(COCOTB_TOPLEVEL) $(ARCH) --vpi=$(shell cocotb-config --lib-name-path vpi ghdl) $(SIM_ARGS) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(SIM_CMD_SUFFIX)
+	$(SIM_CMD_PREFIX) $(CMD) -r $(GHDL_ARGS) $(GHDL_RUN_ARGS) --workdir=$(SIM_BUILD) -P$(SIM_BUILD) --work=$(RTL_LIBRARY) $(COCOTB_TOPLEVEL) $(ARCH) --vpi=$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi ghdl) $(SIM_ARGS) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(SIM_CMD_SUFFIX)
 
 	$(call check_results)
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.icarus
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.icarus
@@ -29,8 +29,6 @@
 
 TOPLEVEL_LANG ?= verilog
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 ifneq ($(or $(filter-out $(TOPLEVEL_LANG),verilog),$(VHDL_SOURCES)),)
 
 $(COCOTB_RESULTS_FILE):
@@ -97,7 +95,7 @@ $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	$(RM) $(COCOTB_RESULTS_FILE)
 
 	COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) COCOTB_TESTCASE=$(call deprecate,TESTCASE,COCOTB_TESTCASE) COCOTB_TEST_FILTER=$(COCOTB_TEST_FILTER) COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(SIM_CMD_PREFIX) $(ICARUS_BIN_DIR)/vvp -M $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(FST) $(SIM_CMD_SUFFIX)
+        $(SIM_CMD_PREFIX) $(ICARUS_BIN_DIR)/vvp -M $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-dir) -m $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name vpi icarus) $(SIM_ARGS) $(EXTRA_ARGS) $(SIM_BUILD)/sim.vvp $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(FST) $(SIM_CMD_SUFFIX)
 
 	$(call check_results)
 
@@ -105,7 +103,7 @@ debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS)
 	$(RM) -r $(COCOTB_RESULTS_FILE)
 
 	COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) COCOTB_TESTCASE=$(call deprecate,TESTCASE,COCOTB_TESTCASE) COCOTB_TEST_FILTER=$(COCOTB_TEST_FILTER) COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-        $(SIM_CMD_PREFIX) gdb --args $(ICARUS_BIN_DIR)/vvp $(shell cocotb-config --lib-dir) -m $(shell cocotb-config --lib-name vpi icarus) $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(FST) $(SIM_CMD_SUFFIX)
+        $(SIM_CMD_PREFIX) gdb --args $(ICARUS_BIN_DIR)/vvp $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-dir) -m $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name vpi icarus) $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(FST) $(SIM_CMD_SUFFIX)
 
 	$(call check_results)
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.ius
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.ius
@@ -29,8 +29,6 @@
 
 # Common Makefile for Cadence Incisive
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 CMD_BIN := irun
 
 ifdef IUS_BIN_DIR
@@ -74,10 +72,10 @@ ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
-# GPI_EXTRA=$(shell cocotb-config --lib-name-path vhpi ius) if needed.
+# GPI_EXTRA=$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi ius) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if vpi library name is libvpi.so
-GPI_ARGS = -loadvpi $(shell cocotb-config --lib-name-path vpi ius):vlog_startup_routines_bootstrap
+GPI_ARGS = -loadvpi $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi ius):vlog_startup_routines_bootstrap
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     EXTRA_ARGS += -v93
@@ -85,10 +83,10 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     ROOT_LEVEL = $(COCOTB_TOPLEVEL)
 ifneq ($(VHDL_SOURCES),)
     HDL_SOURCES += $(VHDL_SOURCES)
-    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi ius):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi ius):cocotbvhpi_entry_point
 endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi ius):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi ius):cocotbvhpi_entry_point
     EXTRA_ARGS += -v93
     EXTRA_ARGS += -top $(COCOTB_TOPLEVEL)
     RTL_LIBRARY ?= $(COCOTB_TOPLEVEL)

--- a/src/cocotb_tools/makefiles/simulators/Makefile.modelsim
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.modelsim
@@ -29,4 +29,4 @@
 
 
 # Identical to Questa
-include $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)/simulators/Makefile.questa
+include $(COCOTB_MAKEFILES_DIR)/simulators/Makefile.questa

--- a/src/cocotb_tools/makefiles/simulators/Makefile.modelsim
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.modelsim
@@ -29,4 +29,4 @@
 
 
 # Identical to Questa
-include $(shell cocotb-config --makefiles)/simulators/Makefile.questa
+include $(shell $(PYTHON_BIN) -m cocotb_tools.config --makefiles)/simulators/Makefile.questa

--- a/src/cocotb_tools/makefiles/simulators/Makefile.nvc
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.nvc
@@ -2,8 +2,6 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 ifneq ($(VERILOG_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):
@@ -55,7 +53,7 @@ $(COCOTB_RESULTS_FILE): analyse $(CUSTOM_SIM_DEPS)
 	COCOTB_TESTCASE=$(call deprecate,TESTCASE,COCOTB_TESTCASE) COCOTB_TEST_FILTER=$(COCOTB_TEST_FILTER) COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	  $(SIM_CMD_PREFIX) $(CMD) $(EXTRA_ARGS) --work=$(RTL_LIBRARY):$(SIM_BUILD)/$(RTL_LIBRARY) -L $(SIM_BUILD) \
 	  -e $(COCOTB_TOPLEVEL) --no-save $(NVC_E_ARGS) \
-	  -r --load $(shell cocotb-config --lib-name-path vhpi nvc) $(TRACE) $(NVC_R_ARGS) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(SIM_CMD_SUFFIX)
+	  -r --load $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi nvc) $(TRACE) $(NVC_R_ARGS) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) $(SIM_CMD_SUFFIX)
 
 	$(call check_results)
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.questa
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.questa
@@ -27,8 +27,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 CMD_BIN := vsim
 
 ifdef MODELSIM_BIN_DIR
@@ -73,14 +71,14 @@ else
     VSIM_ARGS += -onfinish exit
 endif
 
-FLI_LIB := $(shell cocotb-config --lib-name-path fli questa)
+FLI_LIB := $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path fli questa)
 # if this target is run, then cocotb did not build the library
 $(FLI_LIB):
 	@echo -e "ERROR: cocotb was not installed with an FLI library, as the mti.h header could not be located.\n\
 	If you installed an FLI-capable simulator after cocotb, you will need to reinstall cocotb.\n\
 	Please check the cocotb documentation on ModelSim support." >&2 && exit 1
 
-VHPI_LIB := $(shell cocotb-config --lib-name-path vhpi questa)
+VHPI_LIB := $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi questa)
 
 GPI_EXTRA :=
 
@@ -99,13 +97,13 @@ else
     VSIM_ARGS += -voptargs="-access=rw+/." -foreign \"vhpi_startup_routines_bootstrap $(call to_tcl_path,$(VHPI_LIB))\"
 endif
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA :=  $(shell cocotb-config --lib-name-path vpi questa):cocotbvpi_entry_point
+    GPI_EXTRA :=  $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi questa):cocotbvpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),verilog)
-    VSIM_ARGS += -pli $(shell cocotb-config --lib-name-path vpi questa)
+    VSIM_ARGS += -pli $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi questa)
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA := $(shell cocotb-config --lib-name-path $(VHDL_GPI_INTERFACE) questa):cocotb$(VHDL_GPI_INTERFACE)_entry_point
+    GPI_EXTRA := $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path $(VHDL_GPI_INTERFACE) questa):cocotb$(VHDL_GPI_INTERFACE)_entry_point
 endif
 
 else

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -29,8 +29,6 @@
 
 # Common Makefile for Aldec Riviera-PRO simulator
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 ifeq ($(GUI),1)
     CMD_BIN := riviera
 else
@@ -77,7 +75,7 @@ else
 endif
 
 # Pass the VPI library to the Verilog compilation to get extended checking.
-ALOG_ARGS += -pli $(shell cocotb-config --lib-name-path vpi riviera)
+ALOG_ARGS += -pli $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi riviera)
 
 # Aldec-specific coverage types:
 # - (s)tatement
@@ -98,15 +96,15 @@ endif
 
 GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
-    GPI_ARGS = -pli $(shell cocotb-config --lib-name-path vpi riviera)
+    GPI_ARGS = -pli $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi riviera)
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi riviera):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi riviera):cocotbvhpi_entry_point
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_ARGS = -loadvhpi $(shell cocotb-config --lib-name-path vhpi riviera):vhpi_startup_routines_bootstrap
+    GPI_ARGS = -loadvhpi $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi riviera):vhpi_startup_routines_bootstrap
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = $(shell cocotb-config --lib-name-path vpi riviera):cocotbvpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi riviera):cocotbvpi_entry_point
 endif
 
 else

--- a/src/cocotb_tools/makefiles/simulators/Makefile.vcs
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.vcs
@@ -27,8 +27,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 ifneq ($(VHDL_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):
@@ -79,7 +77,7 @@ $(SIM_BUILD)/simv: $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(CUSTOM_COMPILE_DEPS
 	COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) \
 	$(CMD) -top $(COCOTB_TOPLEVEL) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) -debug_access+all -debug_region+cell +vpi -P pli.tab -sverilog \
 	-timescale=$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) -debug_acc+pp+f+dmptf -debug_region+cell+encrypt -load $(shell cocotb-config --lib-name-path vpi vcs) $(COMPILE_ARGS) $(VERILOG_SOURCES)
+	$(EXTRA_ARGS) -debug_acc+pp+f+dmptf -debug_region+cell+encrypt -load $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi vcs) $(COMPILE_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)

--- a/src/cocotb_tools/makefiles/simulators/Makefile.verilator
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.verilator
@@ -4,8 +4,6 @@
 
 TOPLEVEL_LANG ?= verilog
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 ifneq ($(or $(filter-out $(TOPLEVEL_LANG),verilog),$(VHDL_SOURCES)),)
 
 results.xml:
@@ -54,13 +52,13 @@ endif
 
 COMPILE_ARGS += --timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)
 
-COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o Vtop -LDFLAGS "-Wl,-rpath,$(shell cocotb-config --lib-dir) -L$(shell cocotb-config --lib-dir) -lcocotbvpi_verilator"
+COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o Vtop -LDFLAGS "-Wl,-rpath,$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-dir) -L$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-dir) -lcocotbvpi_verilator"
 
 ifdef VERILOG_INCLUDE_DIRS
   COMPILE_ARGS += $(addprefix +incdir+, $(VERILOG_INCLUDE_DIRS))
 endif
 
-VERILATOR_CPP := $(shell cocotb-config --share)/lib/verilator/verilator.cpp
+VERILATOR_CPP := $(shell $(PYTHON_BIN) -m cocotb_tools.config --share)/lib/verilator/verilator.cpp
 
 $(SIM_BUILD)/Vtop.mk: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(VERILATOR_CPP) | $(SIM_BUILD)
 	$(CMD) -cc --exe -Mdir $(SIM_BUILD) $(TOPMODULE_ARG) $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES) $(VERILATOR_CPP)

--- a/src/cocotb_tools/makefiles/simulators/Makefile.verilator
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.verilator
@@ -52,7 +52,8 @@ endif
 
 COMPILE_ARGS += --timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)
 
-COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o Vtop -LDFLAGS "-Wl,-rpath,$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-dir) -L$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-dir) -lcocotbvpi_verilator"
+_COCOTB_LIB_DIR = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-dir)
+COMPILE_ARGS += --vpi --public-flat-rw --prefix Vtop -o Vtop -LDFLAGS "-Wl,-rpath,$(_COCOTB_LIB_DIR) -L$(_COCOTB_LIB_DIR) -lcocotbvpi_verilator"
 
 ifdef VERILOG_INCLUDE_DIRS
   COMPILE_ARGS += $(addprefix +incdir+, $(VERILOG_INCLUDE_DIRS))

--- a/src/cocotb_tools/makefiles/simulators/Makefile.xcelium
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.xcelium
@@ -27,8 +27,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 # Common Makefile for Cadence Xcelium
 
 CMD_BIN := xrun
@@ -82,20 +80,20 @@ ifneq (,$(filter -timescale%,$(EXTRA_ARGS)))
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
-# GPI_EXTRA=$(shell cocotb-config --lib-name-path vhpi xcelium) if needed.
+# GPI_EXTRA=$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi xcelium) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if VPI library name is libvpi.so
-GPI_ARGS = -loadvpi $(shell cocotb-config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap
+GPI_ARGS = -loadvpi $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap
 ifeq ($(TOPLEVEL_LANG),verilog)
     HDL_SOURCES = $(VERILOG_SOURCES)
     ROOT_LEVEL = $(COCOTB_TOPLEVEL)
     EXTRA_ARGS += -top $(COCOTB_TOPLEVEL)
     ifneq ($(VHDL_SOURCES),)
         HDL_SOURCES += $(VHDL_SOURCES)
-        GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point
+        GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point
     endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_EXTRA = $(shell cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point
     EXTRA_ARGS += -top $(COCOTB_TOPLEVEL)
     # Xcelium 23.09.004 fixes cocotb issue #1076 as long as the following define
     # is set.

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -602,17 +602,14 @@ class Icarus(Runner):
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}
 
-    @staticmethod
-    def _simulator_in_path() -> None:
+    def _simulator_in_path(self) -> None:
         if shutil.which("iverilog") is None:
             raise SystemExit("ERROR: iverilog executable not found!")
 
-    @staticmethod
-    def _get_include_options(includes: Sequence[PathLike]) -> _Command:
+    def _get_include_options(self, includes: Sequence[PathLike]) -> _Command:
         return [f"-I{include}" for include in includes]
 
-    @staticmethod
-    def _get_define_options(defines: Mapping[str, object]) -> _Command:
+    def _get_define_options(self, defines: Mapping[str, object]) -> _Command:
         return [f"-D{name}={value}" for name, value in defines.items()]
 
     def _get_parameter_options(self, parameters: Mapping[str, object]) -> _Command:
@@ -736,24 +733,20 @@ class Questa(Runner):
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["fli", "vhpi"]}
 
-    @staticmethod
-    def _simulator_in_path() -> None:
+    def _simulator_in_path(self) -> None:
         if shutil.which("vsim") is None:
             raise SystemExit("ERROR: vsim executable not found!")
 
-    @staticmethod
-    def _get_include_options(includes: Sequence[PathLike]) -> _Command:
+    def _get_include_options(self, includes: Sequence[PathLike]) -> _Command:
         return [f"+incdir+{_as_tcl_value(str(include))}" for include in includes]
 
-    @staticmethod
-    def _get_define_options(defines: Mapping[str, object]) -> _Command:
+    def _get_define_options(self, defines: Mapping[str, object]) -> _Command:
         return [
             f"+define+{_as_tcl_value(name)}={_as_tcl_value(str(value))}"
             for name, value in defines.items()
         ]
 
-    @staticmethod
-    def _get_parameter_options(parameters: Mapping[str, object]) -> _Command:
+    def _get_parameter_options(self, parameters: Mapping[str, object]) -> _Command:
         return [f"-g{name}={value}" for name, value in parameters.items()]
 
     def _build_command(self) -> List[_Command]:
@@ -877,8 +870,7 @@ class Ghdl(Runner):
         if "COCOTB_TRUST_INERTIAL_WRITES" not in self.env:
             self.env["COCOTB_TRUST_INERTIAL_WRITES"] = "1"
 
-    @staticmethod
-    def _simulator_in_path() -> None:
+    def _simulator_in_path(self) -> None:
         if shutil.which("ghdl") is None:
             raise SystemExit("ERROR: ghdl executable not found!")
 
@@ -893,16 +885,13 @@ class Ghdl(Runner):
         )
         return "mcode" in result.stdout
 
-    @staticmethod
-    def _get_include_options(includes: Sequence[PathLike]) -> _Command:
+    def _get_include_options(self, includes: Sequence[PathLike]) -> _Command:
         raise RuntimeError
 
-    @staticmethod
-    def _get_define_options(defines: Mapping[str, object]) -> _Command:
+    def _get_define_options(self, defines: Mapping[str, object]) -> _Command:
         raise RuntimeError
 
-    @staticmethod
-    def _get_parameter_options(parameters: Mapping[str, object]) -> _Command:
+    def _get_parameter_options(self, parameters: Mapping[str, object]) -> _Command:
         return [f"-g{name}={value}" for name, value in parameters.items()]
 
     def _build_command(self) -> List[_Command]:
@@ -997,21 +986,17 @@ class Nvc(Runner):
         if "COCOTB_TRUST_INERTIAL_WRITES" not in self.env:
             self.env["COCOTB_TRUST_INERTIAL_WRITES"] = "1"
 
-    @staticmethod
-    def _simulator_in_path() -> None:
+    def _simulator_in_path(self) -> None:
         if shutil.which("nvc") is None:
             raise SystemExit("ERROR: nvc executable not found!")
 
-    @staticmethod
-    def _get_include_options(includes: Sequence[PathLike]) -> _Command:
+    def _get_include_options(self, includes: Sequence[PathLike]) -> _Command:
         raise RuntimeError
 
-    @staticmethod
-    def _get_define_options(defines: Mapping[str, object]) -> _Command:
+    def _get_define_options(self, defines: Mapping[str, object]) -> _Command:
         raise RuntimeError
 
-    @staticmethod
-    def _get_parameter_options(parameters: Mapping[str, object]) -> _Command:
+    def _get_parameter_options(self, parameters: Mapping[str, object]) -> _Command:
         return [f"-g{name}={value}" for name, value in parameters.items()]
 
     def _build_command(self) -> List[_Command]:
@@ -1062,24 +1047,20 @@ class Riviera(Runner):
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["vhpi"]}
 
-    @staticmethod
-    def _simulator_in_path() -> None:
+    def _simulator_in_path(self) -> None:
         if shutil.which("vsimsa") is None:
             raise SystemExit("ERROR: vsimsa executable not found!")
 
-    @staticmethod
-    def _get_include_options(includes: Sequence[PathLike]) -> _Command:
+    def _get_include_options(self, includes: Sequence[PathLike]) -> _Command:
         return [f"+incdir+{_as_tcl_value(str(include))}" for include in includes]
 
-    @staticmethod
-    def _get_define_options(defines: Mapping[str, object]) -> _Command:
+    def _get_define_options(self, defines: Mapping[str, object]) -> _Command:
         return [
             f"+define+{_as_tcl_value(name)}={_as_tcl_value(str(value))}"
             for name, value in defines.items()
         ]
 
-    @staticmethod
-    def _get_parameter_options(parameters: Mapping[str, object]) -> _Command:
+    def _get_parameter_options(self, parameters: Mapping[str, object]) -> _Command:
         return [f"-g{name}={value}" for name, value in parameters.items()]
 
     def _build_command(self) -> List[_Command]:
@@ -1223,16 +1204,13 @@ class Verilator(Runner):
             raise SystemExit("ERROR: verilator executable not found!")
         self.executable: str = executable
 
-    @staticmethod
-    def _get_include_options(includes: Sequence[PathLike]) -> _Command:
+    def _get_include_options(self, includes: Sequence[PathLike]) -> _Command:
         return [f"-I{include}" for include in includes]
 
-    @staticmethod
-    def _get_define_options(defines: Mapping[str, object]) -> _Command:
+    def _get_define_options(self, defines: Mapping[str, object]) -> _Command:
         return [f"-D{name}={value}" for name, value in defines.items()]
 
-    @staticmethod
-    def _get_parameter_options(parameters: Mapping[str, object]) -> _Command:
+    def _get_parameter_options(self, parameters: Mapping[str, object]) -> _Command:
         return [f"-G{name}={value}" for name, value in parameters.items()]
 
     def _build_command(self) -> List[_Command]:
@@ -1328,21 +1306,17 @@ class Xcelium(Runner):
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["vhpi"]}
 
-    @staticmethod
-    def _simulator_in_path() -> None:
+    def _simulator_in_path(self) -> None:
         if shutil.which("xrun") is None:
             raise SystemExit("ERROR: xrun executable not found!")
 
-    @staticmethod
-    def _get_include_options(includes: Sequence[PathLike]) -> _Command:
+    def _get_include_options(self, includes: Sequence[PathLike]) -> _Command:
         return [f"-incdir {include}" for include in includes]
 
-    @staticmethod
-    def _get_define_options(defines: Mapping[str, object]) -> _Command:
+    def _get_define_options(self, defines: Mapping[str, object]) -> _Command:
         return [f"-define {name}={value}" for name, value in defines.items()]
 
-    @staticmethod
-    def _get_parameter_options(parameters: Mapping[str, object]) -> _Command:
+    def _get_parameter_options(self, parameters: Mapping[str, object]) -> _Command:
         return [f'-gpg "{name} => {value}"' for name, value in parameters.items()]
 
     def _build_command(self) -> List[_Command]:


### PR DESCRIPTION
A collection of random small fixes for issues I saw while perusing the Makefiles.

Most important of these is the change to use `$(PYTHON_BIN) -m cocotb_tools.config` over `cocotb-config`, which should reduce the number of issues users have with entry points not being on their PATH by default. There have been a couple issues opened wrt to that.