### PR TITLE
Use ellipses instead of `pass`

### DIFF
--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -191,12 +191,19 @@ In most cases no arguments are passed to the decorator so cocotb tests can be wr
     # A valid cocotb test
     @cocotb.test
     async def test(dut):
-        pass
+        ...
 
     # Also a valid cocotb test
-    @cocotb.test()
+    @cocotb.test()  # added ()
     async def test(dut):
-        pass
+        ...
+
+    # Another valid cocotb test
+    @cocotb.test(
+        skip=cocotb.top.feature.value != 1  # skip if feature disabled
+    )
+    async def test(dut):
+        ...
 
 .. _writing_tbs_concurrent_sequential:
 

--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -357,7 +357,8 @@ def test(
                     @cocotb.test(**decorator_kwargs)
                     @functools.wraps(obj)
                     async def test(dut, **test_kwargs):
-                        pass  # your code here
+                        # your code here
+                        ...
 
                     return obj
 

--- a/src/cocotb/types/_range.py
+++ b/src/cocotb/types/_range.py
@@ -129,12 +129,10 @@ class Range(Sequence[int]):
         return len(self._range)
 
     @overload
-    def __getitem__(self, item: int) -> int:
-        pass  # pragma: no cover
+    def __getitem__(self, item: int) -> int: ...
 
     @overload
-    def __getitem__(self, item: slice) -> "Range":
-        pass  # pragma: no cover
+    def __getitem__(self, item: slice) -> "Range": ...
 
     def __getitem__(self, item: Union[int, slice]) -> Union[int, "Range"]:
         if isinstance(item, int):


### PR DESCRIPTION
It prevents confusion with "passing a test" in docs. Also deleted a couple uses in the source. `...` lines are excluded from coverage by default so we can remove the pragmas.