### PR TITLE
Use short "a | b" syntax for Literal types in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,6 +110,9 @@ autoclass_content = "both"
 autodoc_typehints = "description"  # show type hints in the list of parameters
 autodoc_typehints_description_target = "documented"
 
+# use short "a | b" syntax for Literal types
+python_display_short_literal_types = True
+
 # Options for automatic links from code examples to reference docs
 # (https://sphinx-codeautolink.readthedocs.io/)
 codeautolink_warn_on_missing_inventory = True


### PR DESCRIPTION
Improves readability, see https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-python_display_short_literal_types

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
