### PR TITLE
Fix remaining type issues and add `mypy` to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
     - pytest
     - coverage
     - nox
-    exclude: ^(tests/|examples/|docs/|src/cocotb_tools/)
+    files: ^(src/cocotb/|src/pygpi/|noxfile.py)
 
 ci:
   autofix_prs: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,5 +54,15 @@ repos:
     additional_dependencies:
       - tomli
 
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.15.0
+  hooks:
+  - id: mypy
+    additional_dependencies:
+    - pytest
+    - coverage
+    - nox
+    exclude: ^(tests/|examples/|docs/|src/cocotb_tools/)
+
 ci:
   autofix_prs: false

--- a/docs/source/developing.rst
+++ b/docs/source/developing.rst
@@ -5,7 +5,9 @@ Developing cocotb
 Setting Up a Development Environment
 ====================================
 
-Assuming you have used cocotb prior to reading this guide, you will already have the cocotb :ref:`installation prerequisites <install>` and standard development tools (editor, shell, git, etc.) installed.
+:ref:`Install prerequisites to build the development version of cocotb <install-devel>` and standard development tools (editor, shell, git, etc.).
+
+.. note:: Type checking and documentation generation require Python 3.11+.
 
 First, you should `fork and clone <https://guides.github.com/activities/forking/>`__ the cocotb repo to your machine.
 This will allow you to make changes to the cocotb source code, create pull requests, and run regressions and build documentation locally.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -35,6 +35,8 @@ The current stable version of cocotb requires:
 
 .. note:: In order to use a 32-bit simulator you need to use a 32-bit version of Python.
 
+.. note:: Type checking cocotb code requires Python 3.11+.
+
 The installation instructions vary depending on your operating system:
 
 .. tab-set::
@@ -127,9 +129,9 @@ The installation instructions vary depending on your package manager:
 
       First, set up the `Guix-science channel <https://codeberg.org/guix-science/guix-science>`_. Then, in a terminal, run
 
-      .. code-block:: bash
+        .. code-block:: bash
 
-	  guix install python-cocotb
+	        guix install python-cocotb
 
 Post installation
 =================

--- a/docs/source/install_devel.rst
+++ b/docs/source/install_devel.rst
@@ -27,6 +27,8 @@ Namely, it requires the Python development headers and a C/C++ compiler.
 * GNU Make
 * A Verilog or VHDL simulator, depending on your :term:`RTL` source code
 
+.. note:: Type checking cocotb code requires Python 3.11+.
+
 The installation instructions vary depending on your operating system:
 
 .. tab-set::

--- a/docs/source/newsfragments/4672.feature.rst
+++ b/docs/source/newsfragments/4672.feature.rst
@@ -1,0 +1,1 @@
+Added :ref:`mypy <https://mypy.readthedocs.io/en/stable/getting_started.html>` checking to CI to ensure type correctness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,3 +164,17 @@ ignore-words-list = [
     "sting",
     "synopsys",
 ]
+
+[tool.mypy]
+packages = ["cocotb", "pygpi"]
+modules = ["noxfile"]
+disallow_untyped_defs = true
+disallow_any_unimported = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+implicit_reexport = false
+show_error_codes = true
+pretty = true

--- a/src/cocotb/_base_triggers.py
+++ b/src/cocotb/_base_triggers.py
@@ -7,9 +7,9 @@
 """A collection of triggers which a testbench can :keyword:`await`."""
 
 import logging
+import sys
 import warnings
 from typing import (
-    TYPE_CHECKING,
     Any,
     AsyncContextManager,
     Awaitable,
@@ -24,7 +24,7 @@ from cocotb._deprecation import deprecated
 from cocotb._py_compat import cached_property
 from cocotb._utils import pointer_str
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 11):
     from typing import Self
 
 

--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -107,7 +107,9 @@ class _Parameterized(Generic[F]):
 
             # create wrapper function to bind kwargs
             @functools.wraps(self.test_function)
