### PR TITLE
Enable Python 3.14 test

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 24
+        after_n_builds: 25
 
 coverage:
     status:

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -102,15 +102,14 @@ ENVS = [
         "group": "ci",
     },
     # A single test for the upcoming Python version.
-    # TODO: Enable once Python 3.14 development starts.
-    # {
-    #     "lang": "vhdl",
-    #     "sim": "nvc",
-    #     "sim-version": "r1.16.0",
-    #     "os": "ubuntu-22.04",
-    #     "python-version": "3.14.0-alpha - 3.14.0",
-    #     "group": "experimental",
-    # },
+    {
+        "lang": "vhdl",
+        "sim": "nvc",
+        "sim-version": "r1.16.0",
+        "os": "ubuntu-22.04",
+        "python-version": "3.14-dev",
+        "group": "ci",
+    },
     # Test Icarus on Ubuntu
     {
         "lang": "verilog",

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -111,6 +111,10 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       run: conda install --yes python=${{matrix.python-version}}
 
+      # Install
+    - name: Install XML-dependencies for Python 3.14
+      if: startsWith(matrix.python-version, '3.14') && startsWith(matrix.os, 'ubuntu')
+      run: sudo apt-get install -y --no-install-recommends libxml2-dev libxslt-dev
       # Run tests that don't need a simulator.
     - name: Install Python testing dependencies
       run: |


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
Running in CI now to see that it works etc. Will change back to experimental after confirmation.

Seems to run as expected. The fail comes from a dependency not working in 3.14 (I think).