### PR TITLE
Improve typing

### DIFF
--- a/examples/matrix_multiplier/tests/matrix_multiplier_tests.py
+++ b/examples/matrix_multiplier/tests/matrix_multiplier_tests.py
@@ -18,7 +18,6 @@ from typing import (
     Sequence,
     Tuple,
     TypeVar,
-    Union,
 )
 
 import cocotb
@@ -91,7 +90,7 @@ class DataValidMonitor(Generic[T]):
         self._datas = datas
         self._valid = valid
         self._callbacks: List[Callable[[Dict[str, T]], Any]] = []
-        self._task: Union[Task[None], None] = None
+        self._task: Optional[Task[None]] = None
 
     def add_callback(self, callback: Callable[[Dict], Any]) -> None:
         """Add callback to be called with transaction data when a transaction is observed."""
@@ -154,7 +153,7 @@ class DataValidDriver(Generic[T]):
         self._datas = datas
         self._valid = valid
         self._initial_values = initial_values
-        self._task: Union[Task[None], None] = None
+        self._task: Optional[Task[None]] = None
         self._mb = Mailbox[Tuple[Dict[str, T], Event]]()
 
     def send(self, data: Dict[str, T]) -> Trigger:

--- a/src/cocotb/_base_triggers.py
+++ b/src/cocotb/_base_triggers.py
@@ -17,7 +17,6 @@ from typing import (
     Generator,
     List,
     Optional,
-    Union,
 )
 
 from cocotb._deprecation import deprecated
@@ -142,7 +141,7 @@ class Event:
 
     def __init__(self, name: Optional[str] = None) -> None:
         self._pending_events: List[_Event] = []
-        self._name: Union[str, None] = None
+        self._name: Optional[str] = None
         if name is not None:
             self.name = name
         self._fired: bool = False
@@ -150,7 +149,7 @@ class Event:
 
     @property
     @deprecated("The name field will be removed in a future release.")
-    def name(self) -> Union[str, None]:
+    def name(self) -> Optional[str]:
         """Name of the Event.
 
         .. deprecated:: 2.0
@@ -160,7 +159,7 @@ class Event:
 
     @name.setter
     @deprecated("The name field will be removed in a future release.")
-    def name(self, new_name: Union[str, None]) -> None:
+    def name(self, new_name: Optional[str]) -> None:
         self._name = new_name
 
     @property

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -98,7 +98,7 @@ class Combine(_AggregateWaitable["Combine"]):
             waiters: List[Task[object]] = []
             completed: List[Task[Any]] = []
             done = _InternalEvent(self)
-            exception: Union[BaseException, None] = None
+            exception: Optional[BaseException] = None
 
             def on_done(
                 task: Task[object],
@@ -255,7 +255,7 @@ class ClockCycles(Waitable["ClockCycles"]):
             bool, Type[RisingEdge], Type[FallingEdge], Type[ValueChange], None
         ] = None,
         *,
-        rising: Union[bool, None] = None,
+        rising: Optional[bool] = None,
     ) -> None:
         self._signal = signal
         self._num_cycles = num_cycles

--- a/src/cocotb/_gpi_triggers.py
+++ b/src/cocotb/_gpi_triggers.py
@@ -367,7 +367,7 @@ class Edge(ValueChange):
 
 
 # The initializer is a lie, but a useful one. Perhaps one day this can be something like `StartupTrigger`.`
-_current_gpi_trigger = Timer(1, "step")  # type: Union[None, GPITrigger]
+_current_gpi_trigger: GPITrigger = Timer(1, "step")
 
 
 def current_gpi_trigger() -> GPITrigger:

--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -10,7 +10,7 @@ if they want to use these shims in their own code
 
 import sys
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Optional, TypeVar, Union, overload
 
 __all__ = ("nullcontext", "insertion_ordered_dict", "cached_property", "StrEnum")
 
@@ -45,7 +45,7 @@ class nullcontext(_NullContextBase[T]):
     def __init__(self: "nullcontext[T]", enter_result: T) -> None: ...
 
     def __init__(
-        self: "nullcontext[Union[T, None]]", enter_result: Union[T, None] = None
+        self: "nullcontext[Optional[T]]", enter_result: Optional[T] = None
     ) -> None:
         self.enter_result = enter_result
 
@@ -83,18 +83,18 @@ else:
 
         @overload
         def __get__(
-            self, instance: None, owner: Union[Type[Any], None] = None
+            self, instance: None, owner: Optional[Type[Any]] = None
         ) -> "cached_property[T_co]": ...
 
         @overload
         def __get__(
-            self, instance: object, owner: Union[Type[Any], None] = None
+            self, instance: object, owner: Optional[Type[Any]] = None
         ) -> T_co: ...
 
         def __get__(
             self,
-            instance: Union[object, None],
-            owner: Union[Type[Any], None] = None,
+            instance: Optional[object],
+            owner: Optional[Type[Any]] = None,
         ) -> Union["cached_property[T_co]", T_co]:
             if instance is None:
                 return self

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -52,7 +52,7 @@ class TestSuccess(BaseException):
     Users are *not* intended to catch this exception type.
     """
 
