### PR TITLE
Handle passing no triggers to Combine and First

### DIFF
--- a/docs/source/newsfragments/4409.bugfix.1.rst
+++ b/docs/source/newsfragments/4409.bugfix.1.rst
@@ -1,0 +1,1 @@
+Passing no triggers to :class:`~cocotb.triggers.First` used to hang the simulation indefinitely. Now it raises a :exc:`ValueError` exception.

--- a/docs/source/newsfragments/4409.bugfix.1.rst
+++ b/docs/source/newsfragments/4409.bugfix.1.rst
@@ -1,1 +1,1 @@
-Passing no triggers to :class:`~cocotb.triggers.First` used to hang the simulation indefinitely. Now it raises a :exc:`ValueError` exception.
+Passing no triggers to :class:`~cocotb.triggers.First` previously hung the simulation indefinitely. Now, doing so raises a :exc:`ValueError` exception.

--- a/docs/source/newsfragments/4409.bugfix.rst
+++ b/docs/source/newsfragments/4409.bugfix.rst
@@ -1,0 +1,1 @@
+Passing no triggers to :class:`~cocotb.triggers.Combine` used to hang the simulation indefinitely. Now it behaves equivalently to :class:`await NullTrigger() <cocotb.triggers.NullTrigger>`.

--- a/docs/source/newsfragments/4409.bugfix.rst
+++ b/docs/source/newsfragments/4409.bugfix.rst
@@ -1,1 +1,1 @@
-Passing no triggers to :class:`~cocotb.triggers.Combine` used to hang the simulation indefinitely. Now it behaves equivalently to :class:`await NullTrigger() <cocotb.triggers.NullTrigger>`.
+Passing no triggers to :class:`~cocotb.triggers.Combine` previously hung the simulation indefinitely. Now, doing so makes ``Combine`` behave equivalently to :class:`~cocotb.triggers.NullTrigger`.

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -10,7 +10,7 @@ import re
 import pytest
 
 import cocotb
-from cocotb.triggers import Lock, NullTrigger, Timer, _InternalEvent
+from cocotb.triggers import Combine, First, Lock, NullTrigger, Timer, _InternalEvent
 from cocotb.utils import get_sim_time
 
 
@@ -149,3 +149,19 @@ async def test_internalevent(dut):
     time_ns = get_sim_time(units="ns")
     await e
     assert get_sim_time(units="ns") == time_ns
+
+
+@cocotb.test
+async def test_empty_Combine(_) -> None:
+    """Test that a Combine with no triggers passes no time."""
+    start_time = get_sim_time(units="ns")
+    await Combine()
+    end_time = get_sim_time(units="ns")
+    assert end_time == start_time
+
+
+@cocotb.test
+async def test_empty_First(_) -> None:
+    """Test that a First with no triggers raises an error."""
+    with pytest.raises(ValueError):
+        await First()


### PR DESCRIPTION
Closes #4407.  `First()` causes a `ValueError` and `Combine()` acts like `NullTrigger()`.

## TODO
- [x] newsfrag