### PR TITLE
Fix Ctrl-C and `sys.exit()`

### DIFF
--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -16,6 +16,7 @@ the ReadOnly (and this is invalid, at least in Modelsim).
 import logging
 import os
 import threading
+from bdb import BdbQuit
 from collections import OrderedDict
 from typing import Any, Dict, Union
 
@@ -390,7 +391,7 @@ class Scheduler:
             # This function runs in the scheduler thread
             try:
                 _outcome = Value(await task)
-            except (KeyboardInterrupt, SystemExit):
+            except (KeyboardInterrupt, SystemExit, BdbQuit):
                 # Allow these to bubble up to the execution root to fail the sim immediately.
                 # This follows asyncio's behavior.
                 raise

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -158,6 +158,7 @@ class Test:
         self._main_task: Task[None]
         self._outcome: Union[None, Outcome[Any]] = None
         self._shutdown_errors: list[Outcome[Any]] = []
+        self._started: bool = False
         self._start_time: float
         self._start_sim_time: float
 
@@ -195,6 +196,8 @@ class Test:
         self._start_sim_time = get_sim_time("ns")
         self._start_time = time.time()
 
+        self._started = True
+
         cocotb._scheduler_inst._schedule_task_internal(self._main_task)
         cocotb._scheduler_inst._event_loop()
 
@@ -220,8 +223,12 @@ class Test:
         for task in self.tasks[:]:
             task._cancel_now()
 
-        self.wall_time = time.time() - self._start_time
-        self.sim_time_ns = get_sim_time("ns") - self._start_sim_time
+        if self._started:
+            self.wall_time = time.time() - self._start_time
+            self.sim_time_ns = get_sim_time("ns") - self._start_sim_time
+        else:
+            self.wall_time = 0
+            self.sim_time_ns = 0
         self._test_complete_cb()
 
     def add_task(self, task: Task[Any]) -> None:

--- a/src/cocotb/share/lib/fli/FliCbHdl.cpp
+++ b/src/cocotb/share/lib/fli/FliCbHdl.cpp
@@ -25,7 +25,10 @@ void handle_fli_callback(void* data) {
     }
     // LCOV_EXCL_STOP
 
-    cb_hdl->run();
+    if (cb_hdl->run()) {
+        // sim failed, so call shutdown
+        gpi_embed_end();
+    }
 
     gpi_to_simulator();
 }
@@ -45,13 +48,14 @@ int FliTimedCbHdl::arm() {
 }
 
 int FliTimedCbHdl::run() {
+    int res = 0;
     if (!m_removed) {
         // Prevent the callback from calling up if it's been removed.
-        m_cb_func(m_cb_data);
+        res = m_cb_func(m_cb_data);
     }
     // Don't delete, but release back to the appropriate cache to be reused.
     release();
-    return 0;
+    return res;
 }
 
 int FliTimedCbHdl::remove() {
@@ -85,8 +89,9 @@ int FliSignalCbHdl::run() {
         }
     }
 
