### PR TITLE
Introduce `EmptyTrigger` to replace some uses of `NullTrigger`

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -191,9 +191,6 @@ Triggers dealing with Tasks or running multiple Tasks concurrently.
 .. autoclass:: cocotb.task.TaskComplete
     :members:
 
-.. autoclass:: cocotb.triggers.NullTrigger
-    :members:
-
 .. autoclass:: cocotb.triggers.Combine
     :members:
 
@@ -218,6 +215,16 @@ They are used to synchronize coroutines with each other.
 .. autoclass:: cocotb.triggers.SimTimeoutError
 
 .. autofunction:: cocotb.triggers.with_timeout
+
+
+Miscellaneous Triggers
+----------------------
+
+.. autoclass:: cocotb.triggers.EmptyTrigger
+    :members:
+
+.. autoclass:: cocotb.triggers.NullTrigger
+    :members:
 
 
 Abstract Triggers

--- a/docs/source/newsfragments/4559.feature.rst
+++ b/docs/source/newsfragments/4559.feature.rst
@@ -1,0 +1,1 @@
+Introduced :class:`.EmptyTrigger` to replace some uses of :class:`.NullTrigger`.

--- a/src/cocotb/_base_triggers.py
+++ b/src/cocotb/_base_triggers.py
@@ -143,16 +143,15 @@ class Event:
             e = Event()
 
 
-            async def task1():
+            async def coro1():
                 await e.wait()
                 print("resuming!")
 
 
-            cocotb.start_soon(task1())
-            # do stuff
+            task1 = cocotb.start_soon(coro1())
             e.set()
-            await NullTrigger()  # allows task1 to execute
-            # resuming!
+            await task1  # allows task1 to execute
+            # "resuming!"
 
     .. versionremoved:: 2.0
 
@@ -213,7 +212,7 @@ class Event:
         call :meth:`clear`.
         """
         if self._fired:
-            return NullTrigger(name=f"{str(self)}.wait()")
+            return EmptyTrigger()
         return _Event(self)
 
     def clear(self) -> None:
@@ -413,10 +412,100 @@ class Lock(AsyncContextManager[None]):
         self.release()
 
 
-class NullTrigger(Trigger):
+class EmptyTrigger(Trigger):
     """Fires immediately.
 
-    This is primarily for forcing the current Task to be rescheduled after all currently pending Tasks.
+    Mostly useful for building higher-order functions which need to take or return Triggers.
+
+    .. versionadded:: 2.0
+    """
+
+    def __await__(self) -> Generator["Self", None, "Self"]:
+        yield from []  # Forces this to be a generator
+        return self
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__qualname__} at {pointer_str(self)}>"
+
+
+class NullTrigger(Trigger):
+    """Fires after all currently scheduled Tasks are resumed.
+
+    The firing of this Trigger with respect to any other Trigger or Task is not deterministic,
+    so it should generally not be relied upon.
+    Below are examples showing usage of alternatives.
+
+    Instead of using this Trigger after a call to :meth:`cocotb.start_soon`,
+    use :class:`.TaskStarted` like so:
+
+    .. code-block:: python
+
+        task = cocotb.start_soon(coro())
+        await task.started
+
+    Instead of using this as a "no-op" Trigger, instead use :class:`.EmptyTrigger` like so:
+
+    .. code-block:: python
+
+        def wait_for_event() -> Trigger:
+            if event.is_set():
+                return EmptyTrigger()
+            return event.wait()
+
+    Instead of using this Trigger to push the Task until "after" another Task has run,
+    instead use other synchronization techniques, such as using an :class:`.Event`.
+
+    **Do not** do this:
+
+    .. code-block:: python
+
+        transaction_data = None
+
+
+        def monitor():
+            while dut.valid.value != 1 and dut.ready.value != 1:
+                await RisingEdge(dut.clk)
+            transaction_data = dut.data.value
+
+
+        def use_transaction():
+            while True:
+                await RisingEdge(dut.clk)
+                # We need the NullTrigger here because both Tasks react to RisingEdge,
+                # but there's no guarantee about which Task is run first,
+                # so we need to force this one to run "later" using NullTrigger.
+                await NullTrigger()
+                if transaction_data is not None:
+                    process(transaction_data)
+
+
+        use_task = cocotb.start_soon(use_transaction())
+        monitor_task = cocotb.start_soon(monitor())
+
+    Instead use an :class:`!.Event`, like so:
+
+    .. code-block:: python
+
+        transaction_data = None
+        transaction_event = Event()
+
+
+        def monitor():
+            while dut.valid.value != 1 and dut.ready.value != 1:
+                await RisingEdge(dut.clk)
+            transaction_data = dut.data.value
+            transaction_event.set()
+
+
+        def use_transaction():
+            # Now we don't need the NullTrigger.
+            # This Task will wake up *strictly* after `monitor_task` sets the transaction.
+            await transaction_event.wait()
+            process(transaction_data)
+
+
+        use_task = cocotb.start_soon(use_transaction())
+        monitor_task = cocotb.start_soon(monitor())
 
     .. versionremoved:: 2.0
         The *outcome* parameter was removed. There is no alternative.

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -44,7 +44,7 @@ from typing import (
 )
 
 import cocotb.handle
-from cocotb._base_triggers import NullTrigger, Trigger, _InternalEvent
+from cocotb._base_triggers import EmptyTrigger, Trigger, _InternalEvent
 from cocotb._gpi_triggers import FallingEdge, RisingEdge, Timer, ValueChange
 from cocotb._typing import TimeUnit
 from cocotb.task import Task
@@ -112,7 +112,7 @@ class Combine(_AggregateWaitable["Combine"]):
 
     async def _wait(self) -> "Combine":
         if len(self._triggers) == 0:
-            await NullTrigger()
+            await EmptyTrigger()
         elif len(self._triggers) == 1:
             await self._triggers[0]
         else:

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from cocotb._base_triggers import Event, Lock, NullTrigger, Trigger
+from cocotb._base_triggers import EmptyTrigger, Event, Lock, NullTrigger, Trigger
 from cocotb._extended_awaitables import (
     ClockCycles,
     Combine,
@@ -45,4 +45,5 @@ __all__ = (
     "ClockCycles",
     "with_timeout",
     "SimTimeoutError",
+    "EmptyTrigger",
 )

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -24,6 +24,7 @@ from cocotb.clock import Clock
 from cocotb.task import CancellationError, Task
 from cocotb.triggers import (
     Combine,
+    EmptyTrigger,
     Event,
     First,
     NullTrigger,
@@ -991,3 +992,17 @@ async def test_start_again_while_pending(_) -> None:
     b = cocotb.start_soon(a)
     assert b is a
     await a
+
+
+@cocotb.test
+async def test_EmptyTrigger_doesnt_yield(_) -> None:
+    task_ran = False
+
+    async def coro() -> None:
+        nonlocal task_ran
+        task_ran = True
+
+    task = cocotb.start_soon(coro())
+    await EmptyTrigger()
+    task.cancel()
+    assert not task_ran


### PR DESCRIPTION
Closes #4493. I think we decided not to rename NullTrigger? If we had not decided, let this PR be the battleground.
Depends on #4558.

### TODO
- [x] newsfrags