### PR TITLE
Import typing.Literal to improve doc rendering

### DIFF
--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -29,7 +29,7 @@ from cocotb._base_triggers import Trigger
 from cocotb._typing import TimeUnit
 
 if sys.version_info >= (3, 10):
-    from typing import TypeAlias
+    from typing import Literal, TypeAlias  # noqa: F401  # used in type strings
 
 
 class Test:

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -6,6 +6,7 @@
 
 """A collection of triggers which a testbench can :keyword:`await`."""
 
+import sys
 from abc import abstractmethod
 from decimal import Decimal
 from typing import (
@@ -27,6 +28,10 @@ from cocotb._base_triggers import NullTrigger, Trigger, _InternalEvent
 from cocotb._gpi_triggers import FallingEdge, RisingEdge, Timer, ValueChange
 from cocotb._typing import TimeUnit
 from cocotb.task import Task
+
+if sys.version_info >= (3, 10):
+    from typing import Literal  # noqa: F401  # used in type strings
+
 
 T = TypeVar("T")
 

--- a/src/cocotb/_gpi_triggers.py
+++ b/src/cocotb/_gpi_triggers.py
@@ -32,6 +32,9 @@ from cocotb.utils import get_sim_steps, get_time_from_sim_steps
 if sys.version_info >= (3, 11):
     from typing import Self
 
+if sys.version_info >= (3, 10):
+    from typing import Literal  # noqa: F401  # used in type strings
+
 
 class GPITrigger(Trigger):
     """A trigger for a simulation event."""

--- a/src/cocotb/_test_factory.py
+++ b/src/cocotb/_test_factory.py
@@ -5,6 +5,7 @@
 import functools
 import inspect
 import logging
+import sys
 import warnings
 from itertools import product
 from types import FrameType, FunctionType
@@ -25,6 +26,9 @@ from typing import (
 from cocotb._base_triggers import Trigger
 from cocotb._decorators import Test
 from cocotb._typing import TimeUnit
+
+if sys.version_info >= (3, 10):
+    from typing import Literal  # noqa: F401  # used in type strings
 
 
 class TestFactory:


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
