### PR TITLE
Use uv to install dependencies in RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,20 +4,40 @@
 
 version: 2
 
+# uv support as per https://github.com/readthedocs/readthedocs.org/issues/11289#issuecomment-2575933870
 build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
   apt_packages:
     - graphviz
+  jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv
+    install:
+      - uv pip install -r docs/requirements.txt
+    build:
+      html:
+        - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
 
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
-      extra_requirements:
-        - bus
+# build:
+#   os: ubuntu-22.04
+#   tools:
+#     python: "3.12"
+#   apt_packages:
+#     - graphviz
+#
+# python:
+#   install:
+#     - requirements: docs/requirements.txt
+#     - method: pip
+#       path: .
+#       extra_requirements:
+#         - bus
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,24 +20,10 @@ build:
       - uv venv
     install:
       - uv pip install -r docs/requirements.txt
+      - uv pip install .[bus]
     build:
       html:
-        - uv run sphinx-build -T -b html docs/source $READTHEDOCS_OUTPUT/html
-
-# build:
-#   os: ubuntu-22.04
-#   tools:
-#     python: "3.12"
-#   apt_packages:
-#     - graphviz
-#
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
-#     - method: pip
-#       path: .
-#       extra_requirements:
-#         - bus
+        - uv run sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,7 +22,7 @@ build:
       - uv pip install -r docs/requirements.txt
     build:
       html:
-        - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
+        - uv run sphinx-build -T -b html docs/source $READTHEDOCS_OUTPUT/html
 
 # build:
 #   os: ubuntu-22.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,10 +20,24 @@ build:
       - uv venv
     install:
       - uv pip install -r docs/requirements.txt
-      - uv pip install .[bus]
     build:
       html:
-        - uv run sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+        - uv run sphinx-build -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+
+# build:
+#   os: ubuntu-22.04
+#   tools:
+#     python: "3.12"
+#   apt_packages:
+#     - graphviz
+#
+# python:
+#   install:
+#     - requirements: docs/requirements.txt
+#     - method: pip
+#       path: .
+#       extra_requirements:
+#         - bus
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,22 +22,13 @@ build:
       - uv pip install -r docs/requirements.txt
     build:
       html:
-        - uv run sphinx-build -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
-
-# build:
-#   os: ubuntu-22.04
-#   tools:
-#     python: "3.12"
-#   apt_packages:
-#     - graphviz
-#
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
-#     - method: pip
-#       path: .
-#       extra_requirements:
-#         - bus
+        - uv run sphinx-build \
+          --show-traceback \
+          --builder html \
+          --doctree-dir _build/doctrees \
+          --define language=en \
+          docs/source \
+          $READTHEDOCS_OUTPUT/html
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,8 +21,8 @@ build:
     install:
       - uv pip install -r docs/requirements.txt
     build:
-      html:
-        - uv run sphinx-build \
+      html: |
+        uv run sphinx-build \
           --show-traceback \
           --builder html \
           --doctree-dir _build/doctrees \

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,14 +21,7 @@ build:
     install:
       - uv pip install -r docs/requirements.txt
     build:
-      html: |
-        uv run sphinx-build \
-          --show-traceback \
-          --builder html \
-          --doctree-dir _build/doctrees \
-          --define language=en \
-          docs/source \
-          $READTHEDOCS_OUTPUT/html
+      html: uv run sphinx-build -T -b html -d _build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html
 
 sphinx:
   configuration: docs/source/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,11 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+# "[project]" added for supporting uv in the ReadTheDocs config
+[project]
+name = "cocotb"
+dynamic = ["version", "dependencies", "scripts", "urls", "classifiers", "maintainers", "authors", "license", "requires-python", "readme"]
+
 [tool.towncrier]
     package = "cocotb"
     directory = "docs/source/newsfragments"


### PR DESCRIPTION
https://github.com/readthedocs/readthedocs.org/issues/11289#issuecomment-2103747567 and the one after that suggest quite some speed improvements.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
