### PR TITLE
Fix ResourceWarnings from being emitted by Tasks which are scheduled but never resumed

### DIFF
--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -345,18 +345,13 @@ class Task(Generic[ResultType]):
         self._cancelled_msg = msg
         self._must_cancel = True
 
-        if self._state is _TaskState.UNSTARTED:
-            self._coro.close()
-            # must fail immediately
-            self._set_outcome(Error(self._cancelled_error), _TaskState.CANCELLED)
-
-        elif self._state is _TaskState.PENDING:
+        if self._state is _TaskState.PENDING:
             # unprime triggers if pending
             cocotb._scheduler_inst._unschedule(self)
             # schedule wakeup to throw CancelledError
             cocotb._scheduler_inst._schedule_task_internal(self)
 
-        elif self._state is _TaskState.RUNNING:
+        elif self._state in (_TaskState.RUNNING, _TaskState.UNSTARTED):
             # Reschedule to throw CancelledError
             cocotb._scheduler_inst._schedule_task_internal(self)
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -250,14 +250,18 @@ class Task(Generic[ResultType]):
 
     def kill(self) -> None:
         """Kill a coroutine."""
-        if self.done():
-            return
 
-        if self._state is _TaskState.RUNNING:
-            raise RuntimeError("Can't kill currently running Task")
-        else:
-            # unschedule if scheduled and unprime triggers if pending
+        if self._state in (_TaskState.PENDING, _TaskState.SCHEDULED):
+            # Unschedule if scheduled and unprime triggers if pending.
             cocotb._scheduler_inst._unschedule(self)
+        elif self._state is _TaskState.UNSTARTED:
+            # Don't need to unschedule.
+            pass
+        elif self._state in (_TaskState.FINISHED, _TaskState.CANCELLED):
+            # Do nothing if already done.
+            return
+        else:
+            raise RuntimeError("Can't kill currently running Task")
 
         # Close native coroutines if they were never resumed to prevent ResourceWarnings.
         if (
@@ -339,22 +343,23 @@ class Task(Generic[ResultType]):
 
         Returns: ``True`` if the Task was cancelled; ``False`` otherwise.
         """
-        if self.done():
+        if self._state is _TaskState.PENDING:
+            # Unprime trigger if pending
+            cocotb._scheduler_inst._unschedule(self)
+            # Schedule wakeup to throw CancelledError
+            cocotb._scheduler_inst._schedule_task_internal(self)
+        elif self._state is _TaskState.SCHEDULED:
+            # Already scheduled, so we just hijack it to throw CancelledError
+            pass
+        elif self._state in (_TaskState.UNSTARTED, _TaskState.RUNNING):
+            # (Re)schedule to throw CancelledError
+            cocotb._scheduler_inst._schedule_task_internal(self)
+        else:
+            # Already finished or cancelled
             return False
 
         self._cancelled_msg = msg
         self._must_cancel = True
-
-        if self._state is _TaskState.PENDING:
-            # unprime triggers if pending
-            cocotb._scheduler_inst._unschedule(self)
-            # schedule wakeup to throw CancelledError
-            cocotb._scheduler_inst._schedule_task_internal(self)
-
-        elif self._state in (_TaskState.RUNNING, _TaskState.UNSTARTED):
-            # Reschedule to throw CancelledError
-            cocotb._scheduler_inst._schedule_task_internal(self)
-
         return True
 
     def cancelled(self) -> bool:


### PR DESCRIPTION
Closes #4572.

Follow on to #4583. I figured that `PYTHONWARNINGS` would elevate any ResourceWarnings, due to unawaited coroutines, to an error, but apparently they are special since they are emitted in `__del__`, so any exception is squashed. This *actually* fixes the issue.

Since `kill` requires the Task to be finished immediately and since we won't have `_has_resumed` after #4565 is merged. This uses `inspect.getcoroutinestate` in `kill`, so we are only paying for it when needed, to determine if we need to `close` the Task's coroutine.

asyncio doesn't bother with closing coroutines, `Task.cancel` scheduled unstarted coroutines to be resumed with the `CancelledError` which when `throw`n is not thrown by the coroutine and follows normal cancellation path.