-    def __init__(self, msg: Union[str, None]) -> None:
+    def __init__(self, msg: Optional[str]) -> None:
         super().__init__(msg)
         self.msg = msg
 
@@ -366,7 +366,7 @@ def create_task(
         )
 
 
-def pass_test(msg: Union[str, None] = None) -> NoReturn:
+def pass_test(msg: Optional[str] = None) -> NoReturn:
     """Force a test to pass.
 
     The test will end and enter termination phase when this is called.

--- a/src/cocotb/_xunit_reporter.py
+++ b/src/cocotb/_xunit_reporter.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import xml.etree.ElementTree as ET
-from typing import Union
+from typing import Optional
 from xml.etree.ElementTree import Element, SubElement
 
 
@@ -22,7 +22,7 @@ class XUnitReporter:
         return self.last_testsuite
 
     def add_testcase(
-        self, testsuite: Union[Element, None] = None, **kwargs: str
+        self, testsuite: Optional[Element] = None, **kwargs: str
     ) -> Element:
         if testsuite is None:
             testsuite = self.last_testsuite
@@ -30,19 +30,19 @@ class XUnitReporter:
         return self.last_testcase
 
     def add_property(
-        self, testsuite: Union[Element, None] = None, **kwargs: str
+        self, testsuite: Optional[Element] = None, **kwargs: str
     ) -> Element:
         if testsuite is None:
             testsuite = self.last_testsuite
         self.last_property = SubElement(testsuite, "property", kwargs)
         return self.last_property
 
-    def add_failure(self, testcase: Union[Element, None] = None, **kwargs: str) -> None:
+    def add_failure(self, testcase: Optional[Element] = None, **kwargs: str) -> None:
         if testcase is None:
             testcase = self.last_testcase
         SubElement(testcase, "failure", kwargs)
 
-    def add_skipped(self, testcase: Union[Element, None] = None, **kwargs: str) -> None:
+    def add_skipped(self, testcase: Optional[Element] = None, **kwargs: str) -> None:
         if testcase is None:
             testcase = self.last_testcase
         SubElement(testcase, "skipped", kwargs)

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -10,7 +10,7 @@ import logging
 from decimal import Decimal
 from fractions import Fraction
 from logging import Logger
-from typing import TYPE_CHECKING, Type, Union
+from typing import TYPE_CHECKING, Optional, Type, Union
 
 import cocotb
 from cocotb._py_compat import cached_property
@@ -142,7 +142,7 @@ class Clock:
                 f"Invalid clock impl {impl!r}, must be one of: {valid_impls_str}"
             )
 
-        self._task: Union[Task[None], None] = None
+        self._task: Optional[Task[None]] = None
 
     @property
     def signal(self) -> LogicObject:

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -291,7 +291,7 @@ class _HierarchyObjectBase(SimHandleBase, Generic[KeyType]):
 
     def _get(
         self, key: KeyType, discovery_method: GPIDiscovery = GPIDiscovery.AUTO
-    ) -> Union[SimHandleBase, None]:
+    ) -> Optional[SimHandleBase]:
         """Query the simulator for an object with the specified *key*.
 
         Like Python's native dictionary ``get``-function, this returns ``None`` if the object
