### PR TITLE
Fix hang with `Event.wait()`

### DIFF
--- a/docs/source/newsfragments/4675.bugfix.rst
+++ b/docs/source/newsfragments/4675.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where calling :meth:`.Event.wait` but not ``await``\ ing the returned Trigger, then calling :meth:`.Event.set`, then ``await``\ ing the Trigger would hang.

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -7,7 +7,7 @@ Tests for synchronization primitives like Lock and Event
 
 import random
 import re
-from typing import List
+from typing import Any, List
 
 import pytest
 from common import assert_takes
@@ -21,6 +21,7 @@ from cocotb.triggers import (
     NullTrigger,
     ReadOnly,
     Timer,
+    with_timeout,
 )
 
 
@@ -235,3 +236,16 @@ async def test_Event_multiple_task_share_trigger(_) -> None:
     cocotb.start_soon(waiter(e_trigger))
 
     await Timer(1, "ns")
+
+
+@cocotb.test
+async def test_Event_wait_after_set(_: Any) -> None:
+    """Test that getting the _Event Trigger, setting it, then awaiting the Trigger doesn't hang."""
+
+    e = Event()
+    trigger = e.wait()
+
+    e.set()
+
+    # Should not block
+    await with_timeout(trigger, 1, "step")

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -223,7 +223,7 @@ async def test_Lock_multiple_users_acquire_triggers(_) -> None:
     await Timer(1, "ns")
 
 
-@cocotb.test(expect_error=RuntimeError)
+@cocotb.test
 async def test_Event_multiple_task_share_trigger(_) -> None:
     """Test that multiple tasks aren't allowed to share an Event trigger."""
 


### PR DESCRIPTION
If one calls `Event.wait()` on an un-set Event, it returns an `_Event`. If they then call `Event.set()` before `await`ing that `_Event`, it doesn't wake up any Task. Then if they `await` that `_Event`, it blocks until the next `Event.set()` despite the `Event` being in the set state.

- [x] newsfrag