### PR TITLE
Rename time 'units' to 'unit'

### DIFF
--- a/docs/source/coroutines.rst
+++ b/docs/source/coroutines.rst
@@ -26,7 +26,7 @@ For example:
 
     async def wait_10ns():
         cocotb.log.info("About to wait for 10 ns")
-        await Timer(10, units='ns')
+        await Timer(10, unit='ns')
         cocotb.log.info("Simulation time has advanced by 10 ns")
 
 Coroutines may also await on other coroutines:
@@ -66,15 +66,15 @@ some time after the current Task yields control.
         """While reset is active, toggle signals"""
         tb = uart_tb(dut)
         # "Clock" is a built in class for toggling a clock signal
-        Clock(dut.clk, 1, units='ns').start()
+        Clock(dut.clk, 1, unit='ns').start()
         # reset_dut is a function -
         # part of the user-generated "uart_tb" class
         # run reset_dut immediately before continuing
         await tb.reset_dut(dut.rstn, 20)
 
-        await Timer(10, units='ns')
+        await Timer(10, unit='ns')
         print("Reset is still active: %d" % dut.rstn)
-        await Timer(15, units='ns')
+        await Timer(15, unit='ns')
         print("Reset has gone inactive: %d" % dut.rstn)
 
 Other tasks can be used in an await statement to suspend the current task until the other task finishes.
@@ -83,7 +83,7 @@ Other tasks can be used in an await statement to suspend the current task until 
 
     @cocotb.test()
     async def test_count_edge_cycles(dut, period_ns=1, clocks=6):
-        Clock(dut.clk, period_ns, units='ns').start()
+        Clock(dut.clk, period_ns, unit='ns').start()
         await RisingEdge(dut.clk)
 
         timer = Timer(period_ns + 10, 'ns')
@@ -107,23 +107,23 @@ forcing their completion before they would naturally end.
 
     @cocotb.test()
     async def test_different_clocks(dut):
-        clk_1mhz   = Clock(dut.clk, 1.0, units='us')
-        clk_250mhz = Clock(dut.clk, 4.0, units='ns')
+        clk_1mhz   = Clock(dut.clk, 1.0, unit='us')
+        clk_250mhz = Clock(dut.clk, 4.0, unit='ns')
 
         clk_1mhz.start()
-        start_time_ns = get_sim_time(units='ns')
-        await Timer(1, units='ns')
+        start_time_ns = get_sim_time(unit='ns')
+        await Timer(1, unit='ns')
         await RisingEdge(dut.clk)
-        edge_time_ns = get_sim_time(units='ns')
+        edge_time_ns = get_sim_time(unit='ns')
         assert isclose(edge_time_ns, start_time_ns + 1000.0), "Expected a period of 1 us"
 
         clk_1mhz.stop()  # stop 1MHz clock here
 
         clk_250mhz.start()
-        start_time_ns = get_sim_time(units='ns')
-        await Timer(1, units='ns')
+        start_time_ns = get_sim_time(unit='ns')
+        await Timer(1, unit='ns')
         await RisingEdge(dut.clk)
-        edge_time_ns = get_sim_time(units='ns')
+        edge_time_ns = get_sim_time(unit='ns')
         assert isclose(edge_time_ns, start_time_ns + 4.0), "Expected a period of 4 ns"
 
 

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -289,9 +289,8 @@ Logging
 
 .. attribute:: logging.LogRecord.created_sim_time
 
-    The result of :func:`~cocotb.utils.get_sim_time` at the point the log was created
-    (in simulator units). The formatter is responsible for converting this
-    to something like nanoseconds via :func:`~cocotb.utils.get_time_from_sim_steps`.
+    The result of :func:`~cocotb.utils.get_sim_time` at the point the log was created (in simulation time).
+    The formatter is responsible for converting this to something like nanoseconds via :func:`~cocotb.utils.get_time_from_sim_steps`.
 
     This is added by :class:`cocotb.log.SimTimeContextFilter`.
 

--- a/docs/source/newsfragments/4396.change.rst
+++ b/docs/source/newsfragments/4396.change.rst
@@ -1,1 +1,1 @@
-The attribute ``frequency`` on :class:`~cocotb.clock.Clock` was removed, and the attribute :attr:`~cocotb.clock.Clock.period` was changed to be in terms of the passed-in units rather than simulation steps.
+The attribute ``frequency`` on :class:`~cocotb.clock.Clock` was removed, and the attribute :attr:`~cocotb.clock.Clock.period` was changed to be in terms of the passed-in unit rather than simulation steps.

--- a/docs/source/newsfragments/4455.change.rst
+++ b/docs/source/newsfragments/4455.change.rst
@@ -1,0 +1,1 @@
+The ``units`` argument was renamed to ``unit`` in :class:`~cocotb.clock.Clock`, :class:`~cocotb.triggers.Timer`, :class:`~cocotb.triggers.with_timeout`, :func:`~cocotb.utils.get_sim_time`, :func:`~cocotb.utils.get_time_from_sim_steps`, and :func:`~cocotb.utils.get_sim_steps`.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -81,7 +81,7 @@ for more information on such concurrent processes.
    No need to write your own clock generator!
 
    You would start :class:`~cocotb.clock.Clock` with
-   ``Clock(dut.clk, 1, units="ns").start()`` near the top of your test,
+   ``Clock(dut.clk, 1, unit="ns").start()`` near the top of your test,
    after importing it with ``from cocotb.clock import Clock``.
 
 

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -180,7 +180,7 @@ The following example shows these in action:
     # A coroutine
     async def reset_dut(reset_n, duration_ns):
         reset_n.value = 0
-        await Timer(duration_ns, units="ns")
+        await Timer(duration_ns, unit="ns")
         reset_n.value = 1
         reset_n._log.debug("Reset complete")
 
@@ -196,7 +196,7 @@ The following example shows these in action:
         reset_thread = cocotb.start_soon(reset_dut(reset_n, duration_ns=500))
 
         # This timer will complete before the timer in the concurrently executing "reset_thread"
-        await Timer(250, units="ns")
+        await Timer(250, unit="ns")
         dut._log.debug("During reset (reset_n = %s)" % reset_n.value)
 
         # Wait for the other thread to complete

--- a/examples/adder/tests/test_adder.py
+++ b/examples/adder/tests/test_adder.py
@@ -24,7 +24,7 @@ async def adder_basic_test(dut):
     dut.A.value = A
     dut.B.value = B
 