+    int res = 0;
     if (pass) {
-        m_cb_func(m_cb_data);
+        res = m_cb_func(m_cb_data);
 
         // Don't delete, but desensitize the process from the signal change and
         // release back to the appropriate cache to be reused.
@@ -94,7 +99,7 @@ int FliSignalCbHdl::run() {
         release();
     }  // else don't remove and let it fire again.
 
-    return 0;
+    return res;
 }
 
 int FliSignalCbHdl::remove() {
@@ -112,13 +117,14 @@ int FliSimPhaseCbHdl::arm() {
 }
 
 int FliSimPhaseCbHdl::run() {
+    int res = 0;
     if (!m_removed) {
         // Prevent the callback from calling up if it's been removed.
-        m_cb_func(m_cb_data);
+        res = m_cb_func(m_cb_data);
     }
     // Don't delete, but release back to the appropriate cache to be reused.
     release();
-    return 0;
+    return res;
 }
 
 int FliSimPhaseCbHdl::remove() {
@@ -156,9 +162,9 @@ int FliStartupCbHdl::arm() {
 }
 
 int FliStartupCbHdl::run() {
-    m_cb_func(m_cb_data);
+    int res = m_cb_func(m_cb_data);
     delete this;
-    return 0;
+    return res;
 }
 
 int FliStartupCbHdl::remove() {
@@ -173,9 +179,9 @@ int FliShutdownCbHdl::arm() {
 }
 
 int FliShutdownCbHdl::run() {
-    m_cb_func(m_cb_data);
+    int res = m_cb_func(m_cb_data);
     delete this;
-    return 0;
+    return res;
 }
 
 int FliShutdownCbHdl::remove() {

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -98,12 +98,14 @@ int gpi_register_impl(GpiImplInterface *func_tbl) {
 bool gpi_has_registered_impl() { return registered_impls.size() > 0; }
 
 void gpi_embed_init(int argc, char const *const *argv) {
-    if (embed_sim_init(argc, argv)) gpi_embed_end();
+    if (embed_sim_init(argc, argv)) {
+        gpi_embed_end();
+    }
 }
 
 void gpi_embed_end() {
-    sim_ending = true;
     embed_sim_event("Simulator shut down prematurely");
+    gpi_sim_end();
 }
 
 void gpi_sim_end() {

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -182,9 +182,13 @@ int handle_gpi_callback(void *user_data) {
     // The best thing to do here is shutdown as any subsequent
     // calls will go back to Python which is now in an unknown state
     if (pValue == NULL) {
-        PyErr_Print();
-        gpi_sim_end();
-        return 0;
+        // Printing a SystemExit calls exit(1), which we don't want.
+        if (!PyErr_ExceptionMatches(PyExc_SystemExit)) {
+            PyErr_Print();
+        }
+        // Clear error so re-entering Python doesn't fail.
+        PyErr_Clear();
+        return -1;
     }
 
     // We don't care about the result

--- a/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -30,7 +30,10 @@ void handle_vhpi_callback(const vhpiCbDataT *cb_data) {
     }
     // LCOV_EXCL_STOP
 
-    cb_hdl->run();
+    if (cb_hdl->run()) {
+        // sim failed, so call shutdown
+        gpi_embed_end();
+    }
 
     gpi_to_simulator();
 }
@@ -466,10 +469,12 @@ int VhpiCbHdl::arm() {
 }
 
 int VhpiCbHdl::run() {
+    int res = 0;
+
     // LCOV_EXCL_START
     if (!m_removed) {
         // Only call up if not removed.
-        m_cb_func(m_cb_data);
+        res = m_cb_func(m_cb_data);
     }
     // LCOV_EXCL_STOP
 
@@ -489,7 +494,7 @@ int VhpiCbHdl::run() {
     else {
         delete this;
     }
-    return 0;
+    return res;
 }
 
 // Value related functions
@@ -894,8 +899,9 @@ int VhpiValueCbHdl::run() {
         }
     }
 
+    int res = 0;
     if (pass) {
-        m_cb_func(m_cb_data);
+        res = m_cb_func(m_cb_data);
 
         // Remove recurring callback once fired
         auto err = vhpi_remove_cb(get_handle<vhpiHandleT>());
@@ -914,7 +920,7 @@ int VhpiValueCbHdl::run() {
 
     }  // else Don't remove and let it fire again.
 
-    return 0;
+    return res;
 }
 
 VhpiStartupCbHdl::VhpiStartupCbHdl(GpiImplInterface *impl) : VhpiCbHdl(impl) {

--- a/src/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -126,11 +126,12 @@ class VhpiStartupCbHdl : public VhpiCbHdl {
     // don't try. TODO Is this still accurate?
 
     int run() override {
+        int res = 0;
         if (!m_removed) {
-            m_cb_func(m_cb_data);
+            res = m_cb_func(m_cb_data);
         }
         delete this;
-        return 0;
+        return res;
     }
 
     int remove() override {
@@ -147,11 +148,12 @@ class VhpiShutdownCbHdl : public VhpiCbHdl {
     // don't try. TODO Is this still accurate?
 
     int run() override {
+        int res = 0;
         if (!m_removed) {
-            m_cb_func(m_cb_data);
+            res = m_cb_func(m_cb_data);
         }
         delete this;
-        return 0;
+        return res;
     }
 
     int remove() override {

--- a/src/cocotb/share/lib/vpi/VpiImpl.h
+++ b/src/cocotb/share/lib/vpi/VpiImpl.h
@@ -125,11 +125,12 @@ class VpiStartupCbHdl : public VpiCbHdl {
     // don't try. TODO Is this still accurate?
 
     int run() override {
+        int res = 0;
         if (!m_removed) {
-            m_cb_func(m_cb_data);
+            res = m_cb_func(m_cb_data);
         }
         delete this;
-        return 0;
+        return res;
     }
 
     int remove() override {
@@ -146,11 +147,12 @@ class VpiShutdownCbHdl : public VpiCbHdl {
     // don't try. TODO Is this still accurate?
 
     int run() override {
+        int res = 0;
         if (!m_removed) {
-            m_cb_func(m_cb_data);
+            res = m_cb_func(m_cb_data);
         }
         delete this;
-        return 0;
+        return res;
     }
 
     int remove() override {

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -216,9 +216,10 @@ class Task(Generic[ResultType]):
             else:
                 self._set_outcome(outcome)
             return None
-        except (KeyboardInterrupt, SystemExit):
+        except (KeyboardInterrupt, SystemExit) as e:
             # Allow these to bubble up to the execution root to fail the sim immediately.
             # This follows asyncio's behavior.
+            self._set_outcome(Error(remove_traceback_frames(e, ["_advance"])))
             raise
         except CancelledError as e:
             self._set_outcome(

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -7,6 +7,7 @@ import logging
 import os
 import traceback
 from asyncio import CancelledError, InvalidStateError
+from bdb import BdbQuit
 from enum import auto
 from types import CoroutineType
 from typing import (
@@ -216,7 +217,7 @@ class Task(Generic[ResultType]):
             else:
                 self._set_outcome(outcome)
             return None
-        except (KeyboardInterrupt, SystemExit) as e:
+        except (KeyboardInterrupt, SystemExit, BdbQuit) as e:
             # Allow these to bubble up to the execution root to fail the sim immediately.
             # This follows asyncio's behavior.
             self._set_outcome(Error(remove_traceback_frames(e, ["_advance"])))

--- a/tests/test_cases/test_kill_sim/Makefile
+++ b/tests/test_cases/test_kill_sim/Makefile
@@ -8,8 +8,10 @@ COCOTB_TEST_MODULES := kill_sim_tests
 tests:
 	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_sys_exit
 	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_task_sys_exit
+	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_trigger_sys_exit
 	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_keyboard_interrupt
 	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_task_keyboard_interrupt
+	$(MAKE) test_kill_sim COCOTB_TEST_FILTER=test_trigger_keyboard_interrupt
 
 .PHONY: test_kill_sim
 test_kill_sim:

--- a/tests/test_cases/test_kill_sim/kill_sim_tests.py
+++ b/tests/test_cases/test_kill_sim/kill_sim_tests.py
@@ -5,6 +5,7 @@ import sys
 from typing import Any
 
 import cocotb
+from cocotb.triggers import Timer
 
 
 def make_failure_file() -> None:
@@ -22,17 +23,30 @@ async def test_sys_exit_sim_continued(_: Any) -> None:
     make_failure_file()
 
 
-@cocotb.test(_expect_sim_failure=True)
+@cocotb.test(expect_error=SystemExit)
 async def test_task_sys_exit(_: Any) -> None:
     async def coro():
         sys.exit(1)
 
-    await cocotb.start_soon(coro())
+    cocotb.start_soon(coro())
+    await Timer(1)
     make_failure_file()
 
 
 @cocotb.test(_expect_sim_failure=True)
 async def test_task_sys_exit_sim_continued(_: Any) -> None:
+    make_failure_file()
+
+
+@cocotb.test(expect_error=SystemExit)
+async def test_trigger_sys_exit(_: Any) -> None:
+    await Timer(1)
+    sys.exit(1)
+    make_failure_file()
+
+
+@cocotb.test(_expect_sim_failure=True)
+async def test_trigger_sys_exit_sim_continued(_: Any) -> None:
     make_failure_file()
 
 
@@ -47,15 +61,28 @@ async def test_keyboard_interrupt_sim_continued(_: Any) -> None:
     make_failure_file()
 
 
-@cocotb.test(_expect_sim_failure=True)
+@cocotb.test(expect_error=KeyboardInterrupt)
 async def test_task_keyboard_interrupt(_: Any) -> None:
     async def coro():
         raise KeyboardInterrupt  # Analogous to Ctrl-C
 
-    await cocotb.start_soon(coro())
+    cocotb.start_soon(coro())
+    await Timer(1)
     make_failure_file()
 
 
 @cocotb.test(_expect_sim_failure=True)
 async def test_task_keyboard_interrupt_sim_continued(_: Any) -> None:
+    make_failure_file()
+
+
+@cocotb.test(expect_error=KeyboardInterrupt)
+async def test_trigger_keyboard_interrupt(_: Any) -> None:
+    await Timer(1)
+    raise KeyboardInterrupt  # Analogous to Ctrl-C
+    make_failure_file()
+
+
+@cocotb.test(_expect_sim_failure=True)
+async def test_trigger_keyboard_interrupt_sim_continued(_: Any) -> None:
     make_failure_file()

--- a/tests/test_cases/test_kill_sim/kill_sim_tests.py
+++ b/tests/test_cases/test_kill_sim/kill_sim_tests.py
@@ -11,7 +11,7 @@ def make_failure_file() -> None:
     open("test_failed", "w").close()
 
 
-@cocotb.test(_expect_sim_failure=True)
+@cocotb.test(expect_error=SystemExit)
 async def test_sys_exit(_: Any) -> None:
     sys.exit(1)
     make_failure_file()
@@ -36,7 +36,7 @@ async def test_task_sys_exit_sim_continued(_: Any) -> None:
     make_failure_file()
 
 
-@cocotb.test(_expect_sim_failure=True)
+@cocotb.test(expect_error=KeyboardInterrupt)
 async def test_keyboard_interrupt(_: Any) -> None:
     raise KeyboardInterrupt  # Analogous to Ctrl-C
     make_failure_file()


### PR DESCRIPTION
Closes #4563. Basically we catch `SystemExit` in C and don't print it so `exit()` is never called. Also cleans up a couple other issues seen in the test_kill_sim tests.

### TODO
- [x] ~~newsfrags~~ Not needed as this bug wasn't present in 1.9.
- [x] add a test for doing `sys.exit` and `Ctrl-C` after a GPI trigger fires to hit the missing lines in `simulatormodule.cpp`