### PR TITLE
iverilog wave dump - allow user to specify dump file location

### DIFF
--- a/docs/source/newsfragments/4721.feature.rst
+++ b/docs/source/newsfragments/4721.feature.rst
@@ -1,0 +1,1 @@
+Allow user to specify iverilog wave dump file location at run time with a plusarg.

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -45,6 +45,10 @@ To enable FST tracing, set :make:var:`WAVES` to ``1``.
 
     make SIM=icarus WAVES=1
 
+By default, the wave file will be named `<hdl_toplevel>.fst`. Unlike other simulators, it will be placed in the build directory, rather than the test directory.
+
+To redirect the wave file to a different location, use the plusarg `dumpfile_path` when running the test.
+
 .. _sim-icarus-issues:
 
 Issues for this simulator

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -699,8 +699,10 @@ class Icarus(Runner):
             f.write("module cocotb_iverilog_dump();\n")
             f.write("initial begin\n")
             f.write("    string dumpfile_path;")
-            f.write(f'    if ($value$plusargs("dumpfile_path=%s", dumpfile_path)) begin\n')
-            f.write(f'        $dumpfile(dumpfile_path);\n')
+            f.write(
+                '    if ($value$plusargs("dumpfile_path=%s", dumpfile_path)) begin\n'
+            )
+            f.write("        $dumpfile(dumpfile_path);\n")
             f.write("    end else begin\n")
             f.write(f'        $dumpfile("{dumpfile_path}");\n')
             f.write("    end\n")

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -698,7 +698,12 @@ class Icarus(Runner):
         with open(self.iverilog_dump_file, "w") as f:
             f.write("module cocotb_iverilog_dump();\n")
             f.write("initial begin\n")
-            f.write(f'    $dumpfile("{dumpfile_path}");\n')
+            f.write("    string dumpfile_path;")
+            f.write(f'    if ($value$plusargs("dumpfile_path=%s", dumpfile_path)) begin\n')
+            f.write(f'        $dumpfile(dumpfile_path);\n')
+            f.write("    end else begin\n")
+            f.write(f'        $dumpfile("{dumpfile_path}");\n')
+            f.write("    end\n")
             f.write(f"    $dumpvars(0, {self.hdl_toplevel});\n")
             f.write("end\n")
             f.write("endmodule\n")


### PR DESCRIPTION
iverilog requires the build step to create a verilog shim to dump the waves to a file. This shim can't then be modified at test time.

This causes issues when running under a build system like bazel, where the test/run directory can't be the same as the build directory, and the build directory is read-only for the test.

The best solution I've found for this is to use plusargs, so that the user can specify the wave dump file location at run time.

This solution still means iverilog behaves differently from other simulators with regard to waves, but it doesn't change the existing behaviour, and presents a purely optional means to change the output location for those who need it.

Closes #4720