### PR TITLE
Fix Combine and First leaking Tasks if cancelled

### DIFF
--- a/docs/source/newsfragments/4542.bugfix.rst
+++ b/docs/source/newsfragments/4542.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where :meth:`cancelling <cocotb.task.Task.cancel>` a Task that is awaiting a :class:`.First` or :class:`.Combine` doesn't cancel the underlying waiter Tasks, leading to lower performance or concealing test failures.

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -129,7 +129,7 @@ class Combine(_AggregateWaitable["Combine"]):
                     completed.append(task)
                     if len(completed) == len(waiters):
                         done.set()
-                        return
+                    return
                 e = task.exception()
                 if e is not None:
                     nonlocal exception
@@ -147,12 +147,13 @@ class Combine(_AggregateWaitable["Combine"]):
                 cocotb.start_soon(task)
                 waiters.append(task)
 
-            # wait for the last waiter to complete
-            await done
-
-            # kill remaining waiters
-            for w in waiters:
-                w.kill()
+            try:
+                # wait for the last waiter to complete
+                await done
+            finally:
+                # kill remaining waiters
+                for w in waiters:
+                    w.cancel()
 
             if exception is not None:
                 raise exception
@@ -214,12 +215,13 @@ class First(_AggregateWaitable[Any]):
             cocotb.start_soon(task)
             waiters.append(task)
 
-        # wait for a waiter to complete
-        await done
-
-        # kill all the other waiters
-        for w in waiters:
-            w.kill()
+        try:
+            # wait for a waiter to complete
+            await done
+        finally:
+            # kill all the other waiters
+            for w in waiters:
+                w.kill()
 
         return completed[0].result()
 

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -11,7 +11,7 @@ from random import randint
 from typing import Any
 
 import pytest
-from common import _check_traceback, assert_takes
+from common import MyException, _check_traceback, assert_takes
 
 import cocotb
 from cocotb.task import Task
@@ -265,3 +265,87 @@ async def test_invalid_trigger_types(dut):
 
     with pytest.raises(TypeError):
         await Combine(Timer(1), o)
+
+
+@cocotb.test
+async def test_Combine_empty(_) -> None:
+    """Test that a Combine with no triggers passes no time."""
+    combine = Combine()
+    with assert_takes(0, "ns"):
+        res = await combine
+    assert res is combine
+
+
+@cocotb.test
+async def test_Combine_single(_) -> None:
+    """Test Combine with a single trigger acts the same as awaiting the trigger directly."""
+    combine = Combine(Timer(9, "ns"))
+    with assert_takes(9, "ns"):
+        res = await combine
+    assert res is combine
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+async def test_Combine_exception(dut) -> None:
+    """Test Combine with exception ends immediately and isn't blocked by unfired triggers."""
+
+    e = Event()  # we never plan on setting this
+
+    async def raises_after_1ns():
+        await Timer(1, "ns")
+        raise MyException
+
+    combine = Combine(cocotb.start_soon(raises_after_1ns()), Timer(10, "ns"), e.wait())
+    with assert_takes(1, "ns"):
+        with pytest.raises(MyException):
+            await combine
+
+
+@cocotb.test
+async def test_First_empty(_) -> None:
+    """Test that a First with no triggers raises an error."""
+    with pytest.raises(ValueError):
+        await First()
+
+
+@cocotb.test
+async def test_First_single(_) -> None:
+    """Test First with a single trigger acts the same as awaiting the trigger directly."""
+    timer = Timer(13, "ns")
+    with assert_takes(13, "ns"):
+        res = await First(timer)
+    assert res is timer
+
+
+@cocotb.test(timeout_time=10, timeout_unit="ns")
+async def test_First_exception(_) -> None:
+    """Test First with exception ends immediately and isn't blocked by unfired triggers."""
+
+    e = Event()  # we never plan on setting this
+
+    async def raises_after_1ns():
+        await Timer(1, "ns")
+        raise MyException
+
+    first = First(cocotb.start_soon(raises_after_1ns()), Timer(10, "ns"), e.wait())
+    with assert_takes(1, "ns"):
+        with pytest.raises(MyException):
+            await first
+
+
+@cocotb.test
+async def test_Combine_objects_shared_by_multiple(_: Any) -> None:
+    """Test waiting for the same objects in multiple concurrent Combines."""
+    count = 0
+    events = [Event() for _ in range(5)]
+
+    async def wait_for_all_events():
+        nonlocal count
+        await Combine(*(event.wait() for event in events))
+        count += 1
+
+    waiters = [cocotb.start_soon(wait_for_all_events()) for _ in range(5)]
+    for e in events:
+        e.set()
+    await Combine(*waiters)
+    assert count == 5

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -7,18 +7,16 @@ Tests for synchronization primitives like Lock and Event
 
 import random
 import re
