### PR TITLE
Improve handling of weak values in Logic/LogicArray

### DIFF
--- a/docs/source/newsfragments/4551.change.1.rst
+++ b/docs/source/newsfragments/4551.change.1.rst
@@ -1,0 +1,1 @@
+:class:`bool(Logic) <cocotb.types.Logic>` casts now treat ``H`` as ``True`` and ``L`` as ``False`` instead of raising :exc:`ValueError`.

--- a/docs/source/newsfragments/4551.change.2.rst
+++ b/docs/source/newsfragments/4551.change.2.rst
@@ -1,0 +1,1 @@
+:meth:`.LogicArray.is_resolvable` now returns ``True`` for arrays containing ``H`` and ``L`` values.

--- a/docs/source/newsfragments/4551.change.rst
+++ b/docs/source/newsfragments/4551.change.rst
@@ -1,0 +1,1 @@
+:class:`int(Logic) <cocotb.types.Logic>` casts now treat ``H`` as ``1`` and ``L`` as ``0`` instead of raising :exc:`ValueError`.

--- a/src/cocotb/types/logic.py
+++ b/src/cocotb/types/logic.py
@@ -87,7 +87,7 @@ class Logic:
 
     .. note::
 
-        The :class:`int` and :class:`bool` conversions will raise :exc:`ValueError` if the value is not ``0`` or ``1``.
+        The :class:`int` and :class:`bool` conversions will raise :exc:`ValueError` if the value is not ``0``, ``1``, ``L``, or ``H``.
 
     :class:`Logic` values are immutable and therefore hashable and can be placed in :class:`set`\ s and used as keys in :class:`dict`\ s.
 
@@ -229,16 +229,16 @@ class Logic:
         return ("U", "X", "0", "1", "Z", "W", "L", "H", "-")[self._repr]
 
     def __bool__(self) -> bool:
-        if self._repr == _0:
+        if self._repr in (_0, _L):
             return False
-        elif self._repr == _1:
+        elif self._repr in (_1, _H):
             return True
         raise ValueError(f"Cannot convert {self!r} to bool")
 
     def __int__(self) -> int:
-        if self._repr == _0:
+        if self._repr in (_0, _L):
             return 0
-        elif self._repr == _1:
+        elif self._repr in (_1, _H):
             return 1
         raise ValueError(f"Cannot convert {self!r} to int")
 

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -536,8 +536,10 @@ class LogicArray(ArrayLike[Logic]):
 
     @property
     def is_resolvable(self) -> bool:
-        """``True`` if all elements are ``0`` or ``1``."""
-        return all(bit in (Logic(0), Logic(1)) for bit in self)
+        """``True`` if all elements are ``0``, ``1``, ``L``, ``H``."""
+        return all(
+            bit in (Logic("0"), Logic("1"), Logic("L"), Logic("H")) for bit in self
+        )
 
     @property
     @deprecated("`.integer` property is deprecated. Use `value.to_unsigned()` instead.")

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -781,11 +781,9 @@ class LogicArray(ArrayLike[Logic]):
     def __invert__(self) -> "LogicArray":
         return LogicArray(~v for v in self)
 
+    @deprecated(
+        "`bool()` casts and using LogicArray in conditional expressions is deprecated. "
+        """Use explicit comparisons (e.g. `LogicArray() == "11"`) or `all`/`any` expressions instead."""
+    )
     def __bool__(self) -> bool:
-        warnings.warn(
-            "The behavior of bool casts and using LogicArray in conditionals may change in the future. "
-            """Use explicit comparisons (e.g. `LogicArray() == "11"`) instead""",
-            FutureWarning,
-            stacklevel=2,
-        )
         return any(v in (Logic("H"), Logic("1")) for v in self)

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -325,15 +325,16 @@ class LogicArray(ArrayLike[Logic]):
         if self._value_as_int is None:
             # May convert list to str before converting to int.
             value_as_str = self._get_str()
+
+            # always resolve L and H to 0 and 1
+            value_as_str = value_as_str.translate(_resolve_lh_table)
+
             try:
                 self._value_as_int = int(value_as_str, 2)
             except ValueError:
                 # value needs resolving
                 if resolve is None:
                     resolve = RESOLVE_X
-
-                # resolve L and H to 0 and 1
-                value_as_str = value_as_str.translate(_resolve_lh_table)
 
                 # resolve remaining
                 resolve_table = _resolve_tables[resolve]

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -64,11 +64,19 @@ def test_logic_equality():
 
 def test_logic_bool_conversions():
     assert bool(Logic("1")) is True
+    assert bool(Logic("H")) is True
     assert bool(Logic("0")) is False
+    assert bool(Logic("L")) is False
     with pytest.raises(ValueError):
         bool(Logic("X"))
     with pytest.raises(ValueError):
         bool(Logic("Z"))
+    with pytest.raises(ValueError):
+        bool(Logic("U"))
+    with pytest.raises(ValueError):
+        bool(Logic("W"))
+    with pytest.raises(ValueError):
+        bool(Logic("-"))
 
 
 def test_logic_str_conversions():
@@ -88,10 +96,18 @@ def test_logic_index_cast():
 def test_logic_int_conversions():
     assert int(Logic("0")) == 0
     assert int(Logic("1")) == 1
+    assert int(Logic("L")) == 0
+    assert int(Logic("H")) == 1
     with pytest.raises(ValueError):
         int(Logic("X"))
     with pytest.raises(ValueError):
         int(Logic("Z"))
+    with pytest.raises(ValueError):
+        int(Logic("U"))
+    with pytest.raises(ValueError):
+        int(Logic("-"))
+    with pytest.raises(ValueError):
+        int(Logic("W"))
 
 
 def test_logic_repr():

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -396,10 +396,10 @@ def test_null_vector():
 
 
 def test_bool_cast():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert LogicArray("0110")
     with warnings.catch_warnings():
-        warnings.filterwarnings(action="ignore", category=FutureWarning)
+        warnings.filterwarnings(action="ignore", category=DeprecationWarning)
         assert not LogicArray("0000")
         assert LogicArray("01XZ")
         assert LogicArray("XZ01")


### PR DESCRIPTION
Closes #4550. @markusdd 

I made `bool(Logic)` work like ~~it does in VHDL 2019 where 1 and H are `True` and everything else is `False`~~ `int(Logic)`. I made `int(Logic)` also respect weak values since we are doing that in LogicArray with the `int` cast. And since we unconditionally resolve weak values I moved the L/H resolving up so it could cache the values in LogicArray if the value is only `01LH`.

`LogicArray.__bool__` was moved to DeprecatedWarning because instead of keeping it and changing the behavior, I'd like to remove it. It behaves as it did for 1.9 in BinaryValue, so it's a deprecated backwards-compatible interface. VHDL doesn't define this operation and what should occur when non-0/1/L/H values are seen is debatable. I will refuse the temptation to guess.

### TODO
- [x] newsfrags