### PR TITLE
Undeprecate-len-on-scalars

### DIFF
--- a/docs/source/newsfragments/4318.change.rst
+++ b/docs/source/newsfragments/4318.change.rst
@@ -1,1 +1,1 @@
-Scalar logic objects, such as un-arrayed ``logic`` in Verilog and ``std_logic`` in VHDL, no longer support ``handle.range`` or ``len(handle)``. Additionally, ``handle.value`` on such subject objects now returns a :class:`.Logic` rather than a :class:`.LogicArray`.
+For scalar logic objects, such as un-arrayed ``logic`` in Verilog and ``std_logic`` in VHDL, ``handle.value`` now returns a :class:`.Logic` rather than a :class:`.LogicArray`.

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -945,9 +945,6 @@ class LogicObject(NonArrayValueObject[Logic, Union[Logic, int, str]]):
         """A trigger which fires whenever the value changes to a ``0``."""
         return FallingEdge._make(self)
 
-    @deprecated(
-        "`len(handle)` of scalar objects is redundant. This method will be removed."
-    )
     def __len__(self) -> int:
         return 1
 

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -149,8 +149,6 @@ async def test_logic_scalar_object_methods_deprecated(dut) -> None:
         assert int(dut.stream_in_valid) == 1
     with pytest.warns(DeprecationWarning):
         assert str(dut.stream_in_valid) == "1"
-    with pytest.warns(DeprecationWarning):
-        assert len(dut.stream_in_valid) == 1
 
 
 @cocotb.test


### PR DESCRIPTION
closes #4518

main rationales are:

- API unsymmetry compared to single-bit vectors
- unnecessary code complication in generic testbench code which now would reuqire isinstance calls to get a simple '1' width
- a lot of existing code breakages - we have over 500 places alone that would now require 'isinstance' checks
- keeping it does not hurt anything, it's a simple return 1
