### PR TITLE
Add deprecated setters to `LogicArray` for `BinaryValue` back-compat

### DIFF
--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -484,13 +484,32 @@ class LogicArray(AbstractArray[Logic]):
             return NotImplemented
 
     @property
-    @deprecated("`.binstr` property is deprecated. Use `str(value)` instead.")
+    @deprecated(
+        "`logic_array.binstr` getter is deprecated. Use `str(logic_array)` instead."
+    )
     def binstr(self) -> str:
-        """Convert the value to the :class:`str` literal representation.
+        """The :class:`!LogicArray`'s value in :class:`str` literal representation.
 
-        .. deprecated:: 2.0
+        :getter:
+            Return the :class:`!LogicArray`'s value in :class:`str` literal representation.
+
+            .. deprecated:: 2.0
+                Use ``str(logic_array)`` instead.
+
+        :setter:
+            Set the :class:`!LogicArray`'s value using a :class:`str` literal representation.
+
+            .. deprecated:: 2.0
+                Use ``logic_array[:] = value`` instead.
         """
         return str(self)
+
+    @binstr.setter
+    @deprecated(
+        "`logic_array.binstr = value` setter is deprecated. Use `logic_array[:] = value` instead."
+    )
+    def binstr(self, value: str) -> None:
+        self[:] = value
 
     @property
     def is_resolvable(self) -> bool:
@@ -500,54 +519,105 @@ class LogicArray(AbstractArray[Logic]):
         )
 
     @property
-    @deprecated("`.integer` property is deprecated. Use `value.to_unsigned()` instead.")
+    @deprecated(
+        "`logic_array.integer` getter is deprecated. Use `logic_array.to_unsigned()` instead."
+    )
     def integer(self) -> int:
-        """Convert the value to an :class:`int` by interpreting it using unsigned representation.
+        """The :class:`!LogicArray`'s value as an unsigned :class:`int`.
 
-        The :class:`LogicArray` is treated as an arbitrary-length vector of bits
+        The :class:`!LogicArray` is treated as an arbitrary-length vector of bits
         with the left-most bit being the most significant bit in the integer value.
         The bit vector is then interpreted as an integer using unsigned representation.
 
-        Returns:
-            An :class:`int` equivalent to the value by interpreting it using unsigned representation.
+        :getter:
+            Return the :class:`!LogicArray`'s value as an unsigned integer.
 
-        .. deprecated:: 2.0
+            .. deprecated:: 2.0
+                Use :meth:`logic_array.to_unsigned() <cocotb.types.LogicArray.to_unsigned>` instead.
+
+        :setter:
+            Set the :class:`!LogicArray`'s value using an unsigned integer.
+
+            .. deprecated:: 2.0
+                Use ``logic_array[:] = value`` instead.
+
+        :setter
         """
         return self.to_unsigned()
 
+    @integer.setter
+    @deprecated(
+        "`logic_array.integer = value` setter is deprecated. Use `logic_array[:] = value` instead."
+    )
+    def integer(self, value: int) -> None:
+        self[:] = value
+
     @property
     @deprecated(
-        "`.signed_integer` property is deprecated. Use `value.to_signed()` instead."
+        "`logic_array.signed_integer` getter is deprecated. Use `logic_array.to_signed()` instead."
     )
     def signed_integer(self) -> int:
-        """Convert the value to an :class:`int` by interpreting it using two's complement representation.
+        """The :class:`!LogicArray`'s value as a signed :class:`int`.
 
-        The :class:`LogicArray` is treated as an arbitrary-length vector of bits
+        The :class:`!LogicArray` is treated as an arbitrary-length vector of bits
         with the left-most bit being the most significant bit in the integer value.
         The bit vector is then interpreted as an integer using two's complement representation.
 
-        Returns:
-            An :class:`int` equivalent to the value by interpreting it using two's complement representation.
+        :getter:
+            Return the :class:`!LogicArray`'s value as a signed integer.
 
-        .. deprecated:: 2.0
+            .. deprecated:: 2.0
+                Use :meth:`logic_array.to_signed() <cocotb.types.LogicArray.to_signed>` instead.
+
+        :setter:
+            Set the :class:`!LogicArray`'s value using a signed integer.
+
+            .. deprecated:: 2.0
+                Use ``logic_array[:] = LogicArray.from_signed(value, len(logic_array))`` instead.
         """
         return self.to_signed()
 
+    @signed_integer.setter
+    @deprecated(
+        "`logic_array.signed_integer = value` setter is deprecated. "
+        "Use `logic_array[:] = LogicArray.from_signed(value, len(logic_array))` instead."
+    )
+    def signed_integer(self, value: int) -> None:
+        self[:] = LogicArray.from_signed(value, len(self))
+
     @property
-    @deprecated("`.buff` property is deprecated. Use `v.to_bytes()` instead.")
+    @deprecated(
+        "`logic_array.buff` getter is deprecated. "
+        'Use `logic_array.to_bytes(byteorder="big")` instead.'
+    )
     def buff(self) -> bytes:
-        """Convert the value to :class:`bytes` by interpreting it as an unsigned integer in big-endian byte order.
+        """The :class:`!LogicArray`'s value as :class:`bytes`.
 
         The object is first converted to an :class:`int` as in :meth:`to_unsigned`.
         Then the object is converted to :class:`bytes` by converting the resulting integer value as in :meth:`int.to_bytes`.
         This assumes big-endian byte order and the minimal number of bytes necessary to hold any value of the current object.
 
-        Returns:
-            A :class:`bytes` object equivalent to the value.
+        :getter:
+            Return the :class:`!LogicArray`'s value as :class:`bytes`.
 
-        .. deprecated:: 2.0
+            .. deprecated:: 2.0
+                Use :meth:`logic_array.to_bytes(byteorder="big") <cocotb.types.LogicArray.to_bytes>` instead.
+
+        :setter:
+            Set the :class:`!LogicArray`'s value using :class:`bytes`.
+
+            .. deprecated:: 2.0
+                Use ``logic_array[:] = LogicArray.from_bytes(value, len(logic_array), byteorder="big")`` instead.
         """
         return self.to_bytes(byteorder="big")