-            async def _my_test(dut, kwargs: Dict[str, Any] = test_kwargs) -> None:
+            async def _my_test(
+                dut: object, kwargs: Dict[str, Any] = test_kwargs
+            ) -> None:
                 await self.test_function(dut, **kwargs)
 
             yield Test(
@@ -147,7 +149,7 @@ def _repr(v: Any) -> Optional[str]:
         return repr(v)
     elif isinstance(v, type):
         return v.__qualname__
-    elif callable(v) and hasattr(v, "__qualname__"):
+    elif hasattr(v, "__qualname__"):
         return v.__qualname__
     else:
         return None

--- a/src/cocotb/_gpi_triggers.py
+++ b/src/cocotb/_gpi_triggers.py
@@ -6,10 +6,10 @@
 
 """A collection of triggers which a testbench can :keyword:`await`."""
 
+import sys
 from decimal import Decimal
 from fractions import Fraction
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -28,14 +28,8 @@ from cocotb._typing import TimeUnit
 from cocotb._utils import pointer_str, singleton
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 11):
     from typing import Self
-
-    from cocotb.handle import (
-        LogicObject,
-        ValueObjectBase,
-        _NonIndexableValueObjectBase,
-    )
 
 
 class GPITrigger(Trigger):
@@ -226,7 +220,7 @@ class NextTimeStep(GPITrigger):
         return f"{type(self).__qualname__}()"
 
 
-_SignalType = TypeVar("_SignalType", bound="ValueObjectBase[Any, Any]")
+_SignalType = TypeVar("_SignalType", bound="cocotb.handle.ValueObjectBase[Any, Any]")
 
 
 class _EdgeBase(GPITrigger, Generic[_SignalType]):
@@ -279,7 +273,7 @@ class RisingEdge(_EdgeBase):
 
     _edge_type = simulator.RISING
 
