### PR TITLE
Add support for DSim simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,10 @@ examples/*/tests/compile
 tests/test_cases/*/verilog.log
 examples/*/tests/verilog.log
 
+# DSim
+dsim*
+metrics.db
+
 # Build artifacts
 /dist/
 src/cocotb/_version.py

--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -827,4 +827,14 @@ def get_ext():
         )
         ext.append(nvc_vhpi_ext)
 
+    #
+    # DSim
+    #
+    if os.name == "posix":
+        logger.info("Compiling libraries for DSim")
+        dsim_vpi_ext = _get_vpi_lib_ext(
+            include_dirs=include_dirs, share_lib_dir=share_lib_dir, sim_define="DSim"
+        )
+        ext.append(dsim_vpi_ext)
+
     return ext

--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -185,3 +185,11 @@ Tachyon DA CVC
 
 * Extend the ``cvc64`` call with the option
   ``+interp +acc+2 +loadvpi=$(cocotb-config --lib-name-path vpi cvc):vlog_startup_routines_bootstrap``.
+
+.. _custom-flows-dsim:
+
+Siemens DSim
+============
+
+* Extend the ``dsim`` call with the option
+  ``-pli_lib $(cocotb-config --lib-name-path vpi dsim) +acc+rwcbfsWF``.

--- a/docs/source/newsfragments/3990.feature.rst
+++ b/docs/source/newsfragments/3990.feature.rst
@@ -1,0 +1,1 @@
+The Siemens DSim simulator is now supported by cocotb.

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -451,3 +451,49 @@ Issues for this simulator
 -------------------------
 
 * `All issues with label category:simulators:cvc <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Acvc>`_
+
+.. _sim-dsim:
+
+Siemens DSim
+============
+
+.. warning::
+
+    DSim support for cocotb is experimental.
+    Some features of cocotb may not work correctly or at all.
+    At least DSim version 2025 is required.
+
+In order to use this simulator, set :make:var:`SIM` to ``dsim``:
+
+.. code-block:: bash
+
+    make SIM=dsim
+
+.. note::
+
+    A working installation of `DSim <https://altair.com/dsim>`_ is required.
+    You can install DSim simulator directly from `Altair Marketplace <https://altairone.com/Marketplace?tab=Info&app=dsim>`_ and find information regarding getting a free license.
+    See `Altair Learning <https://learn.altair.com/course/view.php?id=810&_gl=1*1rpezuc*_gcl_au*MjAzMDIwNjg5Ny4xNzQzNDI0MjQ5>`_ for an installation procedure.
+
+.. _sim-dsim-waveforms:
+
+Waveforms
+---------
+
+DSim can produce waveform traces in the VCD format.
+They can be viewed with GTKWave or with `Surfer <https://surfer-project.org/>`_.
+
+To enable VCD tracing, set :make:var:`WAVES` to ``1``.
+
+.. code-block:: bash
+
+    make SIM=dsim WAVES=1
+
+.. _sim-dsim-issues:
+
+Issues for this simulator
+-------------------------
+
+* `All issues with label category:simulators:dsim <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Adsim>`_
+
+.. versionadded:: 2.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,6 +57,7 @@ def simulator_support_matrix() -> List[Tuple[str, str, str]]:
     # Special-case simulators.
     special = [
         ("cvc", "verilog", "vpi"),
+        ("dsim", "verilog", "vpi"),
         ("ghdl", "vhdl", "vpi"),
         ("icarus", "verilog", "vpi"),
         ("nvc", "vhdl", "vhpi"),

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -116,6 +116,7 @@ def lib_name(interface: str, simulator: str) -> str:
         "activehdl",
         "cvc",
         "nvc",
+        "dsim",
     ]
     if simulator not in supported_sims:
         raise ValueError(

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -187,6 +187,12 @@ clean::
 	@$(RM) -rf xmsim.*
 	@$(RM) -rf gdb_cmd_xmsim
 
+# DSim
+clean::
+	@$(RM) -rf dsim.*
+	@$(RM) -rf metrics.db
+	@$(RM) -rf file.vcd
+
 else
     $(warning Including Makefile.inc from a user makefile is a no-op and deprecated. Remove the Makefile.inc inclusion from your makefile, and only leave the Makefile.sim include.)
 endif # COCOTB_MAKEFILE_INC_INCLUDED

--- a/src/cocotb_tools/makefiles/simulators/Makefile.dsim
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.dsim
@@ -1,0 +1,39 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+CMD_BIN := dsim
+
+ifdef DSIM_BIN_DIR
+    CMD := $(shell :; command -v $(DSIM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+else
+    # auto-detect bin dir from system path
+    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+endif
+
+ifeq (, $(CMD))
+    $(error Unable to locate command >$(CMD_BIN)<)
+endif
+
+ifeq ($(WAVES), 1)
+    WAVE_ARG := -waves file.vcd
+else
+    WAVE_ARG :=
+endif
+
+TOPMODULE_ARG = -top $(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL)
+
+DSIM_ARGS = -work $(SIM_BUILD) -pli_lib $(shell cocotb-config --lib-name-path vpi dsim) +acc+rwcbfsWF
+COMP_ARGS = $(DSIM_ARGS) -genimage image -timescale $(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)
+RUN_ARGS = $(DSIM_ARGS) -image image $(WAVE_ARG)
+
+$(SIM_BUILD)/image.so: $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS)
+	$(SIM_CMD_PREFIX) $(CMD) $(COMP_ARGS) $(TOPMODULE_ARG) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+
+$(COCOTB_RESULTS_FILE): $(SIM_BUILD)/image.so $(CUSTOM_SIM_DEPS)
+	$(RM) $(COCOTB_RESULTS_FILE)
+	COCOTB_TEST_MODULES=$(call deprecate,MODULE,COCOTB_TEST_MODULES) COCOTB_TESTCASE=$(call deprecate,TESTCASE,COCOTB_TESTCASE) COCOTB_TEST_FILTER=$(COCOTB_TEST_FILTER) COCOTB_TOPLEVEL=$(call deprecate,TOPLEVEL,COCOTB_TOPLEVEL) \
+	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
+	$(SIM_CMD_PREFIX) $(CMD) $(RUN_ARGS) $(TOPMODULE_ARG) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+
+	$(call check_results)


### PR DESCRIPTION
Support DSim in the Makefile flow, with split compile and run phases and with wave generation support.

Closes #3990