### PR TITLE
Refactor X resolution

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -170,21 +170,26 @@ Cocotb
     Defines how to resolve bits with a value of ``X``, ``Z``, ``U``, ``W``, or ``-`` when being converted to integer.
     Valid settings are:
 
-    ``VALUE_ERROR``
-       Raise a :exc:`ValueError` exception.
-    ``ZEROS``
-       Resolve to ``0``.
-    ``ONES``
-       Resolve to ``1``.
-    ``RANDOM``
-       Randomly resolve to a ``0`` or a ``1``.
+    ``error``
+        Resolves nothing.
+    ``weak``
+        Resolves ``L`` to ``0`` and ``H`` to ``1``.
+    ``zeros``
+        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values to ``0``.
+    ``ones``
+        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values to ``1``.
+    ``random``
+        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values randomly to either ``0`` or ``1``.
 
-    Set to ``VALUE_ERROR`` by default.
+    There is also a slight difference in behavior of ``bool(logic)`` when this environment variable is set.
+    When this variable is set, ``bool(logic)`` treats all non-\ ``0``\ /\ ``1`` values as equivalent to ``0``.
+    When this variable is *not* set, ``bool(logic)`` will fail on non-\ ``0``\ /\ ``1`` values.
 
     .. warning::
+        Using this feature is *not* recommended.
 
-        This exists for backwards-compatability reasons.
-        Using any value besides ``VALUE_ERROR`` is *not* recommended.
+    .. deprecated:: 2.0
+        The previously accepted values ``VALUE_ERROR``, ``ZEROS``, ``ONES``, and ``RANDOM`` are deprecated.
 
 .. envvar:: LIBPYTHON_LOC
 

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -137,11 +137,6 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
     :members:
     :inherited-members:
 
-.. autoclass:: cocotb.types.logic_array.ResolveX
-
-.. autodata:: cocotb.types.logic_array.RESOLVE_X
-
-
 .. _triggers::
 
 Triggers

--- a/docs/source/newsfragments/4622.feature.1.rst
+++ b/docs/source/newsfragments/4622.feature.1.rst
@@ -1,0 +1,1 @@
+Added :meth:`.Logic.resolve` and :meth:`.LogicArray.resolve` to resolve non-``0``/``1`` values on demand.

--- a/docs/source/newsfragments/4622.feature.rst
+++ b/docs/source/newsfragments/4622.feature.rst
@@ -1,0 +1,1 @@
+:class:`.LogicArray` now supports :class:`bool` casts and usage in conditionals (e.g. ``if dut.data.value: ...``).

--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -12,7 +12,11 @@ import sys
 from contextlib import AbstractContextManager
 from typing import TypeVar, Union, overload
 
-__all__ = ("StrEnum", "cached_property", "insertion_ordered_dict", "nullcontext")
+__all__ = (
+    "cached_property",
+    "insertion_ordered_dict",
+    "nullcontext",
+)
 
 T = TypeVar("T")
 
@@ -101,13 +105,3 @@ else:
             res = self._method(instance)
             instance.__dict__[self._method.__name__] = res
             return res
-
-
-# inheriting from (str, Enum) was broken in 3.11 and StrEnum must be used
-if sys.version_info >= (3, 11):
-    from enum import StrEnum
-else:
-    from enum import Enum
-
-    class StrEnum(str, Enum):
-        pass

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -27,8 +27,6 @@ from typing import (
     overload,
 )
 
-from cocotb._py_compat import StrEnum
-
 
 @lru_cache(maxsize=None)
 def want_color_output() -> bool:
@@ -199,20 +197,6 @@ class DocIntEnum(IntEnum):
 
     def __new__(cls: Type[IntEnumT], value: int, doc: Optional[str] = None) -> IntEnumT:
         self = int.__new__(cls, value)
