### PR TITLE
Update type names in GPI

### DIFF
--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -183,6 +183,12 @@ typedef enum gpi_range_dir_e {
     GPI_RANGE_UP = 1,
 } gpi_range_dir;
 
+typedef enum gpi_edge_e {
+    GPI_RISING,
+    GPI_FALLING,
+    GPI_VALUE_CHANGE,
+} gpi_edge;
+
 // Functions for iterating over entries of a handle
 // Returns an iterator handle which can then be used in gpi_next calls
 //
@@ -244,19 +250,13 @@ GPI_EXPORT void gpi_set_signal_value_str(
     gpi_sim_hdl gpi_hdl, const char *str,
     gpi_set_action_t action);  // String of ASCII char(s)
 
-typedef enum gpi_edge {
-    GPI_RISING,
-    GPI_FALLING,
-    GPI_VALUE_CHANGE,
-} gpi_edge_e;
-
 // The callback registering functions
 GPI_EXPORT gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
                                                   void *gpi_cb_data,
                                                   uint64_t time);
 GPI_EXPORT gpi_cb_hdl gpi_register_value_change_callback(
     int (*gpi_function)(void *), void *gpi_cb_data, gpi_sim_hdl gpi_hdl,
-    gpi_edge_e edge);
+    gpi_edge edge);
 GPI_EXPORT gpi_cb_hdl
 gpi_register_readonly_callback(int (*gpi_function)(void *), void *gpi_cb_data);
 GPI_EXPORT gpi_cb_hdl

--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -177,6 +177,12 @@ typedef enum gpi_set_action_e {
     GPI_NO_DELAY = 3,
 } gpi_set_action_t;
 
+typedef enum gpi_range_dir_e {
+    GPI_RANGE_DOWN = -1,
+    GPI_RANGE_NO_DIR = 0,
+    GPI_RANGE_UP = 1,
+} gpi_range_dir;
+
 // Functions for iterating over entries of a handle
 // Returns an iterator handle which can then be used in gpi_next calls
 //
@@ -200,7 +206,7 @@ GPI_EXPORT int gpi_get_range_right(gpi_sim_hdl gpi_sim_hdl);
 
 // Returns the direction of the range constraint
 // +1 for ascending, -1 for descending, 0 for no direction
-GPI_EXPORT int gpi_get_range_dir(gpi_sim_hdl gpi_sim_hdl);
+GPI_EXPORT gpi_range_dir gpi_get_range_dir(gpi_sim_hdl gpi_sim_hdl);
 
 // Functions for querying the properties of a handle
 // Caller responsible for freeing the returned string.
@@ -243,12 +249,6 @@ typedef enum gpi_edge {
     GPI_FALLING,
     GPI_VALUE_CHANGE,
 } gpi_edge_e;
-
-typedef enum gpi_range_dir {
-    GPI_RANGE_DOWN = -1,
-    GPI_RANGE_NO_DIR = 0,
-    GPI_RANGE_UP = 1,
-} gpi_range_dir_e;
 
 // The callback registering functions
 GPI_EXPORT gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),

--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -160,7 +160,7 @@ typedef enum gpi_objtype_e {
     GPI_PACKED_STRUCTURE = 14,
     GPI_LOGIC = 15,
     GPI_LOGIC_ARRAY = 16,
-} gpi_objtype_t;
+} gpi_objtype;
 
 // When iterating, we can chose to either get child objects, drivers or loads
 typedef enum gpi_iterator_sel_e {
@@ -168,14 +168,14 @@ typedef enum gpi_iterator_sel_e {
     GPI_DRIVERS = 2,
     GPI_LOADS = 3,
     GPI_PACKAGE_SCOPES = 4,
-} gpi_iterator_sel_t;
+} gpi_iterator_sel;
 
 typedef enum gpi_set_action_e {
     GPI_DEPOSIT = 0,
     GPI_FORCE = 1,
     GPI_RELEASE = 2,
     GPI_NO_DELAY = 3,
-} gpi_set_action_t;
+} gpi_set_action;
 
 typedef enum gpi_range_dir_e {
     GPI_RANGE_DOWN = -1,
@@ -196,7 +196,7 @@ typedef enum gpi_edge_e {
 // not supported, If no objects of the requested type are found, an empty
 // iterator is returned.
 GPI_EXPORT gpi_iterator_hdl gpi_iterate(gpi_sim_hdl base,
-                                        gpi_iterator_sel_t type);
+                                        gpi_iterator_sel type);
 
 // Returns NULL when there are no more objects
 GPI_EXPORT gpi_sim_hdl gpi_next(gpi_iterator_hdl iterator);
@@ -226,7 +226,7 @@ GPI_EXPORT const char *gpi_get_signal_name_str(gpi_sim_hdl gpi_hdl);
 GPI_EXPORT const char *gpi_get_signal_type_str(gpi_sim_hdl gpi_hdl);
 
 // Returns one of the types defined above e.g. gpiMemory etc.
-GPI_EXPORT gpi_objtype_t gpi_get_object_type(gpi_sim_hdl gpi_hdl);
+GPI_EXPORT gpi_objtype gpi_get_object_type(gpi_sim_hdl gpi_hdl);
 
 // Get information about the definition of a handle
 GPI_EXPORT const char *gpi_get_definition_name(gpi_sim_hdl gpi_hdl);
@@ -240,15 +240,15 @@ GPI_EXPORT int gpi_is_indexable(gpi_sim_hdl gpi_hdl);
 
 // Functions for setting the properties of a handle
 GPI_EXPORT void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value,
-                                          gpi_set_action_t action);
+                                          gpi_set_action action);
 GPI_EXPORT void gpi_set_signal_value_int(gpi_sim_hdl gpi_hdl, int32_t value,
-                                         gpi_set_action_t action);
+                                         gpi_set_action action);
 GPI_EXPORT void gpi_set_signal_value_binstr(
     gpi_sim_hdl gpi_hdl, const char *str,
-    gpi_set_action_t action);  // String of binary char(s) [1, 0, x, z]
+    gpi_set_action action);  // String of binary char(s) [1, 0, x, z]
 GPI_EXPORT void gpi_set_signal_value_str(
     gpi_sim_hdl gpi_hdl, const char *str,
-    gpi_set_action_t action);  // String of ASCII char(s)
+    gpi_set_action action);  // String of ASCII char(s)
 
 // The callback registering functions
 GPI_EXPORT gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),

