### PR TITLE
Refactor `Join` into `TaskComplete`

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -182,7 +182,9 @@ Python Triggers
 
 .. autoclass:: cocotb.triggers.First
 
-.. autoclass:: cocotb.triggers.Join
+.. autofunction:: cocotb.triggers.Join
+
+.. autoclass:: cocotb.triggers.TaskComplete
     :members:
 
 

--- a/docs/source/newsfragments/4084.removal.rst
+++ b/docs/source/newsfragments/4084.removal.rst
@@ -1,1 +1,1 @@
-:class:`~cocotb.triggers.Join` was deprecated, use the :class:`~cocotb.task.Task` being joined directly wherever ``Join(task)`` was previously used.
+:func:`~cocotb.triggers.Join` was deprecated, use the :class:`~cocotb.task.Task` being joined directly wherever ``Join(task)`` was previously used.

--- a/docs/source/newsfragments/4341.change.rst
+++ b/docs/source/newsfragments/4341.change.rst
@@ -1,0 +1,1 @@
+:func:`~cocotb.triggers.Join` and :meth:`.Task.join` now return the Task to be joined instead of a Trigger. This preserves backwards compatibility for ``await join`` or using the result in :class:`~cocotb.triggers.First` or :class:`~cocotb.triggers.Combine`.

--- a/docs/source/newsfragments/4341.feature.rst
+++ b/docs/source/newsfragments/4341.feature.rst
@@ -1,0 +1,1 @@
+Added :class:`~cocotb.triggers.TaskComplete` Trigger and :attr:`.Task.complete` to get that Trigger for the Task. These are intended to replace :func:`~cocotb.triggers.Join` and :meth:`.Task.join` and do not return the Tasks result when ``await``\ ed.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -59,7 +59,7 @@ Deprecations and Removals
 -------------------------
 
 - ``bool(Lock())`` is deprecated. Use :meth:`~cocotb.triggers.Lock.locked` instead. (:pr:`3871`)
-- :attr:`Join.retval <cocotb.triggers.Join.retval>` is deprecated. Use :meth:`Task.result() <cocotb.task.Task.result>` to get the result of a joined Task. (:pr:`3871`)
+- ``cocotb.triggers.Join.retval`` is deprecated. Use :meth:`.Task.result` to get the result of a finished Task. (:pr:`3871`)
 - Passing the *outcome* argument to :class:`~cocotb.triggers.NullTrigger` - which allowed the user to inject arbitrary outcomes when the trigger was ``await``\ ed - is deprecated. There is no alternative. (:pr:`3871`)
 - :meth:`Event.fired <cocotb.triggers.Event.fired>` is deprecated. Use :meth:`~cocotb.triggers.Event.is_set` instead. (:pr:`3871`)
 

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -143,8 +143,7 @@ def _task_done_callback(task: "cocotb.task.Task[Any]") -> None:
     if task.cancelled():
         return
     # if there's a Task awaiting this one, don't fail
-    join = cocotb.triggers._Join(task)
-    if join in cocotb._scheduler_inst._trigger2tasks:
+    if task.complete in cocotb._scheduler_inst._trigger2tasks:
         return
     # if no failure, do nothing
     e = task.exception()

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -53,7 +53,6 @@ from cocotb.triggers import (
     ReadOnly,
     ReadWrite,
     Trigger,
-    _Join,
 )
 
 # Sadly the Python standard logging module is very slow so it's better not to
@@ -382,8 +381,8 @@ class Scheduler:
         if self._terminate:
             return
 
-        elif _Join(task) in self._trigger2tasks:
-            self._react(_Join(task))
+        elif task.complete in self._trigger2tasks:
+            self._react(task.complete)
 
     def _schedule_task_upon(self, task: Task[Any], trigger: Trigger) -> None:
         """Schedule `task` to be resumed when `trigger` fires."""
@@ -518,13 +517,13 @@ class Scheduler:
     def _trigger_from_started_task(self, result: Task) -> Trigger:
         if _debug:
             self.log.debug(f"Joining to already running task: {result}")
-        return _Join(result)
+        return result.complete
 
     def _trigger_from_unstarted_task(self, result: Task) -> Trigger:
         self._schedule_task(result)
         if _debug:
             self.log.debug(f"Scheduling unstarted task: {result!r}")
-        return _Join(result)
+        return result.complete
 
     def _trigger_from_any(self, result) -> Trigger:
         """Convert a yielded object into a Trigger instance"""

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -8,7 +8,7 @@ import pytest
 
 import cocotb
 from cocotb.regression import TestFactory
-from cocotb.triggers import Event, Join, Timer
+from cocotb.triggers import Event, First, Join, Timer
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 
@@ -80,22 +80,48 @@ async def test_string_handle_casts_deprecated(dut):
 
 @cocotb.test
 async def test_join_trigger_deprecated(_) -> None:
-    async def noop():
-        pass
+    async def returns_1():
+        return 1
 
-    t = cocotb.start_soon(noop())
+    t = cocotb.start_soon(returns_1())
     with pytest.warns(DeprecationWarning, match=r"Join\(task\)"):
-        await Join(t)
+        j = Join(t)
+    assert (await j) == 1
+
+
+@cocotb.test
+async def test_join_trigger_in_first_backwards_compat(_) -> None:
+    async def returns_1():
+        return 1
+
+    t = cocotb.start_soon(returns_1())
+    with pytest.warns(DeprecationWarning, match=r"Join\(task\)"):
+        j = Join(t)
+    res = await First(j, Timer(1))
+    assert res == 1
 
 
 @cocotb.test
 async def test_task_join_deprecated(_) -> None:
-    async def noop():
-        pass
+    async def returns_1():
+        return 1
 
-    t = cocotb.start_soon(noop())
+    t = cocotb.start_soon(returns_1())
     with pytest.warns(DeprecationWarning, match=r"task.join\(\)"):
-        await t.join()
+        j = t.join()
+    assert (await j) == 1
+
+
+@cocotb.test
+async def test_task_join_in_first_backwards_compat(_) -> None:
+    async def returns_1():
+        return 1
+
+    t = cocotb.start_soon(returns_1())
+    with pytest.warns(DeprecationWarning, match=r"task.join\(\)"):
+        j = t.join()
+    res = await First(j, Timer(1))
+    assert res == 1
 
 
 @cocotb.test

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -925,6 +925,7 @@ async def test_task_complete(_) -> None:
 
     tc = TaskComplete(task)
     assert tc is res
+    assert tc.task is task
 
     res = await tc
     assert res is task.complete


### PR DESCRIPTION
Closes #869.

Since `Join(task)` and `task.join()` behave the same as `task` when using the resulting value, these syntaxes were updated to simply return the Task. This allows the Join trigger to work like all other triggers by returning itself when awaited.

The Join trigger  was renamed to TaskComplete and is now avaiable via the `task.complete` attribute.

Storing the TaskComplete trigger on the Task means we don't need to use ParameterizedSingletonMetaclass to associate their lifetimes and preserve uniqueness.