+
+    @buff.setter
+    @deprecated(
+        "`logic_array.buff = value` setter is deprecated. "
+        'Use `logic_array[:] = LogicArray.from_bytes(value, len(logic_array), byteorder="big")` instead.'
+    )
+    def buff(self, value: bytes) -> None:
+        self[:] = LogicArray.from_bytes(value, len(self), byteorder="big")
 
     def to_unsigned(self) -> int:
         """Convert the value to an integer by interpreting it using unsigned representation.

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -147,7 +147,7 @@ class LogicArray(AbstractArray[Logic]):
     .. warning::
         These operations assume the value is entirely ``0``, ``1``, ``L``, or ``H``, and will raise an exception otherwise.
 
-    You can also convert :class:`LogicArray`\ s to hexadecimal or binary strings using
+    You can also convert :class:`!LogicArray`\ s to hexadecimal or binary strings using
     the built-ins :func:`hex:` and :func:`bin`, respectively.
 
     .. code-block:: pycon3
@@ -164,7 +164,7 @@ class LogicArray(AbstractArray[Logic]):
         This means the exact length of the LogicArray is lost.
         It also means that these expressions will raise an exception if the value is not entirely ``0``, ``1``, ``L``, or ``H``.
 
-    :class:`LogicArray`\ s also support element-wise logical operations: ``&``, ``|``,
+    :class:`!LogicArray`\ s also support element-wise logical operations: ``&``, ``|``,
     ``^``, and ``~``.
 
     .. code-block:: pycon3
@@ -292,21 +292,21 @@ class LogicArray(AbstractArray[Logic]):
         value: int,
         range: Union[Range, int],
     ) -> "LogicArray":
-        """Construct a :class:`LogicArray` from an :class:`int` with unsigned representation.
+        """Construct a :class:`!LogicArray` from an :class:`int` with unsigned representation.
 
         The :class:`int` is treated as an arbitrary-length bit vector with unsigned representation where the left-most bit is the most significant bit.
-        This bit vector is then constructed into a :class:`LogicArray`.
+        This bit vector is then constructed into a :class:`!LogicArray`.
 
         Args:
             value: The integer to convert.
             range: Indexing scheme for the LogicArray.
 
         Returns:
-            A :class:`LogicArray` equivalent to the *value*.
+            A :class:`!LogicArray` equivalent to the *value*.
 
         Raises:
             TypeError: When invalid argument types are used.
-            ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*, or *value* is negative.
+            ValueError: When a :class:`!LogicArray` of the given *range* can't hold the *value*, or *value* is negative.
         """
         if value < 0:
             raise ValueError("Expected unsigned integer, got negative value.")
@@ -318,21 +318,21 @@ class LogicArray(AbstractArray[Logic]):
         value: int,
         range: Union[Range, int],
     ) -> "LogicArray":
-        """Construct a :class:`LogicArray` from an :class:`int` with two's complement representation.
+        """Construct a :class:`!LogicArray` from an :class:`int` with two's complement representation.
 
         The :class:`int` is treated as an arbitrary-length bit vector with two's complement representation where the left-most bit is the most significant bit.
-        This bit vector is then constructed into a :class:`LogicArray`.
+        This bit vector is then constructed into a :class:`!LogicArray`.
 
         Args:
             value: The integer to convert.
             range: Indexing scheme for the LogicArray.
 
         Returns:
-            A :class:`LogicArray` equivalent to the *value*.
+            A :class:`!LogicArray` equivalent to the *value*.
 
         Raises:
             TypeError: When invalid argument types are used.