-from typing import Any, List
+from typing import List
 
 import pytest
-from common import MyException, assert_takes
+from common import assert_takes
 
 import cocotb
 from cocotb._base_triggers import Trigger, _InternalEvent
 from cocotb.task import Task
 from cocotb.triggers import (
-    Combine,
     Event,
-    First,
     Lock,
     NullTrigger,
     ReadOnly,
@@ -160,90 +158,6 @@ async def test_internalevent(dut):
     assert e.is_set()
     with assert_takes(0, "ns"):
         await e
-
-
-@cocotb.test
-async def test_Combine_empty(_) -> None:
-    """Test that a Combine with no triggers passes no time."""
-    combine = Combine()
-    with assert_takes(0, "ns"):
-        res = await combine
-    assert res is combine
-
-
-@cocotb.test
-async def test_Combine_single(_) -> None:
-    """Test Combine with a single trigger acts the same as awaiting the trigger directly."""
-    combine = Combine(Timer(9, "ns"))
-    with assert_takes(9, "ns"):
-        res = await combine
-    assert res is combine
-
-
-@cocotb.test(timeout_time=10, timeout_unit="ns")
-async def test_Combine_exception(dut) -> None:
-    """Test Combine with exception ends immediately and isn't blocked by unfired triggers."""
-
-    e = Event()  # we never plan on setting this
-
-    async def raises_after_1ns():
-        await Timer(1, "ns")
-        raise MyException
-
-    combine = Combine(cocotb.start_soon(raises_after_1ns()), Timer(10, "ns"), e.wait())
-    with assert_takes(1, "ns"):
-        with pytest.raises(MyException):
-            await combine
-
-
-@cocotb.test
-async def test_First_empty(_) -> None:
-    """Test that a First with no triggers raises an error."""
-    with pytest.raises(ValueError):
-        await First()
-
-
-@cocotb.test
-async def test_First_single(_) -> None:
-    """Test First with a single trigger acts the same as awaiting the trigger directly."""
-    timer = Timer(13, "ns")
-    with assert_takes(13, "ns"):
-        res = await First(timer)
-    assert res is timer
-
-
-@cocotb.test(timeout_time=10, timeout_unit="ns")
-async def test_First_exception(_) -> None:
-    """Test First with exception ends immediately and isn't blocked by unfired triggers."""
-
-    e = Event()  # we never plan on setting this
-
-    async def raises_after_1ns():
-        await Timer(1, "ns")
-        raise MyException
-
-    first = First(cocotb.start_soon(raises_after_1ns()), Timer(10, "ns"), e.wait())
-    with assert_takes(1, "ns"):
-        with pytest.raises(MyException):
-            await first
-
-
-@cocotb.test
-async def test_Combine_objects_shared_by_multiple(_: Any) -> None:
-    """Test waiting for the same objects in multiple concurrent Combines."""
-    count = 0
-    events = [Event() for _ in range(5)]
-
-    async def wait_for_all_events():
-        nonlocal count
-        await Combine(*(event.wait() for event in events))
-        count += 1
-
-    waiters = [cocotb.start_soon(wait_for_all_events()) for _ in range(5)]
-    for e in events:
-        e.set()
-    await Combine(*waiters)
-    assert count == 5
 
 
 @cocotb.test


### PR DESCRIPTION
Closes #3441.

If a Task awaiting a Combine or First is cancelled, the waiter tasks weren't cleaned up. Now they are. Also fixed a small bug in First where if a waiter task was cancelled it would continue executing the `on_done` callback causing another exception to bubble up through the scheduler.