### PR TITLE
Provide friendlier message for when people try to index packed objects

### DIFF
--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -1034,7 +1034,7 @@ class ArrayObject(
 
     def __getitem__(self, index: int) -> ChildObjectT:
         if isinstance(index, slice):
-            raise IndexError("Slicing is not supported")
+            raise TypeError("Slicing is not supported")
         if index in self._sub_handles:
             return self._sub_handles[index]
         new_handle = self._handle.get_handle_by_index(index)
@@ -1299,6 +1299,14 @@ class LogicArrayObject(
         # can't use `range` to get length because `range` is for outer-most dimension only
         # and this object needs to support multi-dimensional packed arrays.
         return self._handle.get_num_elems()
+
+    def __getitem__(self, _: Any) -> NoReturn:
+        raise TypeError(
+            "Packed objects, either arrays or structs, cannot be indexed.\n"
+            "Try instead reading the whole value and slicing: `t = handle.value; t[0:3]`.\n"
+            "If you need to use an element in an Edge Trigger, consider making the array or struct unpacked.\n"
+            "Alternatively, use `ValueChange` on the whole object and check the bit(s) you care about for changes afterwards."
+        )
 
 
 class RealObject(NonIndexableValueObjectBase[float, float]):

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -581,3 +581,16 @@ async def test_set_at_end_of_test(dut) -> None:
 @cocotb.test
 async def test_set_at_end_of_test_check(dut) -> None:
     assert dut.stream_in_data.value == 5
+
+
+@cocotb.test
+async def test_invalid_indexing(dut) -> None:
+    # Indexing into packed arrays is not supported.
+    with pytest.raises(TypeError):
+        dut.stream_in_data[0]
+    with pytest.raises(TypeError):
+        dut.stream_in_data[0:1]
+
+    # Slicing not supported by ArrayObject.
+    with pytest.raises(TypeError):
+        dut.array_7_downto_4[6:5]


### PR DESCRIPTION
Closes #4323.

Explains what's happening when a user indexes into a packed object and provides suggestions on how to move forward.

### TODO
- [x] Test indexing packed objects (I can't believe we weren't already doing that 😞)