### PR TITLE
Add envvar to customize installing pytest assertion rewriting hook

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -342,6 +342,15 @@ Regression Manager
    See also the :ref:`troubleshooting-attaching-debugger-python` subsection of :ref:`troubleshooting-attaching-debugger`.
 
 
+.. envvar:: COCOTB_REWRITE_ASSERTION_FILES
+
+    Select the Python files to apply ``pytest``'s assertion rewriting to.
+    This is useful to get more informative assertion error messages in cocotb tests.
+    Specify using a space-separated list of file globs, e.g. ``test_*.py testbench_common/**/*.py``.
+    Set to the empty string to disable assertion rewriting.
+    Defaults to ``*.py`` (all Python files, even third-party modules like ``scipy``).
+
+
 Scheduler
 ~~~~~~~~~
 

--- a/docs/source/newsfragments/4728.feature.rst
+++ b/docs/source/newsfragments/4728.feature.rst
@@ -1,0 +1,1 @@
+Added :envvar:`COCOTB_REWRITE_ASSERTION_FILES` to allow users to select which files to enable ``pytest``'s assertion rewriting in, or disable it.

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -240,8 +240,14 @@ class RegressionManager:
             from _pytest.assertion import install_importhook
             from _pytest.config import Config
 
+            python_files = os.getenv("COCOTB_REWRITE_ASSERTION_FILES", "*.py").strip()
+            if not python_files:
+                # Even running the hook causes exceptions in some cases, so if the user
+                # selects nothing, don't install the hook at all.
+                return
+
             pytest_conf = Config.fromdictargs(
-                {}, ["--capture=no", "-o", "python_files=*.py"]
+                {}, ["--capture=no", "-o", f"python_files={python_files}"]
             )
             install_importhook(pytest_conf)
         except Exception:


### PR DESCRIPTION
Closes #4343. Applying rewriting to all Python files has some issues, so we add this option to allow users to select which files to rewrite, or to disable it entirely.