### PR TITLE
Move Edge Trigger lifetimes to Handles

### DIFF
--- a/docs/source/newsfragments/4382.removal.rst
+++ b/docs/source/newsfragments/4382.removal.rst
@@ -1,0 +1,1 @@
+:any:`~cocotb.triggers.Edge` has been deprecated in favor of the new name :class:`~cocotb.triggers.ValueChange`.

--- a/examples/analog_model/test_analog_model.py
+++ b/examples/analog_model/test_analog_model.py
@@ -6,7 +6,7 @@ from afe import AFE
 import cocotb
 from cocotb.clock import Clock
 from cocotb.queue import Queue
-from cocotb.triggers import Edge, RisingEdge, Timer
+from cocotb.triggers import RisingEdge, Timer, ValueChange
 
 """
 This example uses the Python model of an Analog Front-End (AFE)
@@ -22,7 +22,7 @@ async def gain_select(digital, afe) -> None:
     """Set gain factor of PGA when gain select from the HDL changes."""
 
     while True:
-        await Edge(digital.pga_high_gain)
+        await ValueChange(digital.pga_high_gain)
         if digital.pga_high_gain.value == 0:
             afe.pga.gain = 5.0
         else:

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -27,25 +27,19 @@
 
 """Utilities for implementors."""
 
-import inspect
 import os
 import sys
 import traceback
 import types
-import weakref
-from abc import ABCMeta
 from enum import Enum
 from functools import lru_cache, update_wrapper, wraps
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
-    Dict,
     Iterable,
     List,
     Optional,
-    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -53,39 +47,6 @@ from typing import (
     cast,
     overload,
 )
-
-
-class ParameterizedSingletonMetaclass(ABCMeta):
-    """A metaclass that allows class construction to reuse an existing instance.
-
-    We use this so that many triggers classes return the same object rather than make new ones.
-    """
-
-    __singleton_key__: Callable[..., Any]
-
-    def __init__(
-        cls, name: str, bases: Sequence[Type[object]], dct: Dict[str, Any]
-    ) -> None:
-        # Attach a lookup table to this class.
-        # Weak such that if the instance is no longer referenced, it can be
-        # collected.
-        cls.__instances: weakref.WeakValueDictionary[Any, Any] = (
-            weakref.WeakValueDictionary()
-        )
-
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
-        key = cls.__singleton_key__(*args, **kwargs)
-        try:
-            return cls.__instances[key]
-        except KeyError:
-            # construct the object as normal
-            self = super().__call__(*args, **kwargs)
-            cls.__instances[key] = self
-            return self
-
-    @property
-    def __signature__(cls) -> inspect.Signature:
-        return inspect.signature(cls.__singleton_key__)
 
 
 @lru_cache(maxsize=None)

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -248,24 +248,30 @@ _T = TypeVar("_T", bound=type)
 _Value = TypeVar("_Value", bound=object)
 
 
-def singleton(orig_cls: _T) -> _T:
-    """Class decorator which turns a type into a Singleton type."""
-    orig_new = orig_cls.__new__
-    orig_init = orig_cls.__init__
-    instance = None
+if TYPE_CHECKING:
 
-    @wraps(orig_cls.__new__)
-    def __new__(cls: Type[_Value], *args: Any, **kwargs: Any) -> _Value:
-        nonlocal instance
-        if instance is None:
-            instance = orig_new(cls, *args, **kwargs)
-            orig_init(instance, *args, **kwargs)
-        return instance
+    def singleton(orig_cls: _T) -> _T: ...
 
-    @wraps(orig_cls.__init__)
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        pass
+else:
 
-    orig_cls.__new__ = __new__
-    orig_cls.__init__ = __init__
-    return orig_cls
+    def singleton(orig_cls):
+        """Class decorator which turns a type into a Singleton type."""
+        orig_new = orig_cls.__new__
+        orig_init = orig_cls.__init__
+        instance = None
+
+        @wraps(orig_cls.__new__)
+        def __new__(cls: Type[_Value], *args: Any, **kwargs: Any) -> _Value:
+            nonlocal instance
+            if instance is None:
+                instance = orig_new(cls, *args, **kwargs)
+                orig_init(instance, *args, **kwargs)
+            return instance
+
+        @wraps(orig_cls.__init__)
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        orig_cls.__new__ = __new__
+        orig_cls.__init__ = __init__
+        return orig_cls

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -40,7 +40,14 @@ from cocotb._write_scheduler import trust_inertial
 from cocotb.handle import LogicObject
 from cocotb.simulator import clock_create
 from cocotb.task import Task
-from cocotb.triggers import ClockCycles, Edge, Event, FallingEdge, RisingEdge, Timer
+from cocotb.triggers import (
+    ClockCycles,
+    Event,
+    FallingEdge,
+    RisingEdge,
+    Timer,
+    ValueChange,
+)
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -264,7 +271,9 @@ class Clock:
     async def cycles(
         self,
         num_cycles: int,
-        edge_type: Union[Type[RisingEdge], Type[FallingEdge], Type[Edge]] = RisingEdge,
+        edge_type: Union[
+            Type[RisingEdge], Type[FallingEdge], Type[ValueChange]
+        ] = RisingEdge,
     ) -> None:
         """Wait for a number of clock cycles."""
         # TODO Improve implementation to use a Timer to skip most of the cycles

--- a/tests/test_cases/issue_348/issue_348.py
+++ b/tests/test_cases/issue_348/issue_348.py
@@ -1,5 +1,5 @@
 import cocotb
-from cocotb.triggers import Edge, FallingEdge, RisingEdge, Timer
+from cocotb.triggers import FallingEdge, RisingEdge, Timer, ValueChange
 
 
 async def clock_gen(signal, num):
@@ -48,5 +48,5 @@ async def issue_348_falling(dut):
 
 @cocotb.test()
 async def issue_348_either(dut):
-    """Start two monitors on Edge"""
-    await DualMonitor(Edge, dut.clk).start()
+    """Start two monitors on ValueChange"""
+    await DualMonitor(ValueChange, dut.clk).start()

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -8,7 +8,7 @@ import pytest
 
 import cocotb
 from cocotb.regression import TestFactory
-from cocotb.triggers import Event, First, Join, Timer
+from cocotb.triggers import Edge, Event, First, Join, Timer
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 
@@ -151,3 +151,10 @@ async def test_logic_scalar_object_methods_deprecated(dut) -> None:
         assert str(dut.stream_in_valid) == "1"
     with pytest.warns(DeprecationWarning):
         assert len(dut.stream_in_valid) == 1
+
+
+@cocotb.test
+async def test_edge_trigger_deprecated(dut) -> None:
+    with pytest.warns(DeprecationWarning):
+        e = Edge(dut.stream_in_valid)
+    assert e is dut.stream_in_valid.value_change

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -14,7 +14,7 @@ import pytest
 import cocotb
 import cocotb.triggers
 from cocotb.handle import LogicArrayObject, StringObject, _Limits
-from cocotb.triggers import Edge, FallingEdge, Timer
+from cocotb.triggers import FallingEdge, Timer, ValueChange
 from cocotb.types import Logic, LogicArray
 
 SIM_NAME = cocotb.SIM_NAME.lower()
@@ -462,7 +462,7 @@ async def test_immediate_reentrace(dut):
 
     async def watch():
         nonlocal seen, nested
-        await Edge(dut.mybits_uninitialized)
+        await ValueChange(dut.mybits_uninitialized)
         seen += 1
         dut.mybit.setimmediatevalue(0)
         with pytest.warns(FutureWarning):

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -27,7 +27,6 @@ from cocotb.triggers import (
     Event,
     First,
     NullTrigger,
-    ReadOnly,
     RisingEdge,
     TaskComplete,
     Timer,
@@ -115,17 +114,19 @@ async def consistent_join(dut):
         rising_edge = RisingEdge(clk)
         for _ in range(cycles):
             await rising_edge
-        return 3
+        return cycles
 
     cocotb.start_soon(Clock(dut.clk, 2000, "ps").start())
 
     short_wait = cocotb.start_soon(wait_for(dut.clk, 10))
     long_wait = cocotb.start_soon(wait_for(dut.clk, 30))
 
-    await wait_for(dut.clk, 20)
-    a = await short_wait
-    b = await long_wait
-    assert a == b == 3
+    a = await wait_for(dut.clk, 20)
+    assert a == 20
+    b = await short_wait
+    assert b == 10
+    c = await long_wait
+    assert c == 30
 
 
 @cocotb.test()
@@ -299,7 +300,7 @@ async def test_last_scheduled_write_wins(dut):
     assert dut.stream_in_data.value == 0
     dut.stream_in_data.value = 1
     dut.stream_in_data.value = 2
-    await ReadOnly()
+    await Timer(1, "ns")
     assert dut.stream_in_data.value == 2
 
 
@@ -314,7 +315,7 @@ async def test_last_scheduled_write_wins_array(dut):
     dut.array_7_downto_4.value = [1, 2, 3, 4]
     dut.array_7_downto_4[7].value = 10
 
-    await ReadOnly()
+    await Timer(1, "ns")
 
     assert dut.array_7_downto_4.value == [10, 2, 3, 4]
 


### PR DESCRIPTION
Closes #3855. ~~May help with #4379.~~ May help performance by not deleting and remaking Trigger objects constantly due to the weakref cache. Also renames `Edge` to `ValueChange`. Supersedes #3365.