### PR TITLE
Cancelled error

### DIFF
--- a/docs/source/newsfragments/4524.change.rst
+++ b/docs/source/newsfragments/4524.change.rst
@@ -1,0 +1,1 @@
+:meth:`.Task.cancel` now causes a :exc:`~asyncio.CancelledError` to be thrown into the coroutine. This behavior is *scheduled*, so Tasks will not become cancelled immediately.

--- a/docs/source/newsfragments/4524.removal.rst
+++ b/docs/source/newsfragments/4524.removal.rst
@@ -1,0 +1,1 @@
+Undocumented ``__name__`` and ``__qualname__`` were removed from :class:`cocotb.task.Task` to mirror :class:`asyncio.Task`.

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -52,7 +52,7 @@ from cocotb._gpi_triggers import (
     Trigger,
 )
 from cocotb._profiling import profiling_context
-from cocotb.task import Task
+from cocotb.task import Task, _TaskState
 from cocotb.triggers import Event
 
 # Sadly the Python standard logging module is very slow so it's better not to
@@ -363,7 +363,7 @@ class Scheduler:
         """Schedule `task` to be resumed when `trigger` fires."""
         # TODO Move this all into Task
         task._trigger = trigger
-        task._state = Task._State.PENDING
+        task._state = _TaskState.PENDING
 
         trigger_tasks = self._trigger2tasks.setdefault(trigger, [])
         trigger_tasks.append(task)
@@ -398,7 +398,7 @@ class Scheduler:
         self, task: Task[Any], outcome: _outcomes.Outcome[Any] = _none_outcome
     ) -> None:
         # TODO Move state tracking into Task
-        task._state = Task._State.SCHEDULED
+        task._state = _TaskState.SCHEDULED
         self._scheduled_tasks[task] = outcome
 
     def _queue_function(self, task):
@@ -509,7 +509,7 @@ class Scheduler:
 
         # TODO move this into Task
         if isinstance(result, Task):
-            if result._state is Task._State.UNSTARTED:
+            if result._state is _TaskState.UNSTARTED:
                 return self._trigger_from_unstarted_task(result)
             else:
                 return self._trigger_from_started_task(result)

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -483,42 +483,6 @@ class Scheduler:
 
         return wrapper()
 
