### PR TITLE
Move `COCOTB_PDB_ON_EXCEPTION` to as soon as it ends the test

### DIFF
--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -2,6 +2,8 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import inspect
+import os
+import pdb
 from typing import (
     Any,
     Callable,
@@ -18,6 +20,8 @@ from cocotb._outcomes import Error, Outcome, Value
 from cocotb._test_functions import TestSuccess
 from cocotb.task import ResultType, Task
 from cocotb.triggers import NullTrigger
+
+_pdb_on_exception = "COCOTB_PDB_ON_EXCEPTION" in os.environ
 
 
 class RunningTest:
@@ -82,6 +86,10 @@ class RunningTest:
             if isinstance(outcome, Error):
                 self._shutdown_errors.append(outcome)
             return
+
+        # Break into pdb on test end before all Tasks are killed.
+        if _pdb_on_exception and isinstance(outcome, Error):
+            pdb.post_mortem(outcome.error.__traceback__)
 
         # Set outcome and cancel Tasks.
         self._outcome = outcome

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -11,7 +11,6 @@ import hashlib
 import inspect
 import logging
 import os
-import pdb
 import random
 import re
 import time
@@ -61,9 +60,6 @@ __all__ = (
 Parameterized.__module__ = __name__
 Test.__module__ = __name__
 TestFactory.__module__ = __name__
-
-
-_pdb_on_exception = "COCOTB_PDB_ON_EXCEPTION" in os.environ
 
 
 class SimFailure(BaseException):
@@ -505,9 +501,6 @@ class RegressionManager:
                 result=exc,
                 msg=msg,
             )
-
-        if _pdb_on_exception and not passed and exc is not None:
-            pdb.post_mortem(exc.__traceback__)
 
     def _get_lineno(self, test: Test) -> int:
         try:


### PR DESCRIPTION
This allows debugging while the remainder of the Tasks are still executing.
