### PR TITLE
Timescale: add to Dsim, add not supported to Vcs, test more simulators

### DIFF
--- a/docs/source/newsfragments/4630.bugfix.rst
+++ b/docs/source/newsfragments/4630.bugfix.rst
@@ -1,1 +1,1 @@
-Support ``waves`` argument to :meth:`Runner.build() <cocotb_tools.runner.Runner.build>` for GHDL and NVC.
+Support ``waves`` argument to :meth:`Runner.test() <cocotb_tools.runner.Runner.test>` for GHDL and NVC.

--- a/docs/source/newsfragments/4645.bugfix.rst
+++ b/docs/source/newsfragments/4645.bugfix.rst
@@ -1,0 +1,1 @@
+Support ``timescale`` argument to :meth:`Runner.build() <cocotb_tools.runner.Runner.build>` and :meth:`Runner.test() <cocotb_tools.runner.Runner.test>` for DSim.

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1529,6 +1529,7 @@ class Vcs(Runner):
 
     * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     * Does not support VHDL.
+    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}
@@ -1650,6 +1651,8 @@ class Dsim(Runner):
         if self.waves:
             plusargs += ["-waves file.vcd"]
 
+        if self.timescale:
+            plusargs += ["-timescale {}/{}".format(*self.timescale)]
         if self.pre_cmd is not None:
             raise ValueError("WARNING: pre_cmd is not implemented for DSim.")
 

--- a/tests/pytest/test_timescale.py
+++ b/tests/pytest/test_timescale.py
@@ -32,8 +32,8 @@ async def check_timescale(dut):
 
 @pytest.mark.simulator_required
 @pytest.mark.skipif(
-    os.getenv("SIM", "icarus") not in ["icarus", "ghdl"],
-    reason="Currently only Icarus and GHDL support timescale setting when using Cocotb runner",
+    os.getenv("SIM", "icarus") not in ["icarus", "ghdl", "verilator", "dsim"],
+    reason="Currently only Icarus, GHDL, Verilator, and Dsim support timescale setting when using Cocotb runner",
 )
 @pytest.mark.parametrize("precision", ["fs", "ps", "ns", "us", "ms", "s"])
 def test_precision(precision):


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
I *think* that it is only required for test...

See https://help.metrics.ca/support/solutions/articles/154000141196 to confirm that it exists.