-    # This collection of functions parses a trigger out of the object
-    # that was yielded by a task, converting `list` -> `Waitable`,
-    # `Waitable` -> `Task`, `Task` -> `Trigger`.
-    # Doing them as separate functions allows us to avoid repeating unnecessary
-    # `isinstance` checks.
-
-    def _trigger_from_started_task(self, result: Task) -> Trigger:
-        if _debug:
-            self.log.debug(f"Joining to already running task: {result}")
-        return result.complete
-
-    def _trigger_from_unstarted_task(self, result: Task) -> Trigger:
-        self._schedule_task_internal(result)
-        if _debug:
-            self.log.debug(f"Scheduling unstarted task: {result!r}")
-        return result.complete
-
-    def _trigger_from_any(self, result) -> Trigger:
-        """Convert a yielded object into a Trigger instance"""
-        # note: the order of these can significantly impact performance
-
-        if isinstance(result, Trigger):
-            return result
-
-        # TODO move this into Task
-        if isinstance(result, Task):
-            if result._state is _TaskState.UNSTARTED:
-                return self._trigger_from_unstarted_task(result)
-            else:
-                return self._trigger_from_started_task(result)
-
-        raise TypeError(
-            f"Coroutine yielded an object of type {type(result)}, which the scheduler can't "
-            f"handle: {result!r}\n"
-        )
-
     def _resume_task(self, task: Task, exc: Union[BaseException, None]) -> None:
         """Resume *task* with *outcome*.
 
@@ -537,25 +501,25 @@ class Scheduler:
         try:
             self._current_task = task
 
-            result = task._advance(exc)
+            trigger = task._advance(exc)
 
             if task.done():
                 if _debug:
                     self.log.debug(f"{task} completed with {task._outcome}")
-                assert result is None
+                assert trigger is None
                 self._unschedule(task)
 
             if not task.done():
                 if _debug:
-                    self.log.debug(f"{task!r} yielded {result} ({cocotb.sim_phase})")
-                try:
-                    result = self._trigger_from_any(result)
-                except TypeError as e:
-                    # restart this task with an exception object telling it that
-                    # it wasn't allowed to yield that
+                    self.log.debug(f"{task!r} yielded {trigger} ({cocotb.sim_phase})")
+                if not isinstance(trigger, Trigger):
+                    e = TypeError(
+                        f"Coroutine yielded an object of type {type(trigger)}, which the scheduler can't "
+                        f"handle: {trigger!r}\n"
+                    )
                     self._schedule_task_internal(task, e)
                 else:
-                    self._schedule_task_upon(task, result)
+                    self._schedule_task_upon(task, trigger)
 
             # We do not return from here until pending threads have completed, but only
             # from the main thread, this seems like it could be problematic in cases

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -357,8 +357,6 @@ class Scheduler:
                 trigger._unprime()
                 del self._trigger2tasks[trigger]
 
-        self._react(task.complete)
-
     def _schedule_task_upon(self, task: Task[Any], trigger: Trigger) -> None:
         """Schedule `task` to be resumed when `trigger` fires."""
         # TODO Move this all into Task

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -239,8 +239,7 @@ class TestTask(Task[None]):
 
     def __init__(self, inst: Coroutine[Any, Any, None], name: str) -> None:
         super().__init__(inst)
-        self.__name__ = f"Test {name}"
-        self.__qualname__ = self.__name__
+        self._name = f"Test {name}"
 
 
 def start_soon(

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 import cocotb
+from cocotb._base_triggers import Trigger
 from cocotb._deprecation import deprecated
 from cocotb._exceptions import InternalError
 from cocotb._outcomes import Error, Outcome
@@ -237,7 +238,7 @@ class Test:
 class TestTask(Task[None]):
     """Specialized Task for Tests."""
 
-    def __init__(self, inst: Coroutine[Any, Any, None], name: str) -> None:
+    def __init__(self, inst: Coroutine[Trigger, None, None], name: str) -> None:
         super().__init__(inst)
         self._name = f"Test {name}"
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -61,7 +61,6 @@ class Task(Generic[ResultType]):
         Use :meth:`result`, :meth:`done`, and :meth:`done` methods instead, respectively.
     """
 
-    _name: str = "Task"  # class name of schedulable task
     _id_count = 0  # used by the scheduler for debug
 
     def __init__(self, inst):
@@ -86,17 +85,15 @@ class Task(Generic[ResultType]):
 
         self._task_id = self._id_count
         type(self)._id_count += 1
-        self.__name__ = f"{type(self)._name} {self._task_id}"
-        self.__qualname__ = self.__name__
+        self._name = f"Task {self._task_id}"
 
     @cached_property
     def _log(self) -> logging.Logger:
-        return logging.getLogger(
-            f"cocotb.{self.__qualname__}.{self._coro.__qualname__}"
-        )
+        return logging.getLogger(f"cocotb.{self._name}.{self._coro.__qualname__}")
 
     def __str__(self) -> str:
-        return f"<{self.__name__}>"
+        # TODO Do we really need this?
+        return f"<{self._name}>"
 
     def _get_coro_stack(self) -> Any:
         """Get the coroutine callstack of this Task."""
