### PR TITLE
Use commit hash for actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Backport Action
         if: fromJSON(steps.check_labels.outputs.matched) > 0
-        uses: sorenlouv/backport-github-action@v9.5.1
+        uses: sorenlouv/backport-github-action@ad888e978060bc1b2798690dd9d03c4036560947  # v9.5.1
         with:
           # GITHUB_TOKEN is available by default, but the powers it has are
           # configurable. Follow the GitHub documentation at

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,9 +23,9 @@ jobs:
           - python-version: 3.9
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: Set up Python ${{matrix.python-version}}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: ${{matrix.python-version}}
 
@@ -58,7 +58,7 @@ jobs:
     - name: Generate a token to access cocotb/cocotb-benchmark-results
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       id: generate_token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e  # v2.0.6
       with:
         app-id: ${{ secrets.COCOTB_CI_REPOACCESS_APP_ID }}
         private-key: ${{ secrets.COCOTB_CI_REPOACCESS_APP_PRIVATE_KEY }}
@@ -67,7 +67,7 @@ jobs:
 
     - name: Store benchmark result
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-      uses: benchmark-action/github-action-benchmark@v1
+      uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7  # v1.20.4
       continue-on-error: true
       with:
         tool: 'pytest'

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -25,8 +25,8 @@ jobs:
           - windows-2022
           - macos-13
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Install nox
@@ -38,7 +38,7 @@ jobs:
       - name: Build cocotb release
         run: nox -s release_build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: cocotb-dist-${{ matrix.os }}
           path: |
@@ -50,11 +50,11 @@ jobs:
     needs: build_release
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: "3.12"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
       with:
         path: dist
         pattern: cocotb-dist-*
@@ -83,16 +83,16 @@ jobs:
     # Only upload tagged releases.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: "3.12"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
       with:
         path: dist
         pattern: cocotb-dist-*
         merge-multiple: true
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ecosystem-compat.yml
+++ b/.github/workflows/ecosystem-compat.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -34,12 +34,12 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends iverilog
 
       - name: Checkout cocotb repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           path: cocotb
 
       - name: Checkout cocotb-coverage repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: mciepluc/cocotb-coverage
           path: cocotb-coverage
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -76,12 +76,12 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends iverilog
 
       - name: Checkout cocotb repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           path: cocotb
 
       - name: Checkout pyuvm repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           path: pyuvm_clone
           repository: pyuvm/pyuvm

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate a list of environments to run tests against
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - run: ./.github/generate-envs.py --output-format=gha --gha-output-file="$GITHUB_OUTPUT" --group="${{inputs.group}}"
       id: run_generate_script
     outputs:
@@ -72,7 +72,7 @@ jobs:
       max-parallel: ${{ inputs.max_parallel }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         # GitHub PR's create a merge commit, and Actions are run on that commit.
         # Codecov's uploader needs the previous commit (tip of PR branch) to associate coverage correctly.
@@ -80,7 +80,7 @@ jobs:
         fetch-depth: 2
 
      # Download distribution artifacts (if any).
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
       with:
         path: dist
         pattern: cocotb-dist-*
@@ -90,19 +90,19 @@ jobs:
       # Install Python
     - name: Set up Python ${{matrix.python-version}} (setup-python)
       if: matrix.setup_python == '' && (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos'))
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: ${{matrix.python-version}}
         allow-prereleases: true
     - name: Set up Python ${{matrix.python-version}} (pyenv)
       if: matrix.setup_python == 'pyenv' && (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos'))
-      uses: gabrielfalcao/pyenv-action@v18
+      uses: gabrielfalcao/pyenv-action@a1fc55906be92612782934c70e3985b940bd0165  # v18
       with:
         default: ${{matrix.python-version}}
         command: pip install -U pip  # upgrade pip after installing python
     - name: Set up Anaconda ${{matrix.python-version}} (Windows)
       if: startsWith(matrix.os, 'windows')
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830  # v3.1.1
       with:
         auto-update-conda: true
         # Use base environment to properly import _sqlite3 DLL - see gh-3166
@@ -263,7 +263,7 @@ jobs:
 
     - name: Upload to codecov
       if: inputs.collect_coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
       env:
         # https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
         CODECOV_TOKEN: 669f2048-851e-479e-a618-8fa64f3736cc

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
       with:
         repo-token: ${{secrets.GITHUB_TOKEN}}
         days-before-stale: 30


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

See https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash for motivation why this is the safer option.

This works transparently with dependabot which will update with commit hashes.