### PR TITLE
Deprecate `Task.kill`

### DIFF
--- a/docs/source/newsfragments/4573.removal.rst
+++ b/docs/source/newsfragments/4573.removal.rst
@@ -1,0 +1,1 @@
+:meth:`.Task.kill` is deprecated in favor of :meth:`.Task.cancel`.

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -200,7 +200,7 @@ class First(_AggregateWaitable[Any]):
         finally:
             # kill all the other waiters
             for w in waiters:
-                w.kill()
+                w.cancel()
 
         return completed[0].result()
 
@@ -411,7 +411,7 @@ async def with_timeout(
         if not shielded:
             # shielded = False only when trigger is a Task created to wrap a Coroutine
             trigger = cast(Task[Any], trigger)
-            trigger.kill()
+            trigger.cancel()
         raise SimTimeoutError
     else:
         return res

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -125,7 +125,7 @@ class Test:
                 try:
                     res = await with_timeout(running_co, timeout_time, timeout_unit)
                 except SimTimeoutError:
-                    running_co.kill()
+                    running_co.cancel()
                     raise
                 else:
                     return res

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -748,7 +748,7 @@ def _start_write_scheduler() -> None:
 def _stop_write_scheduler() -> None:
     global _write_task
     if _write_task is not None:
-        _write_task.kill()
+        _write_task.cancel()
         _write_task = None
     _write_calls.clear()
     _writes_pending.clear()

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -234,6 +234,7 @@ class Task(Generic[ResultType]):
             else:
                 return trigger
 
+    @deprecated("`task.kill()` is deprecated in favor of `task.cancel()`")
     def kill(self) -> None:
         """Kill a coroutine."""
 

--- a/tests/test_cases/issue_588/issue_588.py
+++ b/tests/test_cases/issue_588/issue_588.py
@@ -22,7 +22,7 @@ async def issue_588_coroutine_list(dut):
     # Yield a list, containing a RisingEdge trigger and a coroutine.
     coro = cocotb.start_soon(sample_coroutine(dut))
     await First(coro, Timer(100, "ns"))
-    coro.kill()
+    coro.cancel()
 
     # Make sure that only 5 ns passed, because the sample coroutine
     # terminated first.

--- a/tests/test_cases/test_3270/test_3270.py
+++ b/tests/test_cases/test_3270/test_3270.py
@@ -35,7 +35,7 @@ class MonitorChange:
 
     def stop_monitor(self):
         if self.monitor_process is not None:
-            self.monitor_process.kill()
+            self.monitor_process.cancel()
         self.monitor_process = None
 
     def start_monitor(self):

--- a/tests/test_cases/test_3270/test_3270.py
+++ b/tests/test_cases/test_3270/test_3270.py
@@ -60,7 +60,9 @@ async def init_dut(dut):
     dut.i_rst_n.value = 0
     await Timer(10, "ns")
     dut.i_rst_n.value = 1
-    return cocotb.start_soon(Clock(dut.i_clk, 1, "ns").start())
+    clk = Clock(dut.i_clk, 1, "ns")
+    clk.start()
+    return clk
 
 
 @cocotb.test()
@@ -83,8 +85,8 @@ async def buggy(dut):
     dut.i_trg.value = 0
 
     await RisingEdge(dut.o_pulse)
-    clk.kill()
-    coro.kill()
+    clk.stop()
+    coro.cancel()
     await Timer(1, "us")
 
 
@@ -105,4 +107,4 @@ async def basic_ok(dut):
         await Timer(10, "ns")
 
     await Timer(10, "ns")
-    clk.kill()
+    clk.stop()

--- a/tests/test_cases/test_cocotb/test_queues.py
+++ b/tests/test_cases/test_cocotb/test_queues.py
@@ -93,7 +93,7 @@ async def test_queue_contention(dut):
 
     # test killed putter
     coro = cocotb.start_soon(putter(putter_list, 100))
-    coro.kill()
+    coro.cancel()
     coro_list.append(cocotb.start_soon(putter(putter_list, 101)))
 
     for k in range(NUM_PUTTERS):
@@ -118,7 +118,7 @@ async def test_queue_contention(dut):
 
     # test killed getter
     coro2 = cocotb.start_soon(getter(getter_list, 100))
-    coro2.kill()
+    coro2.cancel()
     coro_list.append(cocotb.start_soon(getter(getter_list, 101)))
 
     for k in range(NUM_PUTTERS):

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -198,7 +198,7 @@ async def test_Lock_fair_scheduling(_) -> None:
     # We cancel tasks randomly to ensure that doesn't effect acquisition order.
     while not all(t.done() for t in tasks):
         # Randomly kill a remaining waiter.
-        tasks[random.randrange(last_scheduled, len(tasks))].kill()
+        tasks[random.randrange(last_scheduled, len(tasks))].cancel()
         # Wait some random time until killing another.
         await Timer(
             (random.random() * 2 * average_killer_wakeup), "ns", round_mode="ceil"


### PR DESCRIPTION
Closes #4556. Blocked by #4574. Everything necessary to replace `Task.kill` with `Task.cancel` internally outside of doing so at test end (different PR).

### TODO
- [x] newsfrags
- [x] Fix deprecated uses of `Clock.start()` Task killing.
- [x] deprecate `Task.kill`
