### PR TITLE
Remove Makefile.inc from VCS makefile

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.vcs
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.vcs
@@ -4,8 +4,6 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-include $(shell cocotb-config --makefiles)/Makefile.inc
-
 ifneq ($(VHDL_SOURCES),)
 
 $(COCOTB_RESULTS_FILE):


### PR DESCRIPTION
```
Makefile.inc:173: Including Makefile.inc from a user makefile is a
no-op and deprecated. Remove the Makefile.inc inclusion from your
makefile, and only leave the Makefile.sim include.
```

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
