### PR TITLE
Cache getting values from handles

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -295,6 +295,8 @@ Logging
     This is added by :class:`cocotb.log.SimTimeContextFilter`.
 
 
+.. _sim-handles:
+
 Simulation Object Handles
 =========================
 

--- a/docs/source/newsfragments/4462.feature.rst
+++ b/docs/source/newsfragments/4462.feature.rst
@@ -1,0 +1,1 @@
+Improve performance by caching simulator values on :ref:`sim-handles`.

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -274,6 +274,9 @@ class Scheduler:
             if trigger is self._read_write:
                 cocotb._write_scheduler.apply_scheduled_writes()
 
+            # Increment GPI trigger counter to invalidate simulator values on handles.
+            cocotb._write_scheduler.current_timestamp += 1
+
             self._react(trigger)
             self._event_loop()
 

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -233,6 +233,7 @@ class LogicArray(ArrayLike[Logic]):
     # implementations are faster for particular operations.
     # Each implementation can be present, or None if the implementation has not been
     # computed or has been invalidated by a mutating operation.
+    _dirty: bool
     _value_as_array: Union[List[Logic], None]
     _value_as_int: Union[int, None]
     _value_as_str: Union[str, None]
@@ -340,6 +341,7 @@ class LogicArray(ArrayLike[Logic]):
         *,
         width: Union[int, None] = None,
     ) -> None:
+        self._dirty = False
         self._value_as_array = None
         self._value_as_int = None
         self._value_as_str = None
@@ -585,6 +587,7 @@ class LogicArray(ArrayLike[Logic]):
         # simulator which we expect to be well-formed.
         # Values are required to be uppercase.
         self = super().__new__(cls)
+        self._dirty = False
         self._value_as_array = None
         self._value_as_int = None
         self._value_as_str = value
@@ -606,6 +609,7 @@ class LogicArray(ArrayLike[Logic]):
                 f"{new_range!r} not the same length as old range: {self._range!r}."
             )
         self._range = new_range
+        self._dirty = True
 
     def __iter__(self) -> Iterator[Logic]:
         return iter(self._get_array())
@@ -848,6 +852,7 @@ class LogicArray(ArrayLike[Logic]):
         if isinstance(item, int):
             idx = self._translate_index(item)
             array[idx] = Logic(cast(LogicConstructibleT, value))
+            self._dirty = True
         elif isinstance(item, slice):
             start = item.start if item.start is not None else self.left
             stop = item.stop if item.stop is not None else self.right
@@ -867,6 +872,7 @@ class LogicArray(ArrayLike[Logic]):
                     f"value of length {len(value_as_logics)!r} will not fit in slice [{start}:{stop}]"
                 )
             array[start_i : stop_i + 1] = value_as_logics
+            self._dirty = True
         else:
             raise TypeError(
                 f"indexes must be ints or slices, not {type(item).__name__}"


### PR DESCRIPTION
Closes #4460.

* Cache values from the simulator on the handle.
* Invalidate the value on every GPI Trigger firing.
* Introduce a global timestamp value that increments whenever a GPI Trigger fires to aid in invalidating the cached value when GPI Trigger fires.
* Invalidate the value if the type is mutable and it becomes dirty by being mutated (only `LogicArray` suffers this)
* Invalidate the value if we write the value "immediately" as some simulators do update the value immediately.
* Refactor of handle value getter and setter to prevent repeating ourselves.

## TODO
- [x] newfragment
- [x] test LogicArray dirty
- [x] test getting handle value multiple times (I'm surprised this wasn't hit)