### PR TITLE
Backport #4444: Explicitly Mention Python 3.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 The current stable version of cocotb requires:
 
-- Python 3.6+
+- Python 3.6.2+
 - GNU Make 3+
 - An HDL simulator (such as [Icarus Verilog](https://docs.cocotb.org/en/stable/simulator_support.html#icarus-verilog),
 [Verilator](https://docs.cocotb.org/en/stable/simulator_support.html#verilator),

--- a/documentation/source/extensions.rst
+++ b/documentation/source/extensions.rst
@@ -80,7 +80,7 @@ All packaging metadata goes into :file:`setup.py`.
         version = '0.1',
         packages = find_namespace_packages(include=['cocotbext.*']),
         install_requires = ['cocotb'],
-        python_requires = '>=3.6',
+        python_requires = '>=3.6.2',
         classifiers = [
           "Programming Language :: Python :: 3",
           "Operating System :: OS Independent",

--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -16,7 +16,7 @@ Installation of Prerequisites
 
 The current stable version of cocotb requires:
 
-* Python 3.6+
+* Python 3.6.2+
 * GNU Make 3+
 * A Verilog or VHDL simulator, depending on your :term:`RTL` source code
 

--- a/documentation/source/install_devel.rst
+++ b/documentation/source/install_devel.rst
@@ -18,7 +18,7 @@ The development version of cocotb has different prerequisites
 than the stable version (see below).
 Namely, it requires the Python development headers and a C/C++ compiler.
 
-* Python 3.6+
+* Python 3.6.2+
 * Python development packages
 * GCC 4.8.1+, Clang 3.3+ or Microsoft Visual C++ 14.21+ and associated development packages
 * On Linux: A static build of the C++ standard library ``libstdc++``.

--- a/documentation/source/platform_support.rst
+++ b/documentation/source/platform_support.rst
@@ -19,16 +19,18 @@ The :ref:`platform-support-policy` discusses the underlying policy.
 Supported Python Versions
 =========================
 
-The following versions of Python (CPython), and all associated patch releases (e.g. 3.8.4), are supported by cocotb.
+The following versions of Python, and all associated patch releases (except where noted) are supported by cocotb.
+cocotb depends on CPython APIs;
+alternative Python implementations like PyPy or Jython are not supported.
 
-* Python 3.6
-* Python 3.7
-* Python 3.8
-* Python 3.9
-* Python 3.10
-* Python 3.11
-* Python 3.12
-* Python 3.13
+* CPython 3.6  (requires 3.6.2+)
+* CPython 3.7
+* CPython 3.8
+* CPython 3.9
+* CPython 3.10
+* CPython 3.11
+* CPython 3.12
+* CPython 3.13
 
 Supported Linux Distributions and Versions
 ==========================================

--- a/documentation/source/platform_support.rst
+++ b/documentation/source/platform_support.rst
@@ -57,6 +57,8 @@ This version of Python can be used with cocotb unless noted otherwise.
   `Upstream support until April 2025 <https://wiki.ubuntu.com/Releases>`_.
 * **Ubuntu 22.04 LTS amd64**, shipping with Python 3.10, pip 22, glibc 2.35.
   `Upstream support until April 2027 <https://wiki.ubuntu.com/Releases>`_.
+* **Ubuntu 24.04 LTS amd64**, shipping with Python 3.12, pip 24, glibc 2.39.
+  `Upstream support until June 2029 <https://wiki.ubuntu.com/Releases>`_.
 
 .. note::
 

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@
 
 import sys
 
-if sys.version_info[:2] < (3, 6):
+if sys.version_info[:3] < (3, 6, 2):
     msg = [
-        "This version of cocotb requires at least Python 3.6,",
+        "This version of cocotb requires at least Python 3.6.2,",
         "you are running Python %d.%d.%d."
         % (sys.version_info[0], sys.version_info[1], sys.version_info[2]),
     ]
@@ -68,7 +68,7 @@ def read_file(fname):
 
 def package_files(directory):
     paths = []
-    for (fpath, directories, filenames) in walk(directory):
+    for fpath, directories, filenames in walk(directory):
         for filename in filenames:
             paths.append(path.join("..", fpath, filename))
     return paths
@@ -100,7 +100,7 @@ setup(
     install_requires=[
         "find_libpython",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.6.2",
     packages=find_packages(),
     package_data={
         "cocotb": (


### PR DESCRIPTION
Backport of #4444.