### PR TITLE
LogicArray: enforce _value_as_int to be an int

### DIFF
--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -227,7 +227,7 @@ class LogicArray(AbstractArray[Logic]):
             else:
                 self._range = Range(len(self._value_as_str) - 1, "downto", 0)
         elif isinstance(value, int):
-            value = int(value) # force bool to int
+            value = int(value)  # force bool to int
             if value < 0:
                 raise ValueError("Invalid int literal")
             if range is None:


### PR DESCRIPTION
When `LogicArray` is initialized with a value of type `bool` (for which `isinstance(value, int)` is true), that will become the type of `_value_as_int`. When converting the object to an integer (via `__int__()` -> `to_unsigned()` -> `_get_int()`), it triggers https://github.com/python/cpython/blob/725da50520c5cc3002f6f55bf67c56853507c604/Objects/abstract.c#L1540 .
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
