### PR TITLE
Improve suggestion in error message

### DIFF
--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -280,7 +280,7 @@ def _setup_regression_manager() -> None:
         raise RuntimeError("Specify only one of COCOTB_TESTCASE or COCOTB_TEST_FILTER")
     elif testcase_str:
         warnings.warn(
-            "TESTCASE is deprecated in favor of COCOTB_TEST_FILTER",
+            "COCOTB_TESTCASE is deprecated in favor of COCOTB_TEST_FILTER",
             DeprecationWarning,
         )
         filters = [f"{s.strip()}$" for s in testcase_str.split(",") if s.strip()]


### PR DESCRIPTION
We are actually looking for COCOTB_TESTCASE these days, not just
the plain TESTCASE. Improve the error message to use the same variable
as the code.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
