### PR TITLE
Store exception info on failure

### DIFF
--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -656,9 +656,7 @@ class RegressionManager:
             sim_time_ns=repr(sim_time_ns),
             ratio_time=repr(ratio_time),
         )
-        self.xunit.add_failure(
-            message=f"Test failed with RANDOM_SEED={cocotb._random_seed}"
-        )
+        self.xunit.add_failure(error_type=type(result).__name__, error_msg=str(result))
 
         # update running passed/failed/skipped counts
         self.failures += 1


### PR DESCRIPTION
This stores the exception type and message in the xml results, rather than a message with the seed. The seed is already stored once in the xml, and this makes more sense since it's set once at the beginning of running all the tests.