### PR TITLE
Always log interface issues at DEBUG

### DIFF
--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -629,9 +629,7 @@ def _get_vpi_lib_ext(
         libcocotbvpi_sources += [lib_name + ".rc"]
     libcocotbvpi = Extension(
         os.path.join("cocotb", "libs", lib_name),
-        define_macros=[("COCOTBVPI_EXPORTS", ""), ("VPI_CHECKING", "1")]
-        + [(sim_define, "")]
-        + _extra_defines,
+        define_macros=[("COCOTBVPI_EXPORTS", "")] + [(sim_define, "")] + _extra_defines,
         include_dirs=include_dirs,
         libraries=["gpi", "gpilog"] + extra_lib,
         library_dirs=extra_lib_dir,
@@ -654,7 +652,7 @@ def _get_vhpi_lib_ext(
     libcocotbvhpi = Extension(
         os.path.join("cocotb", "libs", lib_name),
         include_dirs=include_dirs,
-        define_macros=[("COCOTBVHPI_EXPORTS", ""), ("VHPI_CHECKING", 1)]
+        define_macros=[("COCOTBVHPI_EXPORTS", "")]
         + [(sim_define, "")]
         + _extra_defines,
         libraries=["gpi", "gpilog"] + extra_lib,

--- a/docs/source/newsfragments/4510.change.rst
+++ b/docs/source/newsfragments/4510.change.rst
@@ -1,0 +1,1 @@
+``VPI_CHECKING`` and ``VHPI_CHECKING`` are removed and interface issues are now always emitted with a log level of :data:`logging.DEBUG`.

--- a/src/cocotb/share/include/py_gpi_logging.h
+++ b/src/cocotb/share/include/py_gpi_logging.h
@@ -19,8 +19,6 @@
 extern "C" {
 #endif
 
-PYGPILOG_EXPORT void py_gpi_logger_set_level(int level);
-
 PYGPILOG_EXPORT void py_gpi_logger_initialize(PyObject* handler,
                                               PyObject* get_logger);
 

--- a/src/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
+++ b/src/cocotb/share/lib/py_gpi_log/py_gpi_logging.cpp
@@ -165,9 +165,15 @@ static void py_gpi_log_handler(void *, const char *name, int level,
     Py_DECREF(handler_ret);
 }
 
-extern "C" void py_gpi_logger_set_level(int level) {
+static bool py_gpi_log_filter(void *, const char *, int level) {
+    return level >= py_gpi_log_level;
+}
+
+static bool py_gpi_logger_set_level(void *, const char *, int level) {
+    auto old_level = py_gpi_log_level;
     py_gpi_log_level = level;
     gpi_native_logger_set_level(level);
+    return old_level;
 }
 
 extern "C" void py_gpi_logger_initialize(PyObject *log_func,
@@ -176,7 +182,8 @@ extern "C" void py_gpi_logger_initialize(PyObject *log_func,
     Py_INCREF(get_logger);
     m_log_func = log_func;
     m_get_logger = get_logger;
-    gpi_set_log_handler(py_gpi_log_handler, nullptr);
+    gpi_set_log_handler(py_gpi_log_handler, py_gpi_log_filter,
+                        py_gpi_logger_set_level, nullptr);
 }
 
 extern "C" void py_gpi_logger_finalize() {

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -798,7 +798,7 @@ static PyObject *set_gpi_log_level(PyObject *, PyObject *args) {
         return NULL;
     }
 
-    py_gpi_logger_set_level(l_level);
+    gpi_log_set_level("gpi", l_level);
 
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
Adding this feature required making improvements to the GPI logging libraries. Namely, we needed a function to check the current log level so we could condition calling `vpi_chk_error` and `vhpi_check_error`.