-        self._value_ = value
-        if doc is not None:
-            self.__doc__ = doc
-        return self
-
-
-StrEnumT = TypeVar("StrEnumT", bound=StrEnum)
-
-
-class DocStrEnum(StrEnum):
-    """Like DocEnum but for StrEnum enum types."""
-
-    def __new__(cls: Type[StrEnumT], value: str, doc: Optional[str] = None) -> StrEnumT:
-        self = str.__new__(cls, value)
         self._value_ = value
         if doc is not None:
             self.__doc__ = doc

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -88,32 +88,35 @@ _resolve_tables = {
 
 
 class LogicArray(AbstractArray[Logic]):
-    r"""Fixed-sized, arbitrarily-indexed, array of :class:`cocotb.types.Logic`.
+    r"""Fixed-sized, arbitrarily-indexed, Array of Logics.
 
     .. currentmodule:: cocotb.types
 
-    :class:`LogicArray`\ s can be constructed from iterables of values
-    constructible into :class:`Logic` like :class:`bool`, :class:`str`, :class:`int`,
-    or it can be constructed :class:`str` or :class:`int` literals syntaxes, as seen below.
+    An :class:`Array`, where all elements are enforced to be :class:`Logic`.
+    This allows the additional of bit-wise logical operators, conversions to integers and bytes, and ``X`` testing and mapping.
 
-    Like :class:`Array`, if *range* is not given, the range ``Range(len(value)-1, "downto", 0)`` is used.
-    If an :class:`int` is passed for *range*, the range ``Range(range-1, "downto", 0)`` is used.
+    :class:`!LogicArray`\ s can be constructed from an iterable of :class:`!Logic`\ s,
+    or values constructible into :class:`!Logic`, like :class:`bool`, :class:`str`, or :class:`int`.
+    Alternatively, they can be constructed from :class:`!str` or :class:`!int` literals.
+
+    Like :class:`Array`, if *range* is not given, the range ``Range(len(value)-1, "downto", 0)`` is used;
+    and if an :class:`int` is passed for *range*, the range ``Range(range-1, "downto", 0)`` is used.
 
     .. code-block:: pycon3
 
         >>> LogicArray(0b0111, 4)
         LogicArray('0111', Range(3, 'downto', 0))
 
-        >>> LogicArray("01XZ")
-        LogicArray('01XZ', Range(3, 'downto', 0))
+        >>> LogicArray("01XZ", Range(0, "to", 3))
+        LogicArray('01XZ', Range(0, 'to', 3))
 
-        >>> LogicArray([0, True, "X"])
-        LogicArray('01X', Range(2, 'downto', 0))
+        >>> LogicArray([0, True, "X", Logic("-")])
+        LogicArray('01X-', Range(3, 'downto', 0))
 
     .. note::
-        If constructing from an unsigned :class:`int` literal, *range* `must` be given.
+        If constructing from an unsigned :class:`!int` literal, *range* `must` be given.
 
-    :class:`LogicArray`\ s can be constructed from :class:`int`\ s using :meth:`from_unsigned` or :meth:`from_signed`.
+    :class:`!LogicArray`\ s can be constructed from :class:`int`\ s using :meth:`from_unsigned` or :meth:`from_signed`.
 
     .. code-block:: pycon3
 
@@ -123,7 +126,7 @@ class LogicArray(AbstractArray[Logic]):
         >>> LogicArray.from_signed(-4, Range(0, "to", 3))  # will sign-extend
         LogicArray('1100', Range(0, 'to', 3))
 
-    :class:`LogicArray`\ s can be constructed from :class:`bytes` or :class:`bytearray` using :meth:`from_bytes`.
+    :class:`!LogicArray`\ s can be constructed from :class:`bytes` or :class:`bytearray` using :meth:`from_bytes`.
     Use the *byteorder* argument to control endianness.
 
     .. code-block:: pycon3
@@ -134,87 +137,90 @@ class LogicArray(AbstractArray[Logic]):
         >>> LogicArray.from_bytes(b"1n", byteorder="little")
         LogicArray('0110111000110001', Range(15, 'downto', 0))
 
-    :class:`LogicArray`\ s support the same :class:`list`-like operations as :class:`Array`;
-    however, it enforces the condition that all elements must be a :class:`Logic`.
+    :class:`!LogicArray`\ s support the same :class:`list`-like operations as :class:`Array`;
+    however, it enforces the condition that all elements must be a :class:`!Logic`.
 
     .. code-block:: pycon3
 
-        >>> la = LogicArray("1010")
-        >>> la[0]  # is indexable
+        >>> array = LogicArray("1010")
+        >>> array[0]  # is indexable
         Logic('0')
 
-        >>> la[1:]  # is slice-able
+        >>> array[1:]  # is slice-able
         LogicArray('10', Range(1, 'downto', 0))
 
-        >>> Logic("0") in la  # is a collection
+        >>> Logic("0") in array  # is a collection
         True
 
-        >>> list(la)  # is an iterable
+        >>> list(array)  # is an iterable
         [Logic('1'), Logic('0'), Logic('1'), Logic('0')]
 
-    When setting an element or slice, the *value* is first constructed into a
-    :class:`Logic`.
+    When setting an element or slice, the *value* is first constructed into a :class:`Logic`.
 
     .. code-block:: pycon3
 
-        >>> la = LogicArray("1010")
-        >>> la[3] = "Z"
-        >>> la[3]
+        >>> array = LogicArray("1010")
+        >>> array[3] = "Z"
+        >>> array[3]
         Logic('Z')
 
-        >>> la[2:] = ["X", True, 0]
-        >>> la
+        >>> array[2:] = ["X", True, 0]
+        >>> array
         LogicArray('ZX10', Range(3, 'downto', 0))
 
-        >>> la[:] = 0b0101
-        >>> la
+        >>> array[:] = 0b0101
+        >>> array
         LogicArray('0101', Range(3, 'downto', 0))
 
-    :class:`LogicArray`\ s can be converted into their :class:`str` or :class:`int` literal values using casts.
+    :class:`!LogicArray`\ s can be converted into their :class:`str` or :class:`int` literal values using casts.
 
     .. code-block:: pycon3
 
-        >>> la = LogicArray("1010")
-        >>> str(la)
+        >>> value = LogicArray("1010")
+        >>> str(value)
         '1010'
-        >>> int(la)
+
+        >>> int(value)
         10
 
     .. warning::
-        The :class:`int` cast assumes the value is entirely ``0`` or ``1`` and will raise an exception otherwise.
+        The :class:`int` cast and :class:`bool` cast assumes the
+        value is entirely ``0``, ``1``, ``L``, or ``H``, and will raise an exception otherwise.
 
     The :meth:`to_unsigned`, :meth:`to_signed`, and :meth:`to_bytes` methods can be used to convert
     the value into an unsigned or signed integer, or bytes, respectively.
 
     .. code-block:: pycon3
 
-        >>> la.to_unsigned()
+        >>> value = LogicArray("1010")
+        >>> value.to_unsigned()
         10
 
-        >>> la.to_signed()
+        >>> value.to_signed()
         -6
 
-        >>> la.to_bytes(byteorder="big")
+        >>> value.to_bytes(byteorder="big")
         b'\n'
 
     .. warning::
-        These operations assume the value is entirely ``0`` or ``1`` and will raise an exception otherwise.
+        These operations assume the value is entirely ``0``, ``1``, ``L``, or ``H``, and will raise an exception otherwise.
 
     You can also convert :class:`LogicArray`\ s to hexadecimal or binary strings using
     the built-ins :func:`hex:` and :func:`bin`, respectively.
 
     .. code-block:: pycon3
 
-        >>> la = LogicArray("01111010")
-        >>> hex(la)
+        >>> value = LogicArray("01111010")
+        >>> hex(value)
         '0x7a'
-        >>> bin(la)
+
+        >>> bin(value)
         '0b1111010'
 
     .. warning::
         Using :func:`hex` or :func:`bin` first turns the LogicArray into an :class:`int`.
         This means the exact length of the LogicArray is lost.
-        It also means that these expressions will raise an exception if the value is not entirely ``0`` or ``1``.
+        It also means that these expressions will raise an exception if the value is not entirely ``0``, ``1``, ``L``, or ``H``.
 
     :class:`LogicArray`\ s also support element-wise logical operations: ``&``, ``|``,
     ``^``, and ``~``.
@@ -225,10 +231,10 @@ class LogicArray(AbstractArray[Logic]):
         ...     s = LogicArray([sel] * len(a))
         ...     return (a & ~s) | (b & s)
 
-        >>> la = LogicArray("0110")
-        >>> p = LogicArray("1110")
+        >>> a = LogicArray("0110")
+        >>> b = LogicArray("1110")
         >>> sel = Logic("1")  # choose second option
-        >>> big_mux(la, p, sel)
+        >>> big_mux(a, b, sel)
         LogicArray('1110', Range(3, 'downto', 0))
 
     Args:

--- a/src/cocotb/types/_resolve.py
+++ b/src/cocotb/types/_resolve.py
@@ -1,0 +1,79 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+import os
+import sys
+from functools import lru_cache
+from random import getrandbits
+from typing import Callable, Dict, Union
+
+if sys.version_info >= (3, 10):
+    from typing import Final, Literal, TypeAlias  # noqa: F401  # used in type strings
+
+
+ResolverLiteral: "TypeAlias" = "Literal['weak', 'zeros', 'ones', 'random']"
+
+
+_ord_0 = ord("0")
+
+
+class _random_resolve_table(Dict[int, int]):
+    def __init__(self) -> None:
+        self[ord("0")] = ord("0")
+        self[ord("1")] = ord("1")
+        self[ord("L")] = ord("0")
+        self[ord("H")] = ord("1")
+
+    def __missing__(self, _: str) -> int:
+        return getrandbits(1) + _ord_0
+
+
+_resolve_tables: Dict[str, Dict[int, int]] = {
+    "error": {},
+    "weak": str.maketrans("LHW", "01X"),
+    "zeros": str.maketrans("LHUXZW-", "0100000"),
+    "ones": str.maketrans("LHUXZW-", "0111111"),
+    "random": _random_resolve_table(),
+}
+
+_VALID_RESOLVERS = ("error", "weak", "zeros", "ones", "random")
+_VALID_RESOLVERS_ERR_MSG = (
+    "Valid values are 'error', 'weak', 'zeros', 'ones', or 'random'"
+)
+
+
+@lru_cache(maxsize=None)
+def get_str_resolver(resolver: ResolverLiteral) -> Callable[[str], str]:
+    if resolver not in _VALID_RESOLVERS:
+        raise ValueError(f"Invalid resolver: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}")
+
+    resolve_table = _resolve_tables[resolver]
+
+    def resolve_func(value: str) -> str:
+        return value.translate(resolve_table)
+
+    return resolve_func
+
+
+def _init() -> Union[Callable[[str], str], None]:
+    _envvar = os.getenv("COCOTB_RESOLVE_X", None)
+
+    # no resolver
+    if _envvar is None:
+        return None
+
+    # backwards compatibility
+    resolver = _envvar.strip().lower()
+    if resolver == "value_error":
+        resolver = "error"
+
+    # get resolver
+    try:
+        return get_str_resolver(resolver)
+    except ValueError:
+        raise ValueError(
+            f"Invalid COCOTB_RESOLVE_X value: {_envvar!r}. {_VALID_RESOLVERS_ERR_MSG}"
+        ) from None
+
+
+RESOLVE_X: "Final" = _init()

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -162,3 +162,24 @@ def test_logic_identity():
     assert Logic("1") is Logic(1)
     assert Logic("X") is Logic("x")
     assert Logic("z") is Logic("Z")
+
+
+def test_resolve():
+    for inp, exp in zip("UX01ZWLH-", "UX01ZX01-"):
+        assert Logic(inp).resolve("weak") == Logic(exp)
+
+    for inp, exp in zip("UX01ZWLH-", "000100010"):
+        assert Logic(inp).resolve("zeros") == Logic(exp)
+
+    for inp, exp in zip("UX01ZWLH-", "110111011"):
+        assert Logic(inp).resolve("ones") == Logic(exp)
+
+    assert Logic("U").resolve("random") in (Logic("0"), Logic("1"))
+    assert Logic("X").resolve("random") in (Logic("0"), Logic("1"))
+    assert Logic("0").resolve("random") == Logic("0")
+    assert Logic("1").resolve("random") == Logic("1")
+    assert Logic("Z").resolve("random") in (Logic("0"), Logic("1"))
+    assert Logic("W").resolve("random") in (Logic("0"), Logic("1"))
+    assert Logic("L").resolve("random") == Logic("0")
+    assert Logic("H").resolve("random") == Logic("1")
+    assert Logic("-").resolve("random") in (Logic("0"), Logic("1"))

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -1,7 +1,6 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-import warnings
 
 import pytest
 
@@ -404,53 +403,16 @@ def test_null_vector():
 
 
 def test_bool_cast():
-    with pytest.warns(DeprecationWarning):
-        assert LogicArray("0110")
-    with warnings.catch_warnings():
-        warnings.filterwarnings(action="ignore", category=DeprecationWarning)
-        assert not LogicArray("0000")
-        assert LogicArray("01XZ")
-        assert LogicArray("XZ01")
-
-
-def test_resolve_x():
-    a = LogicArray("UX01ZWLH-")
-
+    assert not LogicArray("0000")
+    assert LogicArray("0100")
     with pytest.raises(ValueError):
-        a.to_unsigned("error")
-    with pytest.raises(ValueError):
-        a.to_signed("error")
-    assert LogicArray("01LH").to_unsigned("error") == 0b0101
-
-    assert a.to_unsigned("ones") == 0b110111011
-
-    assert a.to_unsigned("zeros") == 0b000100010
-
-    rand_val = a.to_unsigned("random")
-    # check known bits only
-    assert (rand_val >> 1) & 1 == 1
-    assert (rand_val >> 2) & 1 == 0
-    assert (rand_val >> 5) & 1 == 1
-    assert (rand_val >> 6) & 1 == 0
+        bool(LogicArray("XZ01"))
 
 
-def test_resolve_default_behavior():
-    import cocotb.types._logic_array
-
-    a = LogicArray("01X")
-
-    cocotb.types._logic_array.RESOLVE_X = "error"
-    with pytest.raises(ValueError):
-        a.to_unsigned()
-
-    cocotb.types._logic_array.RESOLVE_X = "zeros"
-    assert a.to_unsigned() == 0b010
-
-    cocotb.types._logic_array.RESOLVE_X = "ones"
-    assert a.to_unsigned() == 0b011
-
-    cocotb.types._logic_array.RESOLVE_X = "random"
-    rand_val = a.to_unsigned()
-    # check known bits only
-    assert (rand_val >> 1) & 1 == 1
-    assert (rand_val >> 2) & 1 == 0
+def test_resolve():
+    assert LogicArray("UX01ZWLH-").resolve("weak") == LogicArray("UX01ZX01-")
+    assert LogicArray("UX01ZWLH-").resolve("zeros") == LogicArray("000100010")
+    assert LogicArray("UX01ZWLH-").resolve("ones") == LogicArray("110111011")
+    assert LogicArray("01LH").resolve("random") == LogicArray("0101")
+    array = LogicArray("UXZW-").resolve("random")
+    assert all(elem in (Logic("0"), Logic("1")) for elem in array)


### PR DESCRIPTION
Depends upon #4592.

Rather than putting X resolving on Logic and LogicArray and tied to the
integer cast, a new `resolve()` function was added which takes a Logic
or LogicArray, maps the Xs, and returns a copy. This can be used in more
contexts than just for integer conversion.

This functionality was also used to implement a new way to support
COCOTB_RESOLVE_X that isn't strictly backwards compatible, but it
shouldn't be problematic. That being to resolve Xs as soon as the value
is gotten from the handle. This means that COCOTB_RESOLVE_X can be set
*and* X values can still be used properly with any instance of Logic or
LogicArray, when previously all instance were subject to the resolution
function.

To control handles X resolution, not only does COCOTB_RESOLVE_X still
work, but `cocotb.handle.set_resolve_x` allows the user to change it at
test time.

Additionally:
* Changes `if TYPE_CHECKING` blocks to be `sys.version_info` guarded blocks so Sphinx can correctly link functionality included in those conditional blocks (closes #4619).
* Removes some dead code from `cocotb.utils` after the refactor.
* Un-deprecates `LogicArray.__bool__` as the semantics are now self-consistent. The previous 2.0 development behavior can be achieved by using `COCOTB_RESOLVE_X=ZEROS`.

### TODO
- [x] newsfrag add `set_resolve_x()`
- [x] newsfrag `resolve()`
- [x] newsfrag change in `COCOTB_RESOLVE_X` behavior
- [x] cleanup any newsfrag of deprecated `LogicArray.__bool__`.