-    await Timer(2, units="ns")
+    await Timer(2, unit="ns")
 
     assert dut.X.value == adder_model(A, B), (
         f"Adder result is incorrect: {dut.X.value} != 15"
@@ -42,7 +42,7 @@ async def adder_randomised_test(dut):
         dut.A.value = A
         dut.B.value = B
 
-        await Timer(2, units="ns")
+        await Timer(2, unit="ns")
 
         assert dut.X.value == adder_model(A, B), (
             f"Randomised test failed with: {dut.A.value} + {dut.B.value} = {dut.X.value}"

--- a/examples/analog_model/test_analog_model.py
+++ b/examples/analog_model/test_analog_model.py
@@ -33,7 +33,7 @@ async def gain_select(digital, afe) -> None:
 async def test_analog_model(digital) -> None:
     """Exercise an Analog Front-end and its digital controller."""
 
-    clock = Clock(digital.clk, 1, units="us")  # create a 1us period clock on port clk
+    clock = Clock(digital.clk, 1, unit="us")  # create a 1us period clock on port clk
     cocotb.start_soon(clock.start())  # start the clock
 
     afe_in_queue = Queue()

--- a/examples/doc_examples/quickstart/test_my_design.py
+++ b/examples/doc_examples/quickstart/test_my_design.py
@@ -13,9 +13,9 @@ async def my_first_test(dut):
 
     for cycle in range(10):
         dut.clk.value = 0
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
         dut.clk.value = 1
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
 
     dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)
     assert dut.my_signal_2.value == 0, "my_signal_2 is not 0!"
@@ -32,9 +32,9 @@ async def generate_clock(dut):
 
     for cycle in range(10):
         dut.clk.value = 0
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
         dut.clk.value = 1
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
 
 
 @cocotb.test()
@@ -43,7 +43,7 @@ async def my_second_test(dut):
 
     cocotb.start_soon(generate_clock(dut))  # run the clock "in the background"
 
-    await Timer(5, units="ns")  # wait a bit
+    await Timer(5, unit="ns")  # wait a bit
     await FallingEdge(dut.clk)  # wait for falling edge/"negedge"
 
     dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)

--- a/examples/matrix_multiplier/tests/test_matrix_multiplier.py
+++ b/examples/matrix_multiplier/tests/test_matrix_multiplier.py
@@ -156,7 +156,7 @@ class MatrixMultiplierTester:
 async def multiply_test(dut):
     """Test multiplication of many matrices."""
 
-    cocotb.start_soon(Clock(dut.clk_i, 10, units="ns").start())
+    cocotb.start_soon(Clock(dut.clk_i, 10, unit="ns").start())
     tester = MatrixMultiplierTester(dut)
 
     dut._log.info("Initialize and reset model")

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -25,7 +25,7 @@ LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 )
 async def mixed_language_accessing_test(dut):
     """Try accessing handles and setting values in a mixed language environment."""
-    await Timer(100, units="ns")
+    await Timer(100, unit="ns")
 
     verilog = dut.i_swapper_sv
     dut._log.info(f"Got: {repr(verilog._name)}")
@@ -39,10 +39,10 @@ async def mixed_language_accessing_test(dut):
     dut._log.info(f"Got: {repr(vhdl._name)}")
 
     verilog.reset_n.value = 1
-    await Timer(100, units="ns")
+    await Timer(100, unit="ns")
 
     vhdl.reset_n.value = 1
-    await Timer(100, units="ns")
+    await Timer(100, unit="ns")
 
     assert verilog.reset_n.value == vhdl.reset_n.value, "reset_n signals were different"
 
@@ -61,7 +61,7 @@ async def mixed_language_accessing_test(dut):
 )
 async def mixed_language_functional_test(dut):
     """Try concurrent simulation of VHDL and Verilog and check the output."""
-    await Timer(100, units="ns")
+    await Timer(100, unit="ns")
 
     verilog = dut.i_swapper_sv
     dut._log.info(f"Got: {repr(verilog._name)}")
@@ -85,13 +85,13 @@ async def mixed_language_functional_test(dut):
     dut.csr_writedata.value = 0
 
     # reset cycle
-    await Timer(100, units="ns")
+    await Timer(100, unit="ns")
     dut.reset_n.value = 1
-    await Timer(100, units="ns")
+    await Timer(100, unit="ns")
 
     # start clock
-    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
-    await Timer(500, units="ns")
+    cocotb.start_soon(Clock(dut.clk, 10, unit="ns").start())
+    await Timer(500, unit="ns")
 
     previous_indata = 0
     # transmit some packets

