### PR TITLE
More Trigger improvements

### DIFF
--- a/src/cocotb/_base_triggers.py
+++ b/src/cocotb/_base_triggers.py
@@ -110,7 +110,9 @@ class _Event(Trigger):
 
     def _prime(self, callback: Callable[[Trigger], None]) -> None:
         if self._primed:
-            return
+            raise RuntimeError(
+                "Event.wait() result can only be used by one task at a time"
+            )
         self._callback = callback
         self._parent._prime_trigger(self, callback)
         return super()._prime(callback)
@@ -297,7 +299,7 @@ class _Lock(Trigger):
     def _prime(self, callback: Callable[[Trigger], None]) -> None:
         if self._primed:
             raise RuntimeError(
-                "Lock.acquire() result can only be used by one thread at a time"
+                "Lock.acquire() result can only be used by one task at a time"
             )
         self._callback = callback
         self._parent._prime_lock(self)

--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -5,8 +5,14 @@
 Common utilities shared by many tests in this directory
 """
 
+import operator
 import re
 import traceback
+from contextlib import contextmanager
+from typing import Callable, Generator
+
+from cocotb._typing import TimeUnit
+from cocotb.utils import get_sim_steps, get_sim_time, get_time_from_sim_steps
 
 
 async def _check_traceback(running_coro, exc_type, pattern, *match_args):
@@ -29,3 +35,29 @@ class MyException(Exception): ...
 
 
 class MyBaseException(BaseException): ...
+
+
+@contextmanager
+def assert_takes(
+    time: float, unit: TimeUnit, cmp: Callable[[int, int], bool] = operator.eq
+) -> Generator[None, None, None]:
+    """Assert that the block takes a certain amount of time to finish.
+
+    The *cmp* function passes actual after first argument and expected as the second.
+    Other useful comparison functions are: :func:`math.isclose`, and the functions in the
+    :mod:`operator` module.
+
+    Args:
+        time: Time value.
+        unit: Unit of *time*.
+        cmp: Comparison function to use. Defaults to equality.
+    """
+    expected = get_sim_steps(time, unit)
+    start = get_sim_time("step")
+    yield
+    end = get_sim_time("step")
+    actual = end - start
+    actual_in_units = get_time_from_sim_steps(actual, unit)
+    assert cmp(actual, expected), (
+        f"Expected the code to take {time}{unit}, actually took {actual_in_units}{unit}"
+    )

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -323,3 +323,18 @@ async def test_Lock_multiple_users_acquire_triggers(_) -> None:
     cocotb.start_soon(wait(acquire_trigger))
     cocotb.start_soon(wait(acquire_trigger))
     await Timer(1, "ns")
+
+
+@cocotb.test(expect_error=RuntimeError)
+async def test_Event_multiple_task_share_trigger(_) -> None:
+    """Test that multiple tasks aren't allowed to share an Event trigger."""
+
+    async def waiter(trigger: Trigger) -> None:
+        await trigger
+
+    e = Event()
+    e_trigger = e.wait()
+    cocotb.start_soon(waiter(e_trigger))
+    cocotb.start_soon(waiter(e_trigger))
+
+    await Timer(1, "ns")


### PR DESCRIPTION
Closes #4485.

I'm not sure *why* there needs to be separate `_Event`s for each Task, but making it a single shared object made the regression very unhappy so instead I made sure that, like Lock, only one Task can await on an `_Event` trigger simultaneously.

While fixing that I rewrote some broken tests that depended on that behavior. This uncovered a flaw in the implementation of `First` and `Combine` from #4449, so that was also fixed.

And that broke another test because of the issue described in #4485, so I resolved that as well.
