### PR TITLE
Split Test from RegressionManager and Scheduler

### DIFF
--- a/docs/source/newsfragments/4514.bugfix.rst
+++ b/docs/source/newsfragments/4514.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where scheduled writes at the end of a test are cancelled.

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -120,9 +120,7 @@ def run_regression(_: Any) -> None:
     _setup_regression_manager()
 
     # setup global scheduler system
-    cocotb._scheduler_inst = Scheduler(
-        test_complete_cb=cocotb.regression_manager._test_complete
-    )
+    cocotb._scheduler_inst = Scheduler()
 
     # start Regression Manager
     log.info("Running tests")

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -1,0 +1,344 @@
+import functools
+import hashlib
+import inspect
+import random
+import time
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    List,
+    NoReturn,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
+
+import cocotb
+from cocotb._deprecation import deprecated
+from cocotb._exceptions import InternalError
+from cocotb._outcomes import Error, Outcome
+from cocotb._typing import TimeUnit
+from cocotb.task import ResultType, Task
+from cocotb.triggers import NullTrigger, SimTimeoutError, with_timeout
+from cocotb.utils import get_sim_time
+
+Failed: Type[BaseException]
+try:
+    import pytest
+except ModuleNotFoundError:
+    Failed = AssertionError
+else:
+    try:
+        with pytest.raises(Exception):
+            pass
+    except BaseException as _raises_e:
+        Failed = type(_raises_e)
+    else:
+        assert False, "pytest.raises doesn't raise an exception when it fails"
+
+
+# TODO remove SimFailure once we have functionality in place to abort the test without
+# having to set an exception.
+class SimFailure(BaseException):
+    """A Test failure due to simulator failure."""
+
+
+class TestSuccess(BaseException):
+    """Implementation of :func:`pass_test`.
+
+    Users are *not* intended to catch this exception type.
+    """
+
+    def __init__(self, msg: Union[str, None]) -> None:
+        super().__init__(msg)
+        self.msg = msg
+
+
+class Test:
+    """A cocotb test in a regression.
+
+    Args:
+        func:
+            The test function object.
+
+        name:
+            The name of the test function.
+            Defaults to ``func.__qualname__`` (the dotted path to the test function in the module).
+
+        module:
+            The name of the module containing the test function.
+            Defaults to ``func.__module__`` (the name of the module containing the test function).
+
+        doc:
+            The docstring for the test.
+            Defaults to ``func.__doc__`` (the docstring of the test function).
+
+        timeout_time:
+            Simulation time duration before the test is forced to fail with a :exc:`~cocotb.triggers.SimTimeoutError`.
+
+        timeout_unit:
+            Unit of ``timeout_time``, accepts any unit that :class:`~cocotb.triggers.Timer` does.
+
+        expect_fail:
+            If ``True`` and the test fails a functional check via an :keyword:`assert` statement, :func:`pytest.raises`,
+            :func:`pytest.warns`, or :func:`pytest.deprecated_call`, the test is considered to have passed.
+            If ``True`` and the test passes successfully, the test is considered to have failed.
+
+        expect_error:
+            Mark the result as a pass only if one of the given exception types is raised in the test.
+
+        skip:
+            Don't execute this test as part of the regression.
+            The test can still be run manually by setting :envvar:`COCOTB_TESTCASE`.
+
+        stage:
+            Order tests logically into stages.
+            Tests from earlier stages are run before tests from later stages.
+    """
+
+    def __init__(
+        self,
+        *,
+        func: Callable[..., Coroutine[Any, Any, None]],
+        name: Optional[str] = None,
+        module: Optional[str] = None,
+        doc: Optional[str] = None,
+        timeout_time: Optional[float] = None,
+        timeout_unit: TimeUnit = "step",
+        expect_fail: bool = False,
+        expect_error: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = (),
+        skip: bool = False,
+        stage: int = 0,
+        _expect_sim_failure: bool = False,
+    ) -> None:
+        self.func: Callable[..., Coroutine[Any, Any, None]]
+        if timeout_time is not None:
+            co = func  # must save ref because we overwrite variable "func"
+
+            @functools.wraps(func)
+            async def f(*args, **kwargs):
+                running_co = Task(co(*args, **kwargs))
+
+                try:
+                    res = await with_timeout(running_co, timeout_time, timeout_unit)
+                except SimTimeoutError:
+                    running_co.kill()
+                    raise
+                else:
+                    return res
+
+            self.func = f
+        else:
+            self.func = func
+        self.timeout_time = timeout_time
+        self.timeout_unit = timeout_unit
+        self.expect_fail = expect_fail
+        if isinstance(expect_error, type):
+            expect_error = (expect_error,)
+        if _expect_sim_failure:
+            expect_error += (SimFailure,)
+        self.expect_error = expect_error
+        self._expect_sim_failure = _expect_sim_failure
+        self.skip = skip
+        self.stage = stage
+        self.name = self.func.__qualname__ if name is None else name
+        self.module = self.func.__module__ if module is None else module
+        self.doc = self.func.__doc__ if doc is None else doc
+        if self.doc is not None:
+            # cleanup docstring using `trim` function from PEP257
+            self.doc = inspect.cleandoc(self.doc)
+        self.fullname = f"{self.module}.{self.name}"
+
+        self.tasks: List[Task[Any]] = []
+
+        self._test_complete_cb: Callable[[], None]
+        self._main_task: Task[None]
+        self._outcome: Union[None, Outcome[Any]] = None
+        self._start_time: float
+        self._start_sim_time: float
+
+    def init(self, _test_complete_cb: Callable[[], None]) -> None:
+        self._test_complete_cb = _test_complete_cb
+        self._main_task = TestTask(self.func(cocotb.top), self.name)
+        self._main_task._add_done_callback(self._shutdown_test)
+
+    def _shutdown_test(self, task: Task[Any]) -> None:
+        # kill test Tasks
+        while self.tasks:
+            self.tasks[0].kill()
+
+        # record times
+        self.wall_time = time.time() - self._start_time
+        self.sim_time_ns = get_sim_time("ns") - self._start_sim_time
+        self._test_complete_cb()
+
+    def start(self) -> None:
+        # seed random number generator based on test module, name, and COCOTB_RANDOM_SEED
+        hasher = hashlib.sha1()
+        hasher.update(self.fullname.encode())
+        seed = cocotb._random_seed + int(hasher.hexdigest(), 16)
+        random.seed(seed)
+
+        self._start_sim_time = get_sim_time("ns")
+        self._start_time = time.time()
+
+        cocotb._scheduler_inst._schedule_task_internal(self._main_task)
+        cocotb._scheduler_inst._event_loop()
+
+    def result(self) -> Outcome[Any]:
+        if self._outcome is not None:
+            return self._outcome
+        else:
+            assert self._main_task._outcome is not None
+            return self._main_task._outcome
+
+    def abort(self, exc: BaseException) -> None:
+        """Force this test to end early.
+
+        This happens when a background task fails, and is consistent with
+        how the behavior has always been. In future, we may want to behave
+        more gracefully to allow the test body to clean up.
+
+        *exc* is the exception that the test should report as its reason for
+        aborting.
+        """
+        if self._outcome is not None:  # pragma: no cover
+            raise InternalError("Outcome already has a value, but is being set again.")
+        self._outcome = Error(exc)
+        self._main_task.kill()
+
+    def add_task(self, task: Task[Any]) -> None:
+        task._add_done_callback(self._task_done_callback)
+        self.tasks.append(task)
+
+    def _task_done_callback(self, task: Task[Any]) -> None:
+        self.tasks.remove(task)
+        # if cancelled, do nothing
+        if task.cancelled():
+            return
+        # if there's a Task awaiting this one, don't fail
+        if task.complete in cocotb._scheduler_inst._trigger2tasks:
+            return
+        # if no failure, do nothing
+        e = task.exception()
+        if e is None:
+            return
+        # there was a failure and no one is watching, fail test
+        elif isinstance(e, (TestSuccess, Failed, AssertionError)):
+            task._log.info("Test stopped by this task")
+            self.abort(e)
+        else:
+            task._log.error("Exception raised by this task")
+            self.abort(e)
+
+
+class TestTask(Task[None]):
+    """Specialized Task for Tests."""
+
+    def __init__(self, inst: Coroutine[Any, Any, None], name: str) -> None:
+        super().__init__(inst)
+        self.__name__ = f"Test {name}"
+        self.__qualname__ = self.__name__
+
+
+def start_soon(
+    coro: Union[Task[ResultType], Coroutine[Any, Any, ResultType]],
+) -> Task[ResultType]:
+    """
+    Schedule a coroutine to be run concurrently in a :class:`~cocotb.task.Task`.
+
+    Note that this is not an :keyword:`async` function,
+    and the new task will not execute until the calling task yields control.
+
+    Args:
+        coro: A task or coroutine to be run.
+
+    Returns:
+        The :class:`~cocotb.task.Task` that is scheduled to be run.
+
+    .. versionadded:: 1.6
+    """
+    task = create_task(coro)
+    cocotb._scheduler_inst._schedule_task(task)
+    return task
+
+
+@deprecated("Use ``cocotb.start_soon`` instead.")
+async def start(
+    coro: Union[Task[ResultType], Coroutine[Any, Any, ResultType]],
+) -> Task[ResultType]:
+    """
+    Schedule a coroutine to be run concurrently, then yield control to allow pending tasks to execute.
+
+    The calling task will resume execution before control is returned to the simulator.
+
+    When the calling task resumes, the newly scheduled task may have completed,
+    raised an Exception, or be pending on a :class:`~cocotb.triggers.Trigger`.
+
+    Args:
+        coro: A task or coroutine to be run.
+
+    Returns:
+        The :class:`~cocotb.task.Task` that has been scheduled and allowed to execute.
+
+    .. versionadded:: 1.6
+
+    .. deprecated:: 2.0
+        Use :func:`cocotb.start_soon` instead.
+        If you need the scheduled Task to run before continuing the current Task,
+        follow the call to :func:`cocotb.start_soon` with an :class:`await NullTrigger() <cocotb.triggers.NullTrigger>`.
+    """
+    task = start_soon(coro)
+    await NullTrigger()
+    return task
+
+
+def create_task(
+    coro: Union[Task[ResultType], Coroutine[Any, Any, ResultType]],
+) -> Task[ResultType]:
+    """
+    Construct a coroutine into a :class:`~cocotb.task.Task` without scheduling the task.
+
+    The task can later be scheduled with :func:`cocotb.start` or :func:`cocotb.start_soon`.
+
+    Args:
+        coro: An existing task or a coroutine to be wrapped.
+
+    Returns:
+        Either the provided :class:`~cocotb.task.Task` or a new Task wrapping the coroutine.
+
+    .. versionadded:: 1.6
+    """
+    if isinstance(coro, Task):
+        return coro
+    elif isinstance(coro, Coroutine):
+        task = Task[ResultType](coro)
+        cocotb.regression_manager._test.add_task(task)
+        return task
+    elif inspect.iscoroutinefunction(coro):
+        raise TypeError(
+            f"Coroutine function {coro} should be called prior to being scheduled."
+        )
+    elif inspect.isasyncgen(coro):
+        raise TypeError(
+            f"{coro.__qualname__} is an async generator, not a coroutine. "
+            "You likely used the yield keyword instead of await."
+        )
+    else:
+        raise TypeError(
+            f"Attempt to add an object of type {type(coro)} to the scheduler, "
+            f"which isn't a coroutine: {coro!r}\n"
+        )
+
+
+def pass_test(msg: Union[str, None] = None) -> NoReturn:
+    """Force a test to pass.
+
+    The test will end and enter termination phase when this is called.
+
+    Args:
+        msg: The message to display when the test passes.
+    """
+    raise TestSuccess(msg)

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -258,13 +258,12 @@ else:
             return lookup
 
 
