### PR TITLE
Make `@cached_method` callable

### DIFF
--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -252,6 +252,10 @@ else:
             setattr(instance, self._method.__name__, lookup)
             return lookup
 
+        def __call__(self, instance, *args, **kwargs):
+            func = getattr(instance, self._method.__name__)
+            return func(*args, **kwargs)
+
 
 T = TypeVar("T")
 

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Type, Union
 import cocotb
 from cocotb._py_compat import cached_property
 from cocotb._typing import TimeUnit
-from cocotb._utils import cached_method
 from cocotb.handle import LogicObject, _trust_inertial
 from cocotb.simulator import clock_create
 from cocotb.task import Task
@@ -263,8 +262,11 @@ class Clock:
         # TODO Improve implementation to use a Timer to skip most of the cycles
         await ClockCycles(self._signal, num_cycles, edge_type)
 
-    @cached_method
     def __repr__(self) -> str:
+        return self._repr
+
+    @cached_property
+    def _repr(self) -> str:
         freq_mhz = 1 / get_time_from_sim_steps(
             get_sim_steps(self._period, self._unit), "us"
         )

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -43,7 +43,7 @@ from cocotb._gpi_triggers import (
     current_gpi_trigger,
 )
 from cocotb._py_compat import cached_property
-from cocotb._utils import DocIntEnum, cached_method
+from cocotb._utils import DocIntEnum
 from cocotb.task import Task
 from cocotb.types import Array, Logic, LogicArray, Range
 
@@ -1320,10 +1320,13 @@ class LogicArrayObject(
     def __str__(self) -> str:
         return str(self.value)
 
-    @cached_method
     def __len__(self) -> int:
         # can't use `range` to get length because `range` is for outer-most dimension only
         # and this object needs to support multi-dimensional packed arrays.
+        return self._len
+
+    @cached_property
+    def _len(self) -> int:
         return self._handle.get_num_elems()
 
     def __getitem__(self, _: Any) -> NoReturn:

--- a/tests/pytest/test_range.py
+++ b/tests/pytest/test_range.py
@@ -50,6 +50,13 @@ def test_downto_range():
     assert r.count(10) == 0
 
 
+def test_range_index_from_class():
+    r = Range(9, "downto", 4)
+    assert Range.index(r, 8) == 1
+    with pytest.raises(ValueError):
+        Range.index(r, 0)
+
+
 def test_null_range():
     r = Range(1, "downto", 4)
     assert r.left == 1


### PR DESCRIPTION
Makes `cls.method(inst, ...)` work. Also makes sphinx happy because previously the `cls.method` object wasn't callable and trying to link it as a method would cause autodoc to warn.

`@cached_property` and call is faster than using `@cached_method`, so replace usages where `@cached_method` is used on functions that don't take arguments.