### PR TITLE
Fix github -> gitter link in support.rst

### DIFF
--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -5,7 +5,7 @@ Getting Help
 Getting in Contact with a Maintainer
 ====================================
 
-All of the :ref:`maintainers <maintainers>` are active on the `Gitter channel <https://github.com/cocotb/cocotb>`__.
+All of the :ref:`maintainers <maintainers>` are active on the `Gitter channel <https://gitter.im/cocotb/Lobby>`__.
 They prefer inquiries go through direct messages on Gitter,
 or by mentioning them in the main `cocotb Gitter channel <https://gitter.im/cocotb/Lobby>`__ using ``@{maintainer name}``.
 Maintainers are unpaid volunteers, so it might take a while for a maintainer to get back to you.


### PR DESCRIPTION
Was link to github

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
