### PR TITLE
Cleanup/Fix leak in simulatormodule.cpp

### DIFF
--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -195,13 +195,6 @@ int handle_gpi_callback(void *user_data) {
     PyGILState_STATE gstate = PyGILState_Ensure();
     DEFER(PyGILState_Release(gstate));
 
-    // Python allowed
-
-    if (!PyCallable_Check(cb_data->function)) {
-        LOG_ERROR("Callback fired but function isn't callable?!\n");
-        return 1;
-    }
-
     // Call the callback
     PyObject *pValue =
         PyObject_Call(cb_data->function, cb_data->args, cb_data->kwargs);

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -35,14 +35,12 @@
  */
 
 #include <Python.h>
-#include <cocotb_utils.h>    // to_python to_simulator
-#include <py_gpi_logging.h>  // py_gpi_logger_set_level
 
 #include <cerrno>
-#include <limits>
-#include <type_traits>
 
+#include "cocotb_utils.h"  // to_python to_simulator
 #include "gpi.h"
+#include "py_gpi_logging.h"  // py_gpi_logger_set_level
 
 // This file defines the routines available to Python
 
@@ -194,19 +192,13 @@ int handle_gpi_callback(void *user_data) {
 
     PythonCallback *cb_data = (PythonCallback *)user_data;
 
-    if (cb_data->id_value != COCOTB_ACTIVE_ID) {
-        fprintf(stderr, "Userdata corrupted!\n");
-        return 1;
-    }
-    cb_data->id_value = COCOTB_INACTIVE_ID;
-
     PyGILState_STATE gstate = PyGILState_Ensure();
     DEFER(PyGILState_Release(gstate));
 
     // Python allowed
 
     if (!PyCallable_Check(cb_data->function)) {
-        fprintf(stderr, "Callback fired but function isn't callable?!\n");
+        LOG_ERROR("Callback fired but function isn't callable?!\n");
         return 1;
     }
 
@@ -226,10 +218,7 @@ int handle_gpi_callback(void *user_data) {
     // We don't care about the result
     Py_DECREF(pValue);
 
-    // Remove callback data if no longer active
-    if (cb_data->id_value == COCOTB_INACTIVE_ID) {
-        delete cb_data;
-    }
+    delete cb_data;
 
     return 0;
 }


### PR DESCRIPTION
If the `handle_gpi_callback` function failed for any reason the memory would not be freed, and the Python objects would not be decref'd. `DEFER` helps prevent issues.

Taking ownership makes the object a bit easier to reason about (all new refs are always decref'd in the function that got them), which follows how Python C API code is typically written.

Also removed unnecessary checking. The `COCOTB_ACTIVE_ID` stuff only existed to work with how the GPIcallback objects worked prior to #4392.