### PR TITLE
Introduce `TaskStarted` to replace some uses of `NullTrigger`

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -189,9 +189,15 @@ Triggers dealing with Tasks or running multiple Tasks concurrently.
 
 .. autoclass:: cocotb.task.Join
     :members:
+    :inherited-members:
+
+.. autoclass:: cocotb.triggers.TaskStarted
+    :members:
+    :inherited-members:
 
 .. autoclass:: cocotb.task.TaskComplete
     :members:
+    :inherited-members:
 
 .. autoclass:: cocotb.triggers.Combine
     :members:

--- a/docs/source/newsfragments/4558.feature.rst
+++ b/docs/source/newsfragments/4558.feature.rst
@@ -1,0 +1,1 @@
+Introduce :class:`.TaskStarted` Trigger and :attr:`.Task.started` attribute for waiting until a Task has started.

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -22,7 +22,7 @@ from cocotb._exceptions import InternalError
 from cocotb._outcomes import Error, Outcome
 from cocotb._typing import TimeUnit
 from cocotb.task import ResultType, Task
-from cocotb.triggers import NullTrigger, SimTimeoutError, with_timeout
+from cocotb.triggers import SimTimeoutError, with_timeout
 from cocotb.utils import get_sim_time
 
 Failed: Type[BaseException]
@@ -265,7 +265,7 @@ def start_soon(
     return task
 
 
-@deprecated("Use ``cocotb.start_soon`` instead.")
+@deprecated("Use `cocotb.start_soon` instead.")
 async def start(
     coro: Union[Task[ResultType], Coroutine[Any, Any, ResultType]],
 ) -> Task[ResultType]:
@@ -288,10 +288,15 @@ async def start(
     .. deprecated:: 2.0
         Use :func:`cocotb.start_soon` instead.
         If you need the scheduled Task to run before continuing the current Task,
-        follow the call to :func:`cocotb.start_soon` with an :class:`await NullTrigger() <cocotb.triggers.NullTrigger>`.
+        follow the call to :func:`cocotb.start_soon` with an :data:`await task.started <cocotb.task.Task.started>`.
+
+        .. code-block:: python3
+
+            task = cocotb.start_soon(coro())
+            await task.started
     """
     task = start_soon(coro)
-    await NullTrigger()
+    await task.started
     return task
 
 

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -22,7 +22,7 @@ from cocotb._gpi_triggers import (
     ValueChange,
     current_gpi_trigger,
 )
-from cocotb.task import Join, TaskComplete
+from cocotb.task import Join, TaskComplete, TaskStarted
 
 __all__ = (
     "Trigger",
@@ -39,6 +39,7 @@ __all__ = (
     "ValueChange",
     "Edge",
     "TaskComplete",
+    "TaskStarted",
     "Join",
     "Waitable",
     "First",


### PR DESCRIPTION
Closes #4494. Depends on #4544. `TaskStarted` Trigger fires after a Task is scheduled for the first time. This can be used after a `start_soon` to emulate the old behavior of `cocotb.fork`.

- [x] newsfrag