### PR TITLE
Rename `cocotb.pass_test` to `cocotb.fpass`

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -396,7 +396,7 @@ Miscellaneous
 Test Control
 ------------
 
-.. autofunction:: cocotb.pass_test
+.. autofunction:: cocotb.fpass
 
 Other Runtime Information
 -------------------------

--- a/docs/source/newsfragments/4477.feature.rst
+++ b/docs/source/newsfragments/4477.feature.rst
@@ -1,1 +1,1 @@
-:func:`cocotb.pass_test` was introduced to immediately end a test with a passing outcome.
+:func:`cocotb.fpass` was introduced to immediately end a test with a passing outcome.

--- a/docs/source/newsfragments/4477.removal.rst
+++ b/docs/source/newsfragments/4477.removal.rst
@@ -1,1 +1,1 @@
-``cocotb.result.TestSuccess`` was removed. Use :func:`cocotb.pass_test` instead.
+``cocotb.result.TestSuccess`` was removed. Use :func:`cocotb.fpass` instead.

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -383,7 +383,7 @@ For example, see the below output for the first test from above.
 
 
 If a test coroutine completes without `failing` or `erroring`,
-or if the test coroutine or any running :class:`~cocotb.task.Task` calls :func:`~cocotb.pass_test`,
+or if the test coroutine or any running :class:`~cocotb.task.Task` calls :func:`~cocotb.fpass`,
 the test is considered to have `passed`.
 Below are examples of `passing` tests.
 
@@ -395,13 +395,13 @@ Below are examples of `passing` tests.
 
     @cocotb.test()
     async def test(dut):
-        cocotb.pass_test("Reason")  # ends test with success early
+        cocotb.fpass("Reason")  # ends test with success early
         assert 1 > 2  # this would fail, but it isn't run because the test was ended early
 
     @cocotb.test()
     async def test(dut):
         async def ends_test_with_pass():
-            cocotb.pass_test("Reason")
+            cocotb.fpass("Reason")
         cocotb.start_soon(ends_test_with_pass())
         await Timer(10, 'ns')
 

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -18,7 +18,7 @@ from cocotb._decorators import (
     test,
 )
 from cocotb._scheduler import Scheduler
-from cocotb._test import create_task, pass_test, start, start_soon
+from cocotb._test import create_task, fpass, start, start_soon
 from cocotb.regression import RegressionManager
 
 from ._version import __version__
@@ -28,7 +28,7 @@ __all__ = (
     "resume",
     "test",
     "parametrize",
-    "pass_test",
+    "fpass",
     "create_task",
     "start",
     "start_soon",

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -47,7 +47,7 @@ class SimFailure(BaseException):
 
 
 class TestSuccess(BaseException):
-    """Implementation of :func:`pass_test`.
+    """Implementation of :func:`fpass`.
 
     Users are *not* intended to catch this exception type.
     """
@@ -359,7 +359,7 @@ def create_task(
         )
 
 
-def pass_test(msg: Union[str, None] = None) -> NoReturn:
+def fpass(msg: Union[str, None] = None) -> NoReturn:
     """Force a test to pass.
 
     The test will end and enter termination phase when this is called.

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -199,15 +199,15 @@ async def test_test_without_parenthesis_ran(dut):
 
 
 @cocotb.test
-async def test_pass_test_in_task(_) -> None:
+async def test_fpass_in_task(_) -> None:
     async def raise_test_success():
         await Timer(1, unit="ns")
-        cocotb.pass_test("Finished test early")
+        cocotb.fpass("Finished test early")
 
     cocotb.start_soon(raise_test_success())
     await Timer(10, unit="ns")
 
 
 @cocotb.test
-async def test_pass_test_in_test(_) -> None:
-    cocotb.pass_test("Finished test early")
+async def test_fpass_in_test(_) -> None:
+    cocotb.fpass("Finished test early")


### PR DESCRIPTION
I think the "test" in "pass_test" is redundant and doesn't signal this is a "forced" pass. We follow pytest's naming convention where it uses "xfail" instead of "expected_fail", so we use "fpass" instead of "force_pass".