### PR TITLE
Use Sphinx 8.1 specifically for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies to build the documentation
 
-Sphinx ~= 8.0
+Sphinx == 8.1
 breathe
 sphinx-book-theme == 1.1.3  # pin this to exact version to guard against any CSS changes
 sphinx-design >= 0.6.1


### PR DESCRIPTION
Maybe we can update to `!bad version` if we better understand what's going on.
