### PR TITLE
Fix VPI error for non-vector logic objects

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/vpi/VpiSignal.cpp
@@ -58,7 +58,7 @@ int VpiSignalObjHdl::initialise(const std::string &name,
                             name.c_str(), vpi_get_str(vpiType, hdl), type);
                         return -1;
                     }
-                } else {
+                } else if (m_indexable) {  // Only try to get range handles if it's a vector
                     vpiHandle leftRange = vpi_handle(vpiLeftRange, hdl);
                     check_vpi_error();
                     vpiHandle rightRange = vpi_handle(vpiRightRange, hdl);


### PR DESCRIPTION
Fixes #4104 <!-- Needed for GitHub to link the issue to the PR -->

## Fix VPI error for non-vector logic objects
This change fixes VPI errors that occurred when trying to get range handles for non-vector logic objects. The patch adds a condition to only attempt getting range handles (`vpiLeftRange` and `vpiRightRange`) when dealing with vector types (`m_indexable`). This prevents unnecessary error messages for scalar signals while maintaining the existing functionality for vector signals.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1YnVzZXJjb250ZW50LmNvbS9oYXJyeS1wYXRjaGVyLzY0MmIzMzI1YzQ5ODdkZTVkMjUzNmVhNTIwZDU1MTU2L3Jhdy84M2YwYjlkZTZmOTBjNThlNmZkNTdhNmQ5N2M5MTRmZTkxNDBmMjI1L3N3ZWJlbmNoX2NvY290Yl9fY29jb3RiLTQxMDQuanNvbg&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL2NvY290Yi9jb2NvdGIvcHVsbC80Njkx) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=https%3A//github.com/cocotb/cocotb/pull/4691&rb85bea8de07843f9835f9d001f689f4c=https%3A//github.com/cocotb/cocotb&r034de175aef248b29aaf36f2a5e92912=https%3A//github.com/cocotb/cocotb/pull/4691&r9e0cc5d7ff8b484e81eb97531d4cefd7=https%3A//github.com/cocotb/cocotb/pull/4691) 📬.