### PR TITLE
Revert new Triggers

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -193,6 +193,9 @@ Triggers dealing with Tasks or running multiple Tasks concurrently.
 .. autoclass:: cocotb.task.TaskComplete
     :members:
 
+.. autoclass:: cocotb.triggers.NullTrigger
+    :members:
+
 .. autoclass:: cocotb.triggers.Combine
     :members:
 
@@ -217,16 +220,6 @@ They are used to synchronize coroutines with each other.
 .. autoclass:: cocotb.triggers.SimTimeoutError
 
 .. autofunction:: cocotb.triggers.with_timeout
-
-
-Miscellaneous Triggers
-----------------------
-
-.. autoclass:: cocotb.triggers.EmptyTrigger
-    :members:
-
-.. autoclass:: cocotb.triggers.NullTrigger
-    :members:
 
 
 Abstract Triggers

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -189,15 +189,9 @@ Triggers dealing with Tasks or running multiple Tasks concurrently.
 
 .. autoclass:: cocotb.task.Join
     :members:
-    :inherited-members:
-
-.. autoclass:: cocotb.triggers.TaskStarted
-    :members:
-    :inherited-members:
 
 .. autoclass:: cocotb.task.TaskComplete
     :members:
-    :inherited-members:
 
 .. autoclass:: cocotb.triggers.Combine
     :members:

--- a/docs/source/newsfragments/4558.feature.rst
+++ b/docs/source/newsfragments/4558.feature.rst
@@ -1,1 +1,0 @@
-Introduce :class:`.TaskStarted` Trigger and :attr:`.Task.started` attribute for waiting until a Task has started.

--- a/docs/source/newsfragments/4559.feature.rst
+++ b/docs/source/newsfragments/4559.feature.rst
@@ -1,1 +1,0 @@
-Introduced :class:`.EmptyTrigger` to replace some uses of :class:`.NullTrigger`.

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 import cocotb.handle
-from cocotb._base_triggers import EmptyTrigger, Trigger, _InternalEvent
+from cocotb._base_triggers import NullTrigger, Trigger, _InternalEvent
 from cocotb._gpi_triggers import FallingEdge, RisingEdge, Timer, ValueChange
 from cocotb._typing import TimeUnit
 from cocotb.task import Task
@@ -91,7 +91,7 @@ class Combine(_AggregateWaitable["Combine"]):
 
     async def _wait(self) -> "Combine":
         if len(self._triggers) == 0:
-            await EmptyTrigger()
+            await NullTrigger()
         elif len(self._triggers) == 1:
             await self._triggers[0]
         else:

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -287,8 +287,20 @@ async def start(
 
     .. deprecated:: 2.0
         Use :func:`cocotb.start_soon` instead.
-        If you need the scheduled Task to run before continuing the current Task,
-        follow the call to :func:`cocotb.start_soon` with an :class:`await NullTrigger() <cocotb.triggers.NullTrigger>`.
+        If you need the scheduled Task to start before continuing the current Task,
+        use an :class:`.Event` to block the current Task until the scheduled Task starts,
+        like so:
+
+        .. code-block:: python
+
+            async def coro(started: Event) -> None:
+                started.set()
+                # Do stuff...
+
+
+            task_started = Event()
+            task = cocotb.start_soon(coro(task_started))
+            await task_started.wait()
     """
     task = start_soon(coro)
     await NullTrigger()

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -22,7 +22,7 @@ from cocotb._exceptions import InternalError
 from cocotb._outcomes import Error, Outcome
 from cocotb._typing import TimeUnit
 from cocotb.task import ResultType, Task
-from cocotb.triggers import SimTimeoutError, with_timeout
+from cocotb.triggers import NullTrigger, SimTimeoutError, with_timeout
 from cocotb.utils import get_sim_time
 
 Failed: Type[BaseException]
@@ -265,7 +265,7 @@ def start_soon(
     return task
 
 
-@deprecated("Use `cocotb.start_soon` instead.")
+@deprecated("Use ``cocotb.start_soon`` instead.")
 async def start(
     coro: Union[Task[ResultType], Coroutine[Any, Any, ResultType]],
 ) -> Task[ResultType]:
@@ -288,15 +288,10 @@ async def start(
     .. deprecated:: 2.0
         Use :func:`cocotb.start_soon` instead.
         If you need the scheduled Task to run before continuing the current Task,
-        follow the call to :func:`cocotb.start_soon` with an :data:`await task.started <cocotb.task.Task.started>`.
-
-        .. code-block:: python3
-
-            task = cocotb.start_soon(coro())
-            await task.started
+        follow the call to :func:`cocotb.start_soon` with an :class:`await NullTrigger() <cocotb.triggers.NullTrigger>`.
     """
     task = start_soon(coro)
-    await task.started
+    await NullTrigger()
     return task
 
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -13,7 +13,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    ClassVar,
     Coroutine,
     Generator,
     Generic,
@@ -98,7 +97,6 @@ class Task(Generic[ResultType]):
         self._done_callbacks: List[Callable[[Task[ResultType]], Any]] = []
         self._cancelled_msg: Union[str, None] = None
         self._must_cancel: bool = False
-        self._has_resumed: bool = False
 
         self._task_id = self._id_count
         type(self)._id_count += 1
@@ -196,10 +194,6 @@ class Task(Generic[ResultType]):
         """
         self._state = _TaskState.RUNNING
 
-        if not self._has_resumed:
-            self._has_resumed = True
-            cocotb._scheduler_inst._react(self.started)
-
         if self._must_cancel:
             exc = self._cancelled_error
 
@@ -262,19 +256,6 @@ class Task(Generic[ResultType]):
             cocotb._scheduler_inst._unschedule(self)
 
         self._set_outcome(Value(None))  # type: ignore  # `kill()` sets the result to None regardless of the ResultType
-
-    @cached_property
-    def started(self) -> "TaskStarted[ResultType]":
-        """Trigger which fires after the first time the Task resumes.
-
-        Mostly useful as a way to emulate :func:`cocotb.start` and ``cocotb.fork``'s behavior of returning after the Task has started running.
-
-        .. code-block:: python
-
-            task = cocotb.start_soon(coro())
-            await task.started
-        """
-        return TaskStarted._make(self)
 
     @cached_property
     def complete(self) -> "TaskComplete[ResultType]":
@@ -420,56 +401,7 @@ class Task(Generic[ResultType]):
         return self.result()
 
 
-class _TaskTriggerBase(Trigger, Generic[ResultType]):
-    _task_attr: ClassVar[str]
-    _task: Task[ResultType]
-
-    def __new__(cls, task: Task[ResultType]) -> "TaskComplete[ResultType]":
-        raise NotImplementedError(
-            f"{cls.__qualname__} cannot be instantiated. Use the `Task.{cls._task_attr}` attribute."
-        )
-
-    def __init__(self, task: Task[ResultType]) -> None:
-        pass
-
-    @classmethod
-    def _make(cls, task: Task[ResultType]) -> "Self":
-        self = super().__new__(cls)
-        super().__init__(self)
-        self._task = task
-        return self
-
-    def __repr__(self) -> str:
-        return f"{type(self).__qualname__}({self._task!s})"
-
-    @property
-    def task(self) -> Task[ResultType]:
-        """The :class:`.Task` associated with this completion event."""
-        return self._task
-
-
-class TaskStarted(_TaskTriggerBase[ResultType]):
-    """Trigger which fires after the first time the Task resumes.
-
-    See :attr:`.Task.started` for more info.
-
-    .. warning::
-        This class cannot be instantiated in the normal way.
-        You must use :attr:`.Task.started`.
-
-    .. versionadded:: 2.0
-    """
-
-    _task_attr = "started"
-
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
-        if self._task._has_resumed:
-            callback(self)
-        else:
-            super()._prime(callback)
-
-
-class TaskComplete(_TaskTriggerBase[ResultType]):
+class TaskComplete(Trigger, Generic[ResultType]):
     r"""Fires when a :class:`~cocotb.task.Task` completes.
 
     Unlike :class:`~cocotb.triggers.Join`, this Trigger does not return the result of the Task when :keyword:`await`\ ed.
@@ -482,13 +414,33 @@ class TaskComplete(_TaskTriggerBase[ResultType]):
     .. versionadded:: 2.0
     """
 
-    _task_attr = "complete"
+    _task: Task[ResultType]
+
+    def __new__(cls, task: Task[ResultType]) -> "TaskComplete[ResultType]":
+        raise NotImplementedError(
+            "TaskComplete cannot be instantiated in this way. Use the `task.complete` attribute."
+        )
+
+    @classmethod
+    def _make(cls, task: Task[ResultType]) -> "Self":
+        self = super().__new__(cls)
+        super().__init__(self)
+        self._task = task
+        return self
 
     def _prime(self, callback: Callable[[Trigger], None]) -> None:
         if self._task.done():
             callback(self)
         else:
             super()._prime(callback)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__qualname__}({self._task!s})"
+
+    @property
+    def task(self) -> Task[ResultType]:
+        """The :class:`.Task` associated with this completion event."""
+        return self._task
 
 
 class Join(TaskComplete[ResultType]):
@@ -523,6 +475,9 @@ class Join(TaskComplete[ResultType]):
     )
     def __new__(cls, task: Task[ResultType]) -> "Join[ResultType]":
         return task._join
+
+    def __init__(self, task: Task[ResultType]) -> None:
+        pass
 
     def __await__(self) -> Generator["Self", None, ResultType]:  # type: ignore[override]
         yield self

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from cocotb._base_triggers import EmptyTrigger, Event, Lock, NullTrigger, Trigger
+from cocotb._base_triggers import Event, Lock, NullTrigger, Trigger
 from cocotb._extended_awaitables import (
     ClockCycles,
     Combine,
@@ -46,6 +46,5 @@ __all__ = (
     "ClockCycles",
     "with_timeout",
     "SimTimeoutError",
-    "EmptyTrigger",
     "current_gpi_trigger",
 )

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -22,7 +22,7 @@ from cocotb._gpi_triggers import (
     ValueChange,
     current_gpi_trigger,
 )
-from cocotb.task import Join, TaskComplete, TaskStarted
+from cocotb.task import Join, TaskComplete
 
 __all__ = (
     "Trigger",
@@ -39,7 +39,6 @@ __all__ = (
     "ValueChange",
     "Edge",
     "TaskComplete",
-    "TaskStarted",
     "Join",
     "Waitable",
     "First",

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -24,7 +24,6 @@ from cocotb.clock import Clock
 from cocotb.task import CancellationError, Task
 from cocotb.triggers import (
     Combine,
-    EmptyTrigger,
     Event,
     First,
     NullTrigger,
@@ -1000,17 +999,3 @@ async def test_start_again_while_pending(_) -> None:
     b = cocotb.start_soon(a)
     assert b is a
     await a
-
-
-@cocotb.test
-async def test_EmptyTrigger_doesnt_yield(_) -> None:
-    task_ran = False
-
-    async def coro() -> None:
-        nonlocal task_ran
-        task_ran = True
-
-    task = cocotb.start_soon(coro())
-    await EmptyTrigger()
-    task.cancel()
-    assert not task_ran

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -31,7 +31,6 @@ from cocotb.triggers import (
     RisingEdge,
     Timer,
     Trigger,
-    with_timeout,
 )
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
@@ -1015,28 +1014,3 @@ async def test_EmptyTrigger_doesnt_yield(_) -> None:
     await EmptyTrigger()
     task.cancel()
     assert not task_ran
-
-
-@cocotb.test
-async def test_task_started(_) -> None:
-    has_resumed = False
-
-    async def coro() -> None:
-        nonlocal has_resumed
-        has_resumed = True
-        await Timer(1, "ns")
-
-    task = cocotb.start_soon(coro())
-    assert not has_resumed
-    await task.started
-    assert has_resumed
-
-
-@cocotb.test
-async def test_task_already_started(_) -> None:
-    async def coro() -> None:
-        await Timer(5, "ns")
-
-    task = cocotb.start_soon(coro())
-    await Timer(1, "ns")
-    await with_timeout(task.started, 1, "step")


### PR DESCRIPTION
Reverts #4558 and #4559.

* `EmptyTrigger` not rescheduling can potentially lead to livelocks.
* Making `EmptyTrigger` reschedule makes it equivalent to `NullTrigger`, so I just made `NullTrigger`'s documentation reflect that instead of explicitly mentioning rescheduling.
* `TaskStarted` has a negative performance effect on all Tasks for behavior very few people need.
* Also it had a bug where awaiting `TaskStarted` a Task which was `kill()`ed or `cancel()`ed before resuming once would hang indefinitely.
* `cocotb.start` deprecation was updated to mention using an `Event` for synchronization instead of `TaskStarted` or `NullTrigger`.

Maybe there's a better solution out there, but we can handle it later.