--- a/examples/mixed_signal/tests/test_regulator_plot.py
+++ b/examples/mixed_signal/tests/test_regulator_plot.py
@@ -20,7 +20,7 @@ async def test_trim_vals(tb_hdl):
     probedata = []
     for trim_val in [0, 3, -5]:
         tb_hdl.trim_val.value = trim_val
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
         trimmed_volt = await get_voltage(tb_hdl, probed_node)
         actual_trim_val = tb_hdl.trim_val.value.to_signed()
         tb_hdl._log.info(
@@ -35,14 +35,12 @@ async def test_trim_vals(tb_hdl):
 
 async def get_voltage(tb_hdl, node):
     """Measure voltage on *node*."""
-    await Timer(1, units="ps")  # let trim_val take effect
+    await Timer(1, unit="ps")  # let trim_val take effect
     tb_hdl.i_analog_probe.node_to_probe.value = node.encode("ascii")
     tb_hdl.i_analog_probe.probe_voltage_toggle.value = ~int(
         tb_hdl.i_analog_probe.probe_voltage_toggle
     )
-    await Timer(
-        1, units="ps"
-    )  # waiting time needed for the analog values to be updated
+    await Timer(1, unit="ps")  # waiting time needed for the analog values to be updated
     tb_hdl._log.debug(
         f"Voltage on node {node} is {tb_hdl.i_analog_probe.voltage.value:.4} V"
     )

--- a/examples/mixed_signal/tests/test_regulator_trim.py
+++ b/examples/mixed_signal/tests/test_regulator_trim.py
@@ -32,7 +32,7 @@ class Regulator_TB:
         self.tb_hdl.i_analog_probe.node_to_probe.value = node.encode("ascii")
         self.analog_probe.probe_voltage_toggle.value = toggle
         await Timer(
-            1, units="ps"
+            1, unit="ps"
         )  # waiting time needed for the analog values to be updated
         self.tb_hdl._log.debug(
             "trim value={}: {}={:.4} V".format(
@@ -64,11 +64,11 @@ class Regulator_TB:
         # the actual trimming procedure:
         # minimum values
         trim_val_node.value = trim_val_min
-        await Timer(self.settling_time_ns, units="ns")
+        await Timer(self.settling_time_ns, unit="ns")
         volt_min = await self.get_voltage(probed_node)
         # maximum values
         trim_val_node.value = trim_val_max
-        await Timer(self.settling_time_ns, units="ns")
+        await Timer(self.settling_time_ns, unit="ns")
         volt_max = await self.get_voltage(probed_node)
         if target_volt > volt_max:
             self.tb_hdl._log.debug(
@@ -107,7 +107,7 @@ async def run_test(tb_hdl):
     )
     best_trim_rounded = round(best_trim_float)
     tb_py.tb_hdl.trim_val.value = best_trim_rounded
-    await Timer(tb_py.settling_time_ns, units="ns")
+    await Timer(tb_py.settling_time_ns, unit="ns")
     trimmed_volt = await tb_py.get_voltage(node)
     tb_py.tb_hdl._log.info(
         f"Best trimming value is {best_trim_rounded} "

--- a/examples/mixed_signal/tests/test_rescap.py
+++ b/examples/mixed_signal/tests/test_rescap.py
@@ -29,10 +29,10 @@ class ResCap_TB:
         self.analog_probe.probe_voltage_toggle.value = toggle
         self.analog_probe.probe_current_toggle.value = toggle
         await Timer(
-            1, units="ps"
+            1, unit="ps"
         )  # waiting time needed for the analog values to be updated
         dataset = Dataset(
-            time=get_sim_time(units="ns"),
+            time=get_sim_time(unit="ns"),
             voltage=self.analog_probe.voltage.value,
             current=self.analog_probe.current.value * 1000.0,  # in mA
         )
@@ -61,7 +61,7 @@ class ResCap_TB:
                 dataset = await self._get_single_sample(node)
                 datasets[node].append(dataset)
             if idx != num:
-                await Timer(delay_ns, units="ns")
+                await Timer(delay_ns, unit="ns")
         return datasets
 
     def plot_data(self, datasets, nodes, graphfile="cocotb_plot.png"):

--- a/examples/mixed_signal/tests/test_rescap_minimalist.py
+++ b/examples/mixed_signal/tests/test_rescap_minimalist.py
@@ -14,11 +14,11 @@ async def rescap_minimalist_test(tb_hdl):
     tb_hdl.i_analog_probe.node_to_probe.value = b"tb_rescap.i_rescap.vout"
 
     for toggle in [1, 0, 1, 0, 1, 0]:
-        await Timer(50, units="ns")
+        await Timer(50, unit="ns")
         tb_hdl.i_analog_probe.probe_voltage_toggle.value = toggle
         tb_hdl.i_analog_probe.probe_current_toggle.value = toggle
         await Timer(
-            1, units="ps"
+            1, unit="ps"
         )  # waiting time needed for the analog values to be updated
         tb_hdl._log.info(
             "tb_hdl.i_analog_probe@{}={:.4} V  {:.4} A".format(

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -20,7 +20,7 @@ async def dff_simple_test(dut):
     # Set initial input value to prevent it from floating
     dut.d.value = 0
 
-    clock = Clock(dut.clk, 10, units="us")  # Create a 10us period clock on port clk
+    clock = Clock(dut.clk, 10, unit="us")  # Create a 10us period clock on port clk
     # Start the clock. Start it low to avoid issues on the first RisingEdge
     cocotb.start_soon(clock.start(start_high=False))
 

--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -48,6 +48,7 @@ from typing import (
 )
 
 import cocotb
+from cocotb._typing import TimeUnit
 from cocotb.regression import Test
 
 Result = TypeVar("Result")
@@ -170,7 +171,7 @@ class _Parameterized(Generic[F]):
         *,
         name: Optional[str] = None,
         timeout_time: Optional[float] = None,
-        timeout_unit: str = "step",
+        timeout_unit: TimeUnit = "step",
         expect_fail: bool = False,
         expect_error: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = (),
         skip: bool = False,
@@ -264,7 +265,7 @@ def test(_func: Union[F, _Parameterized[F]]) -> F: ...
 def test(
     *,
     timeout_time: Optional[float] = None,
-    timeout_unit: str = "step",
+    timeout_unit: TimeUnit = "step",
     expect_fail: bool = False,
     expect_error: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = (),
     skip: bool = False,
@@ -278,7 +279,7 @@ def test(
     _func: Optional[Union[F, _Parameterized[F]]] = None,
     *,
     timeout_time: Optional[float] = None,
-    timeout_unit: str = "step",
+    timeout_unit: TimeUnit = "step",
     expect_fail: bool = False,
     expect_error: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = (),
     skip: bool = False,

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -67,7 +67,7 @@ class TaskComplete(Trigger, Generic[T]):
     .. code-block:: python
 
         async def coro_inner():
-            await Timer(1, units="ns")
+            await Timer(1, unit="ns")
             raise ValueError("Oops")
 
 
@@ -120,7 +120,7 @@ def Join(task: "cocotb.task.Task[T]") -> "cocotb.task.Task[T]":
     .. code-block:: python
 
         async def coro_inner():
-            await Timer(1, units="ns")
+            await Timer(1, unit="ns")
             return "Hello world"
 
 
@@ -136,7 +136,7 @@ def Join(task: "cocotb.task.Task[T]") -> "cocotb.task.Task[T]":
         the result of which will be the result of the Task.
 
     .. deprecated:: 2.0
-        Using ``task`` directly is prefered to ``Join(task)`` in all situations where the latter could be used.
+        Using ``task`` directly is preferred to ``Join(task)`` in all situations where the latter could be used.
     """
     return task
 
@@ -261,8 +261,8 @@ class First(_AggregateWaitable[Any]):
         For this reason, the value of ``t_ret is t1`` in the following example
         is implementation-defined, and will vary by simulator::
 
-            t1 = Timer(10, units="ps")
-            t2 = Timer(10, units="ps")
+            t1 = Timer(10, unit="ps")
+            t2 = Timer(10, unit="ps")
             t_ret = await First(t1, t2)
 
     .. note::
@@ -498,7 +498,7 @@ async def with_timeout(
         timeout_time:
             Simulation time duration before timeout occurs.
         timeout_unit:
-            Units of timeout_time, accepts any units that :class:`~cocotb.triggers.Timer` does.
+            Unit of timeout_time, accepts any unit that :class:`~cocotb.triggers.Timer` does.
         round_mode:
             String specifying how to handle time values that sit between time steps
             (one of ``'error'``, ``'round'``, ``'ceil'``, ``'floor'``).

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -51,6 +51,7 @@ from cocotb._base_triggers import NullTrigger, Trigger, _InternalEvent
 from cocotb._deprecation import deprecated
 from cocotb._gpi_triggers import FallingEdge, RisingEdge, Timer, ValueChange
 from cocotb._outcomes import Error, Outcome, Value
+from cocotb._typing import TimeUnit
 from cocotb._utils import remove_traceback_frames
 
 T = TypeVar("T")
@@ -425,7 +426,7 @@ class SimTimeoutError(TimeoutError):
 async def with_timeout(
     trigger: Trigger,
     timeout_time: Union[float, Decimal],
-    timeout_unit: str = "step",
+    timeout_unit: TimeUnit = "step",
     round_mode: Optional[str] = None,
 ) -> None: ...
 
@@ -434,7 +435,7 @@ async def with_timeout(
 async def with_timeout(
     trigger: Waitable[T],
     timeout_time: Union[float, Decimal],
-    timeout_unit: str = "step",
+    timeout_unit: TimeUnit = "step",
     round_mode: Optional[str] = None,
 ) -> T: ...
 
@@ -443,7 +444,7 @@ async def with_timeout(
 async def with_timeout(
     trigger: "cocotb.task.Task[T]",
     timeout_time: Union[float, Decimal],
-    timeout_unit: str = "step",
+    timeout_unit: TimeUnit = "step",
     round_mode: Optional[str] = None,
 ) -> T: ...
 
@@ -452,7 +453,7 @@ async def with_timeout(
 async def with_timeout(
     trigger: Coroutine[Any, Any, T],
     timeout_time: Union[float, Decimal],
-    timeout_unit: str = "step",
+    timeout_unit: TimeUnit = "step",
     round_mode: Optional[str] = None,
 ) -> T: ...
 
@@ -462,7 +463,7 @@ async def with_timeout(
         Trigger, Waitable[Any], "cocotb.task.Task[Any]", Coroutine[Any, Any, Any]
     ],
     timeout_time: Union[float, Decimal],
-    timeout_unit: str = "step",
+    timeout_unit: TimeUnit = "step",
     round_mode: Optional[str] = None,
 ) -> Any:
     r"""Wait on triggers or coroutines, throw an exception if it waits longer than the given time.

--- a/src/cocotb/_gpi_triggers.py
+++ b/src/cocotb/_gpi_triggers.py
@@ -86,11 +86,14 @@ class Timer(GPITrigger):
             .. versionchanged:: 1.5
                 Previously this argument was misleadingly called `time_ps`.
 
-        units: The unit of the time value.
+        unit: The unit of the time value.
 
             One of ``'step'``, ``'fs'``, ``'ps'``, ``'ns'``, ``'us'``, ``'ms'``, ``'sec'``.
-            When *units* is ``'step'``,
+            When *unit* is ``'step'``,
             the timestep is determined by the simulator (see :make:var:`COCOTB_HDL_TIMEPRECISION`).
+
+            .. versionchanged:: 2.0
+                Renamed from ``units``.
 
         round_mode:
 
@@ -101,24 +104,24 @@ class Timer(GPITrigger):
         ValueError: If a non-positive value is passed for Timer setup.
 
     Usage:
-        >>> await Timer(100, units="ps")
+        >>> await Timer(100, unit="ps")
 
         The time can also be a ``float``:
 
-        >>> await Timer(100e-9, units="sec")
+        >>> await Timer(100e-9, unit="sec")
 
         which is particularly convenient when working with frequencies:
 
         >>> freq = 10e6  # 10 MHz
-        >>> await Timer(1 / freq, units="sec")
+        >>> await Timer(1 / freq, unit="sec")
 
         Other built-in exact numeric types can be used too:
 
         >>> from fractions import Fraction
-        >>> await Timer(Fraction(1, 10), units="ns")
+        >>> await Timer(Fraction(1, 10), unit="ns")
 
         >>> from decimal import Decimal
-        >>> await Timer(Decimal("100e-9"), units="sec")
+        >>> await Timer(Decimal("100e-9"), unit="sec")
 
         These are most useful when using computed durations while
         avoiding floating point inaccuracies.
@@ -128,13 +131,13 @@ class Timer(GPITrigger):
         Warn for 0 as this will cause erratic behavior in some simulators as well.
 
     .. versionchanged:: 1.5
-        Support ``'step'`` as the *units* argument to mean "simulator time step".
+        Support ``'step'`` as the *unit* argument to mean "simulator time step".
 
     .. versionchanged:: 1.6
         Support rounding modes.
 
     .. versionremoved:: 2.0
-        Passing ``None`` as the *units* argument was removed, use ``'step'`` instead.
+        Passing ``None`` as the *unit* argument was removed, use ``'step'`` instead.
 
     .. versionremoved:: 2.0
         The ``time_ps`` parameter was removed, use the ``time`` parameter instead.
@@ -149,7 +152,7 @@ class Timer(GPITrigger):
     def __init__(
         self,
         time: Union[float, Fraction, Decimal],
-        units: str = "step",
+        unit: str = "step",
         *,
         round_mode: Optional[str] = None,
     ) -> None:
@@ -158,7 +161,7 @@ class Timer(GPITrigger):
             raise ValueError("Timer argument time must be positive")
         if round_mode is None:
             round_mode = type(self).round_mode
-        self._sim_steps = get_sim_steps(time, units, round_mode=round_mode)
+        self._sim_steps = get_sim_steps(time, unit, round_mode=round_mode)
         # If we round to 0, we fix it up to 1 step as rounding is imprecise,
         # and Timer(0) is invalid.
         if self._sim_steps == 0:
@@ -177,7 +180,7 @@ class Timer(GPITrigger):
     def __repr__(self) -> str:
         return "<{} of {:1.2f}ps at {}>".format(
             type(self).__qualname__,
-            get_time_from_sim_steps(self._sim_steps, units="ps"),
+            get_time_from_sim_steps(self._sim_steps, unit="ps"),
             pointer_str(self),
         )
 

--- a/src/cocotb/_gpi_triggers.py
+++ b/src/cocotb/_gpi_triggers.py
@@ -46,6 +46,7 @@ import cocotb.handle
 from cocotb import simulator
 from cocotb._base_triggers import Trigger
 from cocotb._deprecation import deprecated
+from cocotb._typing import TimeUnit
 from cocotb._utils import pointer_str, singleton
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 
@@ -152,7 +153,7 @@ class Timer(GPITrigger):
     def __init__(
         self,
         time: Union[float, Fraction, Decimal],
-        unit: str = "step",
+        unit: TimeUnit = "step",
         *,
         round_mode: Optional[str] = None,
     ) -> None:

--- a/src/cocotb/_typing.py
+++ b/src/cocotb/_typing.py
@@ -1,0 +1,12 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import (  # noqa: F401  # These types are used in type strings in this module
+        Literal,
+        TypeAlias,
+    )
+
+TimeUnit: "TypeAlias" = 'Literal["step"] | Literal["fs"] | Literal["ps"] | Literal["ns"] | Literal["us"] | Literal["ms"] | Literal["sec"]'

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Type, Union
 
 import cocotb
 from cocotb._py_compat import cached_property
+from cocotb._typing import TimeUnit
 from cocotb._utils import cached_method
 from cocotb._write_scheduler import trust_inertial
 from cocotb.handle import LogicObject
@@ -146,12 +147,12 @@ class Clock:
         self,
         signal: LogicObject,
         period: Union[float, Fraction, Decimal],
-        unit: str = "step",
+        unit: TimeUnit = "step",
         impl: "Impl | None" = None,
     ) -> None:
         self._signal = signal
         self._period = period
-        self._unit = unit
+        self._unit: TimeUnit = unit
         self._impl: "Impl"  # noqa: UP037  # ruff assumes we are at least using Python 3.7 and gives false positive.
 
         if impl is None:
@@ -177,7 +178,7 @@ class Clock:
         return self._period
 
     @property
-    def unit(self) -> str:
+    def unit(self) -> TimeUnit:
         """The unit of the clock period."""
         return self._unit
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -64,6 +64,7 @@ import cocotb._write_scheduler
 from cocotb import _ANSI, simulator
 from cocotb._exceptions import InternalError
 from cocotb._outcomes import Error, Outcome
+from cocotb._typing import TimeUnit
 from cocotb._utils import (
     DocEnum,
     remove_traceback_frames,
@@ -151,7 +152,7 @@ class Test:
         module: Optional[str] = None,
         doc: Optional[str] = None,
         timeout_time: Optional[float] = None,
-        timeout_unit: str = "step",
+        timeout_unit: TimeUnit = "step",
         expect_fail: bool = False,
         expect_error: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = (),
         skip: bool = False,
@@ -1115,7 +1116,7 @@ class TestFactory(Generic[F]):
         stacklevel: int = 0,
         name: Optional[str] = None,
         timeout_time: Optional[float] = None,
-        timeout_unit: str = "steps",
+        timeout_unit: TimeUnit = "step",
         expect_fail: bool = False,
         expect_error: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = (),
         skip: bool = False,

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -124,7 +124,7 @@ class Test:
             Simulation time duration before the test is forced to fail with a :exc:`~cocotb.triggers.SimTimeoutError`.
 
         timeout_unit:
-            Units of ``timeout_time``, accepts any units that :class:`~cocotb.triggers.Timer` does.
+            Unit of ``timeout_time``, accepts any unit that :class:`~cocotb.triggers.Timer` does.
 
         expect_fail:
             If ``True`` and the test fails a functional check via an :keyword:`assert` statement, :func:`pytest.raises`,

--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -118,7 +118,7 @@ GPI_EXPORT bool gpi_has_registered_impl(void);
 GPI_EXPORT void gpi_sim_end(void);
 
 /**
- * Return simulation time as two uints. Units are default sim units.
+ * Return simulation time as two uints. Unit is the default sim unit.
  */
 GPI_EXPORT void gpi_get_sim_time(uint32_t *high, uint32_t *low);
 GPI_EXPORT void gpi_get_sim_precision(int32_t *precision);

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -213,7 +213,7 @@ class Task(Generic[ResultType]):
         .. code-block:: python
 
             async def coro_inner():
-                await Timer(1, units="ns")
+                await Timer(1, unit="ns")
                 return "Hello world"
 
 
@@ -226,7 +226,7 @@ class Task(Generic[ResultType]):
             the result of which will be the result of the Task.
 
         .. deprecated:: 2.0
-            Using ``task`` directly is prefered to ``task.join()`` in all situations where the latter could be used.
+            Using ``task`` directly is preferred to ``task.join()`` in all situations where the latter could be used.
         """
         return self
 

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -38,6 +38,7 @@ from typing import (
 )
 
 from cocotb import simulator
+from cocotb._typing import TimeUnit
 
 
 def _get_simulator_precision() -> int:
@@ -49,7 +50,7 @@ def _get_simulator_precision() -> int:
 
 
 # Simulator helper functions
-def get_sim_time(unit: str = "step") -> int:
+def get_sim_time(unit: TimeUnit = "step") -> int:
     """Retrieve the simulation time from the simulator.
 
     Args:
@@ -104,7 +105,7 @@ def _ldexp10(frac: Union[float, Fraction, Decimal], exp: int) -> Any:
         return frac / (10**-exp)
 
 
-def get_time_from_sim_steps(steps: int, unit: str) -> int:
+def get_time_from_sim_steps(steps: int, unit: TimeUnit) -> int:
     """Calculate simulation time in the specified *unit* from the *steps* based
     on the simulator precision.
 
@@ -127,7 +128,7 @@ def get_time_from_sim_steps(steps: int, unit: str) -> int:
 
 def get_sim_steps(
     time: Union[float, Fraction, Decimal],
-    unit: str = "step",
+    unit: TimeUnit = "step",
     *,
     round_mode: str = "error",
 ) -> int:
@@ -190,7 +191,7 @@ def get_sim_steps(
 
 
 @lru_cache(maxsize=None)
-def _get_log_time_scale(unit: str) -> int:
+def _get_log_time_scale(unit: TimeUnit) -> int:
     """Retrieves the ``log10()`` of the scale factor for a given time unit.
 
     Args:

--- a/tests/pytest/test_logs.py
+++ b/tests/pytest/test_logs.py
@@ -31,7 +31,7 @@ sim = os.getenv("SIM", "icarus")
 
 @cocotb.test()
 async def clock_design(dut):
-    clock = Clock(dut.clk, 10, units="us")
+    clock = Clock(dut.clk, 10, unit="us")
     cocotb.start_soon(clock.start())
     await ClockCycles(dut.clk, 10)
 

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -27,7 +27,7 @@ sim = os.getenv("SIM", "icarus")
 
 @cocotb.test()
 async def clock_design(dut):
-    clock = Clock(dut.clk, 10, units="us")
+    clock = Clock(dut.clk, 10, unit="us")
     cocotb.start_soon(clock.start())
     await ClockCycles(dut.clk, 10)
 

--- a/tests/test_cases/issue_892/issue_892.py
+++ b/tests/test_cases/issue_892/issue_892.py
@@ -4,11 +4,11 @@ from cocotb.triggers import Timer
 
 
 async def raise_test_success():
-    await Timer(1, units="ns")
+    await Timer(1, unit="ns")
     raise TestSuccess("TestSuccess")
 
 
 @cocotb.test()
 async def error_test(dut):
     cocotb.start_soon(raise_test_success())
-    await Timer(10, units="ns")
+    await Timer(10, unit="ns")

--- a/tests/test_cases/test_3316_a/test_3316_a.py
+++ b/tests/test_cases/test_3316_a/test_3316_a.py
@@ -12,7 +12,7 @@ from cocotb.triggers import RisingEdge
 @cocotb.test()
 async def clk_in_coroutine(dut):
     dut.d.value = 0
-    clock = Clock(dut.clk, 10, units="us")
+    clock = Clock(dut.clk, 10, unit="us")
     cocotb.start_soon(clock.start(start_high=False))
     await RisingEdge(dut.clk)
     for _ in range(3):

--- a/tests/test_cases/test_3316_b/test_3316_b.py
+++ b/tests/test_cases/test_3316_b/test_3316_b.py
@@ -12,7 +12,7 @@ from cocotb.triggers import RisingEdge
 @cocotb.test()
 async def clk_in_coroutine(dut):
     dut.d.value = 0
-    clock = Clock(dut.clk, 10, units="us")
+    clock = Clock(dut.clk, 10, unit="us")
     cocotb.start_soon(clock.start(start_high=False))
     await RisingEdge(dut.clk)
     for _ in range(3):

--- a/tests/test_cases/test_3316_c/test_3316_c.py
+++ b/tests/test_cases/test_3316_c/test_3316_c.py
@@ -12,7 +12,7 @@ from cocotb.triggers import RisingEdge
 @cocotb.test()
 async def clk_in_coroutine(dut):
     dut.d.value = 0
-    clock = Clock(dut.clk, 10, units="us")
+    clock = Clock(dut.clk, 10, unit="us")
     cocotb.start_soon(clock.start(start_high=False))
     await RisingEdge(dut.clk)
     for _ in range(3):

--- a/tests/test_cases/test_3316_d/test_3316_d.py
+++ b/tests/test_cases/test_3316_d/test_3316_d.py
@@ -12,7 +12,7 @@ from cocotb.triggers import RisingEdge
 @cocotb.test()
 async def clk_in_coroutine(dut):
     dut.d.value = 0
-    clock = Clock(dut.clk, 10, units="us")
+    clock = Clock(dut.clk, 10, unit="us")
     cocotb.start_soon(clock.start(start_high=False))
     await RisingEdge(dut.clk)
     for _ in range(3):

--- a/tests/test_cases/test_async_bridge/test_async_bridge.py
+++ b/tests/test_cases/test_async_bridge/test_async_bridge.py
@@ -42,7 +42,7 @@ def return_two(dut):
 async def await_two_clock_edges(dut):
     await RisingEdge(dut.clk)
     await RisingEdge(dut.clk)
-    await Timer(1, units="ns")
+    await Timer(1, unit="ns")
     dut._log.info("Returning from await_two_clock_edges")
     return 2
 
@@ -67,7 +67,7 @@ async def test_time_in_bridge(dut):
     Test that the simulation time does not advance if the wrapped blocking
     routine does not call @cocotb.resume
     """
-    await Timer(10, units="ns")
+    await Timer(10, unit="ns")
     time = get_sim_time("ns")
     dut._log.info("Time at start of test = %d", time)
     for i in range(100):
@@ -75,7 +75,7 @@ async def test_time_in_bridge(dut):
         await cocotb.bridge(print_sim_time)(dut, time)
 
     time_now = get_sim_time("ns")
-    await Timer(10, units="ns")
+    await Timer(10, unit="ns")
 
     assert time == time_now
 
@@ -96,8 +96,8 @@ async def test_time_in_resume(dut):
     def wait_cycles_wrapper(dut, n):
         return wait_cycles(dut, n)
 
-    cocotb.start_soon(Clock(dut.clk, 100, units="ns").start())
-    await Timer(10, units="ns")
+    cocotb.start_soon(Clock(dut.clk, 100, unit="ns").start())
+    await Timer(10, unit="ns")
     for n in range(5):
         for i in range(20):
             await RisingEdge(dut.clk)
@@ -118,11 +118,11 @@ async def test_blocking_function_call_return(dut):
         count = 0
         while True:
             await RisingEdge(dut.clk)
-            await Timer(1000, units="ns")
+            await Timer(1000, unit="ns")
             count += 1
 
     cocotb.start_soon(clock_monitor(dut))
-    cocotb.start_soon(Clock(dut.clk, 100, units="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 100, unit="ns").start())
     value = await cocotb.bridge(return_two)(dut)
     assert value == 2
 
@@ -159,7 +159,7 @@ async def test_resume_from_readonly(dut):
     Test that @cocotb.bridge functions that call @cocotb.resumes that await Triggers
     can be called from ReadOnly state
     """
-    cocotb.start_soon(Clock(dut.clk, 100, units="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 100, unit="ns").start())
 
     await ReadOnly()
     dut._log.info("In readonly")
@@ -174,7 +174,7 @@ async def test_resume_that_awaits(dut):
     awaits Triggers and return values back through to
     the test
     """
-    cocotb.start_soon(Clock(dut.clk, 100, units="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 100, unit="ns").start())
 
     value = await cocotb.bridge(calls_cocotb_resume)(dut)
     assert value == 2
@@ -187,12 +187,12 @@ async def test_await_after_bridge(dut):
     from @cocotb.bridge functions that call @cocotb.resumes that consume
     simulation time
     """
-    cocotb.start_soon(Clock(dut.clk, 100, units="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 100, unit="ns").start())
 
     value = await cocotb.bridge(calls_cocotb_resume)(dut)
     assert value == 2
 
-    await Timer(10, units="ns")
+    await Timer(10, unit="ns")
     await RisingEdge(dut.clk)
 
 
@@ -211,7 +211,7 @@ async def test_bridge_from_start_soon(dut):
         value = await cocotb.bridge(return_two)(dut)
         return value
 
-    cocotb.start_soon(Clock(dut.clk, 100, units="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 100, unit="ns").start())
 
     coro1 = cocotb.start_soon(run_function(dut))
     value = await coro1
@@ -304,7 +304,7 @@ async def test_resume_from_weird_thread_fails(dut):
     async def func():
         nonlocal func_started
         func_started = True
-        await Timer(10, units="ns")
+        await Timer(10, unit="ns")
 
     def function_caller():
         nonlocal raised
@@ -324,7 +324,7 @@ async def test_resume_from_weird_thread_fails(dut):
 
     task = cocotb.start_soon(ext())
 
-    await Timer(20, units="ns")
+    await Timer(20, unit="ns")
 
     assert caller_resumed, "Caller was never resumed"
     assert not func_started, "Function should never have started"
@@ -342,7 +342,7 @@ async def test_resume_called_in_parallel(dut):
 
     @cocotb.resume
     async def function(x):
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
         return x
 
     @cocotb.bridge

--- a/tests/test_cases/test_cocotb/test_clock.py
+++ b/tests/test_cases/test_cocotb/test_clock.py
@@ -24,12 +24,12 @@ LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 @cocotb.test()
 @cocotb.parametrize(impl=["gpi", "py"])
 async def test_clock_with_units(dut, impl: str) -> None:
-    clk_1mhz = Clock(dut.clk, 1.0, units="us", impl=impl)
-    clk_250mhz = Clock(dut.clk, 4, units="ns", impl=impl)
+    clk_1mhz = Clock(dut.clk, 1.0, unit="us", impl=impl)
+    clk_250mhz = Clock(dut.clk, 4, unit="ns", impl=impl)
 
     assert clk_1mhz.signal is dut.clk
     assert clk_1mhz.period == 1.0
-    assert clk_1mhz.units == "us"
+    assert clk_1mhz.unit == "us"
     assert clk_1mhz.impl == impl
 
     assert str(clk_1mhz) == f"<Clock, {dut.clk._path} @ 1.0 MHz>"
@@ -37,36 +37,36 @@ async def test_clock_with_units(dut, impl: str) -> None:
 
     clk_gen = cocotb.start_soon(clk_1mhz.start())
 
-    start_time_ns = get_sim_time(units="ns")
+    start_time_ns = get_sim_time(unit="ns")
 
     await Timer(1, "ns")
     await RisingEdge(dut.clk)
 
-    edge_time_ns = get_sim_time(units="ns")
+    edge_time_ns = get_sim_time(unit="ns")
     assert isclose(edge_time_ns, start_time_ns + 1000.0), "Expected a period of 1 us"
 
     start_time_ns = edge_time_ns
 
     await RisingEdge(dut.clk)
-    edge_time_ns = get_sim_time(units="ns")
+    edge_time_ns = get_sim_time(unit="ns")
     assert isclose(edge_time_ns, start_time_ns + 1000.0), "Expected a period of 1 us"
 
     clk_gen.kill()
 
     clk_gen = cocotb.start_soon(clk_250mhz.start())
 
-    start_time_ns = get_sim_time(units="ns")
+    start_time_ns = get_sim_time(unit="ns")
 
     await Timer(1, "ns")
     await RisingEdge(dut.clk)
 
-    edge_time_ns = get_sim_time(units="ns")
+    edge_time_ns = get_sim_time(unit="ns")
     assert isclose(edge_time_ns, start_time_ns + 4.0), "Expected a period of 4 ns"
 
     start_time_ns = edge_time_ns
 
     await RisingEdge(dut.clk)
-    edge_time_ns = get_sim_time(units="ns")
+    edge_time_ns = get_sim_time(unit="ns")
     assert isclose(edge_time_ns, start_time_ns + 4.0), "Expected a period of 4 ns"
 
     clk_gen.kill()
@@ -81,7 +81,7 @@ async def test_gpi_clock_error_signal_type(_) -> None:
 @cocotb.test
 async def test_gpi_clock_error_impl(dut):
     with pytest.raises(ValueError):
-        Clock(dut.clk, 1.0, units="step", impl="invalid")
+        Clock(dut.clk, 1.0, unit="step", impl="invalid")
 
 
 @cocotb.test
@@ -100,7 +100,7 @@ async def test_gpi_clock_error_timing(dut):
 
 @cocotb.test
 async def test_gpi_clock_error_start(dut):
-    clk = Clock(dut.clk, 1.0, units="step", impl="gpi")
+    clk = Clock(dut.clk, 1.0, unit="step", impl="gpi")
     with pytest.raises(ValueError):
         clk.start()
 
@@ -122,11 +122,11 @@ async def test_clocks_with_other_number_types(dut):
     # Update the simulator invocation if this assert hits!
     assert get_precision() <= -10
 
-    clk1 = cocotb.start_soon(Clock(dut.clk, decimal.Decimal("1"), units="ns").start())
+    clk1 = cocotb.start_soon(Clock(dut.clk, decimal.Decimal("1"), unit="ns").start())
     await Timer(10, "ns")
     with pytest.warns(FutureWarning, match="cause a CancelledError to be thrown"):
         clk1.cancel()
-    clk2 = cocotb.start_soon(Clock(dut.clk, fractions.Fraction(1), units="ns").start())
+    clk2 = cocotb.start_soon(Clock(dut.clk, fractions.Fraction(1), unit="ns").start())
     await Timer(10, "ns")
     with pytest.warns(FutureWarning, match="cause a CancelledError to be thrown"):
         clk2.cancel()
@@ -172,12 +172,12 @@ async def test_clock_cycles(dut) -> None:
     # so we start at a consistent state for math below
     await RisingEdge(dut.clk)
 
-    start_time = get_sim_time(units="ns")
+    start_time = get_sim_time(unit="ns")
     await c.cycles(cycles)
-    end_time = get_sim_time(units="ns")
+    end_time = get_sim_time(unit="ns")
     assert end_time == (start_time + (cycles * period_ns))
 
-    start_time = get_sim_time(units="ns")
+    start_time = get_sim_time(unit="ns")
     await c.cycles(cycles, FallingEdge)
-    end_time = get_sim_time(units="ns")
+    end_time = get_sim_time(unit="ns")
     assert end_time == (start_time + (cycles * period_ns) - (period_ns // 2))

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -84,17 +84,17 @@ async def test_first_does_not_kill(dut):
 
     async def coro():
         nonlocal ran
-        await Timer(2, units="ns")
+        await Timer(2, unit="ns")
         ran = True
 
     # Coroutine runs for 2ns, so we expect the timer to fire first
-    timer = Timer(1, units="ns")
+    timer = Timer(1, unit="ns")
     t = await First(timer, cocotb.start_soon(coro()))
     assert t is timer
     assert not ran
 
     # the background routine is still running, but should finish after 1ns
-    await Timer(2, units="ns")
+    await Timer(2, unit="ns")
 
     assert ran
 
@@ -156,17 +156,17 @@ async def test_event_is_set(dut):
 @cocotb.test()
 async def test_combine_start_soon(_):
     async def coro(delay):
-        start_time = get_sim_time(units="ns")
+        start_time = get_sim_time(unit="ns")
         await Timer(delay, "ns")
-        assert get_sim_time(units="ns") == start_time + delay
+        assert get_sim_time(unit="ns") == start_time + delay
 
     max_delay = 10
 
     tasks = [cocotb.start_soon(coro(d)) for d in range(1, max_delay + 1)]
 
-    test_start = get_sim_time(units="ns")
+    test_start = get_sim_time(unit="ns")
     await Combine(*tasks)
-    assert get_sim_time(units="ns") == test_start + max_delay
+    assert get_sim_time(unit="ns") == test_start + max_delay
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -313,7 +313,7 @@ async def test_both_edge_triggers(dut):
 
     rising_coro = cocotb.start_soon(wait_rising_edge())
     falling_coro = cocotb.start_soon(wait_falling_edge())
-    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 10, unit="ns").start())
     await Combine(rising_coro, falling_coro)
 
 

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -329,7 +329,7 @@ async def test_task_repr(_) -> None:
     coro_e = Event("coroutine_inner")
 
     async def coroutine_wait():
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
 
     async def coroutine_inner():
         await coro_e.wait()
@@ -379,7 +379,7 @@ async def test_task_repr(_) -> None:
         repr(coro_task),
     )
 
-    await Timer(2, units="ns")
+    await Timer(2, unit="ns")
 
     log.info(repr(coro_task))
     assert re.match(
@@ -389,7 +389,7 @@ async def test_task_repr(_) -> None:
 
     async def coroutine_first():
         task = Task(coroutine_wait())
-        await First(task, Timer(2, units="ns"))
+        await First(task, Timer(2, unit="ns"))
         task.kill()
 
     coro_task = cocotb.start_soon(coroutine_first())
@@ -436,7 +436,7 @@ async def test_task_repr(_) -> None:
     )
 
     async def coroutine_timer():
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
 
     coro_task = cocotb.start_soon(coroutine_timer())
     await NullTrigger()
@@ -576,9 +576,9 @@ async def test_await_start_soon(_):
     """Test awaiting start_soon queued coroutine before it starts."""
 
     async def coro():
-        start_time = cocotb.utils.get_sim_time(units="ns")
+        start_time = cocotb.utils.get_sim_time(unit="ns")
         await Timer(1, "ns")
-        assert cocotb.utils.get_sim_time(units="ns") == start_time + 1
+        assert cocotb.utils.get_sim_time(unit="ns") == start_time + 1
 
     coro = cocotb.start_soon(coro())
 

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -107,15 +107,15 @@ async def test_internalevent(dut):
     assert repr(e) == "'test parent'"
 
     async def set_internalevent():
-        await Timer(1, units="ns")
+        await Timer(1, unit="ns")
         e.set()
 
     # Test waiting more than once
     cocotb.start_soon(set_internalevent())
-    time_ns = get_sim_time(units="ns")
+    time_ns = get_sim_time(unit="ns")
     await e
     assert e.is_set()
-    assert get_sim_time(units="ns") == time_ns + 1
+    assert get_sim_time(unit="ns") == time_ns + 1
     # _InternalEvent can only be awaited once
     with pytest.raises(RuntimeError):
         await e
@@ -146,19 +146,19 @@ async def test_internalevent(dut):
     e = _InternalEvent(None)
     assert not e.is_set()
     cocotb.start_soon(set_internalevent())
-    await Timer(2, units="ns")
+    await Timer(2, unit="ns")
     assert e.is_set()
-    time_ns = get_sim_time(units="ns")
+    time_ns = get_sim_time(unit="ns")
     await e
-    assert get_sim_time(units="ns") == time_ns
+    assert get_sim_time(unit="ns") == time_ns
 
 
 @cocotb.test
 async def test_empty_Combine(_) -> None:
     """Test that a Combine with no triggers passes no time."""
-    start_time = get_sim_time(units="ns")
+    start_time = get_sim_time(unit="ns")
     await Combine()
-    end_time = get_sim_time(units="ns")
+    end_time = get_sim_time(unit="ns")
     assert end_time == start_time
 
 

--- a/tests/test_cases/test_cocotb/test_timing_triggers.py
+++ b/tests/test_cases/test_cocotb/test_timing_triggers.py
@@ -64,51 +64,51 @@ async def test_timer_with_units(dut):
     # invocation if this assert hits!
     assert get_precision() == -12
 
-    time_step = get_sim_time(units="step")
+    time_step = get_sim_time(unit="step")
 
     # Await for one simulator time step
     await Timer(1)  # NOTE: explicitly no units argument here!
-    time_step = get_sim_time(units="step") - time_step
+    time_step = get_sim_time(unit="step") - time_step
 
     pattern = "Unable to accurately represent .* with the simulator precision of .*"
     with pytest.raises(ValueError, match=pattern):
-        await Timer(2.5 * time_step, units="step")
+        await Timer(2.5 * time_step, unit="step")
     dut._log.info("As expected, unable to create a timer of 2.5 simulator time steps")
 
-    time_step = get_sim_time(units="step")
+    time_step = get_sim_time(unit="step")
 
     await Timer(3, "ns")
 
-    assert get_sim_time(units="step") == time_step + get_sim_steps(3, "ns")
+    assert get_sim_time(unit="step") == time_step + get_sim_steps(3, "ns")
 
-    time_step = get_sim_time(units="step")
+    time_step = get_sim_time(unit="step")
     await Timer(1.5, "ns")
 
-    assert get_sim_time(units="step") == time_step + get_sim_steps(1.5, "ns")
+    assert get_sim_time(unit="step") == time_step + get_sim_steps(1.5, "ns")
 
-    time_step = get_sim_time(units="step")
+    time_step = get_sim_time(unit="step")
     await Timer(10.0, "ps")
 
-    assert get_sim_time(units="step") == time_step + get_sim_steps(10, "ps")
+    assert get_sim_time(unit="step") == time_step + get_sim_steps(10, "ps")
 
-    time_step = get_sim_time(units="step")
+    time_step = get_sim_time(unit="step")
     await Timer(1.0, "us")
 
-    assert get_sim_time(units="step") == time_step + get_sim_steps(1, "us")
+    assert get_sim_time(unit="step") == time_step + get_sim_steps(1, "us")
 
 
 @cocotb.test()
 async def test_timer_with_rational_units(dut):
     """Test that rounding errors are not introduced in exact values"""
     # now with fractions
-    time_step = get_sim_time(units="step")
-    await Timer(Fraction(1, int(1e9)), units="sec")
-    assert get_sim_time(units="step") == time_step + get_sim_steps(1, "ns")
+    time_step = get_sim_time(unit="step")
+    await Timer(Fraction(1, int(1e9)), unit="sec")
+    assert get_sim_time(unit="step") == time_step + get_sim_steps(1, "ns")
 
     # now with decimals
-    time_step = get_sim_time(units="step")
-    await Timer(Decimal("1e-9"), units="sec")
-    assert get_sim_time(units="step") == time_step + get_sim_steps(1, "ns")
+    time_step = get_sim_time(unit="step")
+    await Timer(Decimal("1e-9"), unit="sec")
+    assert get_sim_time(unit="step") == time_step + get_sim_steps(1, "ns")
 
 
 async def do_test_afterdelay_in_readonly(dut, delay):


### PR DESCRIPTION
Closes #4399.

Also added a type alias for time units. This actually caught a runtime bug. The default value for `timeout_time` in `TestFactory.generate_tests` was `"steps"` instead of `"step"`.