### PR TITLE
Fix and expand number of `paths-ignore` for regressions

### DIFF
--- a/.github/workflows/build-test-dev.yml
+++ b/.github/workflows/build-test-dev.yml
@@ -19,17 +19,29 @@ on:
       # Documentation
       - 'docs/**'
       # Dot-files not related to running tests
+      - '.theia/**'
       - '.backportrc.json'
       - '.clang-format'
       - '.git-blame-ignore-revs'
       - '.gitignore'
-      - '.pre-commit-config.yml'
+      - '.gitpod.Dockerfile'
+      - '.gitpod.yml'
+      - '.pre-commit-config.yaml'
       - '.readthedocs.yml'
-      - '.pylintrc'
       # Information files
       - 'LICENSE'
       - 'README.md'
       - 'CONTRIBUTING.md'
+      - 'MANIFEST.in'
+      # Github files that aren't related to testing
+      - '.github/issue_template.md'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/workflows/backport.yml'
+      - '.github/workflows/benchmark.yml'
+      - '.github/workflows/ecosystem-compat.yml'
+      - '.github/workflows/experimental.yml'
+      - '.github/workflows/extended.yml'
+      - '.github/workflows/stale.yml'
 
 jobs:
   test_dev:

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -19,17 +19,29 @@ on:
       # Documentation
       - 'docs/**'
       # Dot-files not related to running tests
+      - '.theia/**'
       - '.backportrc.json'
       - '.clang-format'
       - '.git-blame-ignore-revs'
       - '.gitignore'
-      - '.pre-commit-config.yml'
+      - '.gitpod.Dockerfile'
+      - '.gitpod.yml'
+      - '.pre-commit-config.yaml'
       - '.readthedocs.yml'
-      - '.pylintrc'
       # Information files
       - 'LICENSE'
       - 'README.md'
       - 'CONTRIBUTING.md'
+      - 'MANIFEST.in'
+      # Github files that aren't related to testing
+      - '.github/issue_template.md'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/workflows/backport.yml'
+      - '.github/workflows/benchmark.yml'
+      - '.github/workflows/ecosystem-compat.yml'
+      - '.github/workflows/experimental.yml'
+      - '.github/workflows/extended.yml'
+      - '.github/workflows/stale.yml'
 
 jobs:
   test_dev:


### PR DESCRIPTION
I realized the spelling of `.pre-commit-config.yaml` was incorrect and fixed that and added a few more files.