### PR TITLE
Add gui option for GHDL, NVC, Verilator, Icarus and Dsim

### DIFF
--- a/docs/source/newsfragments/4635.feature.2.rst
+++ b/docs/source/newsfragments/4635.feature.2.rst
@@ -1,0 +1,1 @@
+The ``GUI`` and ``WAVES`` environment variables can be used to override the corresponding ``gui`` and ``waves`` arguments to pytest test benches. This means that they can be provided at run-time without modifying the test bench.

--- a/docs/source/newsfragments/4635.feature.rst
+++ b/docs/source/newsfragments/4635.feature.rst
@@ -1,0 +1,1 @@
+``gui`` is now supported for NVC, GHDL, Icarus, Verilator, and Dsim using an external waveform viewer, displaying the results after the simulation has ended. cocotb will start Surfer or GTKWave, in that order, if they are in the system path. Use ``COCOTB_WAVEFORM_VIEWER`` to specify viewer.

--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -65,7 +65,7 @@ add the ``-s`` option to the ``pytest`` call:
     in pytest's official documentation.
 
 Direct usage
-=============
+============
 
 You can also run the test directly, that is, without using pytest, like so
 
@@ -80,6 +80,39 @@ For example, add the following code at the end:
 
     if __name__ == "__main__":
         test_simple_dff_runner()
+
+Generate waveforms
+==================
+
+For many simulators it is possible to generate simulation waveforms.
+This can be done by setting the *waves* argument to True in the
+:meth:`Runner.build <cocotb_tools.runner.Runner.build>` and :meth:`Runner.test <cocotb_tools.runner.Runner.test>` functions.
+It is also possible to set the environment variable ``WAVES`` to
+a non-zero value to generate waveform files at run-time without modifying the test code, e.g.,
+
+.. code-block:: bash
+
+    WAVES=1 pytest examples/simple_dff/test_dff.py
+
+Similarly, it is possible to disable the waveform generation set in the test
+code by setting ``WAVES`` to 0.
+
+Starting in GUI mode/viewing waveforms
+======================================
+
+To start the simulator GUI or, for simulators not having a GUI, view
+the waveform file in a waveform viewer after the simulation, it is possible
+to set the *gui* argument to True in :meth:`Runner.test <cocotb_tools.runner.Runner.test>`.
+It is also possible to set the ``GUI`` environment variable to a non-zero value, e.g.,
+
+.. code-block:: bash
+
+    GUI=1 pytest examples/simple_dff/test_dff.py
+
+For simulators without a GUI, cocotb will open a waveform viewer. Either `Surfer <https://surfer-project.org/>`_
+or `GTKWave <https://gtkwave.github.io/gtkwave/>`, in that order, if available in the system path.
+To specify preferred waveform viewer, the ``COCOTB_WAVEFORM_VIEWER`` environment variable
+can be used. This can also be used to set, e.g., the ``surfer.sh`` startup script for WSL.
 
 API
 ===


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

Builds on #4630

Closes #4631

Opening to get feedback on design (third commit, until #4630 is merged) and if it may be possible to test it.

- [x] Add news fragment
- [x] Add documentation about the environment variable

Edit: this now allows passing WAVES and GUI using the corresponding environment variables. If this is a good idea (I think it is, they depend on the runs, not the tests), I should also:

- [x] Add documentation about this.