-            ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
+            ValueError: When a :class:`!LogicArray` of the given *range* can't hold the *value*.
         """
         if isinstance(range, int):
             range = Range(range - 1, "downto", 0)
@@ -364,10 +364,10 @@ class LogicArray(AbstractArray[Logic]):
         *,
         byteorder: "Literal['big'] | Literal['little']",
     ) -> "LogicArray":
-        """Construct a :class:`LogicArray` from :class:`bytes`.
+        """Construct a :class:`!LogicArray` from :class:`bytes`.
 
         The :class:`bytes` is first converted to an unsigned integer using *byteorder*-endian representation,
-        then is converted to a :class:`LogicArray` as in :meth:`from_unsigned`.
+        then is converted to a :class:`!LogicArray` as in :meth:`from_unsigned`.
 
         Args:
             value: The bytes to convert.
@@ -375,10 +375,10 @@ class LogicArray(AbstractArray[Logic]):
             byteorder: The endianness used to construct the intermediate integer, either ``"big"`` or ``"little"``.
 
         Returns:
-            A :class:`LogicArray` equivalent to the *value*.
+            A :class:`!LogicArray` equivalent to the *value*.
 
         Raises:
-            ValueError: When a :class:`LogicArray` of the given *range* can't hold the *value*.
+            ValueError: When a :class:`!LogicArray` of the given *range* can't hold the *value*.
         """
         if range is None:
             range = Range(len(value) * 8 - 1, "downto", 0)
@@ -622,7 +622,7 @@ class LogicArray(AbstractArray[Logic]):
     def to_unsigned(self) -> int:
         """Convert the value to an integer by interpreting it using unsigned representation.
 
-        The :class:`LogicArray` is treated as an arbitrary-length vector of bits
+        The :class:`!LogicArray` is treated as an arbitrary-length vector of bits
         with the left-most bit being the most significant bit in the integer value.
         The bit vector is then interpreted as an integer using unsigned representation.
 
@@ -636,7 +636,7 @@ class LogicArray(AbstractArray[Logic]):
     def to_signed(self) -> int:
         """Convert the value to an integer by interpreting it using two's complement representation.
 
-        The :class:`LogicArray` is treated as an arbitrary-length vector of bits
+        The :class:`!LogicArray` is treated as an arbitrary-length vector of bits
         with the left-most bit being the most significant bit in the integer value.
         The bit vector is then interpreted as an integer using two's complement representation.
 
@@ -658,9 +658,9 @@ class LogicArray(AbstractArray[Logic]):
     ) -> bytes:
         """Convert the value to bytes.
 
-        The :class:`LogicArray` is converted to an unsigned integer as in :meth:`to_unsigned`,
+        The :class:`!LogicArray` is converted to an unsigned integer as in :meth:`to_unsigned`,
         then is converted to :class:`bytes` using *byteorder*-endian representation
-        with the minimum number of bytes which can store all the bits in the original :class:`LogicArray`.
+        with the minimum number of bytes which can store all the bits in the original :class:`!LogicArray`.
 
         Args:
             byteorder: The endianness used to construct the intermediate integer, either ``"big"`` or ``"little"``.

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -140,19 +140,51 @@ def test_logic_array_properties():
 
 def test_logic_array_properties_deprecated():
     with pytest.warns(DeprecationWarning):
-        assert LogicArray("0").integer == 0
-    with pytest.warns(DeprecationWarning):
-        assert LogicArray("0").signed_integer == 0
-    with pytest.warns(DeprecationWarning):
-        assert LogicArray("0").binstr == "0"
-    with pytest.warns(DeprecationWarning):
         assert LogicArray("1010").integer == 10
+
+    l = LogicArray("1100")
+    with pytest.warns(DeprecationWarning):
+        l.integer = 1
+    assert l.to_unsigned() == 1
+    with pytest.warns(DeprecationWarning), pytest.raises(ValueError):
+        l.integer = 100
+    with pytest.warns(DeprecationWarning), pytest.raises(ValueError):
+        l.integer = -1
+
     with pytest.warns(DeprecationWarning):
         assert LogicArray("1010").signed_integer == -6
+
+    l = LogicArray("1100")
+    with pytest.warns(DeprecationWarning):
+        l.signed_integer = 3
+    assert l.to_signed() == 3
+    with pytest.warns(DeprecationWarning):
+        l.signed_integer = -1
+    assert l.to_signed() == -1
+    with pytest.warns(DeprecationWarning), pytest.raises(ValueError):
+        l.signed_integer = 100
+    with pytest.warns(DeprecationWarning), pytest.raises(ValueError):
+        l.signed_integer = -10
+
     with pytest.warns(DeprecationWarning):
         assert LogicArray("1010").binstr == "1010"
+
+    l = LogicArray("1010")
+    with pytest.warns(DeprecationWarning):
+        l.binstr = "0101"
+    assert str(l) == "0101"
+
     with pytest.warns(DeprecationWarning):
         assert LogicArray("01000001" + "00101111").buff == b"\x41\x2f"
+
+    l = LogicArray("0" * 16)
+    with pytest.warns(DeprecationWarning):
+        l.buff = b"\x41\x2f"
+    assert l.to_bytes(byteorder="big") == b"\x41\x2f"
+    with pytest.warns(DeprecationWarning), pytest.raises(ValueError):
+        l.buff = b"\x41\x2f0123"
+    with pytest.warns(DeprecationWarning), pytest.raises(ValueError):
+        l.buff = b""
 
 
 def test_logic_array_setattr():


### PR DESCRIPTION
Should ease porting to 2.0.

### TODO
- [x] fix docs, split into getters/setter