@@ -329,7 +329,7 @@ class _HierarchyObjectBase(SimHandleBase, Generic[KeyType]):
     @abstractmethod
     def _get_handle_by_key(
         self, key: KeyType, discovery_method: GPIDiscovery
-    ) -> Union[simulator.gpi_sim_hdl, None]:
+    ) -> Optional[simulator.gpi_sim_hdl]:
         """Get child object by key from the simulator.
 
         Args:
@@ -501,7 +501,7 @@ class HierarchyObject(_HierarchyObjectBase[str]):
 
     def _get_handle_by_key(
         self, key: str, discovery_method: GPIDiscovery
-    ) -> Union[simulator.gpi_sim_hdl, None]:
+    ) -> Optional[simulator.gpi_sim_hdl]:
         return self._handle.get_handle_by_name(key, discovery_method)
 
 
@@ -571,7 +571,7 @@ class HierarchyArrayObject(_HierarchyObjectBase[int], _RangeableObjectMixin):
 
     def _get_handle_by_key(
         self, key: int, discovery_method: GPIDiscovery
-    ) -> Union[simulator.gpi_sim_hdl, None]:
+    ) -> Optional[simulator.gpi_sim_hdl]:
         if discovery_method is not GPIDiscovery.AUTO:
             raise NotImplementedError(
                 f"Only GPIDiscovery.AUTO is supported for {type(self).__qualname__} right now"
@@ -726,7 +726,7 @@ _trust_inertial = bool(int(os.environ.get("COCOTB_TRUST_INERTIAL_WRITES", "0")))
 # Only the last scheduled write to a particular handle in a timestep is performed.
 _write_calls: "OrderedDict[ValueObjectBase[Any, Any], Tuple[Callable[[int, Any], None], _GPISetAction, Any]]" = OrderedDict()
 
-_write_task: Union[Task[None], None] = None
+_write_task: Optional[Task[None]] = None
 
 _writes_pending = Event()
 

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -11,7 +11,7 @@ Everything related to logging
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from cocotb import _ANSI, simulator
 from cocotb._deprecation import deprecated
@@ -107,7 +107,7 @@ class SimBaseLog(LoggerClass):
 
 
 @deprecated('Use `logging.getLogger(f"{name}.0x{ident:x}")` instead')
-def SimLog(name: str, ident: Union[int, None] = None) -> logging.Logger:
+def SimLog(name: str, ident: Optional[int] = None) -> logging.Logger:
     """Like logging.getLogger, but append a numeric identifier to the name.
 
     Args:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -40,6 +40,7 @@ import cocotb._gpi_triggers
 import cocotb._scheduler
 import cocotb.handle
 from cocotb import _ANSI, simulator
+from cocotb._gpi_triggers import GPITrigger
 from cocotb._outcomes import Error
 from cocotb._test import Failed, SimFailure, Test
 from cocotb._typing import TimeUnit
@@ -49,7 +50,7 @@ from cocotb._utils import (
     want_color_output,
 )
 from cocotb._xunit_reporter import XUnitReporter
-from cocotb.triggers import Timer, Trigger
+from cocotb.triggers import Timer
 from cocotb.utils import get_sim_time
 
 _pdb_on_exception = "COCOTB_PDB_ON_EXCEPTION" in os.environ
@@ -58,7 +59,7 @@ _pdb_on_exception = "COCOTB_PDB_ON_EXCEPTION" in os.environ
 _logger = logging.getLogger(__name__)
 
 
-def _format_doc(docstring: Union[str, None]) -> str:
+def _format_doc(docstring: Optional[str]) -> str:
     if docstring is None:
         return ""
     else:
@@ -120,7 +121,7 @@ class RegressionManager:
         self._filters: List[re.Pattern[str]] = []
         self._mode = RegressionMode.REGRESSION
         self._included: List[bool]
-        self._sim_failure: Union[SimFailure, None] = None
+        self._sim_failure: Optional[SimFailure] = None
 
         # Setup XUnit
         ###################
@@ -303,7 +304,7 @@ class RegressionManager:
 
         return self._tear_down()
 
-    def _schedule_next_test(self, trigger: Optional[Trigger] = None) -> None:
+    def _schedule_next_test(self, trigger: Optional[GPITrigger] = None) -> None:
         if trigger is not None:
             # TODO move to Trigger object
             cocotb._gpi_triggers._current_gpi_trigger = trigger
@@ -352,8 +353,8 @@ class RegressionManager:
 
         # score test
         passed: bool
-        msg: Union[str, None]
-        exc: Union[BaseException, None]
+        msg: Optional[str]
+        exc: Optional[BaseException]
         outcome = test.result()
         try:
             outcome.get()
