### PR TITLE
Coverage Improvements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 18
+        after_n_builds: 25
 
 coverage:
     status:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,4 +144,6 @@ exclude_lines = [
     "\\.\\.\\.",
     # for excluding abstractmethods
     "raise\\s+NotImplementedError",
+    # excluding type checking blocks
+    "if (typing\\.)?TYPE_CHECKING:"
 ]

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -210,7 +210,7 @@ class DocEnum(Enum):
         return self
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     F = TypeVar("F")
 
     def cached_method(f: F) -> F: ...

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -50,7 +50,7 @@ from cocotb.triggers import (
 )
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Literal, TypeAlias
 
     Impl: TypeAlias = Literal["gpi"] | Literal["py"]

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -114,7 +114,7 @@ def default_config() -> None:
     logging.getLogger("gpi").setLevel(level)
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     LoggerClass = logging.Logger
 else:
     LoggerClass = logging.getLoggerClass()

--- a/src/cocotb/types/logic.py
+++ b/src/cocotb/types/logic.py
@@ -2,7 +2,14 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 from functools import lru_cache
-from typing import Dict, Optional, Set, Type, Union
+from typing import (
+    Dict,
+    Optional,
+    Set,
+    Tuple,  # noqa: F401  # Used by doctests, false positive
+    Type,
+    Union,
+)
 
 LogicLiteralT = Union[str, int, bool]
 LogicConstructibleT = Union[LogicLiteralT, "Logic"]

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -22,7 +22,7 @@ from cocotb.types import ArrayLike
 from cocotb.types.logic import Logic, LogicConstructibleT, _str_literals
 from cocotb.types.range import Range
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Literal
 
 

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -136,7 +136,7 @@ class LogicArray(ArrayLike[Logic]):
 
     .. code-block:: python3
 
-        >>> LogicArray.from_bytes(b"1n")
+        >>> LogicArray.from_bytes(b"1n", byteorder="big")
         LogicArray('0011000101101110', Range(15, 'downto', 0))
 
         >>> LogicArray.from_bytes(b"1n", byteorder="little")
@@ -188,8 +188,8 @@ class LogicArray(ArrayLike[Logic]):
         >>> la.to_signed()
         -6
 
-        >>> la.to_bytes()
-        b"\n"
+        >>> la.to_bytes(byteorder="big")
+        b'\n'
 
     You can also convert :class:`LogicArray`\ s to hexadecimal or binary strings using
     the built-ins :func:`hex:` and :func:`bin`, respectively.
@@ -198,9 +198,9 @@ class LogicArray(ArrayLike[Logic]):
 
         >>> la = LogicArray("01111010")
         >>> hex(la)
-        0x7a
+        '0x7a'
         >>> bin(la)
-        0b1111010
+        '0b1111010'
 
     :class:`LogicArray`\ s also support element-wise logical operations: ``&``, ``|``,
     ``^``, and ``~``.


### PR DESCRIPTION
* Add optimization and reduce debugging for release
* Re-enable doctests! (closes #4422)
* Update number of CI runs for coverage reports
* Exclude all TYPE_CHECKING blocks

WRT setting the optimization and debugging flags... The flags used to build the Python executable are used to build extensions due to how distutils uses some sysconfig values. This means that it *could* be passing `-g` to the release build, or `-O2` to dev builds. So we should explicitly override these.

For release builds I added `-O2 -g1`. No optimization flags are set by cibuildwheel and `-O2` could help performance and also reduce binary size over something like `-O0`.  I'm not so worried about binary size, but `-g1` might reduce binary size over `-g` (equivalent to `-g2`) a bit while preserving function names for tracebacks. Alternatively, we could pass `-g0 -Wl,-s` to turn off debugging and strip symbols.

For debug builds we explicitly pass `-Og -g` to optimize for debuggability and improve coverage.