### PR TITLE
Fix docs / README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Cocotb Contribution Guidelines
 
 cocotb welcomes contributions from anyone!
-Please have a look at the [Development & Community](https://docs.cocotb.org/en/latest/contributing.html) section of the cocotb documentation for an in-depth contribution guide.
+Please have a look at the [Development & Community](https://docs.cocotb.org/en/development/contributing.html) section of the cocotb documentation for an in-depth contribution guide.

--- a/README.md
+++ b/README.md
@@ -1,135 +1,17 @@
-**cocotb** is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.
+**cocotb** is a framework empowering users to write VHDL and Verilog testbenches in Python.
 
-[![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=latest)](https://docs.cocotb.org/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/cocotb/badge/?version=development)](https://docs.cocotb.org/en/stable/)
 [![CI](https://github.com/cocotb/cocotb/actions/workflows/build-test-dev.yml/badge.svg?branch=master)](https://github.com/cocotb/cocotb/actions/workflows/build-test-dev.yml)
 [![PyPI](https://img.shields.io/pypi/dm/cocotb.svg?label=PyPI%20downloads)](https://pypi.org/project/cocotb/)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cocotb/cocotb)
 [![codecov](https://codecov.io/gh/cocotb/cocotb/branch/master/graph/badge.svg)](https://codecov.io/gh/cocotb/cocotb)
 
-* Read the [documentation](https://docs.cocotb.org)
-* Get involved:
-  * [Raise a bug / request an enhancement](https://github.com/cocotb/cocotb/issues/new) (Requires a GitHub account)
-  * [Join the Gitter chat room](https://gitter.im/cocotb/Lobby)
+* Check out the [tutorial](https://docs.cocotb.org/en/stable/quickstart.html)
+* Read the [docs](https://docs.cocotb.org/en/stable/)
+* Find more info in the [wiki](https://github.com/cocotb/cocotb/wiki)
+* Discover [useful extensions](https://github.com/cocotb/cocotb/wiki/Further-Resources#utility-libraries-and-frameworks)
+* Join the discussion in the [Gitter chat room](https://gitter.im/cocotb/Lobby)
+* [Ask a question](https://github.com/cocotb/cocotb/discussions)
+* [Raise a bug / request an enhancement](https://github.com/cocotb/cocotb/issues/new)
 
-**Note: The current `master` branch of the cocotb repository is expected to be released as cocotb 2.0, which contains API-breaking changes from previous 1.x releases. Please use the `stable/1.9` branch if you're building cocotb from source, or just [install it from PyPi](https://pypi.org/project/cocotb/).**
-
-## Installation
-
-The current stable version of cocotb requires:
-
-- Python 3.6.2+
-- GNU Make 3+
-- An HDL simulator (such as [Icarus Verilog](https://docs.cocotb.org/en/stable/simulator_support.html#icarus-verilog),
-[Verilator](https://docs.cocotb.org/en/stable/simulator_support.html#verilator),
-[GHDL](https://docs.cocotb.org/en/stable/simulator_support.html#ghdl) or
-[other simulator](https://docs.cocotb.org/en/stable/simulator_support.html))
-
-After installing these dependencies, the latest stable version of cocotb can be installed with pip.
-
-```command
-pip install cocotb
-```
-
-For more details on installation, including prerequisites,
-see [the documentation](https://docs.cocotb.org/en/stable/install.html).
-
-For details on how to install the *development* version of cocotb,
-see [the preliminary documentation of the future release](https://docs.cocotb.org/en/latest/install_devel.html#install-devel).
-
-## Usage
-
-As a first trivial introduction to cocotb, the following example "tests" a flip-flop.
-
-First, we need a hardware design which we can test. For this example, create a file `dff.sv` with SystemVerilog code for a simple [D flip-flop](https://en.wikipedia.org/wiki/Flip-flop_(electronics)#D_flip-flop). You could also use any other language a [cocotb-supported simulator](https://docs.cocotb.org/en/stable/simulator_support.html) understands, e.g. VHDL.
-
-```systemverilog
-// dff.sv
-
-`timescale 1us/1ns
-
-module dff (
-    output logic q,
-    input logic clk, d
-);
-
-always @(posedge clk) begin
-    q <= d;
-end
-
-endmodule
-```
-
-An example of a simple randomized cocotb testbench:
-
-```python
-# test_dff.py
-
-import random
-
-import cocotb
-from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge
-from cocotb.types import LogicArray
-
-@cocotb.test()
-async def dff_simple_test(dut):
-    """Test that d propagates to q"""
-
-    # Assert initial output is unknown
-    assert LogicArray(dut.q.value) == LogicArray("X")
-    # Set initial input value to prevent it from floating
-    dut.d.value = 0
-
-    clock = Clock(dut.clk, 10, units="us")  # Create a 10us period clock on port clk
-    # Start the clock. Start it low to avoid issues on the first RisingEdge
-    cocotb.start_soon(clock.start(start_high=False))
-
-    # Synchronize with the clock. This will regisiter the initial `d` value
-    await RisingEdge(dut.clk)
-    expected_val = 0  # Matches initial input value
-    for i in range(10):
-        val = random.randint(0, 1)
-        dut.d.value = val  # Assign the random value val to the input port d
-        await RisingEdge(dut.clk)
-        assert dut.q.value == expected_val, f"output q was incorrect on the {i}th cycle"
-        expected_val = val # Save random value for next RisingEdge
-
-    # Check the final input on the next clock
-    await RisingEdge(dut.clk)
-    assert dut.q.value == expected_val, "output q was incorrect on the last cycle"
-```
-
-A simple Makefile:
-
-```make
-# Makefile
-
-TOPLEVEL_LANG = verilog
-VERILOG_SOURCES = $(shell pwd)/dff.sv
-TOPLEVEL = dff
-MODULE = test_dff
-
-include $(shell cocotb-config --makefiles)/Makefile.sim
-```
-
-In order to run the test with Icarus Verilog, execute:
-
-```command
-make SIM=icarus
-```
-
-[![asciicast](https://asciinema.org/a/317220.svg)](https://asciinema.org/a/317220)
-
-For more information please see the [cocotb documentation](https://docs.cocotb.org/)
-and [our wiki](https://github.com/cocotb/cocotb/wiki).
-
-## Tutorials, examples and related projects
-
-* the tutorial section [in the official documentation](https://docs.cocotb.org/)
-* [cocotb-bus](https://github.com/cocotb/cocotb-bus) for pre-packaged testbenching tools and reusable bus interfaces.
-* [cocotb-based USB 1.1 test suite](https://github.com/antmicro/usb-test-suite-build) for FPGA IP, with testbenches for a variety of open source USB cores
-* [`cocotb-coverage`](https://github.com/mciepluc/cocotb-coverage), an extension for Functional Coverage and Constrained Randomization
-* [`uvm-python`](https://github.com/tpoikela/uvm-python), an almost 1:1 port of UVM 1.2 to Python
-* [`pyuvm`](https://github.com/pyuvm/pyuvm), The UVM IEEE 1800.2 specification built upon cocotb and implemented from scratch in Python.
-* our wiki [on extension modules](https://github.com/cocotb/cocotb/wiki/Further-Resources#extension-modules-cocotbext)
-* the list of [GitHub projects depending on cocotb](https://github.com/cocotb/cocotb/network/dependents)
+**Note: The current `master` branch of the cocotb repository is expected to be released as cocotb 2.0, which contains API-breaking changes from previous 1.x releases.**

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@ Cocotb documentation
 
 This directory contains the documentation of cocotb, which is built with Doxygen and Sphinx.
 The documentation is automatically built and uploaded with every pull request.
-The documentation for the `master` branch can be found [here](https://docs.cocotb.org/en/latest/).
+The documentation for the `master` branch can be found [here](https://docs.cocotb.org/en/development/).
 
 `nox -e docs` can be used to create an appropriate virtual environment and
 invoke `sphinx-build` to generate the HTML docs.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -64,7 +64,7 @@ Updating documentation requires knowledge of:
 -  `Markdown <https://www.markdownguide.org/>`__
 -  `How to architect documentation <https://documentation.divio.com/>`__
 
-Some documentation should be located in the official documentation on `Read the Docs/RTD <https://docs.cocotb.org/en/latest/>`__, while the rest belongs on the `Wiki <https://github.com/cocotb/cocotb/wiki>`__.
+Some documentation should be located in the official documentation on `Read the Docs/RTD <https://docs.cocotb.org/en/development/>`__, while the rest belongs on the `Wiki <https://github.com/cocotb/cocotb/wiki>`__.
 There are several ways to improve the documentation:
 
 -  Better documenting core functionality (RTD)
@@ -144,7 +144,7 @@ Instead of including that breakdown here, it is done in the `internal documentat
 
 Small improvements to existing features generally do not require maintainer pre-approval.
 Large changes, approximately >150 LOC changed, and new features generally require maintainer pre-approval.
-If a change is deemed too large for the main repo, or out of scope, please feel free to make it an `extension <https://docs.cocotb.org/en/latest/extensions.html>`__.
+If a change is deemed too large for the main repo, or out of scope, please feel free to make it an `extension <https://docs.cocotb.org/en/development/extensions.html>`__.
 
 **New features must not break existing features.**
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -108,7 +108,7 @@ Installation of cocotb
     If this prints "(python 2.7)", use :command:`pip3` or ``python3 -m pip`` in place of :command:`pip` in the command shown.
 
 If you want to install the **development version** of cocotb,
-`instructions are here <https://docs.cocotb.org/en/latest/install_devel.html>`_.
+`instructions are here <https://docs.cocotb.org/en/development/install_devel.html>`_.
 
 After installation, you should be able to execute :command:`cocotb-config`.
 If it is not found, you need to append its location to the :envvar:`PATH` environment variable.

--- a/docs/source/install_devel.rst
+++ b/docs/source/install_devel.rst
@@ -7,12 +7,12 @@ Installing the Development Version
 .. note::
 
    If you want to follow the instructions on this page,
-   make sure you are reading its
-   `latest version <https://docs.cocotb.org/en/latest/install_devel.html>`_.
+   make sure you are reading the
+   `development version <https://docs.cocotb.org/en/development/install_devel.html>`_.
 
    Once you install the development version,
    you should keep reading the
-   `matching documentation <https://docs.cocotb.org/en/latest/>`_.
+   `matching documentation <https://docs.cocotb.org/en/development/>`_.
 
 The development version of cocotb has different prerequisites
 than the stable version (see below).

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -70,7 +70,7 @@ def _get_version() -> str:
 
 def _help_vars_text() -> str:
     if "dev" in _get_version():
-        doclink = "https://docs.cocotb.org/en/latest/building.html"
+        doclink = "https://docs.cocotb.org/en/development/building.html"
     else:
         doclink = f"https://docs.cocotb.org/en/v{_get_version()}/building.html"
 


### PR DESCRIPTION
* `latest` doc links have been replaced with `master`.
* The README no longer contains the tutorial and installation and instead points to the stable docs.
* The extensions listed in the README have been moved to the Wiki

### TODO
- [x] Update slug from "master" to something else?
- [x] ~~Add redirects in for `latest` to the new slug / "master"~~ Unfortunately not possible.
- [x] Update Wiki to have a page for extensions and update the link in the README
- [ ] Investigate ifdefing the installation instructions based on whether the docs are stable or development