### PR TITLE
`cocotb.types` API breaking cleanup

### DIFF
--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -48,6 +48,8 @@ from typing import (
     overload,
 )
 
+from cocotb._py_compat import StrEnum
+
 
 @lru_cache(maxsize=None)
 def want_color_output() -> bool:
@@ -218,6 +220,20 @@ class DocIntEnum(IntEnum):
 
     def __new__(cls: Type[IntEnumT], value: int, doc: Optional[str] = None) -> IntEnumT:
         self = int.__new__(cls, value)
+        self._value_ = value
+        if doc is not None:
+            self.__doc__ = doc
+        return self
+
+
+StrEnumT = TypeVar("StrEnumT", bound=StrEnum)
+
+
+class DocStrEnum(StrEnum):
+    """Like DocEnum but for StrEnum enum types."""
+
+    def __new__(cls: Type[StrEnumT], value: str, doc: Optional[str] = None) -> StrEnumT:
+        self = str.__new__(cls, value)
         self._value_ = value
         if doc is not None:
             self.__doc__ = doc

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -984,7 +984,7 @@ class ArrayObject(
         | ``arr[7:4]`` | ``arr(7 downto 4)`` | ``Array([arr[7].value, arr[6].value, arr[5].value, arr[4].value], range=Range(7, 'downto', 4))`` |
         +--------------+---------------------+--------------------------------------------------------------------------------------------------+
         """
-        return Array((self[i].value for i in self.range), range=self.range)
+        return Array._from_handle([self[i].value for i in self.range], self.range)
 
     def set(
         self,

--- a/src/cocotb/types/array.py
+++ b/src/cocotb/types/array.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import Iterable, Iterator, TypeVar, Union, cast, overload
+from typing import Iterable, Iterator, List, TypeVar, Union, cast, overload
 
 from cocotb.types import ArrayLike
 from cocotb.types.range import Range
@@ -151,6 +151,13 @@ class Array(ArrayLike[T]):
                 raise ValueError(
                     f"Value of length {len(self._value)!r} does not fit in {self._range!r}"
                 )
+
+    @classmethod
+    def _from_handle(cls, value: List[T], range: Range) -> "Array[T]":
+        self = cls.__new__(cls)
+        self._value = value
+        self._range = range
+        return self
 
     @property
     def range(self) -> Range:

--- a/src/cocotb/types/array.py
+++ b/src/cocotb/types/array.py
@@ -13,37 +13,44 @@ class Array(ArrayLike[T]):
     r"""Fixed-size, arbitrarily-indexed, homogeneous collection type.
 
     Arrays are similar to, but different from Python :class:`list`\ s.
-    An array can store values of any type or values of multiple types at a time, just like a :class:`list`.
-    Unlike :class:`list`\ s, an array's size cannot change.
-
-    The indexes of an array can start or end at any integer value, they are not limited to 0-based indexing.
-    Indexing schemes can be either ascending or descending in value.
-    An array's indexes are described using a :class:`~cocotb.types.Range` object.
-
-    Initial values are treated as iterables, which are copied into an internal buffer.
+    An array can store values of any type or values of multiple types at a time, just like a :class:`!list`.
+    Array constructor values can be any Iterable.
 
     .. code-block:: pycon3
 
-        >>> Array("1234")  # the 0-based range `(0, len(value)-1)` is inferred
-        Array(['1', '2', '3', '4'], Range(0, 'to', 3))
+        >>> Array([1, False, "example", None])
+        Array([1, False, 'example', None], Range(0, 'to', 3))
 
-        >>> Array(
-        ...     [1, True, None, "example"], Range(-2, 1)
-        ... )  # initial value and range lengths must be equal
-        Array([1, True, None, 'example'], Range(-2, 'to', 1))
+        >>> Array("Hello!")
+        Array(['H', 'e', 'l', 'l', 'o', '!'], Range(0, 'to', 5))
 
-    Arrays also support "null" ranges; "null" arrays have zero length and cannot be indexed.
+    Unlike :class:`!list`\ s, an array's size cannot change.
+    This means they do not support methods like :meth:`~list.append` or :meth:`~list.insert`.
+
+    The indexes of an Array can start or end at any integer value, they are not limited to 0-based indexing.
+    Indexing schemes are selected using :class:`Range` objects.
+    If *range* is not given, the range ``Range(0, "to", len(value)-1)`` is used.
+    If an :class:`int` is passed for *range*, the range ``Range(0, "to", range-1)`` is used.
 
     .. code-block:: pycon3
 
-        >>> Array([], range=Range(1, "to", 0))
+        >>> a = Array([0, 1, 2, 3], Range(-1, "downto", -4))
+        >>> a[-1]
+        0
+        >>> a[-4]
+        3
+
+    Arrays can also have 0 length using "null" :class:`Range`\ s.
+
+    .. code-block:: pycon3
+
+        >>> Array([], Range(1, "to", 0))  # 1 to 0 is a null Range
         Array([], Range(1, 'to', 0))
 
-    Indexing and slicing is very similar to :class:`list`\ s, but it uses the indexing scheme specified.
-    Slicing, just like the :class:`~cocotb.types.Range` object uses an inclusive right bound,
-    which is commonly seen in HDLs.
-    Like :class:`list`\ s, if a start or stop index is not specified, it is inferred as the start or end of the array.
-    Slicing an array returns a new :class:`~cocotb.types.Array` object, whose bounds are the slice indexes.
+    Indexing and slicing is very similar to :class:`!list`\ s, but it uses the indexing scheme specified with the *range*.
+    Unlike :class:`!list`, slicing uses an inclusive right bound, which is common in HDLs.
+    But like :class:`!list`, if a start or stop index is not specified in the slice, it is inferred as the start or end of the array.
+    Slicing an Array returns a new :class:`~cocotb.types.Array` object, whose bounds are the slice indexes.
 
     .. code-block:: pycon3
 
@@ -96,7 +103,7 @@ class Array(ArrayLike[T]):
         >>> a.range
         Range(3, 'downto', 0)
 
-    Arrays support the methods and semantics defined by :class:`collections.abc.Sequence`.
+    Arrays support many of the methods and semantics defined by :class:`collections.abc.Sequence`.
 
     .. code-block:: pycon3
 
@@ -120,7 +127,7 @@ class Array(ArrayLike[T]):
         range: The indexing scheme of the Array.
 
     Raises:
-        ValueError: When argument values cannot be used to construct an array.
+        ValueError: When argument values cannot be used to construct an Array.
         TypeError: When invalid argument types are used.
     """
 

--- a/src/cocotb/types/array.py
+++ b/src/cocotb/types/array.py
@@ -19,8 +19,6 @@ class Array(ArrayLike[T]):
     The indexes of an array can start or end at any integer value, they are not limited to 0-based indexing.
     Indexing schemes can be either ascending or descending in value.
     An array's indexes are described using a :class:`~cocotb.types.Range` object.
-    Passing an :class:`int` as the second position argument, or as the *width* argument,
-    acts as shorthand for ``Range(0, "to", width-1)``.
 
     Initial values are treated as iterables, which are copied into an internal buffer.
 
@@ -118,52 +116,34 @@ class Array(ArrayLike[T]):
         f
 
     Args:
-        value: Initial value for the array.
-        range: Indexing scheme of the array.
-        width: Shorthand for passing ``Range(0, "to", width - 1)`` to *range*.
+        value: Initial value for the Array.
+        range: The indexing scheme of the Array.
 
     Raises:
         ValueError: When argument values cannot be used to construct an array.
         TypeError: When invalid argument types are used.
     """
 
-    @overload
-    def __init__(self, value: Iterable[T]) -> None: ...
-
-    @overload
-    def __init__(self, value: Iterable[T], *, range: Range) -> None: ...
-
-    @overload
-    def __init__(self, value: Iterable[T], *, width: int) -> None: ...
-
-    @overload
-    def __init__(self, value: Iterable[T], range: Union[Range, int]) -> None: ...
-
     def __init__(
-        self,
-        value: Iterable[T],
-        range: Union[Range, int, None] = None,
-        width: Union[int, None] = None,
+        self, value: Iterable[T], range: Union[Range, int, None] = None
     ) -> None:
         self._value = list(value)
-        if width is not None:
-            if range is not None:
-                raise TypeError("Only provide argument to one of 'range' or 'width'")
-            self._range = Range(0, "to", width - 1)
-        elif range is None:
+        if range is None:
             self._range = Range(0, "to", len(self._value) - 1)
-        elif isinstance(range, int):
-            self._range = Range(0, "to", range - 1)
-        elif isinstance(range, Range):
-            self._range = range
         else:
-            raise TypeError(
-                f"Expected Range or int for parameter 'range', not {type(range).__qualname__}"
-            )
-        if len(self._value) != len(self._range):
-            raise ValueError(
-                f"Value of length {len(self._value)!r} does not fit in {self._range!r}"
-            )
+            if isinstance(range, int):
+                self._range = Range(0, "to", range - 1)
+            elif isinstance(range, Range):
+                self._range = range
+            else:
+                raise TypeError(
+                    f"Expected Range or int for parameter 'range', not {type(range).__qualname__}"
+                )
+
+            if len(self._value) != len(self._range):
+                raise ValueError(
+                    f"Value of length {len(self._value)!r} does not fit in {self._range!r}"
+                )
 
     @property
     def range(self) -> Range:

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from cocotb._deprecation import deprecated
-from cocotb._py_compat import StrEnum
+from cocotb._utils import DocStrEnum
 from cocotb.types import ArrayLike
 from cocotb.types.logic import Logic, LogicConstructibleT, _str_literals
 from cocotb.types.range import Range
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
 
-class ResolveX(StrEnum):
+class ResolveX(DocStrEnum):
     """Resolution behaviors supported when converting a :class:`LogicArray` to an integer.
 
     The values ``L`` and ``H`` are always resolved to ``0`` and ``1`` respectively.
@@ -34,19 +34,16 @@ class ResolveX(StrEnum):
     to either ``0`` or ``1``.
     """
 
-    VALUE_ERROR = "error"
-    ZEROS = "zeros"
-    ONES = "ones"
-    RANDOM = "random"
-
-
-# Must add documentation after the fact because Enum member creation is weird
-ResolveX.VALUE_ERROR.__doc__ = "Throws a :exc:`ValueError` if the :class:`LogicArray` contains non-``0``/``1`` values."
-ResolveX.ZEROS.__doc__ = "Resolves all non-``0``/``1`` values to ``0``."
-ResolveX.ONES.__doc__ = "Resolves all non-``0``/``1`` values to ``1``."
-ResolveX.RANDOM.__doc__ = (
-    "Resolves all non-``0``/``1`` values randomly to either ``0`` or ``1``."
-)
+    VALUE_ERROR = (
+        "error",
+        "Throws a :exc:`ValueError` if the :class:`LogicArray` contains non-``0``/``1`` values.",
+    )
+    ZEROS = ("zeros", "Resolves all non-``0``/``1`` values to ``0``.")
+    ONES = ("ones", "Resolves all non-``0``/``1`` values to ``1``.")
+    RANDOM = (
+        "random",
+        "Resolves all non-``0``/``1`` values randomly to either ``0`` or ``1``.",
+    )
 
 
 RESOLVE_X = ResolveX[os.getenv("COCOTB_RESOLVE_X", "VALUE_ERROR")]

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -114,6 +114,9 @@ class LogicArray(ArrayLike[Logic]):
         >>> LogicArray([0, True, "X"])
         LogicArray('01X', Range(2, 'downto', 0))
 
+    .. note::
+        If constructing from an unsigned :class:`int` literal, *range* `must` be given.
+
     :class:`LogicArray`\ s can be constructed from :class:`int`\ s using :meth:`from_unsigned` or :meth:`from_signed`.
 
     .. code-block:: pycon3
@@ -125,7 +128,7 @@ class LogicArray(ArrayLike[Logic]):
         LogicArray('1100', Range(0, 'to', 3))
 
     :class:`LogicArray`\ s can be constructed from :class:`bytes` or :class:`bytearray` using :meth:`from_bytes`.
-    Use the *byteorder* argument to control endianness; it defaults to ``"big"``.
+    Use the *byteorder* argument to control endianness.
 
     .. code-block:: pycon3
 
@@ -135,7 +138,7 @@ class LogicArray(ArrayLike[Logic]):
         >>> LogicArray.from_bytes(b"1n", byteorder="little")
         LogicArray('0110111000110001', Range(15, 'downto', 0))
 
-    :class:`LogicArray`\ s support the same operations as :class:`Array`;
+    :class:`LogicArray`\ s support the same :class:`list`-like operations as :class:`Array`;
     however, it enforces the condition that all elements must be a :class:`Logic`.
 
     .. code-block:: pycon3
@@ -167,13 +170,27 @@ class LogicArray(ArrayLike[Logic]):
         >>> la
         LogicArray('ZX10', Range(3, 'downto', 0))
 
-    :class:`LogicArray`\ s can be converted into :class:`str`\ s, :class:`int`\ s, or :class:`bytes`\ s.
+        >>> la[:] = 0b0101
+        >>> la
+        LogicArray('0101', Range(3, 'downto', 0))
+
+    :class:`LogicArray`\ s can be converted into their :class:`str` or :class:`int` literal values using casts.
 
     .. code-block:: pycon3
 
         >>> la = LogicArray("1010")
         >>> str(la)
         '1010'
+        >>> int(la)
+        10
+
+    .. warning::
+        The :class:`int` cast assumes the value is entirely ``0`` or ``1`` and will raise an exception otherwise.
+
+    The :meth:`to_unsigned`, :meth:`to_signed`, and :meth:`to_bytes` methods can be used to convert
+    the value into an unsigned or signed integer, or bytes, respectively.
+
+    .. code-block:: pycon3
 
         >>> la.to_unsigned()
         10
@@ -183,6 +200,9 @@ class LogicArray(ArrayLike[Logic]):
 
         >>> la.to_bytes(byteorder="big")
         b'\n'
+
+    .. warning::
+        These operations assume the value is entirely ``0`` or ``1`` and will raise an exception otherwise.
 
     You can also convert :class:`LogicArray`\ s to hexadecimal or binary strings using
     the built-ins :func:`hex:` and :func:`bin`, respectively.
@@ -194,6 +214,11 @@ class LogicArray(ArrayLike[Logic]):
         '0x7a'
         >>> bin(la)
         '0b1111010'
+
+    .. warning::
+        Using :func:`hex` or :func:`bin` first turns the LogicArray into an :class:`int`.
+        This means the exact length of the LogicArray is lost.
+        It also means that these expressions will raise an exception if the value is not entirely ``0`` or ``1``.
 
     :class:`LogicArray`\ s also support element-wise logical operations: ``&``, ``|``,
     ``^``, and ``~``.
@@ -216,7 +241,7 @@ class LogicArray(ArrayLike[Logic]):
 
     Raises:
         TypeError: When invalid argument types are used.
-        ValueError: Generally when *value* will not fit in a LogicArray of the given *range*.
+        ValueError: When *value* will not fit in a LogicArray of the given *range*.
     """
 
     # These three attribute contain the current value of the array in one or more of
@@ -326,7 +351,7 @@ class LogicArray(ArrayLike[Logic]):
         value: int,
         range: Union[Range, int],
     ) -> "LogicArray":
-        """Construct a :class:`LogicArray` from an :class:`int` by interpreting it as a bit vector with unsigned representation.
+        """Construct a :class:`LogicArray` from an :class:`int` with unsigned representation.
 
         The :class:`int` is treated as an arbitrary-length bit vector with unsigned representation where the left-most bit is the most significant bit.
         This bit vector is then constructed into a :class:`LogicArray`.
@@ -336,10 +361,11 @@ class LogicArray(ArrayLike[Logic]):
             range: Indexing scheme for the LogicArray.
 
         Returns:
-            A :class:`LogicArray` equivalent to the *value* by interpreting it as a bit vector with unsigned representation.
+            A :class:`LogicArray` equivalent to the *value*.
 
         Raises:
-            ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
+            TypeError: When invalid argument types are used.
+            ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*, or *value* is negative.
         """
         return LogicArray(value, range)
 
@@ -349,7 +375,7 @@ class LogicArray(ArrayLike[Logic]):
         value: int,
         range: Union[Range, int],
     ) -> "LogicArray":