-_T = TypeVar("_T", bound=type)
-_Value = TypeVar("_Value", bound=object)
+T = TypeVar("T")
 
 
 if TYPE_CHECKING:
 
-    def singleton(orig_cls: _T) -> _T: ...
+    def singleton(orig_cls: T) -> T: ...
 
 else:
 
@@ -275,7 +274,7 @@ else:
         instance = None
 
         @wraps(orig_cls.__new__)
-        def __new__(cls: Type[_Value], *args: Any, **kwargs: Any) -> _Value:
+        def __new__(cls, *args, **kwargs):
             nonlocal instance
             if instance is None:
                 instance = orig_new(cls, *args, **kwargs)
@@ -283,7 +282,7 @@ else:
             return instance
 
         @wraps(orig_cls.__init__)
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
+        def __init__(self, *args, **kwargs):
             pass
 
         orig_cls.__new__ = __new__

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -721,7 +721,7 @@ _trust_inertial = bool(int(os.environ.get("COCOTB_TRUST_INERTIAL_WRITES", "0")))
 # Only the last scheduled write to a particular handle in a timestep is performed.
 _write_calls: "OrderedDict[ValueObjectBase[Any, Any], Tuple[Callable[[int, Any], None], _GPISetAction, Any]]" = OrderedDict()
 
