### PR TITLE
Fix issue with clock

### DIFF
--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -268,7 +268,6 @@ class Clock:
         if self._task is None:
             raise RuntimeError("Stopping a clock that was never started.")
         self._task.kill()
-        self._cleanup()
 
     def _cleanup(self) -> None:
         if self._impl == "gpi":


### PR DESCRIPTION
I'm having a hard time reasoning about done callbacks apparently. This line should be removed or it will call cleanup twice if `clock.stop` is called.