-        """Construct a :class:`LogicArray` from an :class:`int` by interpreting it as a bit vector with two's complement representation.
+        """Construct a :class:`LogicArray` from an :class:`int` with two's complement representation.
 
         The :class:`int` is treated as an arbitrary-length bit vector with two's complement representation where the left-most bit is the most significant bit.
         This bit vector is then constructed into a :class:`LogicArray`.
@@ -359,9 +385,10 @@ class LogicArray(ArrayLike[Logic]):
             range: Indexing scheme for the LogicArray.
 
         Returns:
-            A :class:`LogicArray` equivalent to the *value* by interpreting it as a bit vector with two's complement representation.
+            A :class:`LogicArray` equivalent to the *value*.
 
         Raises:
+            TypeError: When invalid argument types are used.
             ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
         """
         if isinstance(range, int):
@@ -395,7 +422,7 @@ class LogicArray(ArrayLike[Logic]):
             byteorder: The endianness used to construct the intermediate integer, either ``"big"`` or ``"little"``.
 
         Returns:
-            A :class:`LogicArray` equivalent to the *value* by interpreting it as an unsigned integer in big-endian representation.
+            A :class:`LogicArray` equivalent to the *value*.
 
         Raises:
             ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*.

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -382,8 +382,6 @@ class LogicArray(ArrayLike[Logic]):
         if self._value_as_int is None:
             # May convert list to str before converting to int.
             value_as_str = self._get_str()
-            # resolve L and H to 0 and 1
-            value_as_str = value_as_str.translate(_resolve_lh_table)
             try:
                 self._value_as_int = int(value_as_str, 2)
             except ValueError:
@@ -391,6 +389,10 @@ class LogicArray(ArrayLike[Logic]):
                 if resolve is None:
                     resolve = RESOLVE_X
 
+                # resolve L and H to 0 and 1
+                value_as_str = value_as_str.translate(_resolve_lh_table)
+
+                # resolve remaining
                 resolve_table = _resolve_tables[resolve]
                 value_as_str = value_as_str.translate(resolve_table)
                 return int(value_as_str, 2)

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -444,7 +444,7 @@ class LogicArray(ArrayLike[Logic]):
         # Used by cocotb.handle classes to make LogicArray from values gotten from the
         # simulator which we expect to be well-formed.
         # Values are required to be uppercase.
-        self = super().__new__(cls)
+        self = cls.__new__(cls)
         self._value_as_array = None
         self._value_as_int = None
         self._value_as_str = value

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -218,9 +218,8 @@ class LogicArray(ArrayLike[Logic]):
         width: Shorthand for passing ``Range(0, "to", width - 1)`` to *range*.
 
     Raises:
-        OverflowError: When given *value* cannot fit in given *range*.
-        ValueError: When argument values cannot be used to construct an array.
         TypeError: When invalid argument types are used.
+        ValueError: Generally when *value* will not fit in a LogicArray of the given *range*.
     """
 
     # These three attribute contain the current value of the array in one or more of
