### PR TITLE
Change default of `PYTHON_BIN` to `python3`

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -549,8 +549,8 @@ The following variables are makefile variables, not environment variables.
 
 .. make:var:: PYTHON_BIN
 
-    The path to the ``python`` binary.
-    Set to the result of ``cocotb-config --python-bin`` if present on the ``PATH``.
+    The path to the Python binary.
+    Set to the result of ``cocotb-config --python-bin`` if ``cocotb-config`` is present on the ``PATH``.
     Otherwise defaults to ``python3``.
 
 

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -551,7 +551,7 @@ The following variables are makefile variables, not environment variables.
 
     The path to the ``python`` binary.
     Set to the result of ``cocotb-config --python-bin`` if present on the ``PATH``.
-    Otherwise defaults to ``python``.
+    Otherwise defaults to ``python3``.
 
 
 Library Build Process

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -33,7 +33,7 @@ PYTHON_BIN_RES := $(shell cocotb-config --python-bin 2>>/dev/null; echo $$?)
 PYTHON_BIN_RC := $(lastword $(PYTHON_BIN_RES))
 PYTHON_BIN := $(strip $(subst $(PYTHON_BIN_RC)QQQQ,,$(PYTHON_BIN_RES)QQQQ))
 ifneq ($(PYTHON_BIN_RC),0)
-    PYTHON_BIN := python
+    PYTHON_BIN := python3
 endif
 
 export PYGPI_PYTHON_BIN := $(shell $(PYTHON_BIN) -m cocotb_tools.config --python-bin)


### PR DESCRIPTION
Based on https://github.com/cocotb/cocotb/pull/4665#discussion_r2080095731. PEP394 states this should always be available and correct if a Python 3 is installed.
