### PR TITLE
Add TestSuccess and ValueChange to Library Reference

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -86,6 +86,7 @@ Writing and Generating Tests
     :members:
     :member-order: bysource
 
+.. autoclass:: cocotb.result.TestSuccess
 
 Interacting with the Simulator
 ==============================
@@ -151,6 +152,8 @@ Simulator Triggers
 
 Edge Triggers
 ^^^^^^^^^^^^^
+
+.. autoclass:: cocotb.triggers.ValueChange
 
 .. autoclass:: cocotb.triggers.Edge
 

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -418,9 +418,9 @@ class ValueChange(_EdgeBase):
         TypeError: If the signal is not an object which can change value.
 
     .. note::
-        Prefer :attr:`await signal.value_change <cocotb.handle.NonArrayValueObject.rising_edge>` to ``await ValueChange(signal)``.
+        Prefer :attr:`await signal.value_change <cocotb.handle.NonArrayValueObject.value_change>` to ``await ValueChange(signal)``.
 
-    .. versionadded: 2.0
+    .. versionadded:: 2.0
     """
 
     _edge_type = simulator.VALUE_CHANGE
@@ -445,7 +445,7 @@ def Edge(signal: "cocotb.handle.NonArrayValueObject[Any, Any]") -> ValueChange:
     Raises:
         TypeError: If the signal is not an object which can change value.
 
-    .. deprecated: 2.0
+    .. deprecated:: 2.0
 
         Use :attr:`signal.value_change <cocotb.handle.NonArrayValueObject.value_change>` instead.
     """
@@ -800,7 +800,7 @@ class TaskComplete(Trigger, Generic[T]):
     Args:
         task: The Task upon which to wait for completion.
 
-    .. versionadded: 2.0
+    .. versionadded:: 2.0
     """
 
     def __new__(cls, task: "cocotb.task.Task[T]") -> "TaskComplete[T]":


### PR DESCRIPTION
Closes #4436

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
