### PR TITLE
fix support for verilator dumpfile

### DIFF
--- a/docs/source/newsfragments/4591.bugfix.rst
+++ b/docs/source/newsfragments/4591.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue with ``$dumpfile`` and ``$dumpvars`` not working on Verilator without also turning on global tracing.

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -109,8 +109,8 @@ int main(int argc, char** argv) {
     std::unique_ptr<VerilatedVcdC> tfp(new VerilatedVcdC);
 #endif
 
+    Verilated::traceEverOn(true);
     if (traceOn) {
-        Verilated::traceEverOn(true);
         top->trace(tfp.get(), 99);
         tfp->open(traceFile);
     }

--- a/tests/test_cases/test_dumpfile_verilator/Makefile
+++ b/tests/test_cases/test_dumpfile_verilator/Makefile
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Copyright (c) 2015 Potential Ventures Ltd
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+TOPLEVEL_LANG ?= verilog
+SIM ?= verilator
+EXTRA_ARGS += --trace
+
+ifneq ($(SIM),verilator)
+
+all:
+	@echo "Skipping test due to SIM=$(SIM) not being Verilator"
+clean::
+
+else
+
+VERILOG_SOURCES = $(PWD)/test_dumpfile_verilator.sv
+COCOTB_TOPLEVEL = test_dumpfile_verilator
+COCOTB_TEST_MODULES = test_dumpfile_verilator
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+endif

--- a/tests/test_cases/test_dumpfile_verilator/test_dumpfile_verilator.py
+++ b/tests/test_cases/test_dumpfile_verilator/test_dumpfile_verilator.py
@@ -1,0 +1,28 @@
+# Copyright cocotb contributors
+# Copyright (c) 2015, 2018 Potential Ventures Ltd
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from pathlib import Path
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles, Timer
+
+
+async def reset_dut(reset_n, duration_ns):
+    reset_n.value = 0
+    await Timer(duration_ns)
+    reset_n.value = 1
+    reset_n._log.debug("Reset complete")
+
+
+@cocotb.test()
+async def test_dumpfile_verilator(dut):
+    await reset_dut(dut.reset_n, 20)
+    cocotb.start_soon(Clock(dut.clk, 10, "ns").start())
+    await ClockCycles(dut.clk, 0xFF)
+
+    # check that the vcd file exists and that therefore the
+    # $dumfiles and $dumpargs are working
+    assert Path("waves.vcd").exists()

--- a/tests/test_cases/test_dumpfile_verilator/test_dumpfile_verilator.sv
+++ b/tests/test_cases/test_dumpfile_verilator/test_dumpfile_verilator.sv
@@ -1,0 +1,33 @@
+// Copyright cocotb contributors
+// Copyright (c) 2013 Potential Ventures Ltd
+// Copyright (c) 2013 SolarFlare Communications Inc
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/*
+Test the verilog dumpfile and dumpargs in combination with cocotb
+*/
+
+`timescale 1ns / 1ps
+
+module test_dumpfile_verilator (
+    input clk,
+    input reset_n
+);
+
+  reg [31:0] counter;
+
+  always_ff @(posedge clk) begin
+    if (!reset_n) begin
+      counter <= 32'h0;
+    end else begin
+      counter <= counter + 1;
+    end
+  end
+
+  initial begin
+    $dumpfile("waves.vcd");
+    $dumpvars(0, test_custom_vcd);
+  end
+
+endmodule


### PR DESCRIPTION
cocotb support logging to VCD and FST in verilator but I have specific requirements (and existing code) that uses the verilog $dumpfile and $dumpvars commands. 

The normal way to enable VCD logging is to use the compile and runtime flags to enable this e.g. call runner.build and runner.test with the waves=True argument. The suggestion is to build with waves support but run the test without this. This however produced an error %Error: Vtop.cpp:121: Turning on wave traces requires Verilated::traceEverOn(true) call before time 0. that this pull requests fixes.
