### PR TITLE
Deprecate cocotb.start

### DIFF
--- a/docs/source/coroutines.rst
+++ b/docs/source/coroutines.rst
@@ -53,15 +53,11 @@ Coroutines can :keyword:`return` a value, so that they can be used by other coro
 Concurrent Execution
 ====================
 
-Coroutines can be scheduled for concurrent execution with :func:`~cocotb.start` and :func:`~cocotb.start_soon`.
+Coroutines can be scheduled for concurrent execution with :func:`~cocotb.start_soon`.
 These concurrently running coroutines are called :class:`~cocotb.task.Task`\ s.
 
-The :keyword:`async` function :func:`~cocotb.start` schedules the coroutine to be executed concurrently,
-then yields control to allow the new task (and any other pending tasks) to run,
-before resuming the calling task.
-
-:func:`~cocotb.start_soon` schedules the coroutine for future execution,
-after the calling task yields control.
+:func:`~cocotb.start_soon` schedules the coroutine for *future* execution,
+some time after the current Task yields control.
 
 .. code-block:: python
 
@@ -74,7 +70,7 @@ after the calling task yields control.
         # reset_dut is a function -
         # part of the user-generated "uart_tb" class
         # run reset_dut immediately before continuing
-        await cocotb.start(tb.reset_dut(dut.rstn, 20))
+        await tb.reset_dut(dut.rstn, 20)
 
         await Timer(10, units='ns')
         print("Reset is still active: %d" % dut.rstn)
@@ -134,7 +130,7 @@ forcing their completion before they would naturally end.
 .. versionchanged:: 1.4
     The ``cocotb.coroutine`` decorator is no longer necessary for :keyword:`async def` coroutines.
     :keyword:`async def` coroutines can be used, without the ``@cocotb.coroutine`` decorator, wherever decorated coroutines are accepted,
-    including :keyword:`yield` statements and ``cocotb.fork`` (since replaced with :func:`~cocotb.start` and :func:`~cocotb.start_soon`).
+    including :keyword:`yield` statements and ``cocotb.fork`` (since replaced with :func:`~cocotb.start_soon`).
 
 .. versionchanged:: 1.6
     Added :func:`cocotb.start` and :func:`cocotb.start_soon` scheduling functions.
@@ -147,6 +143,9 @@ forcing their completion before they would naturally end.
 
 .. versionchanged:: 2.0
     Removed ``cocotb.coroutine``.
+
+.. versionremoved:: 2.0
+    Removed references to the deprecated :func:`cocotb.start`.
 
 
 Waiting For Multiple Events Simultaneously

--- a/docs/source/newsfragments/4397.removal.rst
+++ b/docs/source/newsfragments/4397.removal.rst
@@ -1,0 +1,1 @@
+:func:`cocotb.start` is deprecated in favor of :func:`cocotb.start_soon`. Follow the call to :func:`cocotb.start_soon` with an :class:`await NullTrigger() <cocotb.triggers.NullTrigger>` if you need the scheduled Task to run before continuing the current Task.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -62,7 +62,7 @@ control back to cocotb (see :ref:`simulator-triggers`).
 It's most likely that you will want to do several things "at the same time" however -
 think multiple ``always`` blocks in Verilog or ``process`` statements in VHDL.
 In cocotb, you might move the clock generation part of the example above into its own
-:keyword:`async` function and :func:`~cocotb.start` it ("start it in the background")
+:keyword:`async` function and :func:`cocotb.start_soon` it ("start it in the background")
 from the test:
 
 .. literalinclude:: ../../examples/doc_examples/quickstart/test_my_design.py

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -168,7 +168,7 @@ Concurrent and sequential execution
 
 An :keyword:`await` will run an :keyword:`async` coroutine and wait for it to complete.
 The called coroutine "blocks" the execution of the current coroutine.
-Wrapping the call in :func:`~cocotb.start` or :func:`~cocotb.start_soon` runs the coroutine concurrently,
+Wrapping the call in :func:`~cocotb.start_soon` runs the coroutine concurrently,
 allowing the current coroutine to continue executing.
 At any time you can await the result of a :class:`~cocotb.task.Task`,
 which will block the current coroutine's execution until the task finishes.

