### PR TITLE
Add deprecated re-exports to `cocotb.results`

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -90,6 +90,8 @@ Writing and Generating Tests
     :members:
     :member-order: bysource
 
+.. autofunction:: cocotb.regression.SimFailure
+
 Interacting with the Simulator
 ==============================
 

--- a/docs/source/newsfragments/4685.change.rst
+++ b/docs/source/newsfragments/4685.change.rst
@@ -1,1 +1,1 @@
-Moved ``cocotb.result.SimFailure`` to :mod:`cocotb.regression`.
+Moved :class:`~cocotb.regression.SimFailure` from :mod:`cocotb.result` to :mod:`cocotb.regression`.

--- a/docs/source/newsfragments/4685.change.rst
+++ b/docs/source/newsfragments/4685.change.rst
@@ -1,0 +1,1 @@
+Moved ``cocotb.result.SimFailure`` to :mod:`cocotb.regression`.

--- a/src/cocotb/result.py
+++ b/src/cocotb/result.py
@@ -1,0 +1,39 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+import warnings
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    if name == "TestSuccess":
+        warnings.warn(
+            "`raise TestSuccess` is deprecated. Use `cocotb.pass_test()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from cocotb._test_functions import TestSuccess
+
+        return TestSuccess
+
+    elif name == "SimFailure":
+        warnings.warn(
+            "SimFailure was moved to `cocotb.regression`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from cocotb.regression import SimFailure
+
+        return SimFailure
+
+    elif name == "SimTimeoutError":
+        warnings.warn(
+            "SimTimeoutError was moved from `cocotb.result` to `cocotb.triggers`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from cocotb.triggers import SimTimeoutError
+
+        return SimTimeoutError
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -2,6 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import os
+import sys
 import warnings
 from typing import Any
 
@@ -215,3 +216,13 @@ async def test_units_deprecated(dut: Any) -> None:
         assert get_time_from_sim_steps(10, units="ns") == get_time_from_sim_steps(
             10, "ns"
         )
+
+
+@cocotb.test(skip=sys.version_info < (3, 7))
+async def test_results_deprecated(_: Any) -> None:
+    with pytest.warns(DeprecationWarning):
+        from cocotb.result import TestSuccess  # noqa: F401
+    with pytest.warns(DeprecationWarning):
+        from cocotb.result import SimFailure  # noqa: F401
+    with pytest.warns(DeprecationWarning):
+        from cocotb.result import SimTimeoutError  # noqa: F401


### PR DESCRIPTION
Depends upon #4677.

Since I'm not interested in doing another 1.9 release (who is?), I added deprecated re-exports for things moved or removed from `cocotb.result` back.

Unfortunately deprecating imports requires module `__getattr__` which only works in Python > 3.7. But that isn't a huge deal, very few people are still using 3.6 and they will just have to immediately update and not get the `DeprecationWarning` :shrug:.