### PR TITLE
Add waves support for GHDL and NVC

### DIFF
--- a/docs/source/newsfragments/4630.bugfix.rst
+++ b/docs/source/newsfragments/4630.bugfix.rst
@@ -1,0 +1,1 @@
+Support ``waves`` argument to :meth:`Runner.build() <cocotb_tools.runner.Runner.build>` for GHDL and NVC.

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -896,7 +896,6 @@ class Ghdl(Runner):
 
     * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     * Does not support the ``gui`` argument to :meth:`.test`.
-    * Does not support the ``waves`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"vhdl": ["vpi"]}
@@ -1001,6 +1000,7 @@ class Ghdl(Runner):
             + ["--vpi=" + cocotb_tools.config.lib_name_path("vpi", "ghdl").as_posix()]
             + self.plusargs
             + self._get_parameter_options(self.parameters)
+            + ([f"--wave={self.hdl_toplevel}.ghw"] if self.waves else [])
         ]
 
         return cmds
@@ -1011,7 +1011,6 @@ class Nvc(Runner):
 
     * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     * Does not support the ``gui`` argument to :meth:`.test`.
-    * Does not support the ``waves`` argument to :meth:`.build` or :meth:`.test`.
     * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
@@ -1068,6 +1067,7 @@ class Nvc(Runner):
             + self.test_args
             + ["--load=" + cocotb_tools.config.lib_name_path("vhpi", "nvc").as_posix()]
             + self.plusargs
+            + ([f"--wave={self.hdl_toplevel}.fst"] if self.waves else [])
         ]
 
         return cmds

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -39,6 +39,7 @@ vhdl_gpi_interfaces = os.getenv("VHDL_GPI_INTERFACE", None)
 if hdl_toplevel_lang == "verilog":
     sources = [os.path.join(tests_dir, "designs", "sample_module", "sample_module.sv")]
     gpi_interfaces = ["vpi"]
+    sim = os.getenv("SIM", "icarus")
 else:
     sources = [
         os.path.join(
@@ -48,8 +49,7 @@ else:
         os.path.join(tests_dir, "designs", "sample_module", "sample_module.vhdl"),
     ]
     gpi_interfaces = [vhdl_gpi_interfaces]
-
-sim = os.getenv("SIM", "icarus")
+    sim = os.getenv("SIM", "nvc")
 compile_args = []
 sim_args = []
 if sim == "questa":

--- a/tests/pytest/test_logs.py
+++ b/tests/pytest/test_logs.py
@@ -26,7 +26,10 @@ from cocotb_tools.runner import get_runner
 
 sys.path.insert(0, str(Path(tests_dir) / "pytest"))
 test_module = Path(__file__).stem
-sim = os.getenv("SIM", "icarus")
+sim = os.getenv(
+    "SIM",
+    "icarus" if os.getenv("HDL_TOPLEVEL_LANG", "verilog") == "verilog" else "nvc",
+)
 
 
 @cocotb.test()

--- a/tests/pytest/test_plusargs.py
+++ b/tests/pytest/test_plusargs.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(test_module_path))
 def test_toplevel_library():
     hdl_toplevel_lang = os.getenv("HDL_TOPLEVEL_LANG", "verilog")
     vhdl_gpi_interfaces = os.getenv("VHDL_GPI_INTERFACE", None)
-    sim = os.getenv("SIM", "icarus")
+    sim = os.getenv("SIM", "icarus" if hdl_toplevel_lang == "verilog" else "nvc")
 
     runner = get_runner(sim)
 

--- a/tests/pytest/test_runner.py
+++ b/tests/pytest/test_runner.py
@@ -18,7 +18,10 @@ tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sim_build = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sim_build")
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
 
-sim = os.getenv("SIM", "icarus")
+sim = os.getenv(
+    "SIM",
+    "icarus" if os.getenv("HDL_TOPLEVEL_LANG", "verilog") == "verilog" else "nvc",
+)
 
 pre_cmd_sims = {
     "questa",
@@ -123,7 +126,10 @@ def test_missing_libpython(monkeypatch):
         hdl_sources = [os.path.join(tests_dir, "designs", "runner", "runner.vhdl")]
         gpi_interfaces = [os.getenv("VHDL_GPI_INTERFACE", None)]
 
-    sim_tool = os.getenv("SIM", "icarus")
+    sim_tool = os.getenv(
+        "SIM",
+        "icarus" if os.getenv("HDL_TOPLEVEL_LANG", "verilog") == "verilog" else "nvc",
+    )
     sim_runner = get_runner(sim_tool)
     sim_params = dict(
         WIDTH_IN="8",

--- a/tests/pytest/test_version.py
+++ b/tests/pytest/test_version.py
@@ -15,4 +15,6 @@ def test_version():
         rev = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"], universal_newlines=True
         ).strip()
-        assert parts[1] == rev
+        assert parts[1] == rev, (
+            "Installed cocotb version is not the same as your latest git version"
+        )

--- a/tests/pytest/test_vhdl_libraries_multiple.py
+++ b/tests/pytest/test_vhdl_libraries_multiple.py
@@ -43,7 +43,7 @@ def test_toplevel_library():
     for lib in ["e", "d", "c", "b"]:
         runner.build(
             hdl_library=f"{lib}lib",
-            vhdl_sources=[src_path / f"{lib}.vhdl"],
+            sources=[src_path / f"{lib}.vhdl"],
             build_args=compile_args,
             build_dir=str(src_path / "sim_build" / "pytest"),
         )
@@ -52,7 +52,7 @@ def test_toplevel_library():
     lib = "a"
     runner.build(
         hdl_library=f"{lib}lib",
-        vhdl_sources=[src_path / f"{lib}.vhdl"],
+        sources=[src_path / f"{lib}.vhdl"],
         hdl_toplevel="a",
         build_args=compile_args,
         build_dir=str(src_path / "sim_build" / "pytest"),

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -22,7 +22,10 @@ from cocotb_tools.runner import get_runner
 
 sys.path.insert(0, os.path.join(tests_dir, "pytest"))
 test_module = os.path.basename(os.path.splitext(__file__)[0])
-sim = os.getenv("SIM", "icarus")
+sim = os.getenv(
+    "SIM",
+    "icarus" if os.getenv("HDL_TOPLEVEL_LANG", "verilog") == "verilog" else "nvc",
+)
 
 
 @cocotb.test()
@@ -62,8 +65,8 @@ def run_simulation(sim, test_args=None):
 
 @pytest.mark.simulator_required
 @pytest.mark.skipif(
-    sim not in ["icarus", "verilator", "xcelium"],
-    reason="Skipping test because it is only for Icarus, Verilator or Xcelium simulators",
+    sim not in ["icarus", "verilator", "xcelium", "nvc", "ghdl"],
+    reason="Skipping test because it is only for Icarus, Verilator, Xcelium, NVC, and GHDL simulators",
 )
 def test_wave_dump():
     run_simulation(sim=sim)
@@ -73,6 +76,10 @@ def test_wave_dump():
         dumpfile_path = os.path.join(sim_build, "dump.vcd")
     elif sim == "xcelium":
         dumpfile_path = os.path.join(sim_build, "cocotb_waves.shm", "cocotb_waves.trn")
+    elif sim == "nvc":
+        dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.fst")
+    elif sim == "ghdl":
+        dumpfile_path = os.path.join(sim_build, f"{hdl_toplevel}.ghw")
     else:
         raise RuntimeError("Not a supported simulator")
     assert os.path.exists(dumpfile_path)
@@ -81,7 +88,7 @@ def test_wave_dump():
 @pytest.mark.simulator_required
 @pytest.mark.skipif(
     sim not in ["verilator"],
-    reason="Skipping test because it is only for Verilator simulators",
+    reason="Skipping test because it is only for the Verilator simulator",
 )
 def test_named_wave_dump():
     temp_dir = Path(tempfile.mkdtemp())


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
Also changed the tests so that it is enough to set `HDL_TOPLEVEL_LANG` to vhdl to be able to run all tests. Arbitrarily selected GHDL as the default VHDL simulator.

In addition, replaced the deprecated `vhdl_sources` argument name and clarified the assertion error that one can get if the installed version is different from the latest commit in git.