--- a/examples/doc_examples/quickstart/test_my_design.py
+++ b/examples/doc_examples/quickstart/test_my_design.py
@@ -41,7 +41,7 @@ async def generate_clock(dut):
 async def my_second_test(dut):
     """Try accessing the design."""
 
-    await cocotb.start(generate_clock(dut))  # run the clock "in the background"
+    cocotb.start_soon(generate_clock(dut))  # run the clock "in the background"
 
     await Timer(5, units="ns")  # wait a bit
     await FallingEdge(dut.clk)  # wait for falling edge/"negedge"

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -40,6 +40,7 @@ from cocotb._decorators import (
     resume,
     test,
 )
+from cocotb._deprecation import deprecated
 from cocotb._scheduler import Scheduler
 from cocotb._utils import DocEnum
 from cocotb.regression import RegressionManager
@@ -158,6 +159,7 @@ def start_soon(
     return task
 
 
+@deprecated("Use ``cocotb.start_soon`` instead.")
 async def start(
     coro: "Union[cocotb.task.Task[cocotb.task.ResultType], Coroutine[Any, Any, cocotb.task.ResultType]]",
 ) -> "cocotb.task.Task[cocotb.task.ResultType]":
@@ -176,6 +178,11 @@ async def start(
         The :class:`~cocotb.task.Task` that has been scheduled and allowed to execute.
 
     .. versionadded:: 1.6
+
+    .. deprecated:: 2.0
+        Use :func:`cocotb.start_soon` instead.
+        If you need the scheduled Task to run before continuing the current Task,
+        follow the call to :func:`cocotb.start_soon` with an :class:`await NullTrigger() <cocotb.triggers.NullTrigger>`.
     """
     task = start_soon(coro)
     await cocotb.triggers.NullTrigger()

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -38,9 +38,8 @@ class Task(Generic[ResultType]):
     """Concurrently executing task.
 
     This class is not intended for users to directly instantiate.
-    Use :func:`cocotb.create_task` to create a Task object,
-    or use :func:`cocotb.start_soon` or :func:`cocotb.start` to
-    create a Task and schedule it to run.
+    Use :func:`cocotb.create_task` to create a Task object
+    or :func:`cocotb.start_soon` to create a Task and schedule it to run.
 
     .. versionchanged:: 1.8
         Moved to the ``cocotb.task`` module.

--- a/tests/test_cases/test_cocotb/test_clock.py
+++ b/tests/test_cases/test_cocotb/test_clock.py
@@ -53,7 +53,7 @@ async def test_clock_with_units(dut, impl: str) -> None:
 
     clk_gen.kill()
 
-    clk_gen = await cocotb.start(clk_250mhz.start())
+    clk_gen = cocotb.start_soon(clk_250mhz.start())
 
     start_time_ns = get_sim_time(units="ns")
 

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -124,7 +124,7 @@ async def test_combine(dut):
     async def coro(delay):
         await Timer(delay, "ns")
 
-    tasks = [await cocotb.start(coro(dly)) for dly in [10, 30, 20]]
+    tasks = [cocotb.start_soon(coro(dly)) for dly in [10, 30, 20]]
 
     await Combine(*tasks)
 

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -158,3 +158,17 @@ async def test_edge_trigger_deprecated(dut) -> None:
     with pytest.warns(DeprecationWarning):
         e = Edge(dut.stream_in_valid)
     assert e is dut.stream_in_valid.value_change
+
+
+@cocotb.test
+async def test_cocotb_start(_) -> None:
+    done = False
+
+    async def do_something():
+        nonlocal done
+        done = True
+
+    with pytest.warns(DeprecationWarning):
+        await cocotb.start(do_something())
+
+    assert done

--- a/tests/test_cases/test_cocotb/test_queues.py
+++ b/tests/test_cases/test_cocotb/test_queues.py
@@ -86,7 +86,8 @@ async def test_queue_contention(dut):
 
     # test put contention
     for k in range(NUM_PUTTERS):
-        coro_list.append(await cocotb.start(putter(putter_list, k)))
+        coro_list.append(cocotb.start_soon(putter(putter_list, k)))
+    await NullTrigger()
 
     assert q.qsize() == QUEUE_SIZE
 
@@ -148,7 +149,8 @@ async def test_fair_scheduling(dut):
     q.put_nowait(None)
 
     # create NUM_PUTTER contending putters
-    putters = [await cocotb.start(putter(i)) for i in range(NUM_PUTTERS)]
+    putters = [cocotb.start_soon(putter(i)) for i in range(NUM_PUTTERS)]
+    await NullTrigger()
 
     # remove value that forced contention
     assert q.get_nowait() is None, "Popped unexpected value"
@@ -190,12 +192,14 @@ async def run_queue_blocking_test(dut, queue_type):
 
     # test put contention
     for k in range(NUM_PUTTERS):
-        coro_list.append(await cocotb.start(putter(putter_list, k)))
+        coro_list.append(cocotb.start_soon(putter(putter_list, k)))
+    await NullTrigger()
 
     assert q.qsize() == QUEUE_SIZE
 
     for k in range(NUM_PUTTERS):
-        coro_list.append(await cocotb.start(getter(getter_list, k)))
+        coro_list.append(cocotb.start_soon(getter(getter_list, k)))
+    await NullTrigger()
 
     await Combine(*coro_list)
 
@@ -211,10 +215,12 @@ async def run_queue_blocking_test(dut, queue_type):
 
     # test get contention
     for k in range(NUM_PUTTERS):
-        coro_list.append(await cocotb.start(getter(getter_list, k)))
+        coro_list.append(cocotb.start_soon(getter(getter_list, k)))
+    await NullTrigger()
 
     for k in range(NUM_PUTTERS):
-        coro_list.append(await cocotb.start(putter(putter_list, k)))
+        coro_list.append(cocotb.start_soon(putter(putter_list, k)))
+    await NullTrigger()
 
     await Combine(*coro_list)
 
@@ -230,7 +236,8 @@ async def test_str_and_repr(_):
     q = Queue[int](maxsize=1)
 
     q.put_nowait(0)
-    await cocotb.start(q.put(1))
+    cocotb.start_soon(q.put(1))
+    await NullTrigger()
 
     s = repr(q)
     assert "maxsize" in s
@@ -248,7 +255,8 @@ async def test_str_and_repr(_):
     assert "_putters" not in s
 
     assert q.get_nowait() == 1
-    getter = await cocotb.start(q.get())
+    getter = cocotb.start_soon(q.get())
+    await NullTrigger()
 
     s = repr(q)
     assert "_putters" not in s

--- a/tests/test_cases/test_cocotb/test_start_soon.py
+++ b/tests/test_cases/test_cocotb/test_start_soon.py
@@ -1,9 +1,6 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-import warnings
-
-from common import MyException
 
 import cocotb
 
@@ -19,18 +16,3 @@ async def test_start_soon_doesnt_start_immediately(_):
     # start_soon doesn't run incremenents() immediately, so "a" is never incremented
     cocotb.start_soon(increments())
     assert a == 0
-
-
-async def coro():
-    raise MyException()
-
-
-@cocotb.test(expect_error=MyException)
-async def test_start_doesnt_keep_running(_):
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-
-        # failing task ends the test, but because we have to suspend the current task
-        # the next raise is never run again after the test fails because the test coro is not scheduled again
-        await cocotb.start(coro())
-        raise RuntimeError()

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -129,7 +129,8 @@ async def test_internalevent(dut):
         ran = True
 
     # Test multiple coroutines waiting
-    await cocotb.start(await_internalevent())
+    cocotb.start_soon(await_internalevent())
+    await NullTrigger()
     assert not e.is_set()
     assert not ran
     # _InternalEvent can only be awaited by one coroutine


### PR DESCRIPTION
Closes #4394. The difference between `cocotb.start` and `cocotb.start_soon` confuses users, so we are deprecating `cocotb.start`. If users need the `cocotb.start` behavior, they can simply call `cocotb.start_soon` followed by `await NullTrigger()`.