@@ -569,8 +570,8 @@ class RegressionManager:
         self,
         wall_time_s: float,
         sim_time_ns: float,
-        result: Union[Exception, None],
-        msg: Union[str, None],
+        result: Optional[Exception],
+        msg: Optional[str],
     ) -> None:
         start_hilight = _ANSI.COLOR_PASSED if want_color_output() else ""
         stop_hilight = _ANSI.COLOR_DEFAULT if want_color_output() else ""
@@ -623,8 +624,8 @@ class RegressionManager:
         self,
         wall_time_s: float,
         sim_time_ns: float,
-        result: Union[BaseException, None],
-        msg: Union[str, None],
+        result: Optional[BaseException],
+        msg: Optional[str],
     ) -> None:
         start_hilight = _ANSI.COLOR_FAILED if want_color_output() else ""
         stop_hilight = _ANSI.COLOR_DEFAULT if want_color_output() else ""

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -20,7 +20,6 @@ from typing import (
     List,
     Optional,
     TypeVar,
-    Union,
     cast,
 )
 
@@ -85,10 +84,10 @@ class Task(Generic[ResultType]):
 
         self._coro = inst
         self._state: _TaskState = _TaskState.UNSTARTED
-        self._outcome: Union[Outcome[ResultType], None] = None
-        self._trigger: Union[Trigger, None] = None
+        self._outcome: Optional[Outcome[ResultType]] = None
+        self._trigger: Optional[Trigger] = None
         self._done_callbacks: List[Callable[[Task[ResultType]], Any]] = []
-        self._cancelled_msg: Union[str, None] = None
+        self._cancelled_msg: Optional[str] = None
         self._must_cancel: bool = False
 
         self._task_id = self._id_count
@@ -173,7 +172,7 @@ class Task(Generic[ResultType]):
         cocotb._scheduler_inst._react(self.complete)
         cocotb._scheduler_inst._react(self._join)
 
-    def _advance(self, exc: Union[BaseException, None]) -> Union[Trigger, None]:
+    def _advance(self, exc: Optional[BaseException]) -> Optional[Trigger]:
         """Resume execution of the Task.
 
         Runs until the coroutine ends, raises, or yields a Trigger.

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -11,6 +11,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Optional,
     Union,
     cast,
     overload,
@@ -246,9 +247,9 @@ class LogicArray(AbstractArray[Logic]):
     # implementations are faster for particular operations.
     # Each implementation can be present, or None if the implementation has not been
     # computed or has been invalidated by a mutating operation.
-    _value_as_array: Union[List[Logic], None]
-    _value_as_int: Union[int, None]
-    _value_as_str: Union[str, None]
+    _value_as_array: Optional[List[Logic]]
+    _value_as_int: Optional[int]
+    _value_as_str: Optional[str]
     _range: Range
 
     def __init__(

--- a/src/cocotb/types/_range.py
+++ b/src/cocotb/types/_range.py
@@ -2,7 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 from functools import lru_cache
-from typing import Iterator, Sequence, Union, overload
+from typing import Iterator, Optional, Sequence, Union, overload
 
 from cocotb._utils import cached_method
 
@@ -79,7 +79,7 @@ class Range(Sequence[int]):
         self,
         left: int,
         direction: Union[int, str, None] = None,
-        right: Union[int, None] = None,
+        right: Optional[int] = None,
     ) -> None:
         start = left
         stop: int

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -88,7 +88,7 @@ for i in range(32):
 _sv_escape_translate_table = str.maketrans(_sv_escapes)
 
 
-def _as_sv_literal(value: str) -> str:
+def _as_sv_literal(value: object) -> str:
     if isinstance(value, (int, float)):
         return str(value)
     elif isinstance(value, str):
@@ -458,7 +458,7 @@ class Runner(ABC):
         else:
             self.current_test_name = "test"
 
-        results_xml_path: Union[None, Path] = (
+        results_xml_path: Optional[Path] = (
             Path(results_xml) if results_xml is not None else None
         )
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
As a preparation for #4586.

The `Optional` is a matter of taste, but to me it makes more sense to use it than `Union[foo, None]`. Both will be converted to `foo | None` in newer versions of Python though. I converted all with a single type, but not those that are like `Union[foo, bar, None]`.

I didn't get all the way with the Trigger/GPITrigger typing though, but this gives fewer errors...
