### PR TITLE
Correct installation instructions for Guix.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -127,7 +127,7 @@ The installation instructions vary depending on your package manager:
 
    .. tab-item:: Guix
 
-      First, set up the `Guix-science channel <https://codeberg.org/guix-science/guix-science>`_. Then, in a terminal, run
+      In a terminal, run
 
         .. code-block:: bash
 


### PR DESCRIPTION
This package is now part of guix, no need to refer to guix-science
channel anymore.

See [here](https://codeberg.org/guix/guix/pulls/56).

	