@@ -140,7 +137,7 @@ class Task(Generic[ResultType]):
                 coro_name = type(self._coro).__name__
 
         repr_string = fmt.format(
-            name=self.__name__,
+            name=self._name,
             coro=coro_name,
             trigger=self._trigger,
             outcome=self._outcome,

--- a/tests/test_cases/test_cocotb/test_clock.py
+++ b/tests/test_cases/test_cocotb/test_clock.py
@@ -109,12 +109,10 @@ async def test_clocks_with_other_number_types(dut):
 
     clk1 = cocotb.start_soon(Clock(dut.clk, decimal.Decimal("1"), unit="ns").start())
     await Timer(10, "ns")
-    with pytest.warns(FutureWarning, match="cause a CancelledError to be thrown"):
-        clk1.cancel()
+    clk1.cancel()
     clk2 = cocotb.start_soon(Clock(dut.clk, fractions.Fraction(1), unit="ns").start())
     await Timer(10, "ns")
-    with pytest.warns(FutureWarning, match="cause a CancelledError to be thrown"):
-        clk2.cancel()
+    clk2.cancel()
 
 
 @cocotb.test
@@ -139,8 +137,7 @@ async def test_clock_stop_and_restart_by_killing(dut) -> None:
     task = c.start()
     for _ in range(10):
         await RisingEdge(dut.clk)
-    with pytest.warns(FutureWarning):
-        task.cancel()
+    task.cancel()
     await NullTrigger()  # cancel() schedules the done callback
     c.start()
     for _ in range(10):

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -465,8 +465,7 @@ async def test_immediate_reentrace(dut):
         await ValueChange(dut.mybits_uninitialized)
         seen += 1
         dut.mybit.value = Immediate(0)
-        with pytest.warns(FutureWarning):
-            nested.cancel()
+        nested.cancel()
 
     cocotb.start_soon(watch())
     await Timer(1, "ns")

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -21,7 +21,7 @@ from common import MyException, assert_takes
 import cocotb
 import cocotb.utils
 from cocotb.clock import Clock
-from cocotb.task import Task
+from cocotb.task import CancellationError, Task
 from cocotb.triggers import (
     Combine,
     Event,
@@ -780,26 +780,58 @@ async def test_task_exception(_):
     assert str(task.exception()) == "msg1234"
 
 
-@cocotb.test()
-async def test_cancel_task(_):
-    async def coro():
-        return 0
+@cocotb.test
+async def test_cancel_task(_: object) -> None:
+    cancelled: bool = False
 
-    task = cocotb.start_soon(coro())
+    async def coro(will_be_cancelled: bool) -> None:
+        try:
+            await Timer(10, "ns")
+        except CancelledError:
+            nonlocal cancelled
+            cancelled = True
+            raise
+        else:
+            assert not will_be_cancelled
+
+    # Test Task succeeds successfully.
+    task = cocotb.start_soon(coro(False))
+    assert not cancelled
     assert not task.cancelled()
     assert not task.done()
     await task
+    assert not cancelled
     assert not task.cancelled()
     assert task.done()
 
-    task = cocotb.start_soon(coro())
-    with pytest.warns(FutureWarning):
-        task.cancel("msg1234")
+    cancelled = False
+    task = cocotb.start_soon(coro(True))
+    await NullTrigger()
+    task.cancel("msg1234")
+    await Timer(1, "ns")
+    assert cancelled
     assert task.cancelled()
+    assert task.done()
     with pytest.raises(CancelledError, match="msg1234"):
         task.result()
     with pytest.raises(CancelledError, match="msg1234"):
         task.exception()
+
+
+@cocotb.test(expect_error=CancellationError)
+async def test_cancel_task_cancellation_error(_: object) -> None:
+    a = Event()
+
+    async def coro():
+        try:
+            await a.wait()
+        except CancelledError:
+            pass
+
+    task = cocotb.start_soon(coro())
+    await NullTrigger()
+    task.cancel()
+    await Timer(1, "ns")
 
 
 @cocotb.test()
@@ -880,8 +912,7 @@ async def test_task_done_callback_cancelled(_) -> None:
     callback_ran = False
     cancelled_task._add_done_callback(done_callback)
     await Timer(1, "ns")
-    with pytest.warns(FutureWarning):
-        cancelled_task.cancel()
+    cancelled_task.cancel()
     await NullTrigger()
     assert callback_ran
 


### PR DESCRIPTION
Depends on #4514. Closes #2679.

### TODO
- [x] tests
- [x] newsfrags

### Follow-ons
* Deprecate `Task.kill` and update all uses in repo
* Fix `First`, `Combine`, and the GPI `Clock` to cleanup up with CancelledError
* Make tests consider `CancellationError` at test end