### PR TITLE
Changes to pyuvm ecosystem test

### DIFF
--- a/.github/workflows/ecosystem-compat.yml
+++ b/.github/workflows/ecosystem-compat.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   cocotb-coverage:
     name: Test cocotb-coverage 1.2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -60,7 +60,7 @@ jobs:
 
   pyuvm:
       name: Test pyuvm 3+
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       steps:
         - name: Set up Python
           uses: actions/setup-python@v5
@@ -84,27 +84,28 @@ jobs:
         - name: Checkout pyuvm repository
           uses: actions/checkout@v4
           with:
+            path: pyuvm_clone
             repository: pyuvm/pyuvm
 
-        - name: Install the release version of cocotb-coverage
+        - name: Install the release version of pyuvm
           run: pip3 install pyuvm>=3.0.0
 
         - name: Run tests
-            # Don't run tests through tox (as present in cocotb-coverage) to be able
+            # Don't run tests through tox (as present in pyuvm) to be able
             # to override the cocotb dependency.
           run: |
             pip3 install pytest
             export SIM=icarus
-            make -C tests/cocotb_tests/run_phase sim checkclean
-            make -C tests/cocotb_tests/decorator sim checkclean
-            make -C tests/cocotb_tests/t05_base_classes sim checkclean
-            make -C tests/cocotb_tests/t08_factories sim checkclean
-            make -C tests/cocotb_tests/t09_phasing sim checkclean
-            make -C tests/cocotb_tests/t12_tlm sim checkclean
-            make -C tests/cocotb_tests/t13_components sim checkclean
-            make -C tests/cocotb_tests/config_db sim checkclean
-            make -C tests/cocotb_tests/t14_15_sequences sim checkclean
-            make -C tests/cocotb_tests/ext_classes sim checkclean
-            make -C examples/TinyALU sim checkclean
-            make -C examples/TinyALU_reg sim checkclean
-            make SIM=ghdl TOPLEVEL_LANG=vhdl -C examples/TinyALU sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/run_phase sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/decorator sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/t05_base_classes sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/t08_factories sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/t09_phasing sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/t12_tlm sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/t13_components sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/config_db sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/t14_15_sequences sim checkclean
+            make -C pyuvm_clone/tests/cocotb_tests/ext_classes sim checkclean
+            make -C pyuvm_clone/examples/TinyALU sim checkclean
+            make -C pyuvm_clone/examples/TinyALU_reg sim checkclean
+            make SIM=ghdl TOPLEVEL_LANG=vhdl -C pyuvm_clone/examples/TinyALU sim checkclean


### PR DESCRIPTION
Should fix the issue where we are accidentally using the local `pyuvm` for imports during tests rather than the installed version.

We should probably expand this to test the latest released cocotb against the latest release pyuvm, as well as cocotb master against pyuvm master.