### PR TITLE
Fix more documentation warnings

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -213,7 +213,7 @@ Details on how to debug cocotb can be found on the `Wiki <https://github.com/coc
 Deprecations and Removals
 -------------------------
 
-Cocotb's treatment of deprecations and removal follows guidelines laid out `here <https://symfony.com/doc/current/setup/upgrade_major.html#make-your-code-deprecation-free>`__.
+Cocotb's treatment of deprecations and removal follows guidelines laid out `here <https://symfony.com/doc/current/setup/upgrade_major.html#1-make-your-code-deprecation-free>`__.
 Deprecations serve the following purposes:
 
 -  Remove legacy code that has been deemed out of scope
@@ -261,7 +261,7 @@ Follow the steps below to get your changes merged, i.e. integrated into the main
    If any of them turns "red," i.e. reports a failure, you most likely need to fix your code before it can be merged.
 7. The pull request needs to be reviewed by at least one of the :ref:`maintainers`.
    We aim to give feedback to all pull requests within a week, but as so often, life can get in the way.
-   If you receive no feedback from a maintainer within that time, please contact them directly (e.g. on `Gitter <https://gitter.im/cocotb>`__ or email).
+   If you receive no feedback from a maintainer within that time, please contact them directly (e.g. on `Gitter <https://gitter.im/cocotb/Lobby>`__ or email).
    If a maintainer asks you to explain or modify code, try to do so.
 8. Once your code has at least one positive review from a maintainer and no maintainer strongly objects it your code is ready to be merged into the ``master`` branch.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -154,7 +154,6 @@ A test can spawn multiple coroutines, allowing for independent flows of executio
    - Add some info from :doc:`coroutines`
    - Add GPI section
    - Explain ``ReadOnly``, ``ReadWrite``, ... phases
-   - Add pitfall from https://github.com/cocotb/cocotb/issues/526#issuecomment-300371629 to troubleshooting
 
 
 ..

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -94,7 +94,7 @@ Installation of cocotb
 
     .. parsed-literal::
 
-        pip install "cocotb~=|version|"
+        pip install "cocotb~=\ |version|\ "
 
 .. only:: not is_release_build
 

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -288,6 +288,8 @@ Logging
 
 .. autofunction:: default_config
 
+.. autofunction:: SimLog
+
 .. autoclass:: SimLogFormatter
     :show-inheritance:
     :no-members:

--- a/docs/source/newsfragments/3634.removal.rst
+++ b/docs/source/newsfragments/3634.removal.rst
@@ -1,1 +1,1 @@
-``cocotb.binary.BinaryValue``, ``cocotb.binary.BinaryRepresentation``, and the ``cocotb.binary`` module have been removed in favor of :class:`~cocotb.types.LogicArray`. See :ref:`the guide <TODO PLACEHOLDER>` for a tutorial on upgrading to :class:`~cocotb.types.LogicArray`.
+``cocotb.binary.BinaryValue``, ``cocotb.binary.BinaryRepresentation``, and the ``cocotb.binary`` module have been removed in favor of :class:`~cocotb.types.LogicArray`.

--- a/docs/source/newsfragments/4672.feature.rst
+++ b/docs/source/newsfragments/4672.feature.rst
@@ -1,1 +1,1 @@
-Added :ref:`mypy <https://mypy.readthedocs.io/en/stable/getting_started.html>` checking to CI to ensure type correctness.
+Added `mypy <https://mypy.readthedocs.io/en/stable/getting_started.html>` checking to CI to ensure type correctness.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -111,7 +111,6 @@ accessible via a TCP socket:
    .. code:: python
 
       rpdb.set_trace()  # <-- debugger stops execution after this line
-      <your code line>  # <-- next statement being evaluated by the interpreter
 
 3. Run the Makefile so that the interpreter hits the breakpoint line and *hangs*.
 4. Connect to the freshly created socket, for instance through :command:`telnet`:


### PR DESCRIPTION
There are still some issues with autocodelink that I'm not sure are worth the effort to fix. And there are a couple links reporting as broken, mostly due to not being able to find anchor points in Github links. There is a broken link to `LOG_WARN` in contributing.rst, but that function is not documented currently. That should go away once #4492 is in as those functions will be included as part of the GPI library.

This is enough now that I think we can Close #4560.