### PR TITLE
Depend on Sphinx ~= 7.3 for the 'versionremoved' directive

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies to build the documentation
 
-Sphinx ~= 7.0
+Sphinx ~= 7.3
 breathe
 sphinx-rtd-theme >= 1.3.0
 sphinxcontrib-svg2pdfconverter[CairoSVG]


### PR DESCRIPTION
See https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionremoved

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
