### PR TITLE
Properly handle `__all__` and re-exports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,7 +118,7 @@ codeautolink_autodoc_inject = True  # Inject an autolink-examples table to the e
 codeautolink_global_preface = textwrap.dedent("""\
     import cocotb
     from cocotb.clock import Clock
-    from cocotb.triggers import Combine, Edge, FallingEdge, First, Join, RisingEdge, Timer, with_timeout
+    from cocotb.triggers import Combine, Edge, FallingEdge, First, RisingEdge, Timer, with_timeout
     from cocotb.types import Array, Logic, LogicArray, Range
     from cocotb.utils import get_sim_time
     """

--- a/docs/source/newsfragments/4084.removal.rst
+++ b/docs/source/newsfragments/4084.removal.rst
@@ -1,1 +1,1 @@
-:class:`~cocotb.triggers.Join` was deprecated, use the :class:`~cocotb.task.Task` being joined directly wherever ``Join(task)`` was previously used.
+:class:`~cocotb.task.Join` was deprecated, use the :class:`~cocotb.task.Task` being joined directly wherever ``Join(task)`` was previously used.

--- a/docs/source/newsfragments/4544.change.rst
+++ b/docs/source/newsfragments/4544.change.rst
@@ -1,0 +1,1 @@
+:class:`.Join` was moved from :mod:`cocotb.triggers` to :mod:`cocotb.task`.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -68,7 +68,7 @@ Changes
 -------
 
 - For Aldec simulators, the `-dbg` and `-O2` options are no longer passed by default, as they reduce simulation speed. Pass these options in ``COMPILE_ARGS`` and ``SIM_ARGS`` if you need them for increased observability. (:pr:`3490`)
-- :keyword:`await`\ ing a :class:`~cocotb.triggers.Join` trigger will yield the Join trigger and not the result of the task in the 2.0 release. (:pr:`3871`)
+- :keyword:`await`\ ing a :class:`~cocotb.task.Join` trigger will yield the Join trigger and not the result of the task in the 2.0 release. (:pr:`3871`)
 - :meth:`Lock.locked <cocotb.triggers.Lock.locked>` is now a method rather than an attribute to mirror :meth:`asyncio.Lock.locked`. (:pr:`3871`)
 
 

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -23,14 +23,31 @@ if TYPE_CHECKING:
     from cocotb.regression import RegressionManager
 
 __all__ = (
+    "RANDOM_SEED",
+    "SIM_NAME",
+    "SIM_VERSION",
     "__version__",
+    "argv",
     "create_task",
+    "is_simulation",
+    "log",
+    "packages",
     "parametrize",
     "pass_test",
+    "plusargs",
     "start",
     "start_soon",
     "test",
+    "top",
 )
+
+# Set __module__ on re-exports
+test.__module__ = __name__
+start_soon.__module__ = __name__
+start.__module__ = __name__
+create_task.__module__ = __name__
+parametrize.__module__ = __name__
+pass_test.__module__ = __name__
 
 
 __version__ = _version

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -67,7 +67,7 @@ class Scheduler:
         so as to wake up Tasks waiting for that Trigger to `fire` (when the event encoded by the Trigger occurs).
         This is accomplished by :meth:`_resume_task_upon`.
         :meth:`_resume_task_upon` also associates the Trigger with the Task waiting on it to fire by adding them to the :attr:`_trigger2tasks` map.
-        If, instead of reaching an :keyword:`await`, a Task finishes, :meth:`_schedule` will cause the :class:`~cocotb.triggers.Join` trigger to fire.
+        If, instead of reaching an :keyword:`await`, a Task finishes, :meth:`_schedule` will cause the :class:`~cocotb.task.Join` trigger to fire.
         Once a Trigger fires it calls the react function which queues all Tasks waiting for that Trigger to fire.
         Then the process repeats.
 
@@ -244,7 +244,7 @@ class Scheduler:
 
         Also:
           * enters the scheduler termination state if the Test Task is unscheduled.
-          * creates and fires a :class:`~cocotb.triggers.Join` trigger.
+          * creates and fires a :class:`~cocotb.task.Join` trigger.
           * forcefully ends the Test if a Task ends with an exception.
         """
 

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -30,6 +30,8 @@ from cocotb.triggers import (
 )
 from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 
+__all__ = ("Clock",)
+
 if sys.version_info >= (3, 10):
     from typing import (
         Literal,

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -47,6 +47,26 @@ from cocotb._utils import DocIntEnum
 from cocotb.task import Task
 from cocotb.types import Array, Logic, LogicArray, Range
 
+__all__ = (
+    "ArrayObject",
+    "Deposit",
+    "EnumObject",
+    "Force",
+    "Freeze",
+    "GPIDiscovery",
+    "HierarchyArrayObject",
+    "HierarchyObject",
+    "Immediate",
+    "IntegerObject",
+    "LogicArrayObject",
+    "LogicObject",
+    "RealObject",
+    "Release",
+    "SimHandleBase",
+    "StringObject",
+    "ValueObjectBase",
+)
+
 
 class _Limits(enum.IntEnum):
     SIGNED_NBIT = 1

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -35,6 +35,16 @@ logging.TRACE = 5  # type: ignore[attr-defined]  # type checkers don't like addi
 logging.addLevelName(5, "TRACE")
 
 
+__all__ = (
+    "SimBaseLog",
+    "SimColourLogFormatter",
+    "SimLog",
+    "SimLogFormatter",
+    "SimTimeContextFilter",
+    "default_config",
+)
+
+
 def default_config() -> None:
     """Apply the default cocotb log formatting to the root logger.
 

--- a/src/cocotb/queue.py
+++ b/src/cocotb/queue.py
@@ -20,6 +20,15 @@ from cocotb._utils import pointer_str
 from cocotb.task import Task
 from cocotb.triggers import Event
 
+__all__ = (
+    "AbstractQueue",
+    "LifoQueue",
+    "PriorityQueue",
+    "Queue",
+    "QueueEmpty",
+    "QueueFull",
+)
+
 
 class QueueFull(asyncio.queues.QueueFull):
     """Raised when the :meth:`Queue.put_nowait()` method is called on a full :class:`Queue`."""

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -57,6 +57,12 @@ __all__ = (
     "TestFactory",
 )
 
+# Set __module__ on re-exports
+Parameterized.__module__ = __name__
+Test.__module__ = __name__
+TestFactory.__module__ = __name__
+
+
 _pdb_on_exception = "COCOTB_PDB_ON_EXCEPTION" in os.environ
 
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -294,7 +294,7 @@ class Task(Generic[ResultType]):
     def join(self) -> "Join[ResultType]":
         r"""Block until the Task completes and return the result.
 
-        Equivalent to calling :class:`Join(self) <cocotb.triggers.Join>`.
+        Equivalent to calling :class:`Join(self) <cocotb.task.Join>`.
 
         .. code-block:: python
 
@@ -435,7 +435,7 @@ class Task(Generic[ResultType]):
 class TaskComplete(Trigger, Generic[ResultType]):
     r"""Fires when a :class:`~cocotb.task.Task` completes.
 
-    Unlike :class:`~cocotb.triggers.Join`, this Trigger does not return the result of the Task when :keyword:`await`\ ed.
+    Unlike :class:`~cocotb.task.Join`, this Trigger does not return the result of the Task when :keyword:`await`\ ed.
     See :attr:`.Task.complete` for more information.
 
     .. warning::

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -51,6 +51,10 @@ __all__ = (
     "resume",
 )
 
+# Set __module__ on re-exports
+bridge.__module__ = __name__
+resume.__module__ = __name__
+
 
 class _TaskState(DocEnum):
     """State of a Task."""

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -1,6 +1,9 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
+import warnings
+from typing import Any
+
 from cocotb._base_triggers import Event, Lock, NullTrigger, Trigger
 from cocotb._extended_awaitables import (
     ClockCycles,
@@ -22,7 +25,6 @@ from cocotb._gpi_triggers import (
     ValueChange,
     current_gpi_trigger,
 )
-from cocotb.task import Join, TaskComplete
 
 __all__ = (
     "ClockCycles",
@@ -32,7 +34,6 @@ __all__ = (
     "FallingEdge",
     "First",
     "GPITrigger",
-    "Join",
     "Lock",
     "NextTimeStep",
     "NullTrigger",
@@ -40,7 +41,6 @@ __all__ = (
     "ReadWrite",
     "RisingEdge",
     "SimTimeoutError",
-    "TaskComplete",
     "Timer",
     "Trigger",
     "ValueChange",
@@ -48,3 +48,16 @@ __all__ = (
     "current_gpi_trigger",
     "with_timeout",
 )
+
+
+def __getattr__(name: str) -> Any:
+    if name == "Join":
+        warnings.warn(
+            "Join has been moved to `cocotb.task`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from cocotb.task import Join
+
+        return Join
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -49,6 +49,11 @@ __all__ = (
     "with_timeout",
 )
 
+# Set __module__ on re-exports
+for name in __all__:
+    obj = globals()[name]
+    obj.__module__ = __name__
+
 
 def __getattr__(name: str) -> Any:
     if name == "Join":

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -7,4 +7,15 @@ from ._logic import Logic
 from ._logic_array import LogicArray
 from ._range import Range
 
+# isort: split
+# These are imports for doctests in the submodules. Since we fix up the `__module__`
+# attribute, `--doctest-modules` thinks this is the module the types were defined in
+# and will evaluate this module first before running tests.
+from typing import Tuple  # noqa: F401
+
 __all__ = ("AbstractArray", "Array", "Logic", "LogicArray", "Range")
+
+# Set __module__ on re-exports
+for name in __all__:
+    obj = globals()[name]
+    obj.__module__ = __name__

--- a/src/cocotb/types/_logic.py
+++ b/src/cocotb/types/_logic.py
@@ -5,7 +5,6 @@ from functools import lru_cache
 from typing import (
     Dict,
     Set,
-    Tuple,  # noqa: F401  # Used by doctests, false positive
     Type,
     Union,
 )

--- a/src/cocotb/utils.py
+++ b/src/cocotb/utils.py
@@ -16,6 +16,12 @@ from typing import Union, overload
 from cocotb import simulator
 from cocotb._typing import TimeUnit, TimeUnitWithoutStep
 
+__all__ = (
+    "get_sim_steps",
+    "get_sim_time",
+    "get_time_from_sim_steps",
+)
+
 
 def _get_simulator_precision() -> int:
     # cache and replace this function

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -12,7 +12,8 @@ from common import assert_takes
 import cocotb
 from cocotb.clock import Clock
 from cocotb.regression import TestFactory
-from cocotb.triggers import Edge, Event, First, Join, Timer
+from cocotb.task import Join
+from cocotb.triggers import Edge, Event, First, Timer
 from cocotb.utils import get_sim_steps, get_sim_time, get_time_from_sim_steps
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
@@ -226,3 +227,9 @@ async def test_results_deprecated(_: Any) -> None:
         from cocotb.result import SimFailure  # noqa: F401
     with pytest.warns(DeprecationWarning):
         from cocotb.result import SimTimeoutError  # noqa: F401
+
+
+@cocotb.test
+async def test_triggers_Join_import_deprecated(_: Any) -> None:
+    with pytest.warns(DeprecationWarning):
+        from cocotb.triggers import Join  # noqa: F401


### PR DESCRIPTION
* Added `__all__` to all public modules and populated it correctly (pylance complains about modifying or partially specifying `__all__`)
* Fixed up `__module__` on all re-exported symbols
* Deprecated importing `Join` from `cocotb.triggers` as there should be exactly one canonical location for each object
* Removed re-exporting `TaskComplete` in `cocotb.triggers`. This is a new type, so it can just live forever in `cocotb.task`


One of these days I'll write a linter that ensures:
1. Exactly one canonical import location for each object
2. That object is included in the `__all__` of the canonical location
3. The `__module__` matches the canonical location

And then prints the full API in a tree so people can easily inspect if there's something that's public that shouldn't be.