### PR TITLE
Fix combine_results not finding results.xml files

### DIFF
--- a/src/cocotb_tools/combine_results.py
+++ b/src/cocotb_tools/combine_results.py
@@ -17,7 +17,7 @@ from xml.etree import ElementTree as ET
 
 def _find_all(name: Pattern, path: Path) -> Iterable[Path]:
     for obj in path.iterdir():
-        if obj.is_file() and re.match(name, str(obj)):
+        if obj.is_file() and re.match(name, obj.name):
             yield obj
         elif obj.is_dir():
             yield from _find_all(name, obj)


### PR DESCRIPTION
The previous implementation only matched the filename and not the full path. I'm wondering if this should instead be `re.search` and use the full path?