### PR TITLE
verilator no-trace error

### DIFF
--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -65,7 +65,9 @@ int main(int argc, char** argv) {
         if (arg == "--trace") {
             traceOn = true;
 #ifndef VM_TRACE
-            fprintf(stderr, "Error: --trace requires the design to be built with trace support\n");
+            fprintf(stderr,
+                    "Error: --trace requires the design to be built with trace "
+                    "support\n");
             return -1;
 #endif
         } else if (arg == "--trace-file") {

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -64,6 +64,10 @@ int main(int argc, char** argv) {
         std::string arg = std::string(argv[i]);
         if (arg == "--trace") {
             traceOn = true;
+#ifndef VM_TRACE
+            fprintf(stderr, "Error: design not built with trace support\n");
+            return -1;
+#endif
         } else if (arg == "--trace-file") {
             if (++i < argc) {
                 traceFile = argv[i];

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
         if (arg == "--trace") {
             traceOn = true;
 #ifndef VM_TRACE
-            fprintf(stderr, "Error: design not built with trace support\n");
+            fprintf(stderr, "Error: --trace requires the design to be built with trace support\n");
             return -1;
 #endif
         } else if (arg == "--trace-file") {


### PR DESCRIPTION
Tosses an error if the user attempts to generate trace data with a no-trace Verilator build.