### PR TITLE
Added timescale flag to Verilator Runner

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1312,6 +1312,11 @@ class Verilator(Runner):
             ]
             + (["--trace"] if self.waves else [])
             + [arg for arg in self.build_args if type(arg) in (str, Verilog)]
+            + (
+                ["--timescale", "{}/{}".format(*self.timescale)]
+                if self.timescale is not None
+                else []
+            )
             + self._get_define_options(self.defines)
             + self._get_include_options(self.includes)
             + self._get_parameter_options(self.parameters)


### PR DESCRIPTION
Change made to Verilator(Runner) class to allow user to set timescale from the runner.build() method