-    def __new__(cls, signal: "LogicObject") -> "RisingEdge":
+    def __new__(cls, signal: "cocotb.handle.LogicObject") -> "RisingEdge":
         if not (isinstance(signal, cocotb.handle.LogicObject)):
             raise TypeError(
                 f"{cls.__qualname__} requires a scalar LogicObject. Got {signal!r} of type {type(signal).__qualname__}"
@@ -308,7 +302,7 @@ class FallingEdge(_EdgeBase):
 
     _edge_type = simulator.FALLING
 
-    def __new__(cls, signal: "LogicObject") -> "FallingEdge":
+    def __new__(cls, signal: "cocotb.handle.LogicObject") -> "FallingEdge":
         if not (isinstance(signal, cocotb.handle.LogicObject)):
             raise TypeError(
                 f"{cls.__qualname__} requires a scalar LogicObject. Got {signal!r} of type {type(signal).__qualname__}"
@@ -333,7 +327,9 @@ class ValueChange(_EdgeBase):
 
     _edge_type = simulator.VALUE_CHANGE
 
-    def __new__(cls, signal: "_NonIndexableValueObjectBase[Any, Any]") -> "ValueChange":
+    def __new__(
+        cls, signal: "cocotb.handle._NonIndexableValueObjectBase[Any, Any]"
+    ) -> "ValueChange":
         if not isinstance(signal, cocotb.handle._NonIndexableValueObjectBase):
             raise TypeError(
                 f"{cls.__qualname__} requires a simulation object derived from ValueObjectBase. "
@@ -357,7 +353,9 @@ class Edge(ValueChange):
     """
 
     @deprecated("Use `signal.value_change` instead.")
-    def __new__(cls, signal: "_NonIndexableValueObjectBase[Any, Any]") -> "Edge":
+    def __new__(
+        cls, signal: "cocotb.handle._NonIndexableValueObjectBase[Any, Any]"
+    ) -> "Edge":
         if not isinstance(signal, cocotb.handle._NonIndexableValueObjectBase):
             raise TypeError(
                 f"{cls.__qualname__} requires a simulation object derived from ValueObjectBase. "

--- a/src/cocotb/_gpi_triggers.py
+++ b/src/cocotb/_gpi_triggers.py
@@ -143,7 +143,7 @@ class Timer(GPITrigger):
         if self._sim_steps == 0:
             self._sim_steps = 1
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self, callback: Callable[["Self"], None]) -> None:
         """Register for a timed callback."""
         if self._cbhdl is None:
             self._cbhdl = simulator.register_timed_callback(
@@ -171,7 +171,7 @@ class ReadOnly(GPITrigger):
     Useful for monitors which need to wait for all processes to execute (both RTL and cocotb) to ensure sampled signal values are final.
     """
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self, callback: Callable[["Self"], None]) -> None:
         if isinstance(current_gpi_trigger(), ReadOnly):
             raise RuntimeError(
                 "Attempted illegal transition: awaiting ReadOnly in ReadOnly phase"
@@ -190,7 +190,7 @@ class ReadOnly(GPITrigger):
 class ReadWrite(GPITrigger):
     """Fires when the read-write simulation phase is reached."""
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self, callback: Callable[["Self"], None]) -> None:
         if isinstance(current_gpi_trigger(), ReadOnly):
             raise RuntimeError(
                 "Attempted illegal transition: awaiting ReadWrite in ReadOnly phase"
@@ -209,7 +209,7 @@ class ReadWrite(GPITrigger):
 class NextTimeStep(GPITrigger):
     """Fires when the next time step is started."""
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self, callback: Callable[["Self"], None]) -> None:
         if self._cbhdl is None:
             self._cbhdl = simulator.register_nextstep_callback(callback, self)
             if self._cbhdl is None:
@@ -239,7 +239,7 @@ class _EdgeBase(GPITrigger, Generic[_SignalType]):
     def __init__(self, _: _SignalType) -> None:
         pass
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self, callback: Callable[["Self"], None]) -> None:
         if self._cbhdl is None:
             self._cbhdl = simulator.register_value_change_callback(
                 self.signal._handle, callback, type(self)._edge_type, self
@@ -252,7 +252,7 @@ class _EdgeBase(GPITrigger, Generic[_SignalType]):
         return f"{type(self).__qualname__}({self.signal!r})"
 
 
-class RisingEdge(_EdgeBase):
+class RisingEdge(_EdgeBase["cocotb.handle.LogicObject"]):
     """Fires on the rising edge of *signal*, on a transition to ``1``.
 
     Only valid for scalar ``logic`` or ``bit``-typed signals.
@@ -281,7 +281,7 @@ class RisingEdge(_EdgeBase):
         return signal.rising_edge
 
 
-class FallingEdge(_EdgeBase):
+class FallingEdge(_EdgeBase["cocotb.handle.LogicObject"]):
     """Fires on the falling edge of *signal*, on a transition to ``0``.
 
     Only valid for scalar ``logic`` or ``bit``-typed signals.
@@ -310,7 +310,7 @@ class FallingEdge(_EdgeBase):
         return signal.falling_edge
 
 
-class ValueChange(_EdgeBase):
+class ValueChange(_EdgeBase["cocotb.handle._NonIndexableValueObjectBase[Any, Any]"]):
     """Fires on any value change of *signal*.
 
     Args:

--- a/src/cocotb/_profiling.py
+++ b/src/cocotb/_profiling.py
@@ -7,13 +7,12 @@
 import cProfile
 import os
 import pstats
+import sys
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING
 
 from cocotb._py_compat import nullcontext
 
-if TYPE_CHECKING:
-    profiling_context: AbstractContextManager[None, None]
+profiling_context: "AbstractContextManager[None, None]"
 
 
 if "COCOTB_ENABLE_PROFILING" in os.environ:
@@ -27,7 +26,7 @@ if "COCOTB_ENABLE_PROFILING" in os.environ:
         ps = pstats.Stats(_profile).sort_stats("cumulative")
         ps.dump_stats("cocotb.pstat")
 
-    if TYPE_CHECKING:
+    if sys.version_info >= (3, 9):
 
         class _ProfilingContextBase(AbstractContextManager[None, None]): ...
     else:

--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -10,13 +10,13 @@ if they want to use these shims in their own code
 
 import sys
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING, TypeVar, Union, overload
+from typing import TypeVar, Union, overload
 
 __all__ = ("StrEnum", "cached_property", "insertion_ordered_dict", "nullcontext")
 
 T = TypeVar("T")
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 9):
 
     class _NullContextBase(AbstractContextManager[T, None]): ...
 else:

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -102,7 +102,7 @@ class Test:
     def __init__(
         self,
         *,
-        func: Callable[..., Coroutine[Any, Any, None]],
+        func: Callable[..., Coroutine[Trigger, None, None]],
         name: Optional[str] = None,
         module: Optional[str] = None,
         doc: Optional[str] = None,
@@ -114,21 +114,19 @@ class Test:
         stage: int = 0,
         _expect_sim_failure: bool = False,
     ) -> None:
-        self.func: Callable[..., Coroutine[Any, Any, None]]
+        self.func: Callable[..., Coroutine[Trigger, None, None]]
         if timeout_time is not None:
             co = func  # must save ref because we overwrite variable "func"
 
             @functools.wraps(func)
-            async def f(*args, **kwargs):
+            async def f(*args: object, **kwargs: object) -> None:
                 running_co = Task(co(*args, **kwargs))
 
                 try:
-                    res = await with_timeout(running_co, timeout_time, timeout_unit)
+                    await with_timeout(running_co, timeout_time, timeout_unit)
                 except SimTimeoutError:
                     running_co.cancel()
                     raise
-                else:
-                    return res
 
             self.func = f
         else:

--- a/src/cocotb/_typing.py
+++ b/src/cocotb/_typing.py
@@ -1,11 +1,11 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import TYPE_CHECKING
+import sys
 
-if TYPE_CHECKING:
-    from typing import (  # noqa: F401  # These types are used in type strings in this module
-        Literal,
+if sys.version_info >= (3, 10):
+    from typing import (
+        Literal,  # noqa: F401  # This type is used in type strings in this module
         TypeAlias,
     )
 

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -7,10 +7,11 @@
 """A clock class."""
 
 import logging
+import sys
 from decimal import Decimal
 from fractions import Fraction
 from logging import Logger
-from typing import TYPE_CHECKING, Type, Union
+from typing import Type, Union
 
 import cocotb
 from cocotb._py_compat import cached_property
@@ -28,10 +29,13 @@ from cocotb.triggers import (
 )
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 
-if TYPE_CHECKING:
-    from typing import Literal, TypeAlias
+if sys.version_info >= (3, 10):
+    from typing import (
+        Literal,
+        TypeAlias,
+    )
 
-    Impl: TypeAlias = Literal["gpi"] | Literal["py"]
+    Impl: TypeAlias = Literal["gpi", "py"]
 
 
 _valid_impls = ("gpi", "py")
@@ -120,6 +124,8 @@ class Clock:
         on the Clock object, so that it may later be :meth:`stop`\ ped.
     """
 
+    _impl: "Impl"
+
     def __init__(
         self,
         signal: LogicObject,
@@ -130,7 +136,6 @@ class Clock:
         self._signal = signal
         self._period = period
         self._unit: TimeUnit = unit
-        self._impl: "Impl"  # noqa: UP037  # ruff assumes we are at least using Python 3.7 and gives false positive.
 
         if impl is None:
             self._impl = "gpi" if _trust_inertial else "py"

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -445,7 +445,7 @@ class HierarchyObject(_HierarchyObjectBase[str]):
 
     def __getattr__(self, name: str) -> SimHandleBase:
         if name.startswith("_"):
-            return object.__getattribute__(self, name)  # type: ignore[no-any-return]  # this will always AttributeError
+            return object.__getattribute__(self, name)
 
         handle = self._get(name)
         if handle is None:
@@ -763,7 +763,7 @@ def _apply_scheduled_writes() -> None:
 
 if _trust_inertial:
 
-    def _schedule_write(  # type: ignore  # pylance doesn't like if/else function definitions
+    def _schedule_write(
         handle: "ValueObjectBase[Any, Any]",
         write_func: Callable[[int, _ValueT], None],
         action: _GPISetAction,

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -312,11 +312,11 @@ class RegressionManager:
 
         return self._tear_down()
 
-    def _schedule_next_test(self, trigger: Optional[Trigger] = None) -> None:
-        if trigger is not None:
-            # TODO move to Trigger object
-            cocotb._gpi_triggers._current_gpi_trigger = trigger
-            trigger._cleanup()
+    def _schedule_next_test(self, trigger: cocotb._gpi_triggers.GPITrigger) -> None:
+        # TODO move to Trigger object
+        cocotb._gpi_triggers._current_gpi_trigger = trigger
+        trigger._cleanup()
+
         self._test.start()
 
     def _tear_down(self) -> None:
@@ -836,7 +836,7 @@ class RegressionManager:
                 return float("inf")
 
 
-F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, None]])
+F = TypeVar("F", bound=Callable[..., Coroutine[Trigger, None, None]])
 
 
 class TestFactory(Generic[F]):
@@ -1085,7 +1085,7 @@ class TestFactory(Generic[F]):
             kwargs.update(testoptions_split)
 
             @functools.wraps(self.test_function)
-            async def _my_test(dut, kwargs: Dict[str, Any] = kwargs) -> None:
+            async def _my_test(dut: object, kwargs: Dict[str, Any] = kwargs) -> None:
                 await self.test_function(dut, *self.args, **kwargs)
 
             _my_test.__doc__ = doc

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -459,7 +459,7 @@ class TaskComplete(Trigger, Generic[ResultType]):
         self._task = task
         return self
 
-    def _prime(self, callback: Callable[[Trigger], None]) -> None:
+    def _prime(self, callback: Callable[["Self"], None]) -> None:
         if self._task.done():
             callback(self)
         else:

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -5,13 +5,13 @@ import collections.abc
 import inspect
 import logging
 import os
+import sys
 import traceback
 from asyncio import CancelledError, InvalidStateError
 from bdb import BdbQuit
 from enum import auto
 from types import CoroutineType
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Coroutine,
@@ -32,7 +32,7 @@ from cocotb._outcomes import Error, Outcome, Value
 from cocotb._py_compat import cached_property
 from cocotb._utils import DocEnum, extract_coro_stack, remove_traceback_frames
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 11):
     from typing import Self
 
 #: Task result type

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import os
 import random
+import sys
 from math import ceil
 from typing import (
-    TYPE_CHECKING,
     Dict,
     Iterable,
     Iterator,
@@ -21,7 +21,7 @@ from cocotb.types._abstract_array import AbstractArray
 from cocotb.types._logic import Logic, LogicConstructibleT, _str_literals
 from cocotb.types._range import Range
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 8):
     from typing import Literal
 
 

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -10,11 +10,7 @@ import math
 from decimal import Decimal
 from fractions import Fraction
 from functools import lru_cache
-from typing import (
-    TYPE_CHECKING,
-    Union,
-    overload,
-)
+from typing import Union, overload
 
 from cocotb import simulator
 from cocotb._typing import TimeUnit, TimeUnitWithoutStep
@@ -162,33 +158,27 @@ def get_sim_steps(
     return result_rounded
 
 
-if TYPE_CHECKING:
+@lru_cache(maxsize=None)
+def _get_log_time_scale(unit: TimeUnitWithoutStep) -> int:
+    """Retrieves the ``log10()`` of the scale factor for a given time unit.
 
-    def _get_log_time_scale(unit: TimeUnitWithoutStep) -> int: ...
+    Args:
+        unit: String specifying the unit
+            (one of ``'fs'``, ``'ps'``, ``'ns'``, ``'us'``, ``'ms'``, ``'sec'``).
 
-else:
+            .. versionchanged:: 2.0
+                Renamed from ``units``.
 
-    @lru_cache(maxsize=None)
-    def _get_log_time_scale(unit):
-        """Retrieves the ``log10()`` of the scale factor for a given time unit.
+    Raises:
+        ValueError: If *unit* is not a valid unit (see Args section).
 
-        Args:
-            unit: String specifying the unit
-                (one of ``'fs'``, ``'ps'``, ``'ns'``, ``'us'``, ``'ms'``, ``'sec'``).
+    Returns:
+        The ``log10()`` of the scale factor for the time unit.
+    """
+    scale = {"fs": -15, "ps": -12, "ns": -9, "us": -6, "ms": -3, "sec": 0}
 
-                .. versionchanged:: 2.0
-                    Renamed from ``units``.
-
-        Raises:
-            ValueError: If *unit* is not a valid unit (see Args section).
-
-        Returns:
-            The ``log10()`` of the scale factor for the time unit.
-        """
-        scale = {"fs": -15, "ps": -12, "ns": -9, "us": -6, "ms": -3, "sec": 0}
-
-        unit_lwr = unit.lower()
-        if unit_lwr not in scale:
-            raise ValueError(f"Invalid unit ({unit}) provided")
-        else:
-            return scale[unit_lwr]
+    unit_lwr = unit.lower()
+    if unit_lwr not in scale:
+        raise ValueError(f"Invalid unit ({unit}) provided")
+    else:
+        return scale[unit_lwr]

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -6,10 +6,10 @@
 
 """Utility functions for dealing with simulation time."""
 
-import math
 from decimal import Decimal
 from fractions import Fraction
 from functools import lru_cache
+from math import ceil, floor
 from typing import Union, overload
 
 from cocotb import simulator
@@ -54,14 +54,20 @@ def get_sim_time(unit: TimeUnit = "step") -> float:
 
 
 @overload
-def _ldexp10(frac: Union[float, Fraction], exp: int) -> float: ...
+def _ldexp10(frac: float, exp: int) -> float: ...
+
+
+@overload
+def _ldexp10(frac: Fraction, exp: int) -> Fraction: ...
 
 
 @overload
 def _ldexp10(frac: Decimal, exp: int) -> Decimal: ...
 
 
-def _ldexp10(frac: Union[float, Fraction, Decimal], exp: int) -> Union[float, Decimal]:
+def _ldexp10(
+    frac: Union[float, Fraction, Decimal], exp: int
+) -> Union[float, Fraction, Decimal]:
     """Like :func:`math.ldexp`, but base 10."""
     # using * or / separately prevents rounding errors if `frac` is a
     # high-precision type
@@ -140,18 +146,18 @@ def get_sim_steps(
         result = time
 
     if round_mode == "error":
-        result_rounded = math.floor(result)
+        result_rounded = floor(result)
         if result_rounded != result:
             precision = _get_simulator_precision()
             raise ValueError(
                 f"Unable to accurately represent {time}({unit}) with the simulator precision of 1e{precision}"
             )
     elif round_mode == "ceil":
-        result_rounded = math.ceil(result)
+        result_rounded = ceil(result)
     elif round_mode == "round":
         result_rounded = round(result)
     elif round_mode == "floor":
-        result_rounded = math.floor(result)
+        result_rounded = floor(result)
     else:
         raise ValueError(f"Invalid round_mode specifier: {round_mode}")
 


### PR DESCRIPTION
Uses version check instead of `TYPE_CHECKING` generally because Sphinx doesn't set it, so all `TypeAlias`es created in those blocks will not be seen or resolved by Sphinx.

Adds a mypy config and fixes the last of the typing issues:
* `Trigger._prime` needs to take callbacks that take `Self` to make calls to `_prime` happy.
* Added typing to `_bridge.py` and related functionality in `_scheduler.py`.
* Various other inaccuracies

We should probably try to clean up uses of `Any` at some point, especially if there are any on public APIs. Also we should extend the amount of typed Python code.

Finally added mypy to pre-commit. This will only check files that changed locally, keeping it shorter to execute. But `pre-commit.ci` runs it on all files, which is why we only explicitly include files we know we can check.