### PR TITLE
Fix bounds check in LogicArray's from_signed()

### DIFF
--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -391,6 +391,8 @@ class LogicArray(ArrayLike[Logic]):
         """
         if isinstance(range, int):
             range = Range(range - 1, "downto", 0)
+        elif not isinstance(range, Range):
+            raise TypeError("Invalid range type")
 
         limit = 1 << (len(range) - 1)
         if (value < -limit) or (value >= limit):

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -392,7 +392,9 @@ class LogicArray(ArrayLike[Logic]):
         if isinstance(range, int):
             range = Range(range - 1, "downto", 0)
         elif not isinstance(range, Range):
-            raise TypeError(f"Expected Range or int for parameter 'range', not {type(range).__qualname__}")
+            raise TypeError(
+                f"Expected Range or int for parameter 'range', not {type(range).__qualname__}"
+            )
 
         limit = 1 << (len(range) - 1)
         if value < -limit or limit <= value:

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -392,16 +392,13 @@ class LogicArray(ArrayLike[Logic]):
         if isinstance(range, int):
             range = Range(range - 1, "downto", 0)
 
-        limit = 2 ** (len(range) - 1)
+        limit = 1 << (len(range) - 1)
         if (value < -limit) or (value >= limit):
             raise ValueError(
                 f"{value!r} will not fit in a LogicArray with bounds: {range!r}."
             )
 
-        if value < 0:
-            value += 2 * limit
-
-        return LogicArray(value, range)
+        return LogicArray(value % (2 * limit), range)
 
     @classmethod
     def from_bytes(

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -392,10 +392,10 @@ class LogicArray(ArrayLike[Logic]):
         if isinstance(range, int):
             range = Range(range - 1, "downto", 0)
         elif not isinstance(range, Range):
-            raise TypeError("Invalid range type")
+            raise TypeError(f"Expected Range or int for parameter 'range', not {type(range).__qualname__}")
 
         limit = 1 << (len(range) - 1)
-        if (value < -limit) or (value >= limit):
+        if value < -limit or limit <= value:
             raise ValueError(
                 f"{value!r} will not fit in a LogicArray with bounds: {range!r}."
             )

--- a/src/cocotb/types/logic_array.py
+++ b/src/cocotb/types/logic_array.py
@@ -391,14 +391,16 @@ class LogicArray(ArrayLike[Logic]):
         """
         if isinstance(range, int):
             range = Range(range - 1, "downto", 0)
-        if value < 0:
-            value += 2 ** len(range)
-        # If value doesn't fit in range, it will still be negative and will blow the
-        # constructor up in a bad way.
-        if value < 0:
+
+        limit = 2 ** (len(range) - 1)
+        if (value < -limit) or (value >= limit):
             raise ValueError(
                 f"{value!r} will not fit in a LogicArray with bounds: {range!r}."
             )
+
+        if value < 0:
+            value += 2 * limit
+
         return LogicArray(value, range)
 
     @classmethod

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -109,6 +109,13 @@ def test_logic_array_signed_conversion():
     with pytest.raises(TypeError):
         LogicArray.from_signed(10, "lol")
 
+    with pytest.raises(ValueError):
+        LogicArray.from_signed(-9, 4)
+    assert LogicArray.from_signed(-8, 4) == LogicArray("1000")
+    assert LogicArray.from_signed(7, 4) == LogicArray("0111")
+    with pytest.raises(ValueError):
+        LogicArray.from_signed(8, 4)
+
 
 def test_logic_array_bytes_conversion():
     assert LogicArray.from_bytes(b"12", byteorder="big") == LogicArray(


### PR DESCRIPTION
There are some issues with the current bounds check when converting signed integers to LogicArrays, where integers in
[-2^n,-2^(n-1)) and [2^(n-1),2^n) pass but shouldn't, and get converted to an incorrect two's complement binary number.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
