### PR TITLE
Add release notes for 1.8.1

### DIFF
--- a/docs/source/newsfragments/3354.bugfix.rst
+++ b/docs/source/newsfragments/3354.bugfix.rst
@@ -1,1 +1,0 @@
-Fix incorrect cleanup of pending Tasks (queued by :func:`cocotb.start_soon` but not started yet) when a test ends.

--- a/docs/source/newsfragments/3409.feature.rst
+++ b/docs/source/newsfragments/3409.feature.rst
@@ -1,1 +1,0 @@
-Python 3.12 is now supported.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -72,6 +72,20 @@ Changes
 - :meth:`Lock.locked <cocotb.triggers.Lock.locked>` is now a method rather than an attribute to mirror :meth:`asyncio.Lock.locked`. (:pr:`3871`)
 
 
+cocotb 1.8.1 (2023-10-06)
+=========================
+
+Features
+--------
+
+- Python 3.12 is now supported. (:issue:`3409`)
+
+Bugfixes
+--------
+
+- Fix incorrect cleanup of pending Tasks (queued by :func:`cocotb.start_soon` but not started yet) when a test ends. (:issue:`3354`)
+
+
 cocotb 1.8.0 (2023-06-15)
 =========================
 


### PR DESCRIPTION
Add release notes for 1.8.1 and remove the newsfrags that are out of date. Closes #4710.