### PR TITLE
Store current GPI trigger rather than just the "SimPhase"

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -143,6 +143,8 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
 Triggers
 ========
 
+.. autofunction:: cocotb.triggers.current_gpi_trigger
+
 .. _edge-triggers:
 
 Edge Triggers
@@ -389,10 +391,6 @@ Other Runtime Information
 .. autodata:: cocotb.top
 
 .. autodata:: cocotb.is_simulation
-
-.. autodata:: cocotb.sim_phase
-
-.. autoenum:: cocotb.SimPhase
 
 .. _combine-results:
 

--- a/docs/source/newsfragments/4022.feature.rst
+++ b/docs/source/newsfragments/4022.feature.rst
@@ -1,1 +1,0 @@
-Added :data:`cocotb.sim_phase` to allow the user to determine what phase of a time step they are in.

--- a/docs/source/newsfragments/4549.feature.rst
+++ b/docs/source/newsfragments/4549.feature.rst
@@ -1,0 +1,1 @@
+Added :data:`cocotb.triggers.current_gpi_trigger` to allow the user to determine the last GPI trigger that fired.

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -25,7 +25,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import logging as py_logging
-from enum import auto
 from types import SimpleNamespace
 from typing import Dict, List, Union
 
@@ -41,7 +40,6 @@ from cocotb._decorators import (
 )
 from cocotb._scheduler import Scheduler
 from cocotb._test import create_task, pass_test, start, start_soon
-from cocotb._utils import DocEnum
 from cocotb.regression import RegressionManager
 
 from ._version import __version__
@@ -118,15 +116,3 @@ and in parameters to :class:`.TestFactory`\ s.
 
 is_simulation: bool = False
 """``True`` if cocotb was loaded in a simulation."""
-
-
-class SimPhase(DocEnum):
-    """A phase of the time step."""
-
-    NORMAL = (auto(), "In the Beginning Of Time Step or a Value Change phase.")
-    READ_WRITE = (auto(), "In a ReadWrite phase.")
-    READ_ONLY = (auto(), "In a ReadOnly phase.")
-
-
-sim_phase: SimPhase = SimPhase.NORMAL
-"""The current phase of the time step."""

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -54,7 +54,15 @@ import cocotb
 from cocotb import simulator
 from cocotb._base_triggers import Event
 from cocotb._deprecation import deprecated
-from cocotb._gpi_triggers import Edge, FallingEdge, ReadWrite, RisingEdge, ValueChange
+from cocotb._gpi_triggers import (
+    Edge,
+    FallingEdge,
+    ReadOnly,
+    ReadWrite,
+    RisingEdge,
+    ValueChange,
+    current_gpi_trigger,
+)
 from cocotb._py_compat import cached_property
 from cocotb._utils import DocIntEnum, cached_method
 from cocotb.task import Task
@@ -788,7 +796,7 @@ else:
         action: _GPISetAction,
         value: _ValueT,
     ) -> None:
-        if cocotb.sim_phase == cocotb.SimPhase.READ_WRITE:
+        if isinstance(current_gpi_trigger(), ReadWrite):
             # If we are already in the ReadWrite phase, apply writes immediately as an optimization.
             write_func(action.value, value)
         elif action == _GPISetAction.DEPOSIT:
@@ -870,7 +878,7 @@ class ValueObjectBase(SimHandleBase, Generic[ValueGetT, ValueSetT]):
                 or if the simulation object is immutable.
             ValueError: If the *value* is of the correct type, but the value fails to convert.
         """
-        if cocotb.sim_phase == cocotb.SimPhase.READ_ONLY:
+        if isinstance(current_gpi_trigger(), ReadOnly):
             raise RuntimeError("Attempting settings a value during the ReadOnly phase.")
         if self.is_const:
             raise TypeError("Attempted setting an immutable object")

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -57,6 +57,7 @@ from typing import (
 )
 
 import cocotb
+import cocotb._gpi_triggers
 import cocotb._scheduler
 import cocotb.handle
 from cocotb import _ANSI, simulator
@@ -325,7 +326,7 @@ class RegressionManager:
     def _schedule_next_test(self, trigger: Optional[Trigger] = None) -> None:
         if trigger is not None:
             # TODO move to Trigger object
-            cocotb.sim_phase = cocotb.SimPhase.NORMAL
+            cocotb._gpi_triggers._current_gpi_trigger = trigger
             trigger._cleanup()
         self._test.start()
 

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -20,6 +20,7 @@ from cocotb._gpi_triggers import (
     RisingEdge,
     Timer,
     ValueChange,
+    current_gpi_trigger,
 )
 from cocotb.task import Join, TaskComplete
 
@@ -46,4 +47,5 @@ __all__ = (
     "with_timeout",
     "SimTimeoutError",
     "EmptyTrigger",
+    "current_gpi_trigger",
 )


### PR DESCRIPTION
Closes #4268. Stores the current GPI trigger and not just the more abstract "SimPhase". This allows users to determine if they are in the start of an eval cycle (testing against `Timer`), ReadWrite, ReadOnly, and ValueChange (`RisingEdge`, `FallingEdge`, and `ValueChange`).