### PR TITLE
Split cocotb initialization into init and run

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -350,7 +350,6 @@ PyGPI
 .. envvar:: PYGPI_ENTRY_POINT
 
     The Python module and callable that starts up the Python cosimulation environment.
-    This defaults to :data:`cocotb:_initialise_testbench`, which is the cocotb standard entry point.
     User overloads can be used to enter alternative Python frameworks or to hook existing cocotb functionality.
     The variable is formatted as ``path.to.entry.module:entry_point.function,other_module:other_func``.
     The string before the colon is the Python module to import

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -9,7 +9,13 @@ def load_entry(argv: List[str]) -> Any:
 
     entry_point_str = os.environ.get(
         "PYGPI_ENTRY_POINT",
-        "cocotb_tools._coverage:start_cocotb_library_coverage,cocotb._init:_initialise_testbench",
+        ",".join(
+            (
+                "cocotb_tools._coverage:start_cocotb_library_coverage",
+                "cocotb._init:init_package_from_simulation",
+                "cocotb._init:run_regression",
+            )
+        ),
     )
 
     # Parse the entry point string of the form "module:func,module:func,...".


### PR DESCRIPTION
This allows users to initialize the global members of the cocotb package without running a regression. Allowing other behaviors like discovering tests or running alternative regression managers possible.