### PR TITLE
Fix Unpacked arrays with Verilator

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -190,7 +190,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v5.032",  # Latest release version.
+        "sim-version": "v5.034",  # Latest release version.
         "os": "ubuntu-22.04",
         "python-version": "3.10",
         "group": "ci",
@@ -203,12 +203,11 @@ ENVS = [
         "os": "ubuntu-22.04",
         "python-version": "3.10",
         "group": "experimental",
-        "may-fail": True,  # cocotb/cocotb#4526
     },
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v5.026",  # Minimum supported version.
+        "sim-version": "v5.034",  # Minimum supported version.
         "os": "ubuntu-22.04",
         "python-version": "3.10",
         "group": "extended",
@@ -247,7 +246,7 @@ ENVS = [
     {
         "lang": "verilog",
         "sim": "verilator",
-        "sim-version": "v5.032",
+        "sim-version": "v5.034",
         "os": "macos-13",
         "python-version": "3.9",
         "group": "ci",

--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -202,6 +202,8 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiIntVar:
         case vpiIntegerVar:
         case vpiIntegerNet:
+        case vpiPackedArrayVar:
+        case vpiPackedArrayNet:
         case vpiRealVar:
         case vpiRealNet:
         case vpiStringVar:
@@ -224,8 +226,6 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiRegArray:
         case vpiNetArray:
         case vpiInterfaceArray:
-        case vpiPackedArrayVar:
-        case vpiPackedArrayNet:
         case vpiMemory:
         case vpiInterconnectArray: {
             const auto is_vector = vpi_get(vpiVector, new_hdl);

--- a/src/cocotb/share/lib/vpi/VpiObj.cpp
+++ b/src/cocotb/share/lib/vpi/VpiObj.cpp
@@ -65,12 +65,15 @@ int VpiArrayObjHdl::initialise(const std::string &name,
     if (iter != NULL) {
         rangeHdl = vpi_scan(iter);
 
+// Questa and VCS vpiRange iter always starts from the first index of the array.
+#if defined(MODELSIM) || defined(VCS)
         for (int i = 0; i < range_idx; ++i) {
             rangeHdl = vpi_scan(iter);
             if (rangeHdl == NULL) {
                 break;
             }
         }
+#endif
         if (rangeHdl == NULL) {
             LOG_ERROR("Unable to get range for indexable array");
             return -1;

--- a/src/cocotb_tools/makefiles/simulators/Makefile.verilator
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.verilator
@@ -36,7 +36,7 @@ else
 endif
 
 ifeq ($(VERILATOR_SIM_DEBUG), 1)
-  COMPILE_ARGS += --debug -CFLAGS "-DVL_DEBUG -DVERILATOR_SIM_DEBUG -g"
+  COMPILE_ARGS += --debug -CFLAGS "-DVL_DEBUG -DVERILATOR_SIM_DEBUG -g -Og"
   DEBUG = +verilator+debug
   BUILD_ARGS += OPT_FAST=-Og OPT_SLOW=-Og OPT_GLOBAL=-Og
 endif

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -19,8 +19,7 @@ async def test_in_vect_packed(dut):
     assert dut.out_vect_packed.value == test_value
 
 
-# Verilator combines 1-dimensional unpacked arrays into a single vector (gh-3611)
-@cocotb.test(expect_fail=SIM_NAME.startswith("verilator"))
+@cocotb.test()
 async def test_in_vect_unpacked(dut):
     assert isinstance(dut.in_vect_unpacked, ArrayObject)
     assert len(dut.in_vect_unpacked) == 3
@@ -75,7 +74,6 @@ async def test_in_2d_vect_packed_unpacked(dut):
 # Icarus flattens multi-dimensional unpacked arrays (gh-2595)
 @cocotb.test(
     expect_fail=SIM_NAME.startswith("icarus"),
-    expect_error=AttributeError if SIM_NAME.startswith("verilator") else (),
 )
 async def test_in_2d_vect_unpacked_unpacked(dut):
     assert isinstance(dut.in_2d_vect_unpacked_unpacked, ArrayObject)
@@ -147,8 +145,6 @@ async def test_in_vect_packed_packed_packed(dut):
 @cocotb.test(
     expect_error=IndexError
     if LANGUAGE == "verilog" and SIM_NAME.startswith("modelsim")
-    else AttributeError
-    if SIM_NAME.startswith("verilator")
     else ()
 )
 async def test_in_vect_packed_packed_unpacked(dut):
@@ -165,11 +161,9 @@ async def test_in_vect_packed_packed_unpacked(dut):
     assert dut.out_vect_packed_packed_unpacked.value == test_value
 
 
-# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 # Icarus flattens multi-dimensional unpacked arrays (gh-2595)
 @cocotb.test(
     expect_fail=SIM_NAME.startswith("icarus"),
-    expect_error=AttributeError if SIM_NAME.startswith("verilator") else (),
 )
 async def test_in_vect_packed_unpacked_unpacked(dut):
     assert isinstance(dut.in_vect_packed_unpacked_unpacked, ArrayObject)
@@ -189,11 +183,9 @@ async def test_in_vect_packed_unpacked_unpacked(dut):
     assert dut.out_vect_packed_unpacked_unpacked.value == test_value
 
 
-# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 # Icarus flattens multi-dimensional unpacked arrays (gh-2595)
 @cocotb.test(
     expect_fail=SIM_NAME.startswith("icarus"),
-    expect_error=AttributeError if SIM_NAME.startswith("verilator") else (),
 )
 async def test_in_vect_unpacked_unpacked_unpacked(dut):
     assert isinstance(dut.in_vect_unpacked_unpacked_unpacked, ArrayObject)
@@ -228,12 +220,9 @@ async def test_in_arr_packed_packed(dut):
 
 
 # Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
-# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 @cocotb.test(
     expect_error=IndexError
     if LANGUAGE == "verilog" and SIM_NAME.startswith("modelsim")
-    else AttributeError
-    if SIM_NAME.startswith("verilator")
     else ()
 )
 async def test_in_arr_packed_unpacked(dut):
@@ -250,11 +239,9 @@ async def test_in_arr_packed_unpacked(dut):
     assert dut.out_arr_packed_unpacked.value == test_value
 
 
-# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 # Icarus flattens multi-dimensional unpacked arrays (gh-2595)
 @cocotb.test(
     expect_fail=SIM_NAME.startswith("icarus"),
-    expect_error=AttributeError if SIM_NAME.startswith("verilator") else (),
 )
 async def test_in_arr_unpacked_unpacked(dut):
     assert isinstance(dut.in_arr_unpacked_unpacked, ArrayObject)
@@ -286,12 +273,9 @@ async def test_in_2d_arr_packed(dut):
 
 
 # Questa is unable to access elements of a logic array if the last dimension is unpacked (gh-2605)
-# Verilator doesn't support multi-dimensional unpacked arrays (gh-3611)
 @cocotb.test(
     expect_error=IndexError
     if LANGUAGE == "verilog" and SIM_NAME.startswith("modelsim")
-    else AttributeError
-    if SIM_NAME.startswith("verilator")
     else ()
 )
 async def test_in_2d_arr_unpacked(dut):


### PR DESCRIPTION
This fixes unpacked array range access with Verilator and updates the latest and minimum version up to the latest. This will be needed to be updated again after 5.036 drops to include the upstream fix for #4526.