### PR TITLE
Deprecate `Lock` `name` field like `Event`

### DIFF
--- a/docs/source/newsfragments/4561.removal.rst
+++ b/docs/source/newsfragments/4561.removal.rst
@@ -1,1 +1,1 @@
-Deprecated :attr:`.Event.name` and passing a ``name`` argument to :class:`.Event` constructors. If you need to associate a name with an Event, create an empty subclass of :class:`!cocotb.triggers.Event` with your desired name.
+Deprecated :attr:`.Event.name` and passing a ``name`` argument to :class:`.Event` constructors.

--- a/docs/source/newsfragments/4723.removal.rst
+++ b/docs/source/newsfragments/4723.removal.rst
@@ -1,0 +1,1 @@
+Deprecated :attr:`.Lock.name` and passing a ``name`` argument to :class:`.Lock` constructors.

--- a/src/cocotb/_base_triggers.py
+++ b/src/cocotb/_base_triggers.py
@@ -150,22 +150,27 @@ class Event:
         self._event: _Event = _Event(self)
         self._name: Union[str, None] = None
         if name is not None:
+            warnings.warn(
+                "The 'name' argument will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self.name = name
         self._fired: bool = False
         self._data: Any = None
 
     @property
-    @deprecated("The name field will be removed in a future release.")
+    @deprecated("The 'name' field will be removed in a future release.")
     def name(self) -> Union[str, None]:
         """Name of the Event.
 
         .. deprecated:: 2.0
-            The name field will be removed in a future release.
+            The *name* field will be removed in a future release.
         """
         return self._name
 
     @name.setter
-    @deprecated("The name field will be removed in a future release.")
+    @deprecated("The 'name' field will be removed in a future release.")
     def name(self, new_name: Union[str, None]) -> None:
         self._name = new_name
 
@@ -342,8 +347,30 @@ class Lock(AsyncContextManager[None]):
 
     def __init__(self, name: Optional[str] = None) -> None:
         self._pending_primed: List[_Lock] = []
-        self.name: Optional[str] = name
+        self._name: Union[str, None] = None
+        if name is not None:
+            warnings.warn(
+                "The 'name' argument will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self._name = name
         self._locked: bool = False
+
+    @property
+    @deprecated("The 'name' field will be removed in a future release.")
+    def name(self) -> Union[str, None]:
+        """Name of the Lock.
+
+        .. deprecated:: 2.0
+            The *name* field will be removed in a future release.
+        """
+        return self._name
+
+    @name.setter
+    @deprecated("The 'name' field will be removed in a future release.")
+    def name(self, new_name: Union[str, None]) -> None:
+        self._name = new_name
 
     def locked(self) -> bool:
         """Return ``True`` if the lock has been acquired.
@@ -387,13 +414,13 @@ class Lock(AsyncContextManager[None]):
         self._acquire_and_fire(lock)
 
     def __repr__(self) -> str:
-        if self.name is None:
+        if self._name is None:
             fmt = "<{0} [{2} waiting] at {3}>"
         else:
             fmt = "<{0} for {1} [{2} waiting] at {3}>"
         return fmt.format(
             type(self).__qualname__,
-            self.name,
+            self._name,
             len(self._pending_primed),
             pointer_str(self),
         )

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -10,6 +10,7 @@ import pytest
 from common import assert_takes
 
 import cocotb
+from cocotb._base_triggers import Lock
 from cocotb.clock import Clock
 from cocotb.regression import TestFactory
 from cocotb.task import Join
@@ -232,3 +233,15 @@ async def test_results_deprecated(_: Any) -> None:
 async def test_triggers_Join_import_deprecated(_: Any) -> None:
     with pytest.warns(DeprecationWarning):
         from cocotb.triggers import Join  # noqa: F401
+
+
+@cocotb.test
+async def test_Lock_name_deprecated(_: object) -> None:
+    with pytest.warns(DeprecationWarning):
+        l = Lock(name="thingy")
+    with pytest.warns(DeprecationWarning):
+        assert l.name == "thingy"
+    with pytest.warns(DeprecationWarning):
+        l.name = "foobar"
+    with pytest.warns(DeprecationWarning):
+        assert l.name == "foobar"

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -84,7 +84,8 @@ async def test_lock_repr(dut):
 
     assert re.match(r"<Lock \[0 waiting\] at \w+>", repr(lock))
 
-    lock = Lock(name="my_lock")
+    with pytest.warns(DeprecationWarning):
+        lock = Lock(name="my_lock")
 
     async def task():
         async with lock:


### PR DESCRIPTION
Closes #4715. Doing the same things as #4561. asyncio's `Lock` does not have a name. If we hope to improve interface compatibility between the two so we may someday replace the scheduler with asyncio, this will be necessary.