### PR TITLE
Support negative values with LogicArray

### DIFF
--- a/docs/source/newsfragments/3792.change.rst
+++ b/docs/source/newsfragments/3792.change.rst
@@ -1,1 +1,0 @@
-When constructing a :class:`~cocotb.types.LogicArray`, if the given value cannot fit in the given range, an :exc:`OverflowError` is now thrown, instead of a :exc:`ValueError`.

--- a/docs/source/newsfragments/3792.removal.3.rst
+++ b/docs/source/newsfragments/3792.removal.3.rst
@@ -1,1 +1,0 @@
-Constructing a :class:`~cocotb.types.LogicArray` from an :class:`int` is deprecated. Use :meth:`LogicArray.from_unsigned() <cocotb.types.LogicArray.from_unsigned>` and :meth:`LogicArray.from_signed() <cocotb.types.LogicArray.from_signed>` instead.

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -49,11 +49,12 @@ def test_logic_array_int_construction():
     assert LogicArray(10, Range(5, "downto", 0)) == LogicArray("001010")
     assert LogicArray(10, 6) == LogicArray("001010")
     assert LogicArray(10, range=Range(5, "downto", 0)) == LogicArray("001010")
-
     with pytest.raises(ValueError):
         LogicArray(10, Range(1, "to", 3))
+
+    assert LogicArray(-10, Range(7, "downto", 0)) == LogicArray("11110110")
     with pytest.raises(ValueError):
-        LogicArray(-10, Range(7, "downto", 0))
+        LogicArray(-10, Range(1, "to", 3))
 
 
 def test_logic_array_bad_construction():
@@ -245,6 +246,8 @@ def test_equality():
     assert LogicArray("0101") != "lol"
     assert LogicArray("0101") != 123
     assert LogicArray("0101") != [7, "f", dict]
+    assert LogicArray("1111") == ~0
+    assert LogicArray("1000") == ~7
 
 
 def test_repr_eval():


### PR DESCRIPTION
Rationale being that `~0`, because Python ints are arbitrary in size, is returned as a negative value assuming two's complement. We would otherwise not be able to support negated values in comparison or construction.

Also removes outdated newsfrags.