@@ -331,7 +330,7 @@ class LogicArray(ArrayLike[Logic]):
             self._value_as_str = value.upper()
             if range is not None:
                 if len(value) != len(range):
-                    raise OverflowError(
+                    raise ValueError(
                         f"Value of length {len(self._value_as_str)} will not fit in {range}"
                     )
                 self._range = range
@@ -344,7 +343,7 @@ class LogicArray(ArrayLike[Logic]):
                 raise TypeError("Missing required arguments: 'range' or 'width'")
             bitlen = max(1, int.bit_length(value))
             if bitlen > len(range):
-                raise OverflowError(
+                raise ValueError(
                     f"{value!r} will not fit in a LogicArray with bounds: {range!r}."
                 )
             self._value_as_int = value
@@ -353,7 +352,7 @@ class LogicArray(ArrayLike[Logic]):
             self._value_as_array = [Logic(v) for v in value]
             if range is not None:
                 if len(self._value_as_array) != len(range):
-                    raise OverflowError(
+                    raise ValueError(
                         f"Value of length {len(self._value_as_array)} will not fit in {range}"
                     )
                 self._range = range
@@ -432,7 +431,7 @@ class LogicArray(ArrayLike[Logic]):
             A :class:`LogicArray` equivalent to the *value* by interpreting it as a bit vector with unsigned representation.
 
         Raises:
-            OverflowError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
+            ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
         """
         range = _make_range(range, width)
         if range is None:
@@ -473,7 +472,7 @@ class LogicArray(ArrayLike[Logic]):
             A :class:`LogicArray` equivalent to the *value* by interpreting it as a bit vector with two's complement representation.
 
         Raises:
-            OverflowError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
+            ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
         """
         range = _make_range(range, width)
         if range is None:
@@ -483,7 +482,7 @@ class LogicArray(ArrayLike[Logic]):
         # If value doesn't fit in range, it will still be negative and will blow the
         # constructor up in a bad way.
         if value < 0:
-            raise OverflowError(
+            raise ValueError(
                 f"{value!r} will not fit in a LogicArray with bounds: {range!r}."
             )
         return LogicArray(value, range)
@@ -542,13 +541,13 @@ class LogicArray(ArrayLike[Logic]):
             A :class:`LogicArray` equivalent to the *value* by interpreting it as an unsigned integer in big-endian representation.
 
         Raises:
-            OverflowError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
+            ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
         """
         range = _make_range(range, width)
         if range is None:
             range = Range(len(value) * 8 - 1, "downto", 0)
         elif len(value) * 8 != len(range):
-            raise OverflowError(
+            raise ValueError(
                 f"Value of length {len(value)} will not fit in a LogicArray with bounds: {range!r}"
             )
         return cls.from_unsigned(

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -104,8 +104,6 @@ class LogicArray(ArrayLike[Logic]):
     of the iterable used to initialize the variable.
     Passing an :class:`int` as the second position argument, or as the *width* argument,
     acts as shorthand for ``Range(width-1, "downto", 0)``.
-    If a *range* argument is given, but no value,
-    the array is filled with the default value of ``Logic()``.
 
     .. code-block:: pycon3
 
@@ -117,9 +115,6 @@ class LogicArray(ArrayLike[Logic]):
 
         >>> LogicArray([0, True, "X"])
         LogicArray('01X', Range(2, 'downto', 0))
-
-        >>> LogicArray(range=Range(0, "to", 3))  # default values
-        LogicArray('XXXX', Range(0, 'to', 3))
 
     :class:`LogicArray`\ s can be constructed from :class:`int`\ s using :meth:`from_unsigned` or :meth:`from_signed`.
 
@@ -319,23 +314,9 @@ class LogicArray(ArrayLike[Logic]):
         range: Union[Range, int],
     ) -> None: ...
 
-    @overload
     def __init__(
         self,
-        *,
-        range: Range,
-    ) -> None: ...
-
-    @overload
-    def __init__(
-        self,
-        *,
-        width: int,
-    ) -> None: ...
-
-    def __init__(
-        self,
-        value: Union[int, str, Iterable[LogicConstructibleT], None] = None,
+        value: Union[int, str, Iterable[LogicConstructibleT]],
         range: Union[Range, int, None] = None,
         *,
         width: Union[int, None] = None,
@@ -367,11 +348,6 @@ class LogicArray(ArrayLike[Logic]):
                     f"{value!r} will not fit in a LogicArray with bounds: {range!r}."
                 )
             self._value_as_int = value
-            self._range = range
-        elif value is None:
-            if range is None:
-                raise TypeError("Missing required arguments: 'range' or 'width'")
-            self._value_as_str = "X" * len(range)
             self._range = range
         else:
             self._value_as_array = [Logic(v) for v in value]

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -21,7 +21,6 @@ def test_both_construction():
 
     Array("1234", 4)
     Array("1234", range=Range(-2, 1))
-    Array("1234", width=4)
 
 
 def test_range_int_construction():
@@ -41,8 +40,6 @@ def test_bad_construction():
         Array(value="1234", range=object())
     with pytest.raises(TypeError):
         Array("1234", range(4))
-    with pytest.raises(TypeError):
-        Array("1234", Range(0, 3), width=4)
 
 
 def test_length():

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -62,10 +62,6 @@ def test_logic_equality():
     assert Logic("1") != 5
 
 
-def test_logic_default_value():
-    assert Logic() == Logic("X")
-
-
 def test_logic_bool_conversions():
     assert bool(Logic("1")) is True
     assert bool(Logic("0")) is False

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -15,7 +15,7 @@ def test_logic_array_str_construction():
     assert LogicArray("1010", range=Range(0, "to", 3)) == LogicArray("1010")
     assert LogicArray("1010", width=4) == LogicArray("1010")
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray("101010", Range(0, "to", 0))
 
     with pytest.raises(ValueError):
@@ -37,7 +37,7 @@ def test_logic_array_iterable_construction():
 
     assert LogicArray(gen()) == LogicArray("10XZ")
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray([1, 0, 1, 0], Range(1, "downto", 0))
     with pytest.raises(ValueError):
         LogicArray(["l", "o", "l"])
@@ -53,7 +53,7 @@ def test_logic_array_int_construction():
     assert LogicArray(10, range=Range(5, "downto", 0)) == LogicArray("001010")
     assert LogicArray(10, width=6) == LogicArray("001010")
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray(10, Range(1, "to", 3))
     with pytest.raises(ValueError):
         LogicArray(-10, Range(7, "downto", 0))
@@ -84,9 +84,9 @@ def test_logic_array_unsigned_conversion():
     )
     assert LogicArray.from_unsigned(10, width=6) == LogicArray("001010")
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_unsigned(10, Range(1, "to", 3))
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_unsigned(10, 3)
 
     with pytest.raises(ValueError):
@@ -108,9 +108,9 @@ def test_logic_array_signed_conversion():
     )
     assert LogicArray.from_signed(-2, width=6) == LogicArray("111110")
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_signed(-45, Range(1, "to", 3))
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_signed(-45, 3)
 
     with pytest.raises(TypeError):
@@ -124,13 +124,13 @@ def test_logic_array_bytes_conversion():
         "0011000100110010"
     )
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_bytes(b"123", Range(6, "downto", 0), byteorder="big")
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_bytes(b"123", 10, byteorder="big")
 
     # b"1" would fit in a 7 bit LogicArray, but we do not guess if top bits are significant or not
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_bytes(b"1", Range(6, "downto", 0), byteorder="big")
 
     assert LogicArray("00101010").to_bytes(byteorder="big") == b"\x2a"
@@ -344,7 +344,7 @@ def test_slice_direction_mismatch():
 
 def test_set_slice_wrong_length():
     a = LogicArray("XXXXXX")
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         a[4:2] = "0000000000000"
 
 
@@ -373,11 +373,11 @@ def test_null_vector():
     LogicArray("", null_range)
     LogicArray([])
     LogicArray([], null_range)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray(0, null_range)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_unsigned(0, null_range)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         LogicArray.from_signed(0, null_range)
 
     null_vector = LogicArray("")

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -59,11 +59,6 @@ def test_logic_array_int_construction():
         LogicArray(-10, Range(7, "downto", 0))
 
 
-def test_logic_array_default_construction():
-    assert LogicArray(range=Range(0, "to", 3)) == LogicArray("XXXX")
-    assert LogicArray(width=4) == LogicArray("XXXX")
-
-
 def test_logic_array_bad_construction():
     with pytest.raises(TypeError):
         LogicArray(object())
@@ -380,7 +375,6 @@ def test_null_vector():
     LogicArray([], null_range)
     with pytest.raises(OverflowError):
         LogicArray(0, null_range)
-    LogicArray(range=null_range)
     with pytest.raises(OverflowError):
         LogicArray.from_unsigned(0, null_range)
     with pytest.raises(OverflowError):
@@ -404,7 +398,6 @@ def test_null_vector():
     assert null_vector == LogicArray("", null_range)
     assert null_vector == LogicArray([])
     assert null_vector == LogicArray([], null_range)
-    assert null_vector == LogicArray(range=null_range)
     with pytest.warns(UserWarning):
         assert null_vector == 0
     assert null_vector == ""

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -13,7 +13,6 @@ def test_logic_array_str_construction():
     assert LogicArray("1010", Range(0, "to", 3)) == LogicArray("1010")
     assert LogicArray("1010", 4) == LogicArray("1010")
     assert LogicArray("1010", range=Range(0, "to", 3)) == LogicArray("1010")
-    assert LogicArray("1010", width=4) == LogicArray("1010")
 
     with pytest.raises(ValueError):
         LogicArray("101010", Range(0, "to", 0))
@@ -27,7 +26,6 @@ def test_logic_array_iterable_construction():
     assert LogicArray((1, 0, 1, 0), Range(0, "to", 3)) == LogicArray("1010")
     assert LogicArray((1, 0, 1, 0), 4) == LogicArray("1010")
     assert LogicArray((1, 0, 1, 0), range=Range(0, "to", 3)) == LogicArray("1010")
-    assert LogicArray((1, 0, 1, 0), width=4) == LogicArray("1010")
 
     def gen():
         yield True
@@ -51,7 +49,6 @@ def test_logic_array_int_construction():
     assert LogicArray(10, Range(5, "downto", 0)) == LogicArray("001010")
     assert LogicArray(10, 6) == LogicArray("001010")
     assert LogicArray(10, range=Range(5, "downto", 0)) == LogicArray("001010")
-    assert LogicArray(10, width=6) == LogicArray("001010")
 
     with pytest.raises(ValueError):
         LogicArray(10, Range(1, "to", 3))
@@ -67,11 +64,7 @@ def test_logic_array_bad_construction():
     with pytest.raises(TypeError):
         LogicArray(range=dict())
     with pytest.raises(TypeError):
-        LogicArray("1010", width=Range(0, 3))
-    with pytest.raises(TypeError):
         LogicArray()
-    with pytest.raises(TypeError):
-        LogicArray("1010", Range(3, 0), width=4)
 
 
 def test_logic_array_unsigned_conversion():
@@ -82,7 +75,6 @@ def test_logic_array_unsigned_conversion():
     assert LogicArray.from_unsigned(10, range=Range(5, "downto", 0)) == LogicArray(
         "001010"
     )
-    assert LogicArray.from_unsigned(10, width=6) == LogicArray("001010")
 
     with pytest.raises(ValueError):
         LogicArray.from_unsigned(10, Range(1, "to", 3))
@@ -106,7 +98,6 @@ def test_logic_array_signed_conversion():
     assert LogicArray.from_signed(-2, range=Range(5, "downto", 0)) == LogicArray(
         "111110"
     )
-    assert LogicArray.from_signed(-2, width=6) == LogicArray("111110")
 
     with pytest.raises(ValueError):
         LogicArray.from_signed(-45, Range(1, "to", 3))

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -407,7 +407,7 @@ async def test_assign_Logic_9value(dut):
 @cocotb.test(skip=LANGUAGE != "vhdl" or SIM_NAME.startswith("ghdl"))
 async def test_assign_LogicArray_9value(dut):
     # Reset to zero.
-    dut.stream_in_data.value = LogicArray(0, width=8)
+    dut.stream_in_data.value = LogicArray(0, 8)
     await Timer(1, "ns")
     assert dut.stream_in_data.value == 0
 

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -424,7 +424,7 @@ async def test_assign_string(dut):
     dut.stream_in_data.value = "10101010"
     await Timer(1, "ns")
     assert dut.stream_in_data.value == "10101010"
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         dut.stream_in_data.value = "XXX"  # not the correct size
     with pytest.raises(ValueError):
         dut.stream_in_data.value = "lol"  # not the correct values


### PR DESCRIPTION
Primarily I was interested in getting rid of all the logic around constructing LogicArray with the whole 'range' vs 'width' nonsense. It's not that valuable and is slow. Same with the default values of Logic and thus LogicArray. I don't want to say the default should be `X` or `U`, and it's not valuable to us really. That helped make the LogicArray change make more sense since we will never see `LogicArray(range=5)` and might not ever see `range` passed as a keyword argument.

While I was there I cleaned up some other things and found a small bug to fix.
* Removed all uses of `OverflowError` in LogicArray and handle.py (xref #4124).
* Found and fixed a small bug with the RESOLVE_X logic.
* Added `Array._from_handle` to hopefully speed up Array construction from handles a bit.
* Touched up the documentation that looked a bit grody. 4 years is a long time ago...
* Fixed documentation of `ResolveX` which was broken.

### TODO
- [x] ~~newsfrags~~  No newsfrags needed, nothing changed from 1.9.