### PR TITLE
Fix segfault

### DIFF
--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -161,11 +161,11 @@ int handle_gpi_callback(void *user_data) {
     to_python();
     DEFER(to_simulator());
 
-    PythonCallback *cb_data = (PythonCallback *)user_data;
-    DEFER(delete cb_data);
-
     PyGILState_STATE gstate = PyGILState_Ensure();
     DEFER(PyGILState_Release(gstate));
+
+    PythonCallback *cb_data = (PythonCallback *)user_data;
+    DEFER(delete cb_data);
 
     // Call the callback
     PyObject *pValue =

--- a/src/cocotb/share/lib/simulator/simulatormodule.cpp
+++ b/src/cocotb/share/lib/simulator/simulatormodule.cpp
@@ -21,11 +21,6 @@
 
 // This file defines the routines available to Python
 
-#define COCOTB_ACTIVE_ID \
-    0xC0C07B  // User data flag to indicate callback is active
-#define COCOTB_INACTIVE_ID \
-    0xDEADB175  // User data flag set when callback has been de-registered
-
 #define MODULE_NAME "simulator"
 
 // callback user data
@@ -41,11 +36,9 @@ struct PythonCallback {
         Py_XDECREF(args);
         Py_XDECREF(kwargs);
     }
-    uint32_t id_value =
-        COCOTB_ACTIVE_ID;  // COCOTB_ACTIVE_ID or COCOTB_INACTIVE_ID
-    PyObject *function;    // Function to call when the callback fires
-    PyObject *args;        // The arguments to call the function with
-    PyObject *kwargs;      // Keyword arguments to call the function with
+    PyObject *function;  // Function to call when the callback fires
+    PyObject *args;      // The arguments to call the function with
+    PyObject *kwargs;    // Keyword arguments to call the function with
 };
 
 class GpiClock;


### PR DESCRIPTION
Closes #4667.

`delete`ing the `PythonCallback` calls Python C API functions, which is not safe unless the GIL is acquired, so the `Ensure` and `DEFER(Release)` were moved up, so the release occurs *after* the delete of the callback when destructors are run.