### PR TITLE
Rename `PYGPI_ENTRY_POINT` to `PYGPI_USERS`

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -360,7 +360,7 @@ PyGPI
     PyGPI is an experimental feature and subject to change.
 
 
-.. envvar:: PYGPI_ENTRY_POINT
+.. envvar:: PYGPI_USERS
 
     The Python module and callable that starts up the Python cosimulation environment.
     User overloads can be used to enter alternative Python frameworks or to hook existing cocotb functionality.
@@ -381,6 +381,9 @@ PyGPI
 
     .. versionchanged:: 2.0
         Multiple entry points can be specified by separating them with a comma.
+
+    .. versionchanged:: 2.0
+        Renamed from ``PYGPI_ENTRY_POINT``.
 
 
 Makefile-based Test Scripts

--- a/docs/source/newsfragments/4310.change.1.rst
+++ b/docs/source/newsfragments/4310.change.1.rst
@@ -1,1 +1,1 @@
-Entry point modules specified by :envvar:`PYGPI_ENTRY_POINT` no longer require the module-level definition of the function ``_sim_event``. Instead call ``cocotb.simulator.set_sim_event_callback`` if you need this functionality.
+PyGPI user modules specified by :envvar:`PYGPI_USERS` no longer require the module-level definition of the function ``_sim_event``. Instead call ``cocotb.simulator.set_sim_event_callback`` if you need this functionality.

--- a/docs/source/newsfragments/4310.change.rst
+++ b/docs/source/newsfragments/4310.change.rst
@@ -1,1 +1,1 @@
-Entry point modules specified by :envvar:`PYGPI_ENTRY_POINT` no longer require the module-level definition of functions ``_log_from_c`` and ``_filter_from_c``. Instead call ``cocotb.simulator.initialize_logger`` if you need this functionality.
+PyGPI user modules specified by :envvar:`PYGPI_USERS` no longer require the module-level definition of functions ``_log_from_c`` and ``_filter_from_c``. Instead call ``cocotb.simulator.initialize_logger`` if you need this functionality.

--- a/docs/source/newsfragments/4310.feature.rst
+++ b/docs/source/newsfragments/4310.feature.rst
@@ -1,1 +1,1 @@
-:envvar:`PYGPI_ENTRY_POINT` supports multiple entry points by comma-separating the entry points.
+:envvar:`PYGPI_USERS` supports multiple user modules by comma-separating them.

--- a/docs/source/newsfragments/4513.change.rst
+++ b/docs/source/newsfragments/4513.change.rst
@@ -1,0 +1,1 @@
+``PYGPI_ENTRY_POINT`` renamed to :envvar:`PYGPI_USERS`.

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -5,10 +5,10 @@ from typing import Any, Callable, List, Tuple, cast
 
 
 def load_entry(argv: List[str]) -> Any:
-    """Gather entry point information by parsing :envvar:`PYGPI_ENTRY_POINT`."""
+    """Gather entry point information by parsing :envvar:`PYGPI_USERS`."""
 
     entry_point_str = os.environ.get(
-        "PYGPI_ENTRY_POINT",
+        "PYGPI_USERS",
         ",".join(
             (
                 "cocotb_tools._coverage:start_cocotb_library_coverage",
@@ -29,9 +29,7 @@ def load_entry(argv: List[str]) -> Any:
             # WITHOUT IMPORTING THEM.
             entry_points.append((entry_module_str, entry_func_str))
     except Exception as e:
-        raise RuntimeError(
-            f"Failure to parse PYGPI_ENTRY_POINT ('{entry_point_str}')"
-        ) from e
+        raise RuntimeError(f"Failure to parse PYGPI_USERS ('{entry_point_str}')") from e
 
     # Run all entry points.
     # Expect failure to stop the loading of any additional entry points.

--- a/tests/test_cases/test_custom_entry/Makefile
+++ b/tests/test_cases/test_custom_entry/Makefile
@@ -1,5 +1,5 @@
 export PYTHONPATH := .
-export PYGPI_ENTRY_POINT := custom_entry:entry_func
+export PYGPI_USERS := custom_entry:entry_func
 
 .PHONY: override_for_this_test
 override_for_this_test:


### PR DESCRIPTION
This will match `GPI_USERS` from #4492. A fairly minor API break.