### PR TITLE
Use ValueError instead of OverflowError in sim objects

### DIFF
--- a/docs/source/newsfragments/4543.change.rst
+++ b/docs/source/newsfragments/4543.change.rst
@@ -1,1 +1,1 @@
-Settings values too large for :class:`~cocotb.handle.IntegerObject`, :class:`~cocotb.handle.EnumObject`, and :class:`~cocotb.handle.LogicArrayObject` now raise :exc:`ValueError` instead of :exc:`OverflowError`.
+Setting values too large for :class:`~cocotb.handle.IntegerObject`, :class:`~cocotb.handle.EnumObject`, and :class:`~cocotb.handle.LogicArrayObject` now raises :exc:`ValueError` instead of :exc:`OverflowError`.

--- a/docs/source/newsfragments/4543.change.rst
+++ b/docs/source/newsfragments/4543.change.rst
@@ -1,0 +1,1 @@
+Settings values too large for :class:`~cocotb.handle.IntegerObject`, :class:`~cocotb.handle.EnumObject`, and :class:`~cocotb.handle.LogicArrayObject` now raise :exc:`ValueError` instead of :exc:`OverflowError`.

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -87,7 +87,7 @@ Cocotb makes no assumptions regarding the signedness of the signal. It only
 considers the width of the signal, so it will allow values in the range from
 the minimum negative value for a signed number up to the maximum positive
 value for an unsigned number: ``-2**(Nbits - 1) <= value <= 2**Nbits - 1``
-Note: assigning out-of-range values will raise an :exc:`OverflowError`.
+Note: assigning out-of-range values will raise an :exc:`ValueError`.
 
 A :class:`~cocotb.types.LogicArray` object can be used instead of a Python int to assign a
 value to signals with more fine-grained control (e.g. signed values only).
@@ -110,8 +110,8 @@ value to signals with more fine-grained control (e.g. signed values only).
     dut.data_in.value = 7
 
     # assignment of out-of-range values
-    dut.data_in.value = 8   # raises OverflowError
-    dut.data_in.value = -5  # raises OverflowError
+    dut.data_in.value = 8   # raises ValueError
+    dut.data_in.value = -5  # raises ValueError
 
 
 .. _writing_tbs_reading_values:

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -1213,7 +1213,7 @@ class LogicArrayObject(
                         )
                     )
             else:
-                raise OverflowError(
+                raise ValueError(
                     f"Int value ({value!r}) out of range for assignment of {len(self)!r}-bit signal ({self._name!r})"
                 )
 
@@ -1266,9 +1266,6 @@ class LogicArrayObject(
         Raises:
             TypeError: If *value* is of a type that can't be assigned to the simulation object, or readily converted into a type that can.
             ValueError: If *value* would not fit in the bounds of the simulation object.
-            OverflowError:
-                If :class:`int` *value* is out of the range that can be represented by the target:
-                ``-2**(Nbits - 1) <= value <= 2**Nbits - 1``.
 
         .. versionchanged:: 2.0
             Using :class:`ctypes.Structure` objects to set values was removed.
@@ -1279,6 +1276,9 @@ class LogicArrayObject(
             Using :class:`dict` objects to set values was removed.
             Convert the dictionary to an integer before assignment using
             ``sum(v << (d['bits'] * i) for i, v in enumerate(d['values']))`` instead.
+
+        .. versionchanged:: 2.0
+            Supplying too large of an :class:`int` value results in raising a :exc:`ValueError` instead of an :exc:`OverflowError`.
         """
         super().set(value)
 
@@ -1384,7 +1384,7 @@ class EnumObject(NonIndexableValueObjectBase[int, int]):
         if min_val <= value <= max_val:
             _schedule_write(self, self._handle.set_signal_val_int, action, value)
         else:
-            raise OverflowError(
+            raise ValueError(
                 f"Int value ({value!r}) out of range for assignment of enum signal ({self._name!r})"
             )
 
@@ -1415,7 +1415,10 @@ class EnumObject(NonIndexableValueObjectBase[int, int]):
 
         Raises:
             TypeError: If *value* is any type other than :class:`int`.
-            OverflowError: If *value* would not fit in a 32-bit signed integer.
+            ValueError: If *value* would not fit in a 32-bit signed integer.
+
+        .. versionchanged:: 2.0
+            Supplying too large of a value results in raising a :exc:`ValueError` instead of an :exc:`OverflowError`.
         """
         super().set(value)
 
@@ -1464,7 +1467,7 @@ class IntegerObject(NonIndexableValueObjectBase[int, int]):
         if min_val <= value <= max_val:
             _schedule_write(self, self._handle.set_signal_val_int, action, value)
         else:
-            raise OverflowError(
+            raise ValueError(
                 f"Int value ({value!r}) out of range for assignment of integer signal ({self._name!r})"
             )
 
@@ -1490,7 +1493,10 @@ class IntegerObject(NonIndexableValueObjectBase[int, int]):
 
         Raises:
             TypeError: If *value* is any type other than :class:`int`.
-            OverflowError: If *value* would not fit in a 32-bit signed integer.
+            ValueError: If *value* would not fit in a 32-bit signed integer.
+
+        .. versionchanged:: 2.0
+            Supplying too large of a value results in raising a :exc:`ValueError` instead of an :exc:`OverflowError`.
         """
         super().set(value)
 

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -199,7 +199,7 @@ async def int_overflow_test(
     else:
         assert False, f"bad test_mode {test_mode}"
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         if setimmediate:
             signal.value = Immediate(value)
         else:

--- a/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
+++ b/tests/test_cases/test_vhdl_zerovector/test_vhdl_zerovector.py
@@ -61,5 +61,5 @@ async def test_write_zero_signal_with_0(dut):
 )
 async def test_write_zero_signal_with_1(dut):
     """Write a zero vector with 1. Should catch a "out of range" exception."""
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         dut.Cntrl_out.value = 0x1


### PR DESCRIPTION
Closes #4124. Now there is no confusion on when to use `ValueError` or `OverflowError`. It's always `ValueError`.
