### PR TITLE
Handle SystemExit in C API functions correctly

### DIFF
--- a/src/cocotb/share/include/py_gpi_logging.h
+++ b/src/cocotb/share/include/py_gpi_logging.h
@@ -24,7 +24,9 @@ PYGPILOG_EXPORT void py_gpi_logger_initialize(PyObject* handler,
 
 PYGPILOG_EXPORT void py_gpi_logger_finalize();
 
-extern PYGPILOG_EXPORT PyObject* pEventFn;  // This is gross but I don't care
+extern PYGPILOG_EXPORT PyObject* pEventFn;
+
+PYGPILOG_EXPORT void handle_error();
 
 #ifdef __cplusplus
 }

--- a/src/cocotb/share/lib/embed/gpi_embed.cpp
+++ b/src/cocotb/share/lib/embed/gpi_embed.cpp
@@ -235,7 +235,7 @@ extern "C" COCOTB_EXPORT int _embed_sim_init(int argc,
     auto entry_utility_module = PyImport_ImportModule("pygpi.entry");
     if (!entry_utility_module) {
         // LCOV_EXCL_START
-        PyErr_Print();
+        handle_error();
         return -1;
         // LCOV_EXCL_STOP
     }
@@ -245,7 +245,7 @@ extern "C" COCOTB_EXPORT int _embed_sim_init(int argc,
     auto argv_list = PyList_New(argc);
     if (argv_list == NULL) {
         // LCOV_EXCL_START
-        PyErr_Print();
+        handle_error();
         return -1;
         // LCOV_EXCL_STOP
     }
@@ -255,7 +255,7 @@ extern "C" COCOTB_EXPORT int _embed_sim_init(int argc,
         auto argv_item = PyUnicode_DecodeLocale(_argv[i], "surrogateescape");
         if (!argv_item) {
             // LCOV_EXCL_START
-            PyErr_Print();
+            handle_error();
             return -1;
             // LCOV_EXCL_STOP
         }
@@ -267,8 +267,8 @@ extern "C" COCOTB_EXPORT int _embed_sim_init(int argc,
         PyObject_CallMethod(entry_utility_module, "load_entry", "O", argv_list);
     if (!cocotb_retval) {
         // LCOV_EXCL_START
-        PyErr_Print();
         gpi_sim_end();
+        handle_error();
         return -1;
         // LCOV_EXCL_STOP
     }
@@ -292,8 +292,8 @@ extern "C" COCOTB_EXPORT void _embed_sim_event(const char *msg) {
         PyObject *pValue = PyObject_CallFunction(pEventFn, "s", msg);
         if (pValue == NULL) {
             // LCOV_EXCL_START
-            PyErr_Print();
             LOG_ERROR("Passing event to upper layer failed");
+            handle_error();
             // LCOV_EXCL_STOP
         }
         Py_XDECREF(pValue);

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -182,8 +182,8 @@ int handle_gpi_callback(void *user_data) {
     // The best thing to do here is shutdown as any subsequent
     // calls will go back to Python which is now in an unknown state
     if (pValue == NULL) {
-        PyErr_Print();
         gpi_sim_end();
+        handle_error();
         return 0;
     }
 
@@ -779,7 +779,7 @@ static PyObject *initialize_logger(PyObject *, PyObject *args) {
     PyObject *log_func;
     PyObject *get_logger;
     if (!PyArg_ParseTuple(args, "OO", &log_func, &get_logger)) {
-        PyErr_Print();
+        handle_error();
         return NULL;
     }
     py_gpi_logger_initialize(log_func, get_logger);
@@ -795,7 +795,7 @@ static PyObject *set_sim_event_callback(PyObject *, PyObject *args) {
 
     PyObject *sim_event_callback;
     if (!PyArg_ParseTuple(args, "O", &sim_event_callback)) {
-        PyErr_Print();
+        handle_error();
         Py_RETURN_NONE;
     }
     Py_INCREF(sim_event_callback);


### PR DESCRIPTION
Closes #4563. `PyErr_Print` when given a `SystemExit` calls `exit()`. We need this to happen strictly after a call to `gpi_sim_end` in `_embed_sim_init` and `handle_gpi_callback` so we can clean up and deregister the shutdown callback (which is what's causing the issue with Questa).

I also added a function to wrap `PyErr_Print` so that it checks for `SystemExit` and calls `gpi_sim_end` for all those calls into Python that aren't the two listed above, just in case they do something bad. `handle_error` should always be called instead of `PyErr_Print`.
