### PR TITLE
Raise logging level of exceptions from tests

### DIFF
--- a/docs/source/newsfragments/4463.change.rst
+++ b/docs/source/newsfragments/4463.change.rst
@@ -1,0 +1,1 @@
+Report exceptions from tests even when COCOTB_LOG_LEVEL=WARNING or COCOTB_LOG_LEVEL=ERROR

--- a/docs/source/newsfragments/4463.change.rst
+++ b/docs/source/newsfragments/4463.change.rst
@@ -1,1 +1,1 @@
-Report exceptions from tests even when COCOTB_LOG_LEVEL=WARNING or COCOTB_LOG_LEVEL=ERROR
+Report exceptions from tests even when COCOTB_LOG_LEVEL=WARNING

--- a/docs/source/newsfragments/4463.change.rst
+++ b/docs/source/newsfragments/4463.change.rst
@@ -1,1 +1,1 @@
-Report exceptions from tests even when COCOTB_LOG_LEVEL=WARNING
+Log test failures at log level :data:`~logging.WARNING`.

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -781,7 +781,8 @@ class RegressionManager:
         else:
             rest = f": {msg}"
         self.log.warning(
-            "%s %sfailed%s%s",
+            "%s%s %sfailed%s%s",
+            stop_hilight,
             self._test.fullname,
             start_hilight,
             stop_hilight,

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -780,7 +780,7 @@ class RegressionManager:
             rest = ""
         else:
             rest = f": {msg}"
-        self.log.error(
+        self.log.warning(
             "%s %sfailed%s%s",
             self._test.fullname,
             start_hilight,

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -780,7 +780,7 @@ class RegressionManager:
             rest = ""
         else:
             rest = f": {msg}"
-        self.log.info(
+        self.log.error(
             "%s %sfailed%s%s",
             self._test.fullname,
             start_hilight,


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

We run cocotb with COCOTB_LOG_LEVEL=WARNING because the default INFO is too chatty for us. When a test throws an exception, the only piece of information that is printed to the console is that a test failed. We would like cocotb to print which test failed, which exception was thrown and a traceback - similar to how pytest behaves when a test throws an exception.

If this is accepted, I will backport the change to stable/1.9