### PR TITLE
Use `assert_takes` everywhere

### DIFF
--- a/src/cocotb/_typing.py
+++ b/src/cocotb/_typing.py
@@ -9,4 +9,5 @@ if TYPE_CHECKING:
         TypeAlias,
     )
 
-TimeUnit: "TypeAlias" = 'Literal["step"] | Literal["fs"] | Literal["ps"] | Literal["ns"] | Literal["us"] | Literal["ms"] | Literal["sec"]'
+TimeUnitWithoutStep: "TypeAlias" = 'Literal["fs", "ps", "ns", "us", "ms", "sec"]'
+TimeUnit: "TypeAlias" = 'Literal["step"] | TimeUnitWithoutStep'

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -14,6 +14,7 @@ import os
 import re
 
 import pytest
+from common import assert_takes
 
 import cocotb
 from cocotb.clock import Clock
@@ -29,7 +30,6 @@ from cocotb.triggers import (
     ValueChange,
     with_timeout,
 )
-from cocotb.utils import get_sim_time
 from cocotb_tools.sim_versions import RivieraVersion
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
@@ -235,10 +235,8 @@ async def test_clock_cycles(dut):
     assert t.num_cycles == cycles
     assert t.edge_type is RisingEdge
 
-    start_time = get_sim_time("ns")
-    await t
-    end_time = get_sim_time("ns")
-    assert end_time == (start_time + (cycles * period))
+    with assert_takes((cycles * period), "ns"):
+        await t
 
     t = ClockCycles(clk, 10, FallingEdge)
     # NVC gives upper-case identifiers for some things, so do case-insensitive match. See gh-3985
@@ -251,10 +249,8 @@ async def test_clock_cycles(dut):
     assert t.num_cycles == cycles
     assert t.edge_type is FallingEdge
 
-    start_time = get_sim_time("ns")
-    await t
-    end_time = get_sim_time("ns")
-    assert end_time == (start_time + (cycles * period) - (period // 2))
+    with assert_takes((cycles * period) - (period // 2), "ns"):
+        await t
 
     # test other edge type construction
     assert ClockCycles(clk, cycles, True).edge_type is RisingEdge

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -16,7 +16,7 @@ from asyncio import CancelledError, InvalidStateError
 from typing import Any, Awaitable, Coroutine
 
 import pytest
-from common import MyException
+from common import MyException, assert_takes
 
 import cocotb
 import cocotb.utils
@@ -576,13 +576,12 @@ async def test_await_start_soon(_):
     """Test awaiting start_soon queued coroutine before it starts."""
 
     async def coro():
-        start_time = cocotb.utils.get_sim_time(unit="ns")
         await Timer(1, "ns")
-        assert cocotb.utils.get_sim_time(unit="ns") == start_time + 1
 
     coro = cocotb.start_soon(coro())
 
-    await coro
+    with assert_takes(1, "ns"):
+        await coro
 
 
 @cocotb.test()


### PR DESCRIPTION
Ran into another random failure in #4479 caused by #4485.

While fixing the issue I found a bug in `cocotb.utils` which I fixed. Correcting the typing would have caught the bug. Whoops...