-_write_task: "Union[Task[None], None]" = None
+_write_task: Union[Task[None], None] = None
 
 _writes_pending = Event()
 
@@ -736,7 +736,8 @@ async def _do_writes() -> None:
 def _start_write_scheduler() -> None:
     global _write_task
     if _write_task is None:
-        _write_task = cocotb.start_soon(_do_writes())
+        _write_task = Task(_do_writes())
+        cocotb._scheduler_inst._schedule_task(_write_task)
 
 
 def _stop_write_scheduler() -> None:
@@ -1267,7 +1268,7 @@ class LogicArrayObject(
             ValueError: If *value* would not fit in the bounds of the simulation object.
             OverflowError:
                 If :class:`int` *value* is out of the range that can be represented by the target:
-                -2**(Nbits - 1) <= value <= 2**Nbits - 1
+                ``-2**(Nbits - 1) <= value <= 2**Nbits - 1``.
 
         .. versionchanged:: 2.0
             Using :class:`ctypes.Structure` objects to set values was removed.

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -316,21 +316,3 @@ class Task(Generic[ResultType]):
         # Hand the coroutine back to the scheduler trampoline.
         yield self
         return self.result()
-
-
-class _RunningTest(Task[None]):
-    """
-    The result of calling a :class:`cocotb.test` decorated object.
-
-    All this class does is change ``__name__`` to show "Test" instead of "Task".
-
-    .. versionchanged:: 1.8
-        Moved to the ``cocotb.task`` module.
-    """
-
-    _name: str = "Test"
-
-    def __init__(self, inst: Coroutine[Any, Any, None], name: str) -> None:
-        super().__init__(inst)
-        self.__name__ = f"{type(self)._name} {name}"
-        self.__qualname__ = self.__name__

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -33,7 +33,6 @@ from fractions import Fraction
 from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
-    Any,
     Union,
     overload,
 )