--- a/src/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/src/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -129,7 +129,7 @@ int FliSimPhaseCbHdl::arm_callback() {
 }
 
 FliSignalCbHdl::FliSignalCbHdl(GpiImplInterface* impl, FliSignalObjHdl* sig_hdl,
-                               gpi_edge_e edge)
+                               gpi_edge edge)
     : GpiCbHdl(impl),
       FliProcessCbHdl(impl),
       GpiValueCbHdl(impl, sig_hdl, edge) {

--- a/src/cocotb/share/lib/fli/FliImpl.cpp
+++ b/src/cocotb/share/lib/fli/FliImpl.cpp
@@ -278,7 +278,7 @@ GpiObjHdl *FliImpl::native_check_create(const std::string &name,
     bool search_var = false;
 
     std::string fq_name = parent->get_fullname();
-    gpi_objtype_t obj_type = parent->get_type();
+    gpi_objtype obj_type = parent->get_type();
 
     if (fq_name == "/") {
         fq_name += name;
@@ -388,7 +388,7 @@ GpiObjHdl *FliImpl::native_check_create(const std::string &name,
  *          a handle if it is
  */
 GpiObjHdl *FliImpl::native_check_create(int32_t index, GpiObjHdl *parent) {
-    gpi_objtype_t obj_type = parent->get_type();
+    gpi_objtype obj_type = parent->get_type();
 
     HANDLE hdl;
     PLI_INT32 accType;
@@ -610,7 +610,7 @@ int FliImpl::deregister_callback(GpiCbHdl *gpi_hdl) {
 }
 
 GpiIterator *FliImpl::iterate_handle(GpiObjHdl *obj_hdl,
-                                     gpi_iterator_sel_t type) {
+                                     gpi_iterator_sel type) {
     GpiIterator *new_iter = NULL;
 
     switch (type) {
@@ -771,7 +771,7 @@ GpiIterator::Status FliIterator::next_handle(std::string &name, GpiObjHdl **hdl,
 
     if (!selected) return GpiIterator::END;
 
-    gpi_objtype_t obj_type = m_parent->get_type();
+    gpi_objtype obj_type = m_parent->get_type();
     std::string parent_name = m_parent->get_name();
 
     /* We want the next object in the current mapping.

--- a/src/cocotb/share/lib/fli/FliImpl.h
+++ b/src/cocotb/share/lib/fli/FliImpl.h
@@ -70,7 +70,7 @@ class FliProcessCbHdl : public virtual GpiCbHdl {
 class FliSignalCbHdl : public FliProcessCbHdl, public GpiValueCbHdl {
   public:
     FliSignalCbHdl(GpiImplInterface *impl, FliSignalObjHdl *sig_hdl,
-                   gpi_edge_e edge);
+                   gpi_edge edge);
 
     int arm_callback() override;
     int cleanup_callback() override {
@@ -181,7 +181,7 @@ class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
 
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
-    GpiCbHdl *register_value_change_callback(gpi_edge_e edge,
+    GpiCbHdl *register_value_change_callback(gpi_edge edge,
                                              int (*function)(void *),
                                              void *cb_data) override;
 

--- a/src/cocotb/share/lib/fli/FliImpl.h
+++ b/src/cocotb/share/lib/fli/FliImpl.h
@@ -162,7 +162,7 @@ class FliObj {
 
 class FliObjHdl : public GpiObjHdl, public FliObj {
   public:
-    FliObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
+    FliObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype objtype,
               int acc_type, int acc_full_type, bool is_const = false)
         : GpiObjHdl(impl, hdl, objtype, is_const),
           FliObj(acc_type, acc_full_type) {}
@@ -173,7 +173,7 @@ class FliObjHdl : public GpiObjHdl, public FliObj {
 
 class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
   public:
-    FliSignalObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
+    FliSignalObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype objtype,
                     bool is_const, int acc_type, int acc_full_type, bool is_var)
         : GpiSignalObjHdl(impl, hdl, objtype, is_const),
           FliObj(acc_type, acc_full_type),
@@ -193,7 +193,7 @@ class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
 
 class FliValueObjHdl : public FliSignalObjHdl {
   public:
-    FliValueObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
+    FliValueObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype objtype,
                    bool is_const, int acc_type, int acc_full_type, bool is_var,
                    mtiTypeIdT valType, mtiTypeKindT typeKind)
         : FliSignalObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type,
@@ -211,12 +211,12 @@ class FliValueObjHdl : public FliSignalObjHdl {
     double get_signal_value_real() override;
     long get_signal_value_long() override;
 
-    int set_signal_value(int32_t value, gpi_set_action_t action) override;
-    int set_signal_value(double value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action action) override;
+    int set_signal_value(double value, gpi_set_action action) override;
     int set_signal_value_str(std::string &value,
-                             gpi_set_action_t action) override;
+                             gpi_set_action action) override;
     int set_signal_value_binstr(std::string &value,
-                                gpi_set_action_t action) override;
+                                gpi_set_action action) override;
 
     void *get_sub_hdl(int index);
 
@@ -235,7 +235,7 @@ class FliValueObjHdl : public FliSignalObjHdl {
 
 class FliEnumObjHdl : public FliValueObjHdl {
   public:
-    FliEnumObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
+    FliEnumObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype objtype,
                   bool is_const, int acc_type, int acc_full_type, bool is_var,
                   mtiTypeIdT valType, mtiTypeKindT typeKind)
         : FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type,
@@ -245,7 +245,7 @@ class FliEnumObjHdl : public FliValueObjHdl {
     long get_signal_value_long() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(int32_t value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action action) override;
 
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
@@ -257,7 +257,7 @@ class FliEnumObjHdl : public FliValueObjHdl {
 
 class FliLogicObjHdl : public FliValueObjHdl {
   public:
-    FliLogicObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
+    FliLogicObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype objtype,
                    bool is_const, int acc_type, int acc_full_type, bool is_var,
                    mtiTypeIdT valType, mtiTypeKindT typeKind)
         : FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type,
@@ -270,9 +270,9 @@ class FliLogicObjHdl : public FliValueObjHdl {
     const char *get_signal_value_binstr() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(int32_t value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action action) override;
     int set_signal_value_binstr(std::string &value,
-                                gpi_set_action_t action) override;
+                                gpi_set_action action) override;
 
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
@@ -286,7 +286,7 @@ class FliLogicObjHdl : public FliValueObjHdl {
 
 class FliIntObjHdl : public FliValueObjHdl {
   public:
-    FliIntObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
+    FliIntObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype objtype,
                  bool is_const, int acc_type, int acc_full_type, bool is_var,
                  mtiTypeIdT valType, mtiTypeKindT typeKind)
         : FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type,
@@ -296,7 +296,7 @@ class FliIntObjHdl : public FliValueObjHdl {
     long get_signal_value_long() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(int32_t value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action action) override;
 
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
@@ -304,7 +304,7 @@ class FliIntObjHdl : public FliValueObjHdl {
 
 class FliRealObjHdl : public FliValueObjHdl {
   public:
-    FliRealObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
+    FliRealObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype objtype,
                   bool is_const, int acc_type, int acc_full_type, bool is_var,
                   mtiTypeIdT valType, mtiTypeKindT typeKind)
         : FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type,
@@ -317,7 +317,7 @@ class FliRealObjHdl : public FliValueObjHdl {
     double get_signal_value_real() override;
 
     using FliValueObjHdl::set_signal_value;
-    int set_signal_value(double value, gpi_set_action_t action) override;
+    int set_signal_value(double value, gpi_set_action action) override;
 
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
@@ -328,7 +328,7 @@ class FliRealObjHdl : public FliValueObjHdl {
 
 class FliStringObjHdl : public FliValueObjHdl {
   public:
-    FliStringObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype,
+    FliStringObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype objtype,
                     bool is_const, int acc_type, int acc_full_type, bool is_var,
                     mtiTypeIdT valType, mtiTypeKindT typeKind)
         : FliValueObjHdl(impl, hdl, objtype, is_const, acc_type, acc_full_type,
@@ -342,7 +342,7 @@ class FliStringObjHdl : public FliValueObjHdl {
 
     using FliValueObjHdl::set_signal_value;
     int set_signal_value_str(std::string &value,
-                             gpi_set_action_t action) override;
+                             gpi_set_action action) override;
 
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
@@ -422,7 +422,7 @@ class FliImpl : public GpiImplInterface {
     GpiObjHdl *native_check_create(void *raw_hdl, GpiObjHdl *paret) override;
     GpiObjHdl *get_root_handle(const char *name) override;
     GpiIterator *iterate_handle(GpiObjHdl *obj_hdl,
-                                gpi_iterator_sel_t type) override;
+                                gpi_iterator_sel type) override;
 
     /* Callback related, these may (will) return the same handle*/
     GpiCbHdl *register_timed_callback(uint64_t time, int (*function)(void *),

--- a/src/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/src/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -135,7 +135,7 @@ long FliValueObjHdl::get_signal_value_long() {
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value(int32_t, gpi_set_action_t) {
+int FliValueObjHdl::set_signal_value(int32_t, gpi_set_action) {
     LOG_ERROR(
         "Setting signal/variable value via int32_t not supported for %s of "
         "type %d",
@@ -143,7 +143,7 @@ int FliValueObjHdl::set_signal_value(int32_t, gpi_set_action_t) {
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value_binstr(std::string &, gpi_set_action_t) {
+int FliValueObjHdl::set_signal_value_binstr(std::string &, gpi_set_action) {
     LOG_ERROR(
         "Setting signal/variable value via string not supported for %s of type "
         "%d",
@@ -151,7 +151,7 @@ int FliValueObjHdl::set_signal_value_binstr(std::string &, gpi_set_action_t) {
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value_str(std::string &, gpi_set_action_t) {
+int FliValueObjHdl::set_signal_value_str(std::string &, gpi_set_action) {
     LOG_ERROR(
         "Setting signal/variable value via string not supported for %s of type "
         "%d",
@@ -159,7 +159,7 @@ int FliValueObjHdl::set_signal_value_str(std::string &, gpi_set_action_t) {
     return -1;
 }
 
-int FliValueObjHdl::set_signal_value(double, gpi_set_action_t) {
+int FliValueObjHdl::set_signal_value(double, gpi_set_action) {
     LOG_ERROR(
         "Setting signal/variable value via double not supported for %s of type "
         "%d",
@@ -220,7 +220,7 @@ long FliEnumObjHdl::get_signal_value_long() {
 }
 
 int FliEnumObjHdl::set_signal_value(const int32_t value,
-                                    const gpi_set_action_t action) {
+                                    const gpi_set_action action) {
     if (value > m_num_enum || value < 0) {
         LOG_ERROR(
             "Attempted to set an enum with range [0,%d] with invalid value %d!",
@@ -345,7 +345,7 @@ const char *FliLogicObjHdl::get_signal_value_binstr() {
 }
 
 int FliLogicObjHdl::set_signal_value(const int32_t value,
-                                     const gpi_set_action_t action) {
+                                     const gpi_set_action action) {
     if (m_fli_type == MTI_TYPE_ENUM) {
         mtiInt32T enumVal = value ? m_enum_map['1'] : m_enum_map['0'];
 
@@ -441,7 +441,7 @@ int FliLogicObjHdl::set_signal_value(const int32_t value,
 }
 
 int FliLogicObjHdl::set_signal_value_binstr(std::string &value,
-                                            const gpi_set_action_t action) {
+                                            const gpi_set_action action) {
     if (m_fli_type == MTI_TYPE_ENUM) {
         if (value.length() != 1) {
             LOG_ERROR(
@@ -594,7 +594,7 @@ long FliIntObjHdl::get_signal_value_long() {
 }
 
 int FliIntObjHdl::set_signal_value(const int32_t value,
-                                   const gpi_set_action_t action) {
+                                   const gpi_set_action action) {
     if (m_is_var) {
         switch (action) {
             case GPI_DEPOSIT:
@@ -663,7 +663,7 @@ double FliRealObjHdl::get_signal_value_real() {
 }
 
 int FliRealObjHdl::set_signal_value(const double value,
-                                    const gpi_set_action_t action) {
+                                    const gpi_set_action action) {
     m_mti_buff[0] = value;
 
     if (m_is_var) {
@@ -737,7 +737,7 @@ const char *FliStringObjHdl::get_signal_value_str() {
 }
 
 int FliStringObjHdl::set_signal_value_str(std::string &value,
-                                          const gpi_set_action_t action) {
+                                          const gpi_set_action action) {
     strncpy(m_mti_buff, value.c_str(), static_cast<size_t>(m_num_elems));
 
     if (m_is_var) {

--- a/src/cocotb/share/lib/fli/FliObjHdl.cpp
+++ b/src/cocotb/share/lib/fli/FliObjHdl.cpp
@@ -38,7 +38,7 @@ using std::abs;
 using std::to_string;
 
 GpiCbHdl *FliSignalObjHdl::register_value_change_callback(
-    gpi_edge_e edge, int (*function)(void *), void *cb_data) {
+    gpi_edge edge, int (*function)(void *), void *cb_data) {
     if (m_is_var) {
         return NULL;
     }

--- a/src/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -98,7 +98,7 @@ int GpiCbHdl::set_user_data(int (*_gpi_function)(void *), void *data) {
 }
 
 GpiValueCbHdl::GpiValueCbHdl(GpiImplInterface *impl, GpiSignalObjHdl *signal,
-                             gpi_edge_e edge)
+                             gpi_edge edge)
     : GpiCbHdl(impl), m_signal(signal) {
     switch (edge) {
         case GPI_RISING: {

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -546,7 +546,7 @@ gpi_range_dir gpi_get_range_dir(gpi_sim_hdl obj_hdl) {
 gpi_cb_hdl gpi_register_value_change_callback(int (*gpi_function)(void *),
                                               void *gpi_cb_data,
                                               gpi_sim_hdl sig_hdl,
-                                              gpi_edge_e edge) {
+                                              gpi_edge edge) {
     GpiSignalObjHdl *signal_hdl = static_cast<GpiSignalObjHdl *>(sig_hdl);
 
     /* Do something based on int & GPI_RISING | GPI_FALLING */

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -373,7 +373,7 @@ gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl base, int32_t index) {
     }
 }
 
-gpi_iterator_hdl gpi_iterate(gpi_sim_hdl obj_hdl, gpi_iterator_sel_t type) {
+gpi_iterator_hdl gpi_iterate(gpi_sim_hdl obj_hdl, gpi_iterator_sel type) {
     if (type == GPI_PACKAGE_SCOPES) {
         if (obj_hdl != NULL) {
             LOG_ERROR("Cannot iterate over package from non-NULL handles");
@@ -488,7 +488,7 @@ const char *gpi_get_signal_type_str(gpi_sim_hdl obj_hdl) {
     return obj_hdl->get_type_str();
 }
 
-gpi_objtype_t gpi_get_object_type(gpi_sim_hdl obj_hdl) {
+gpi_objtype gpi_get_object_type(gpi_sim_hdl obj_hdl) {
     return obj_hdl->get_type();
 }
 
@@ -503,28 +503,28 @@ int gpi_is_indexable(gpi_sim_hdl obj_hdl) {
 }
 
 void gpi_set_signal_value_int(gpi_sim_hdl sig_hdl, int32_t value,
-                              gpi_set_action_t action) {
+                              gpi_set_action action) {
     GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl *>(sig_hdl);
 
     obj_hdl->set_signal_value(value, action);
 }
 
 void gpi_set_signal_value_binstr(gpi_sim_hdl sig_hdl, const char *binstr,
-                                 gpi_set_action_t action) {
+                                 gpi_set_action action) {
     std::string value = binstr;
     GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl *>(sig_hdl);
     obj_hdl->set_signal_value_binstr(value, action);
 }
 
 void gpi_set_signal_value_str(gpi_sim_hdl sig_hdl, const char *str,
-                              gpi_set_action_t action) {
+                              gpi_set_action action) {
     std::string value = str;
     GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl *>(sig_hdl);
     obj_hdl->set_signal_value_str(value, action);
 }
 
 void gpi_set_signal_value_real(gpi_sim_hdl sig_hdl, double value,
-                               gpi_set_action_t action) {
+                               gpi_set_action action) {
     GpiSignalObjHdl *obj_hdl = static_cast<GpiSignalObjHdl *>(sig_hdl);
     obj_hdl->set_signal_value(value, action);
 }

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <vector>
 
+#include "gpi.h"
 #include "gpi_priv.h"
 
 using namespace std;
@@ -538,8 +539,8 @@ int gpi_get_range_right(gpi_sim_hdl obj_hdl) {
     return obj_hdl->get_range_right();
 }
 
-int gpi_get_range_dir(gpi_sim_hdl obj_hdl) {
-    return static_cast<int>(obj_hdl->get_range_dir());
+gpi_range_dir gpi_get_range_dir(gpi_sim_hdl obj_hdl) {
+    return obj_hdl->get_range_dir();
 }
 
 gpi_cb_hdl gpi_register_value_change_callback(int (*gpi_function)(void *),

--- a/src/cocotb/share/lib/gpi/gpi_priv.h
+++ b/src/cocotb/share/lib/gpi/gpi_priv.h
@@ -89,7 +89,7 @@ class GPI_EXPORT GpiHdl {
 class GPI_EXPORT GpiObjHdl : public GpiHdl {
   public:
     GpiObjHdl(GpiImplInterface *impl, void *hdl = nullptr,
-              gpi_objtype_t objtype = GPI_UNKNOWN, bool is_const = false)
+              gpi_objtype objtype = GPI_UNKNOWN, bool is_const = false)
         : GpiHdl(impl, hdl), m_type(objtype), m_const(is_const) {}
 
     virtual ~GpiObjHdl() = default;
@@ -97,7 +97,7 @@ class GPI_EXPORT GpiObjHdl : public GpiHdl {
     virtual const char *get_name_str();
     virtual const char *get_fullname_str();
     virtual const char *get_type_str();
-    gpi_objtype_t get_type() { return m_type; };
+    gpi_objtype get_type() { return m_type; };
     bool get_const() { return m_const; };
     int get_num_elems() {
         LOG_DEBUG("%s has %d elements", m_name.c_str(), m_num_elems);
@@ -137,7 +137,7 @@ class GPI_EXPORT GpiObjHdl : public GpiHdl {
     std::string m_definition_name;
     std::string m_definition_file;
 
-    gpi_objtype_t m_type;
+    gpi_objtype m_type;
     bool m_const;
 };
 
@@ -159,13 +159,12 @@ class GPI_EXPORT GpiSignalObjHdl : public GpiObjHdl {
     int m_length = 0;
 
     virtual int set_signal_value(const int32_t value,
-                                 gpi_set_action_t action) = 0;
-    virtual int set_signal_value(const double value,
-                                 gpi_set_action_t action) = 0;
+                                 gpi_set_action action) = 0;
+    virtual int set_signal_value(const double value, gpi_set_action action) = 0;
     virtual int set_signal_value_str(std::string &value,
-                                     gpi_set_action_t action) = 0;
+                                     gpi_set_action action) = 0;
     virtual int set_signal_value_binstr(std::string &value,
-                                        gpi_set_action_t action) = 0;
+                                        gpi_set_action action) = 0;
     // virtual GpiCbHdl monitor_value(bool rising_edge) = 0; this was for the
     // triggers
     // but the explicit ones are probably better
@@ -262,7 +261,7 @@ class GPI_EXPORT GpiImplInterface {
                                            GpiObjHdl *parent) = 0;
     virtual GpiObjHdl *get_root_handle(const char *name) = 0;
     virtual GpiIterator *iterate_handle(GpiObjHdl *obj_hdl,
-                                        gpi_iterator_sel_t type) = 0;
+                                        gpi_iterator_sel type) = 0;
 
     /* Callback related, these may (will) return the same handle */
     virtual GpiCbHdl *register_timed_callback(uint64_t time,

--- a/src/cocotb/share/lib/gpi/gpi_priv.h
+++ b/src/cocotb/share/lib/gpi/gpi_priv.h
@@ -171,7 +171,7 @@ class GPI_EXPORT GpiSignalObjHdl : public GpiObjHdl {
     // but the explicit ones are probably better
 
     virtual GpiCbHdl *register_value_change_callback(
-        gpi_edge_e edge, int (*gpi_function)(void *), void *gpi_cb_data) = 0;
+        gpi_edge edge, int (*gpi_function)(void *), void *gpi_cb_data) = 0;
 };
 
 /* GPI Callback handle */
@@ -205,7 +205,7 @@ class GPI_EXPORT GpiCbHdl : public GpiHdl {
 class GPI_EXPORT GpiValueCbHdl : public virtual GpiCbHdl {
   public:
     GpiValueCbHdl(GpiImplInterface *impl, GpiSignalObjHdl *signal,
-                  gpi_edge_e edge);
+                  gpi_edge edge);
     int run_callback() override;
 
   protected:

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -487,7 +487,7 @@ static PyObject *iterate(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args) {
         return NULL;
     }
 
-    gpi_iterator_hdl result = gpi_iterate(self->hdl, (gpi_iterator_sel_t)type);
+    gpi_iterator_hdl result = gpi_iterate(self->hdl, (gpi_iterator_sel)type);
 
     return gpi_hdl_New(result);
 }
@@ -554,7 +554,7 @@ static PyObject *get_signal_val_long(gpi_hdl_Object<gpi_sim_hdl> *self,
 static PyObject *set_signal_val_binstr(gpi_hdl_Object<gpi_sim_hdl> *self,
                                        PyObject *args) {
     const char *binstr;
-    gpi_set_action_t action;
+    gpi_set_action action;
 
     if (!PyArg_ParseTuple(args, "is:set_signal_val_binstr", &action, &binstr)) {
         return NULL;
@@ -566,7 +566,7 @@ static PyObject *set_signal_val_binstr(gpi_hdl_Object<gpi_sim_hdl> *self,
 
 static PyObject *set_signal_val_str(gpi_hdl_Object<gpi_sim_hdl> *self,
                                     PyObject *args) {
-    gpi_set_action_t action;
+    gpi_set_action action;
     const char *str;
 
     if (!PyArg_ParseTuple(args, "iy:set_signal_val_str", &action, &str)) {
@@ -580,7 +580,7 @@ static PyObject *set_signal_val_str(gpi_hdl_Object<gpi_sim_hdl> *self,
 static PyObject *set_signal_val_real(gpi_hdl_Object<gpi_sim_hdl> *self,
                                      PyObject *args) {
     double value;
-    gpi_set_action_t action;
+    gpi_set_action action;
 
     if (!PyArg_ParseTuple(args, "id:set_signal_val_real", &action, &value)) {
         return NULL;
@@ -593,7 +593,7 @@ static PyObject *set_signal_val_real(gpi_hdl_Object<gpi_sim_hdl> *self,
 static PyObject *set_signal_val_int(gpi_hdl_Object<gpi_sim_hdl> *self,
                                     PyObject *args) {
     long long value;
-    gpi_set_action_t action;
+    gpi_set_action action;
 
     if (!PyArg_ParseTuple(args, "iL:set_signal_val_int", &action, &value)) {
         return NULL;
@@ -668,7 +668,7 @@ static PyObject *get_name_string(gpi_hdl_Object<gpi_sim_hdl> *self,
 }
 
 static PyObject *get_type(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *) {
-    gpi_objtype_t result = gpi_get_object_type(self->hdl);
+    gpi_objtype result = gpi_get_object_type(self->hdl);
     return PyLong_FromLong(result);
 }
 

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -461,7 +461,7 @@ static PyObject *register_value_change_callback(
     Py_INCREF(function);
 
     PyObject *pedge = PyTuple_GetItem(args, 2);
-    gpi_edge_e edge = (gpi_edge_e)PyLong_AsLong(pedge);
+    gpi_edge edge = (gpi_edge)PyLong_AsLong(pedge);
 
     // Remaining args for function
     PyObject *fArgs = PyTuple_GetSlice(args, 3, numargs);  // New reference

--- a/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -181,7 +181,7 @@ bool get_range(vhpiHandleT hdl, vhpiIntT dim, int *left, int *right,
     return error;
 }
 
-vhpiPutValueModeT map_put_value_mode(gpi_set_action_t action) {
+vhpiPutValueModeT map_put_value_mode(gpi_set_action action) {
     vhpiPutValueModeT put_value_mode = vhpiDeposit;
     switch (action) {
         case GPI_DEPOSIT:
@@ -542,7 +542,7 @@ vhpiEnumT VhpiSignalObjHdl::chr2vhpi(const char value) {
 
 // Value related functions
 int VhpiLogicSignalObjHdl::set_signal_value(int32_t value,
-                                            gpi_set_action_t action) {
+                                            gpi_set_action action) {
     switch (m_value.format) {
         case vhpiEnumVal:
         case vhpiLogicVal: {
@@ -578,7 +578,7 @@ int VhpiLogicSignalObjHdl::set_signal_value(int32_t value,
 }
 
 int VhpiLogicSignalObjHdl::set_signal_value_binstr(std::string &value,
-                                                   gpi_set_action_t action) {
+                                                   gpi_set_action action) {
     switch (m_value.format) {
         case vhpiEnumVal:
         case vhpiLogicVal: {
@@ -626,7 +626,7 @@ int VhpiLogicSignalObjHdl::set_signal_value_binstr(std::string &value,
 }
 
 // Value related functions
-int VhpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action_t action) {
+int VhpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action action) {
     switch (m_value.format) {
         case vhpiEnumVecVal:
         case vhpiLogicVecVal: {
@@ -684,7 +684,7 @@ int VhpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action_t action) {
     return 0;
 }
 
-int VhpiSignalObjHdl::set_signal_value(double value, gpi_set_action_t action) {
+int VhpiSignalObjHdl::set_signal_value(double value, gpi_set_action action) {
     switch (m_value.format) {
         case vhpiRealVal:
             m_value.numElems = 1;
@@ -710,7 +710,7 @@ int VhpiSignalObjHdl::set_signal_value(double value, gpi_set_action_t action) {
 }
 
 int VhpiSignalObjHdl::set_signal_value_binstr(std::string &value,
-                                              gpi_set_action_t action) {
+                                              gpi_set_action action) {
     switch (m_value.format) {
         case vhpiEnumVal:
         case vhpiLogicVal: {
@@ -759,7 +759,7 @@ int VhpiSignalObjHdl::set_signal_value_binstr(std::string &value,
 }
 
 int VhpiSignalObjHdl::set_signal_value_str(std::string &value,
-                                           gpi_set_action_t action) {
+                                           gpi_set_action action) {
     switch (m_value.format) {
         case vhpiStrVal: {
             std::vector<char> writable(value.begin(), value.end());
@@ -1092,7 +1092,7 @@ GpiIterator::Status VhpiIterator::next_handle(std::string &name,
 
     if (!selected) return GpiIterator::END;
 
-    gpi_objtype_t obj_type = m_parent->get_type();
+    gpi_objtype obj_type = m_parent->get_type();
     std::string parent_name = m_parent->get_name();
 
     /* We want the next object in the current mapping.

--- a/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -864,7 +864,7 @@ long VhpiSignalObjHdl::get_signal_value_long() {
 }
 
 GpiCbHdl *VhpiSignalObjHdl::register_value_change_callback(
-    gpi_edge_e edge, int (*function)(void *), void *cb_data) {
+    gpi_edge edge, int (*function)(void *), void *cb_data) {
     VhpiValueCbHdl *cb = new VhpiValueCbHdl(m_impl, this, edge);
     cb->set_user_data(function, cb_data);
     if (cb->arm_callback()) {
@@ -874,7 +874,7 @@ GpiCbHdl *VhpiSignalObjHdl::register_value_change_callback(
 }
 
 VhpiValueCbHdl::VhpiValueCbHdl(GpiImplInterface *impl, VhpiSignalObjHdl *sig,
-                               gpi_edge_e edge)
+                               gpi_edge edge)
     : GpiCbHdl(impl), VhpiCbHdl(impl), GpiValueCbHdl(impl, sig, edge) {
     cb_data.reason = vhpiCbValueChange;
     cb_data.time = &vhpi_time;

--- a/src/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -283,7 +283,7 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl,
                                                 const std::string &name,
                                                 const std::string &fq_name) {
     vhpiIntT type;
-    gpi_objtype_t gpi_type;
+    gpi_objtype gpi_type;
     GpiObjHdl *new_obj = NULL;
 
     if (vhpiVerilog == (type = vhpi_get(vhpiKindP, new_hdl))) {
@@ -615,7 +615,7 @@ GpiObjHdl *VhpiImpl::native_check_create(int32_t index, GpiObjHdl *parent) {
     char buff[14];  // needs to be large enough to hold -2^31 to 2^31-1 in
                     // string form ('(''-'10+'')'\0')
 
-    gpi_objtype_t obj_type = parent->get_type();
+    gpi_objtype obj_type = parent->get_type();
 
     if (obj_type == GPI_GENARRAY) {
         LOG_DEBUG(
@@ -966,7 +966,7 @@ GpiObjHdl *VhpiImpl::get_root_handle(const char *name) {
 }
 
 GpiIterator *VhpiImpl::iterate_handle(GpiObjHdl *obj_hdl,
-                                      gpi_iterator_sel_t type) {
+                                      gpi_iterator_sel type) {
     GpiIterator *new_iter = NULL;
 
     switch (type) {

--- a/src/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -116,7 +116,7 @@ class VhpiSignalObjHdl;
 class VhpiValueCbHdl : public VhpiCbHdl, public GpiValueCbHdl {
   public:
     VhpiValueCbHdl(GpiImplInterface *impl, VhpiSignalObjHdl *sig,
-                   gpi_edge_e edge);
+                   gpi_edge edge);
     int cleanup_callback() override { return VhpiCbHdl::cleanup_callback(); }
 
   private:
@@ -210,7 +210,7 @@ class VhpiSignalObjHdl : public GpiSignalObjHdl {
     /* Value change callback accessor */
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
-    GpiCbHdl *register_value_change_callback(gpi_edge_e edge,
+    GpiCbHdl *register_value_change_callback(gpi_edge edge,
                                              int (*function)(void *),
                                              void *cb_data) override;
 

--- a/src/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -169,7 +169,7 @@ class VhpiReadWriteCbHdl : public VhpiCbHdl {
 class VhpiArrayObjHdl : public GpiObjHdl {
   public:
     VhpiArrayObjHdl(GpiImplInterface *impl, vhpiHandleT hdl,
-                    gpi_objtype_t objtype)
+                    gpi_objtype objtype)
         : GpiObjHdl(impl, hdl, objtype) {}
     ~VhpiArrayObjHdl() override;
 
@@ -179,7 +179,7 @@ class VhpiArrayObjHdl : public GpiObjHdl {
 
 class VhpiObjHdl : public GpiObjHdl {
   public:
-    VhpiObjHdl(GpiImplInterface *impl, vhpiHandleT hdl, gpi_objtype_t objtype)
+    VhpiObjHdl(GpiImplInterface *impl, vhpiHandleT hdl, gpi_objtype objtype)
         : GpiObjHdl(impl, hdl, objtype) {}
     ~VhpiObjHdl() override;
 
@@ -190,7 +190,7 @@ class VhpiObjHdl : public GpiObjHdl {
 class VhpiSignalObjHdl : public GpiSignalObjHdl {
   public:
     VhpiSignalObjHdl(GpiImplInterface *impl, vhpiHandleT hdl,
-                     gpi_objtype_t objtype, bool is_const)
+                     gpi_objtype objtype, bool is_const)
         : GpiSignalObjHdl(impl, hdl, objtype, is_const) {}
     ~VhpiSignalObjHdl() override;
 
@@ -200,12 +200,12 @@ class VhpiSignalObjHdl : public GpiSignalObjHdl {
     long get_signal_value_long() override;
 
     using GpiSignalObjHdl::set_signal_value;
-    int set_signal_value(int32_t value, gpi_set_action_t action) override;
-    int set_signal_value(double value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action action) override;
+    int set_signal_value(double value, gpi_set_action action) override;
     int set_signal_value_str(std::string &value,
-                             gpi_set_action_t action) override;
+                             gpi_set_action action) override;
     int set_signal_value_binstr(std::string &value,
-                                gpi_set_action_t action) override;
+                                gpi_set_action action) override;
 
     /* Value change callback accessor */
     int initialise(const std::string &name,
@@ -223,13 +223,13 @@ class VhpiSignalObjHdl : public GpiSignalObjHdl {
 class VhpiLogicSignalObjHdl : public VhpiSignalObjHdl {
   public:
     VhpiLogicSignalObjHdl(GpiImplInterface *impl, vhpiHandleT hdl,
-                          gpi_objtype_t objtype, bool is_const)
+                          gpi_objtype objtype, bool is_const)
         : VhpiSignalObjHdl(impl, hdl, objtype, is_const) {}
 
     using GpiSignalObjHdl::set_signal_value;
-    int set_signal_value(int32_t value, gpi_set_action_t action) override;
+    int set_signal_value(int32_t value, gpi_set_action action) override;
     int set_signal_value_binstr(std::string &value,
-                                gpi_set_action_t action) override;
+                                gpi_set_action action) override;
 
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
@@ -271,7 +271,7 @@ class VhpiImpl : public GpiImplInterface {
     /* Hierachy related */
     GpiObjHdl *get_root_handle(const char *name) override;
     GpiIterator *iterate_handle(GpiObjHdl *obj_hdl,
-                                gpi_iterator_sel_t type) override;
+                                gpi_iterator_sel type) override;
 
     /* Callback related, these may (will) return the same handle*/
     GpiCbHdl *register_timed_callback(uint64_t time, int (*function)(void *),

--- a/src/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -120,7 +120,7 @@ int VpiCbHdl::cleanup_callback() {
 }
 
 VpiValueCbHdl::VpiValueCbHdl(GpiImplInterface *impl, VpiSignalObjHdl *sig,
-                             gpi_edge_e edge)
+                             gpi_edge edge)
     : GpiCbHdl(impl), VpiCbHdl(impl), GpiValueCbHdl(impl, sig, edge) {
     vpi_time.type = vpiSuppressTime;
     m_vpi_value.format = vpiIntVal;

--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -101,8 +101,8 @@ const char *VpiImpl::get_simulator_version() {
     return m_version.c_str();
 }
 
-static gpi_objtype_t to_gpi_objtype(int32_t vpitype, int num_elements = 0,
-                                    bool is_vector = false) {
+static gpi_objtype to_gpi_objtype(int32_t vpitype, int num_elements = 0,
+                                  bool is_vector = false) {
     switch (vpitype) {
         case vpiNet:
         case vpiNetBit:
@@ -166,7 +166,7 @@ static gpi_objtype_t to_gpi_objtype(int32_t vpitype, int num_elements = 0,
     }
 }
 
-static gpi_objtype_t const_type_to_gpi_objtype(int32_t const_type) {
+static gpi_objtype const_type_to_gpi_objtype(int32_t const_type) {
     // Most simulators only return vpiDecConst or vpiBinaryConst
     switch (const_type) {
 #ifdef IUS
@@ -451,7 +451,7 @@ GpiObjHdl *VpiImpl::native_check_create(int32_t index, GpiObjHdl *parent) {
     char buff[14];  // needs to be large enough to hold -2^31 to 2^31-1 in
                     // string form ('['+'-'10+']'+'\0')
 
-    gpi_objtype_t obj_type = parent->get_type();
+    gpi_objtype obj_type = parent->get_type();
 
     if (obj_type == GPI_GENARRAY) {
         snprintf(buff, 14, "[%d]", index);
@@ -632,7 +632,7 @@ error:
 }
 
 GpiIterator *VpiImpl::iterate_handle(GpiObjHdl *obj_hdl,
-                                     gpi_iterator_sel_t type) {
+                                     gpi_iterator_sel type) {
     GpiIterator *new_iter = NULL;
     switch (type) {
         case GPI_OBJECTS:

--- a/src/cocotb/share/lib/vpi/VpiImpl.h
+++ b/src/cocotb/share/lib/vpi/VpiImpl.h
@@ -106,8 +106,7 @@ class VpiSignalObjHdl;
 
 class VpiValueCbHdl : public VpiCbHdl, public GpiValueCbHdl {
   public:
-    VpiValueCbHdl(GpiImplInterface *impl, VpiSignalObjHdl *sig,
-                  gpi_edge_e edge);
+    VpiValueCbHdl(GpiImplInterface *impl, VpiSignalObjHdl *sig, gpi_edge edge);
     int cleanup_callback() override;
 
   private:
@@ -194,7 +193,7 @@ class VpiSignalObjHdl : public GpiSignalObjHdl {
     /* Value change callback accessor */
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
-    GpiCbHdl *register_value_change_callback(gpi_edge_e edge,
+    GpiCbHdl *register_value_change_callback(gpi_edge edge,
                                              int (*function)(void *),
                                              void *cb_data) override;
 

--- a/src/cocotb/share/lib/vpi/VpiImpl.h
+++ b/src/cocotb/share/lib/vpi/VpiImpl.h
@@ -156,7 +156,7 @@ class VpiShutdownCbHdl : public VpiCbHdl {
 
 class VpiArrayObjHdl : public GpiObjHdl {
   public:
-    VpiArrayObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype)
+    VpiArrayObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype objtype)
         : GpiObjHdl(impl, hdl, objtype) {}
 
     int initialise(const std::string &name,
@@ -165,7 +165,7 @@ class VpiArrayObjHdl : public GpiObjHdl {
 
 class VpiObjHdl : public GpiObjHdl {
   public:
-    VpiObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype)
+    VpiObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype objtype)
         : GpiObjHdl(impl, hdl, objtype) {}
 
     const char *get_definition_name() override;
@@ -174,8 +174,8 @@ class VpiObjHdl : public GpiObjHdl {
 
 class VpiSignalObjHdl : public GpiSignalObjHdl {
   public:
-    VpiSignalObjHdl(GpiImplInterface *impl, vpiHandle hdl,
-                    gpi_objtype_t objtype, bool is_const)
+    VpiSignalObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype objtype,
+                    bool is_const)
         : GpiSignalObjHdl(impl, hdl, objtype, is_const) {}
 
     const char *get_signal_value_binstr() override;
@@ -183,12 +183,12 @@ class VpiSignalObjHdl : public GpiSignalObjHdl {
     double get_signal_value_real() override;
     long get_signal_value_long() override;
 
-    int set_signal_value(const int32_t value, gpi_set_action_t action) override;
-    int set_signal_value(const double value, gpi_set_action_t action) override;
+    int set_signal_value(const int32_t value, gpi_set_action action) override;
+    int set_signal_value(const double value, gpi_set_action action) override;
     int set_signal_value_binstr(std::string &value,
-                                gpi_set_action_t action) override;
+                                gpi_set_action action) override;
     int set_signal_value_str(std::string &value,
-                             gpi_set_action_t action) override;
+                             gpi_set_action action) override;
 
     /* Value change callback accessor */
     int initialise(const std::string &name,
@@ -198,7 +198,7 @@ class VpiSignalObjHdl : public GpiSignalObjHdl {
                                              void *cb_data) override;
 
   private:
-    int set_signal_value(s_vpi_value value, gpi_set_action_t action);
+    int set_signal_value(s_vpi_value value, gpi_set_action action);
 };
 
 class VpiIterator : public GpiIterator {
@@ -284,7 +284,7 @@ class VpiImpl : public GpiImplInterface {
     /* Hierarchy related */
     GpiObjHdl *get_root_handle(const char *name) override;
     GpiIterator *iterate_handle(GpiObjHdl *obj_hdl,
-                                gpi_iterator_sel_t type) override;
+                                gpi_iterator_sel type) override;
     GpiObjHdl *next_handle(GpiIterator *iter);
 
     /* Callback related, these may (will) return the same handle*/

--- a/src/cocotb/share/lib/vpi/VpiIterator.cpp
+++ b/src/cocotb/share/lib/vpi/VpiIterator.cpp
@@ -246,7 +246,7 @@ GpiIterator::Status VpiIterator::next_handle(std::string &name, GpiObjHdl **hdl,
 
     if (!selected) return GpiIterator::END;
 
-    gpi_objtype_t obj_type = m_parent->get_type();
+    gpi_objtype obj_type = m_parent->get_type();
     std::string parent_name = m_parent->get_name();
 
     do {

--- a/src/cocotb/share/lib/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/vpi/VpiSignal.cpp
@@ -253,7 +253,7 @@ int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s,
 }
 
 GpiCbHdl *VpiSignalObjHdl::register_value_change_callback(
-    gpi_edge_e edge, int (*function)(void *), void *cb_data) {
+    gpi_edge edge, int (*function)(void *), void *cb_data) {
     VpiValueCbHdl *cb = new VpiValueCbHdl(this->m_impl, this, edge);
     cb->set_user_data(function, cb_data);
     if (cb->arm_callback()) {

--- a/src/cocotb/share/lib/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/vpi/VpiSignal.cpp
@@ -156,7 +156,7 @@ long VpiSignalObjHdl::get_signal_value_long() {
 }
 
 // Value related functions
-int VpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action_t action) {
+int VpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action action) {
     s_vpi_value value_s;
 
     value_s.value.integer = static_cast<PLI_INT32>(value);
@@ -165,7 +165,7 @@ int VpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action_t action) {
     return set_signal_value(value_s, action);
 }
 
-int VpiSignalObjHdl::set_signal_value(double value, gpi_set_action_t action) {
+int VpiSignalObjHdl::set_signal_value(double value, gpi_set_action action) {
     s_vpi_value value_s;
 
     value_s.value.real = value;
@@ -175,7 +175,7 @@ int VpiSignalObjHdl::set_signal_value(double value, gpi_set_action_t action) {
 }
 
 int VpiSignalObjHdl::set_signal_value_binstr(std::string &value,
-                                             gpi_set_action_t action) {
+                                             gpi_set_action action) {
     s_vpi_value value_s;
 
     std::vector<char> writable(value.begin(), value.end());
@@ -188,7 +188,7 @@ int VpiSignalObjHdl::set_signal_value_binstr(std::string &value,
 }
 
 int VpiSignalObjHdl::set_signal_value_str(std::string &value,
-                                          gpi_set_action_t action) {
+                                          gpi_set_action action) {
     s_vpi_value value_s;
 
     std::vector<char> writable(value.begin(), value.end());
@@ -201,7 +201,7 @@ int VpiSignalObjHdl::set_signal_value_str(std::string &value,
 }
 
 int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s,
-                                      gpi_set_action_t action) {
+                                      gpi_set_action action) {
     PLI_INT32 vpi_put_flag = -1;
     s_vpi_time vpi_time_s;
 


### PR DESCRIPTION
Closes #4357. Names ending with `_t` are reserved by POSIX.