### PR TITLE
Fix converting log level to string.

### DIFF
--- a/src/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -88,8 +88,9 @@ static inline void __check_vhpi_error(const char *file, const char *func,
     }
 
     LOG_EXPLICIT("gpi", GPI_DEBUG, file, func, line,
-                 "VHPI Internal Error: %s @ %s:%d: %s", gpi_log_level(loglevel),
-                 info.file, info.line, info.message);
+                 "VHPI Internal Error: %s @ %s:%d: %s",
+                 gpi_log_level_to_str(loglevel), info.file, info.line,
+                 info.message);
 }
 
 #define check_vhpi_error()                                \

--- a/src/cocotb/share/lib/vpi/VpiImpl.h
+++ b/src/cocotb/share/lib/vpi/VpiImpl.h
@@ -82,8 +82,9 @@ static inline void __check_vpi_error(const char *file, const char *func,
     }
 
     LOG_EXPLICIT("gpi", GPI_DEBUG, file, func, line,
-                 "VPI Internal Error: %s @ %s:%d: %s", gpi_log_level(loglevel),
-                 info.file, info.line, info.message);
+                 "VPI Internal Error: %s @ %s:%d: %s",
+                 gpi_log_level_to_str(loglevel), info.file, info.line,
+                 info.message);
 }
 
 #define check_vpi_error()                                \


### PR DESCRIPTION
Enabling this output causes the simulator to crash due to trying to access the log level as a pointer.

Is it an option to use the `format` attribute for `gpi_log_` when the compiler supports it to get warnings?

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
