### PR TITLE
Don't load cocotb libraries when compiling with VCS

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.vcs
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.vcs
@@ -83,7 +83,7 @@ $(SIM_BUILD)/simv: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) | $(SIM_BUILD)
 	COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) \
 	$(CMD) -top $(COCOTB_TOPLEVEL) $(call deprecate,PLUSARGS,COCOTB_PLUSARGS) -sverilog \
 	-timescale=$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION) \
-	$(EXTRA_ARGS) -load $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi vcs) $(COMPILE_ARGS) $(VERILOG_SOURCES)
+	$(EXTRA_ARGS) $(COMPILE_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
 $(COCOTB_RESULTS_FILE): $(SIM_BUILD)/simv $(CUSTOM_SIM_DEPS)

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1509,7 +1509,6 @@ class Vcs(Runner):
             cmds = [
                 ["vcs"]
                 + self._build_opts
-                + ["-load", cocotb_tools.config.lib_name_path("vpi", "vcs").as_posix()]
                 + self.build_args
                 + self._get_include_options(self.includes)
                 + self._get_define_options(self.defines)


### PR DESCRIPTION
This causes erratic warnings about not supporting `vpi_register_cb` in the compilation phase. We don't register system_tfs so there's no reason for us to load it here.