### PR TITLE
Update minimum Verilator version in Makefile

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.verilator
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.verilator
@@ -22,7 +22,7 @@ else
   VERILATOR_BIN_DIR := $(shell dirname $(CMD))
 endif
 
-VLT_MIN := 4.106
+VLT_MIN := 5.036
 VLT_VERSION := $(shell $(CMD) --version | cut -d " " -f 2)
 MIN_VERSION := $(shell printf "%s\n%s\n" "$(VLT_MIN)" "$(VLT_VERSION)" | sort -g | head -1)
 ifneq ($(MIN_VERSION),$(VLT_MIN))


### PR DESCRIPTION
The Verilator version check in the Makefile didn't get updated in line
with the minimum requirement for Verilator. Synchronize the two.
