### PR TITLE
Deprecate Event name

### DIFF
--- a/docs/source/newsfragments/4561.removal.rst
+++ b/docs/source/newsfragments/4561.removal.rst
@@ -1,0 +1,1 @@
+Deprecated :attr:`.Event.name` and passing a *name* argument to :class:`.Event` constructors. If you need to associate a name with an Event, create an empty subclass of :class:`!.Event` with your desired name.

--- a/src/cocotb/_base_triggers.py
+++ b/src/cocotb/_base_triggers.py
@@ -38,6 +38,7 @@ from typing import (
     Generator,
     List,
     Optional,
+    Union,
 )
 
 from cocotb._deprecation import deprecated
@@ -155,14 +156,32 @@ class Event:
 
     .. versionremoved:: 2.0
 
-        Removed the undocumented *data* attribute and argument to :meth:`set`.
+        Removed the undocumented *data* attribute and argument to :meth:`set`,
+        and the *name* attribute and argument to the constructor.
     """
 
     def __init__(self, name: Optional[str] = None) -> None:
         self._pending_events: List[_Event] = []
-        self.name: Optional[str] = name
+        self._name: Union[str, None] = None
+        if name is not None:
+            self.name = name
         self._fired: bool = False
         self._data: Any = None
+
+    @property
+    @deprecated("The name field will be removed in a future release.")
+    def name(self) -> Union[str, None]:
+        """Name of the Event.
+
+        .. deprecated:: 2.0
+            The name field will be removed in a future release.
+        """
+        return self._name
+
+    @name.setter
+    @deprecated("The name field will be removed in a future release.")
+    def name(self, new_name: Union[str, None]) -> None:
+        self._name = new_name
 
     @property
     @deprecated("The data field will be removed in a future release.")
@@ -228,11 +247,11 @@ class Event:
         return self._fired
 
     def __repr__(self) -> str:
-        if self.name is None:
+        if self._name is None:
             fmt = "<{0} at {2}>"
         else:
             fmt = "<{0} for {1} at {2}>"
-        return fmt.format(type(self).__qualname__, self.name, pointer_str(self))
+        return fmt.format(type(self).__qualname__, self._name, pointer_str(self))
 
 
 class _InternalEvent(Trigger):

--- a/src/cocotb/queue.py
+++ b/src/cocotb/queue.py
@@ -116,7 +116,7 @@ class AbstractQueue(Generic[T]):
         slot is available before adding the item.
         """
         while self.full():
-            event = Event(f"{type(self).__name__} put")
+            event = Event()
             self._putters.append(
                 (event, cast(Task[Any], cocotb._scheduler_inst._current_task))
             )
@@ -139,7 +139,7 @@ class AbstractQueue(Generic[T]):
         If the queue is empty, wait until an item is available.
         """
         while self.empty():
-            event = Event(f"{type(self).__name__} get")
+            event = Event()
             self._getters.append(
                 (event, cast(Task[Any], cocotb._scheduler_inst._current_task))
             )

--- a/tests/test_cases/test_cocotb/test_concurrency_primitives.py
+++ b/tests/test_cases/test_cocotb/test_concurrency_primitives.py
@@ -246,14 +246,19 @@ async def test_recursive_combine(_):
     assert done == {10, 20, 30}
 
 
+class MyEvent(Event):
+    pass
+
+
 @cocotb.test
 async def test_concurrency_trigger_repr(_):
     e = Event()
     assert re.match(r"<Event at \w+>", repr(e))
-    e = Event(name="my_event")
-    assert re.match(r"<Event for my_event at \w+>", repr(e))
+
+    e = MyEvent()
+    assert re.match(r"<MyEvent at \w+>", repr(e))
     w = e.wait()
-    assert re.match(r"<<Event for my_event at \w+>\.wait\(\) at \w+>", repr(w))
+    assert re.match(r"<<MyEvent at \w+>\.wait\(\) at \w+>", repr(w))
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -179,3 +179,18 @@ async def test_cocotb_start(_) -> None:
 async def test_setimmediatevalue(dut) -> None:
     with pytest.warns(DeprecationWarning):
         dut.stream_in_data.setimmediatevalue(10)
+
+
+@cocotb.test
+async def test_event_name_deprecated(_) -> None:
+    with pytest.warns(DeprecationWarning):
+        e = Event("test1")
+
+    with pytest.warns(DeprecationWarning):
+        assert e.name == "test1"
+
+    with pytest.warns(DeprecationWarning):
+        e.name = "test2"
+
+    with pytest.warns(DeprecationWarning):
+        assert e.name == "test2"

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -326,7 +326,7 @@ async def test_task_repr(_) -> None:
     """Test Task.__repr__."""
     log = logging.getLogger("cocotb.test")
 
-    coro_e = Event("coroutine_inner")
+    coro_e = Event()
 
     async def coroutine_wait():
         await Timer(1, unit="ns")


### PR DESCRIPTION
This is not supported by `asyncio.Event` and doesn't provide "functional" utility. This depends on #4559.

### TODO
- [x] newsfrag
- [x] deprecation test