### PR TITLE
Bump Sphinx to 8.2 to use new `py:decorator` role

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies to build the documentation
 
-Sphinx == 8.1
+Sphinx >= 8.2
 breathe
 sphinx-book-theme == 1.1.3  # pin this to exact version to guard against any CSS changes
 sphinx-design >= 0.6.1

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -180,10 +180,10 @@ The Python type of a value depends on the handle's HDL type:
 Identifying tests
 =================
 
-Cocotb tests are identified using the :class:`~cocotb.test` decorator.
+Cocotb tests are identified using the :deco:`cocotb.test` decorator.
 Using this decorator will tell cocotb that this function is a special type of coroutine that is meant
 to either pass or fail.
-The :class:`~cocotb.test` decorator supports several keyword arguments (see section :ref:`writing-tests`).
+The :deco:`cocotb.test` decorator supports several keyword arguments (see section :ref:`writing-tests`).
 In most cases no arguments are passed to the decorator so cocotb tests can be written as:
 
 .. code-block:: python
@@ -383,7 +383,7 @@ For example, see the below output for the first test from above.
 
 
 If a test coroutine completes without `failing` or `erroring`,
-or if the test coroutine or any running :class:`~cocotb.task.Task` calls :func:`~cocotb.pass_test`,
+or if the test coroutine or any running :class:`~cocotb.task.Task` calls :func:`cocotb.pass_test`,
 the test is considered to have `passed`.
 Below are examples of `passing` tests.
 


### PR DESCRIPTION
Closes #4725. Bumps Sphinx version, uses the new `:deco:` role and touchs up some random things in Writing Testbenches.

See https://cocotb--4726.org.readthedocs.build/en/4726/writing_testbenches.html#writing-tbs-identifying-tests.