### PR TITLE
Random fixes

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -311,7 +311,7 @@ Simulation Object Handles
 ..
    Excluding the Assignment Methods that are getting their own section below
 
-.. autofunc:: cocotb.handle.HierarchyObjectBase._get
+.. autofunction:: cocotb.handle.HierarchyObjectBase._get
 
 .. autoenum:: cocotb.handle.GPIDiscovery
 
@@ -356,7 +356,7 @@ Miscellaneous
 Test Control
 ------------
 
-.. autofunc:: cocotb.regression.pass_test
+.. autofunction:: cocotb.regression.pass_test
 
 Other Runtime Information
 -------------------------

--- a/src/cocotb/share/lib/vhpi/VhpiImpl.cpp
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.cpp
@@ -1045,7 +1045,7 @@ GpiCbHdl *VhpiImpl::register_nexttime_callback(int (*cb_func)(void *),
         delete cb_hdl;
         return NULL;
     }
-    // LCOV_EXCL_START
+    // LCOV_EXCL_STOP
     cb_hdl->set_cb_info(cb_func, cb_data);
     return cb_hdl;
 }


### PR DESCRIPTION
See commits. These were generating warnings when building docs and collecting coverage.

https://github.com/cocotb/cocotb/actions/runs/13729161626/job/38402462095?pr=4538#step:26:81