### PR TITLE
Add `units` back, but deprecated and undocumented

### DIFF
--- a/docs/source/newsfragments/4455.change.rst
+++ b/docs/source/newsfragments/4455.change.rst
@@ -1,1 +1,1 @@
-The ``units`` argument was renamed to ``unit`` in :class:`~cocotb.clock.Clock`, :class:`~cocotb.triggers.Timer`, :class:`~cocotb.triggers.with_timeout`, :func:`~cocotb.utils.get_sim_time`, :func:`~cocotb.utils.get_time_from_sim_steps`, and :func:`~cocotb.utils.get_sim_steps`.
+The ``units`` argument was renamed to ``unit`` in :class:`~cocotb.clock.Clock`, :class:`~cocotb.triggers.Timer`, :func:`~cocotb.utils.get_sim_time`, :func:`~cocotb.utils.get_time_from_sim_steps`, and :func:`~cocotb.utils.get_sim_steps`.

--- a/src/cocotb/_gpi_triggers.py
+++ b/src/cocotb/_gpi_triggers.py
@@ -7,6 +7,7 @@
 """A collection of triggers which a testbench can :keyword:`await`."""
 
 import sys
+import warnings
 from decimal import Decimal
 from fractions import Fraction
 from typing import (
@@ -131,10 +132,17 @@ class Timer(GPITrigger):
         unit: TimeUnit = "step",
         *,
         round_mode: Optional[str] = None,
+        units: None = None,
     ) -> None:
         super().__init__()
         if time <= 0:
             raise ValueError("Timer argument time must be positive")
+        if units is not None:
+            warnings.warn(
+                "The 'units' argument has been renamed to 'unit'.",
+                DeprecationWarning,
+            )
+            unit = units
         if round_mode is None:
             round_mode = type(self).round_mode
         self._sim_steps = get_sim_steps(time, unit, round_mode=round_mode)

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -8,6 +8,7 @@
 
 import logging
 import sys
+import warnings
 from decimal import Decimal
 from fractions import Fraction
 from logging import Logger
@@ -132,9 +133,17 @@ class Clock:
         period: Union[float, Fraction, Decimal],
         unit: TimeUnit = "step",
         impl: "Impl | None" = None,
+        *,
+        units: None = None,
     ) -> None:
         self._signal = signal
         self._period = period
+        if units is not None:
+            warnings.warn(
+                "The 'units' argument has been renamed to 'unit'.",
+                DeprecationWarning,
+            )
+            unit = units
         self._unit: TimeUnit = unit
 
         if impl is None:

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -6,6 +6,7 @@
 
 """Utility functions for dealing with simulation time."""
 
+import warnings
 from decimal import Decimal
 from fractions import Fraction
 from functools import lru_cache
@@ -25,7 +26,7 @@ def _get_simulator_precision() -> int:
 
 
 # Simulator helper functions
-def get_sim_time(unit: TimeUnit = "step") -> float:
+def get_sim_time(unit: TimeUnit = "step", *, units: None = None) -> float:
     """Retrieve the simulation time from the simulator.
 
     Args:
@@ -48,6 +49,12 @@ def get_sim_time(unit: TimeUnit = "step") -> float:
     .. versionchanged:: 1.6
         Support ``'step'`` as the the *unit* argument to mean "simulator time step".
     """
+    if units is not None:
+        warnings.warn(
+            "The 'units' argument has been renamed to 'unit'.",
+            DeprecationWarning,
+        )
+        unit = units
     timeh, timel = simulator.get_sim_time()
     steps = timeh << 32 | timel
     return get_time_from_sim_steps(steps, unit) if unit != "step" else steps
@@ -77,7 +84,12 @@ def _ldexp10(
         return frac / (10**-exp)
 
 
-def get_time_from_sim_steps(steps: int, unit: TimeUnit) -> float:
+def get_time_from_sim_steps(
+    steps: int,
+    unit: Union[TimeUnit, None] = None,
+    *,
+    units: None = None,
+) -> float:
     """Calculate simulation time in the specified *unit* from the *steps* based
     on the simulator precision.
 
@@ -95,6 +107,14 @@ def get_time_from_sim_steps(steps: int, unit: TimeUnit) -> float:
     Returns:
         The simulation time in the specified unit.
     """
+    if units is not None:
+        warnings.warn(
+            "The 'units' argument has been renamed to 'unit'.",
+            DeprecationWarning,
+        )
+        unit = units
+    if unit is None:
+        raise TypeError("Missing required argument 'unit'")
     if unit == "step":
         return steps
     return _ldexp10(steps, _get_simulator_precision() - _get_log_time_scale(unit))
@@ -105,6 +125,7 @@ def get_sim_steps(
     unit: TimeUnit = "step",
     *,
     round_mode: str = "error",
+    units: None = None,
 ) -> int:
     """Calculates the number of simulation time steps for a given amount of *time*.
 
@@ -139,6 +160,12 @@ def get_sim_steps(
     .. versionchanged:: 1.6
         Support rounding modes.
     """
+    if units is not None:
+        warnings.warn(
+            "The 'units' argument has been renamed to 'unit'.",
+            DeprecationWarning,
+        )
+        unit = units
     result: Union[float, Fraction, Decimal]
     if unit != "step":
         result = _ldexp10(time, _get_log_time_scale(unit) - _get_simulator_precision())

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -3,12 +3,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import os
 import warnings
+from typing import Any
 
 import pytest
+from common import assert_takes
 
 import cocotb
+from cocotb.clock import Clock
 from cocotb.regression import TestFactory
 from cocotb.triggers import Edge, Event, First, Join, Timer
+from cocotb.utils import get_sim_steps, get_sim_time, get_time_from_sim_steps
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 
@@ -194,3 +198,20 @@ async def test_event_name_deprecated(_) -> None:
 
     with pytest.warns(DeprecationWarning):
         assert e.name == "test2"
+
+
+@cocotb.test
+async def test_units_deprecated(dut: Any) -> None:
+    with assert_takes(10, "ns"):
+        with pytest.warns(DeprecationWarning):
+            await Timer(10, units="ns")
+    with pytest.warns(DeprecationWarning):
+        assert Clock(dut.clk, 10, units="ns").unit == "ns"
+    with pytest.warns(DeprecationWarning):
+        assert get_sim_time(units="ns") == get_sim_time("ns")
+    with pytest.warns(DeprecationWarning):
+        assert get_sim_steps(10, units="ns") == get_sim_steps(10, "ns")
+    with pytest.warns(DeprecationWarning):
+        assert get_time_from_sim_steps(10, units="ns") == get_time_from_sim_steps(
+            10, "ns"
+        )


### PR DESCRIPTION
I don't feel like doing another 1.9 release so much. This is no effort to support deprecated in 2.0. I left the type of `units` as only `None` so type checkers will complain if people try to use it, but will still work at runtime. Also fixed the newsfrag: `with_timeout`'s argument was always `timeout_unit`.