@@ -51,7 +50,7 @@ def _get_simulator_precision() -> int:
 
 
 # Simulator helper functions
-def get_sim_time(unit: TimeUnit = "step") -> int:
+def get_sim_time(unit: TimeUnit = "step") -> float:
     """Retrieve the simulation time from the simulator.
 
     Args:
@@ -75,17 +74,8 @@ def get_sim_time(unit: TimeUnit = "step") -> int:
         Support ``'step'`` as the the *unit* argument to mean "simulator time step".
     """
     timeh, timel = simulator.get_sim_time()
-
-    result = timeh << 32 | timel
-
-    if unit != "step":
-        result = get_time_from_sim_steps(result, unit)
-
-    return result
-
-
-@overload
-def _ldexp10(frac: int, exp: int) -> int: ...
+    steps = timeh << 32 | timel
+    return get_time_from_sim_steps(steps, unit) if unit != "step" else steps
 
 
 @overload
@@ -96,7 +86,7 @@ def _ldexp10(frac: Union[float, Fraction], exp: int) -> float: ...
 def _ldexp10(frac: Decimal, exp: int) -> Decimal: ...
 
 
-def _ldexp10(frac: Union[float, Fraction, Decimal], exp: int) -> Any:
+def _ldexp10(frac: Union[float, Fraction, Decimal], exp: int) -> Union[float, Decimal]:
     """Like :func:`math.ldexp`, but base 10."""
     # using * or / separately prevents rounding errors if `frac` is a
     # high-precision type
@@ -106,7 +96,7 @@ def _ldexp10(frac: Union[float, Fraction, Decimal], exp: int) -> Any:
         return frac / (10**-exp)
 
 
-def get_time_from_sim_steps(steps: int, unit: TimeUnit) -> int:
+def get_time_from_sim_steps(steps: int, unit: TimeUnit) -> float:
     """Calculate simulation time in the specified *unit* from the *steps* based
     on the simulator precision.
 

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -569,3 +569,16 @@ async def test_extended_identifiers(dut):
 
     for name in names:
         assert dut[name]._name == name
+
+
+@cocotb.test
+async def test_set_at_end_of_test(dut) -> None:
+    """Tests that writes at the end of the test are still applied."""
+    dut.stream_in_data.value = 0
+    await Timer(1)
+    dut.stream_in_data.value = 5
+
+
+@cocotb.test
+async def test_set_at_end_of_test_check(dut) -> None:
+    assert dut.stream_in_data.value == 5

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -488,7 +488,7 @@ async def test_test_repr(_):
     """Test RunningTest.__repr__"""
     log = logging.getLogger("cocotb.test")
 
-    current_test = cocotb.regression_manager._test_task
+    current_test = cocotb.regression_manager._test._main_task
     log.info(repr(current_test))
     assert re.match(
         r"<Test test_test_repr running coro=test_test_repr\(\)>", repr(current_test)
@@ -506,7 +506,7 @@ class TestClassRepr(Coroutine):
     async def check_repr(self, dut):
         log = logging.getLogger("cocotb.test")
 
-        current_test = cocotb.regression_manager._test_task
+        current_test = cocotb.regression_manager._test._main_task
         log.info(repr(current_test))
         assert re.match(
             r"<Test TestClassRepr running coro=TestClassRepr\(\)>", repr(current_test)


### PR DESCRIPTION
Closes #791. Closes #4503.

This change removes the test end behavior from the Scheduler. There is now a separate set of tasks being held by the Test object which are killed when the Test ends instead of having the Scheduler kill all living Tasks.

This helps alleviate some of the issues from #4401 by not killing the `_do_writes` Task the writes scheduler is using.