### PR TITLE
Lint all pyprojects using validate-pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
   rev: "2025.05.12"
   hooks:
     - id: validate-pyproject
+      files: pyproject.toml
 
 - repo: local
   hooks:


### PR DESCRIPTION
According to the documentation for `validate-pyproject`, the pre-commit action only validates the top-level pyproject.toml file (why? whatever...). We use the `files` option to expand the glob to all pyproject.toml files in the repo.

`pre-commit run -a -v` after this change...
```
Validate pyproject.toml..................................................Passed
- hook id: validate-pyproject
- duration: 1.85s

Valid file: pyproject.toml
Valid file: src/pyproject.toml
```