### PR TITLE
Make `CancellationError` a `RuntimeError`

### DIFF
--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -41,14 +41,6 @@ ResultType = TypeVar("ResultType")
 _debug = "COCOTB_SCHEDULER_DEBUG" in os.environ
 
 
-class CancellationError(Exception):
-    """Result of a cancelled Task when cancellation exits abnormally."""
-
-    def __init__(self, msg: str, outcome: Outcome[Any]) -> None:
-        super().__init__(msg)
-        self.outcome = outcome
-
-
 class _TaskState(DocEnum):
     """State of a Task."""
 
@@ -207,9 +199,8 @@ class Task(Generic[ResultType]):
             if self._must_cancel:
                 self._set_outcome(
                     Error(
-                        CancellationError(
-                            "Task was cancelled, but exited normally. Did you forget to re-raise the CancelledError?",
-                            outcome,
+                        RuntimeError(
+                            "Task was cancelled, but exited normally. Did you forget to re-raise the CancelledError?"
                         )
                     )
                 )
@@ -232,9 +223,8 @@ class Task(Generic[ResultType]):
             if self._must_cancel:
                 self._set_outcome(
                     Error(
-                        CancellationError(
-                            "Task was cancelled, but continued running. Did you forget to re-raise the CancelledError?",
-                            Value(None),
+                        RuntimeError(
+                            "Task was cancelled, but continued running. Did you forget to re-raise the CancelledError?"
                         )
                     )
                 )

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -19,9 +19,8 @@ import pytest
 from common import MyException, assert_takes
 
 import cocotb
-import cocotb.utils
 from cocotb.clock import Clock
-from cocotb.task import CancellationError, Task
+from cocotb.task import Task
 from cocotb.triggers import (
     Combine,
     Event,
@@ -825,7 +824,7 @@ async def test_cancel_task(_: object) -> None:
     assert task.done()
 
 
-@cocotb.test(expect_error=CancellationError)
+@cocotb.test(expect_error=RuntimeError)
 async def test_cancel_task_cancellation_error(_: object) -> None:
     a = Event()
 
@@ -1001,7 +1000,7 @@ async def test_start_again_while_pending(_) -> None:
     await a
 
 
-@cocotb.test(expect_error=CancellationError)
+@cocotb.test(expect_error=RuntimeError)
 async def test_test_end_cancellation_error(_) -> None:
     """Test that test-end Cancellation causes test failure."""
 


### PR DESCRIPTION
Making it a custom type is not particularly useful, and this reduces the total API size. If we need to make it more specific we can do so later in a backwards-compatible way by inheriting from `RuntimeError`.