### PR TITLE
Require byteorder when converting LogicArray to/from bytes

### DIFF
--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -518,7 +518,7 @@ class LogicArray(ArrayLike[Logic]):
         value: Union[bytes, bytearray],
         *,
         range: Range,
-        byteorder: "Literal['big'] | Literal['little']" = "big",
+        byteorder: "Literal['big'] | Literal['little']",
     ) -> "LogicArray": ...
 
     @overload
@@ -528,7 +528,7 @@ class LogicArray(ArrayLike[Logic]):
         value: Union[bytes, bytearray],
         *,
         width: int,
-        byteorder: "Literal['big'] | Literal['little']" = "big",
+        byteorder: "Literal['big'] | Literal['little']",
     ) -> "LogicArray": ...
 
     @overload
@@ -538,7 +538,7 @@ class LogicArray(ArrayLike[Logic]):
         value: Union[bytes, bytearray],
         range: Union[Range, int, None] = None,
         *,
-        byteorder: "Literal['big'] | Literal['little']" = "big",
+        byteorder: "Literal['big'] | Literal['little']",
     ) -> "LogicArray": ...
 
     @classmethod
@@ -548,7 +548,7 @@ class LogicArray(ArrayLike[Logic]):
         range: Union[Range, int, None] = None,
         *,
         width: Union[int, None] = None,
-        byteorder: "Literal['big'] | Literal['little']" = "big",
+        byteorder: "Literal['big'] | Literal['little']",
     ) -> "LogicArray":
         """Construct a :class:`LogicArray` from :class:`bytes`.
 
@@ -725,7 +725,7 @@ class LogicArray(ArrayLike[Logic]):
 
         .. deprecated:: 2.0
         """
-        return self.to_bytes()
+        return self.to_bytes(byteorder="big")
 
     def to_unsigned(
         self,
@@ -780,7 +780,8 @@ class LogicArray(ArrayLike[Logic]):
 
     def to_bytes(
         self,
-        byteorder: "Literal['big'] | Literal['little']" = "big",
+        *,
+        byteorder: "Literal['big'] | Literal['little']",
     ) -> bytes:
         """Convert the value to bytes.
 

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -125,18 +125,20 @@ def test_logic_array_signed_conversion():
 
 
 def test_logic_array_bytes_conversion():
-    assert LogicArray.from_bytes(b"12") == LogicArray("0011000100110010")
+    assert LogicArray.from_bytes(b"12", byteorder="big") == LogicArray(
+        "0011000100110010"
+    )
 
     with pytest.raises(OverflowError):
-        LogicArray.from_bytes(b"123", Range(6, "downto", 0))
+        LogicArray.from_bytes(b"123", Range(6, "downto", 0), byteorder="big")
     with pytest.raises(OverflowError):
-        LogicArray.from_bytes(b"123", 10)
+        LogicArray.from_bytes(b"123", 10, byteorder="big")
 
     # b"1" would fit in a 7 bit LogicArray, but we do not guess if top bits are significant or not
     with pytest.raises(OverflowError):
-        LogicArray.from_bytes(b"1", Range(6, "downto", 0))
+        LogicArray.from_bytes(b"1", Range(6, "downto", 0), byteorder="big")
 
-    assert LogicArray("00101010").to_bytes() == b"\x2a"
+    assert LogicArray("00101010").to_bytes(byteorder="big") == b"\x2a"
 
 
 def test_logic_array_properties():


### PR DESCRIPTION
This was an oversight by me. This better parallels `int.from_bytes` and `int.to_bytes`.