### PR TITLE
Fix ReST markup in docstring

### DIFF
--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -30,7 +30,7 @@ class DataValidMonitor:
     """
     Reusable Monitor of one-way control flow (data/valid) streaming data interface
 
-    Args
+    Args:
         clk: clock signal
         valid: control signal noting a transaction occured
         datas: named handles to be sampled when transaction occurs
@@ -79,7 +79,7 @@ class MatrixMultiplierTester:
     """
     Reusable checker of a matrix_multiplier instance
 
-    Args
+    Args:
         matrix_multiplier_entity: handle to an instance of matrix_multiplier
     """
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
