### PR TITLE
Unify title case for documentation

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -1,7 +1,7 @@
 .. _building:
 
 ***************************************
-Build options and Environment Variables
+Build Options and Environment Variables
 ***************************************
 
 Make System

--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -1,7 +1,7 @@
 .. _custom-flows:
 
 ******************************
-Extending existing build flows
+Extending Existing Build Flows
 ******************************
 
 In order to extend an existing build flow for use with cocotb,

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -1,5 +1,5 @@
 *************************
-Writing cocotb extensions
+Writing cocotb Extensions
 *************************
 
 This guide explains how to write cocotb extensions, with a focus on the conventions that should be followed.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 ##################################
-Welcome to cocotb's documentation!
+Welcome to cocotb's Documentation!
 ##################################
 
 ..


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
All other use full Title Case.