### PR TITLE
NVC Runner fixes

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1115,7 +1115,12 @@ class Nvc(Runner):
                 )
 
         cmds = [
-            ["nvc", f"--work={self.hdl_library}", "-L", str(self.build_dir)]
+            [
+                "nvc",
+                f"--work={self.hdl_library}",
+                "-L",
+                str(get_abs_path(self.build_dir)),
+            ]
             + [arg for arg in self.build_args if type(arg) in (str, VHDL)]
             + ["-a"]
             + [str(source) for source in self.sources if is_vhdl_source(source)]
@@ -1126,8 +1131,14 @@ class Nvc(Runner):
         return cmds
 
     def _test_command(self) -> List[_Command]:
+        work_library = str(get_abs_path(self.build_dir / self.hdl_toplevel_library))
         cmds = [
-            ["nvc", f"--work={self.hdl_toplevel_library}", "-L", str(self.build_dir)]
+            [
+                "nvc",
+                f"--work={self.hdl_toplevel_library}:{work_library}",
+                "-L",
+                str(get_abs_path(self.build_dir)),
+            ]
             + self.build_args
             + ["-e", self.sim_hdl_toplevel, "--no-save", "--jit"]
             + self.elab_args

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -127,6 +127,7 @@ class Runner(ABC):
         self.parameters: Mapping[str, object] = {}
 
         self.log = logging.getLogger(type(self).__qualname__)
+        self.log.setLevel(logging.INFO)
 
     @abstractmethod
     def _simulator_in_path(self) -> None:


### PR DESCRIPTION
Sets the logger level to INFO so we get INFO diagnostics about things like exact commands being run out which the Makefiles do. Then fixes a bug in the NVC runner where relative paths were used in commands which breaks when `test_dir` is set.