### PR TITLE
Remove patch version from version specifications if the patch is 0

### DIFF
--- a/docs/source/analog_model.rst
+++ b/docs/source/analog_model.rst
@@ -4,7 +4,7 @@
 Models of Analog Circuits
 #########################
 
-.. versionadded:: 1.6.0
+.. versionadded:: 1.6
 
 This is the example :mod:`analog_model` showing how to use Python models
 for analog circuits together with a digital part.

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -52,7 +52,7 @@ Cocotb
     The DUT is available in cocotb tests as a Python object at :data:`cocotb.top`;
     and is also passed to all cocotb tests as the :ref:`first and only parameter <quickstart_creating_a_test>`.
 
-    .. versionchanged:: 1.6.0 Strip leading and trailing whitespace
+    .. versionchanged:: 1.6 Strip leading and trailing whitespace
 
     .. versionchanged:: 2.0
 
@@ -329,11 +329,11 @@ GPI
 
     * ``GPI_EXTRA=libnameA.so:entryA,libnameB.so:entryB`` will first load ``libnameA.so`` with entry point ``entryA`` , then load ``libnameB.so`` with entry point ``entryB``.
 
-    .. versionchanged:: 1.4.0
+    .. versionchanged:: 1.4
         Support for the custom entry point via ``:`` was added.
         Previously ``:`` was used as a separator between libraries instead of ``,``.
 
-    .. versionchanged:: 1.5.0
+    .. versionchanged:: 1.5
         Library name must be fully specified.
         This allows using relative or absolute paths in library names,
         and loading from libraries that `aren't` prefixed with "lib".
@@ -472,7 +472,7 @@ The following variables are makefile variables, not environment variables.
       For example, ``SIM_CMD_PREFIX := LD_PRELOAD="foo.so bar.so"`` can be used to force a particular library to load.
       Or, ``SIM_CMD_PREFIX := gdb --args`` to run the simulation with the GDB debugger.
 
-      .. versionadded:: 1.6.0
+      .. versionadded:: 1.6
 
 .. make:var:: SIM_CMD_SUFFIX
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -20,9 +20,9 @@ The current stable version of cocotb requires:
 * GNU Make 3+
 * A Verilog or VHDL simulator, depending on your :term:`RTL` source code
 
-.. versionchanged:: 1.7.0 Dropped requirement of Python development headers and C++ compiler for release versions.
+.. versionchanged:: 1.7 Dropped requirement of Python development headers and C++ compiler for release versions.
 
-.. versionchanged:: 1.6.0 Dropped Python 3.5 support
+.. versionchanged:: 1.6 Dropped Python 3.5 support
 
 .. versionchanged:: 1.4 Dropped Python 2 support
 

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -118,7 +118,7 @@ HDL Datatypes
 
 These are a set of datatypes that model the behavior of common HDL datatypes.
 
-.. versionadded:: 1.6.0
+.. versionadded:: 1.6
 
 .. autoclass:: cocotb.types.Logic
 

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -151,7 +151,7 @@ def start_soon(
     Returns:
         The :class:`~cocotb.task.Task` that is scheduled to be run.
 
-    .. versionadded:: 1.6.0
+    .. versionadded:: 1.6
     """
     task = create_task(coro)
     cocotb._scheduler_inst._schedule_task(task)
@@ -175,7 +175,7 @@ async def start(
     Returns:
         The :class:`~cocotb.task.Task` that has been scheduled and allowed to execute.
 
-    .. versionadded:: 1.6.0
+    .. versionadded:: 1.6
     """
     task = start_soon(coro)
     await cocotb.triggers.NullTrigger()
@@ -196,7 +196,7 @@ def create_task(
     Returns:
         Either the provided :class:`~cocotb.task.Task` or a new Task wrapping the coroutine.
 
-    .. versionadded:: 1.6.0
+    .. versionadded:: 1.6
     """
     if isinstance(coro, cocotb.task.Task):
         return coro

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -42,7 +42,7 @@ class Task(Generic[ResultType]):
     or use :func:`cocotb.start_soon` or :func:`cocotb.start` to
     create a Task and schedule it to run.
 
-    .. versionchanged:: 1.8.0
+    .. versionchanged:: 1.8
         Moved to the ``cocotb.task`` module.
 
     .. versionchanged:: 2.0
@@ -327,7 +327,7 @@ class _RunningTest(Task[None]):
 
     All this class does is change ``__name__`` to show "Test" instead of "Task".
 
-    .. versionchanged:: 1.8.0
+    .. versionchanged:: 1.8
         Moved to the ``cocotb.task`` module.
     """
 

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -164,7 +164,7 @@ class Timer(GPITrigger):
     Args:
         time: The time value.
 
-            .. versionchanged:: 1.5.0
+            .. versionchanged:: 1.5
                 Previously this argument was misleadingly called `time_ps`.
 
         units: The unit of the time value.
@@ -1213,7 +1213,7 @@ async def with_timeout(
 
     .. versionadded:: 1.3
 
-    .. versionchanged:: 1.7.0
+    .. versionchanged:: 1.7
         Support passing :term:`python:coroutine`\ s.
 
     .. versionchanged:: 2.0

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -66,7 +66,7 @@ def get_sim_time(units: str = "step") -> int:
     Returns:
         The simulation time in the specified units.
 
-    .. versionchanged:: 1.6.0
+    .. versionchanged:: 1.6
         Support ``'step'`` as the the *units* argument to mean "simulator time step".
     """
     timeh, timel = simulator.get_sim_time()


### PR DESCRIPTION
Changing something for the patch 0 release means it was developed as a part of the minor release cycle. The patch 0 is redundant. Only specify a patch release in versions if the tagged item was changed in that patch of the minor release and newer.