### PR TITLE
Avoid using `Any`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -187,7 +187,7 @@ def dev_test_sim(
 
     cocotb_pkg_dir = Path(
         cast(
-            str,
+            "str",
             session.run(
                 "python", "-c", "import cocotb; print(cocotb.__file__)", silent=True
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ extend-select = [
     "PERF102",  # unnecessary dict.items()
     "B007",     # unused loop variable
     "PYI030",   # unnecessary literal union
+    "TC006",    # runtime cast values
 ]
 ignore = [
 

--- a/src/cocotb/_base_triggers.py
+++ b/src/cocotb/_base_triggers.py
@@ -9,7 +9,6 @@
 import logging
 import warnings
 from typing import (
-    Any,
     AsyncContextManager,
     Callable,
     Generator,
@@ -153,7 +152,7 @@ class Event:
             )
             self.name = name
         self._fired: bool = False
-        self._data: Any = None
+        self._data: object = None
 
     @property
     @deprecated("The 'name' field will be removed in a future release.")
@@ -172,7 +171,7 @@ class Event:
 
     @property
     @deprecated("The data field will be removed in a future release.")
-    def data(self) -> Any:
+    def data(self) -> object:
         """The data associated with the Event.
 
         .. deprecated:: 2.0
@@ -183,10 +182,10 @@ class Event:
 
     @data.setter
     @deprecated("The data field will be removed in a future release.")
-    def data(self, new_data: Any) -> None:
+    def data(self, new_data: object) -> None:
         self._data = new_data
 
-    def set(self, data: Optional[Any] = None) -> None:
+    def set(self, data: Optional[object] = None) -> None:
         """Set the Event and unblock all Tasks blocked on this Event."""
         self._fired = True
         if data is not None:
@@ -426,7 +425,7 @@ class Lock(AsyncContextManager[None]):
     async def __aenter__(self) -> None:
         await self.acquire()
 
-    async def __aexit__(self, *args: Any) -> None:
+    async def __aexit__(self, *args: object) -> None:
         self.release()
 
 

--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -130,7 +130,7 @@ class Parameterized:
                 transformed: Dict[str, List[object]] = {}
                 for nam_idx, nam in enumerate(name):
                     transformed[nam] = []
-                    for value_array in cast(Sequence[Sequence[object]], values):
+                    for value_array in cast("Sequence[Sequence[object]]", values):
                         value = value_array[nam_idx]
                         transformed[nam].append(value)
                 for n, vs in transformed.items():
@@ -153,14 +153,14 @@ class Parameterized:
 
                 if isinstance(option_name, str):
                     # single params per option
-                    selected_value = cast(Sequence[object], selected_value)
+                    selected_value = cast("Sequence[object]", selected_value)
                     test_kwargs[option_name] = selected_value
                     test_name_pieces.append(
                         f"/{option_name}={self._option_reprs[option_name][select_idx]}"
                     )
                 else:
                     # multiple params per option
-                    selected_value = cast(Sequence[object], selected_value)
+                    selected_value = cast("Sequence[object]", selected_value)
                     for n, v in zip(option_name, selected_value):
                         test_kwargs[n] = v
                         test_name_pieces.append(
@@ -495,7 +495,7 @@ def parametrize(
             for n in name:
                 if not n.isidentifier():
                     raise ValueError("Option names must be valid Python identifiers")
-            values = cast(Sequence[Sequence[object]], values)
+            values = cast("Sequence[Sequence[object]]", values)
             for value in values:
                 if len(name) != len(value):
                     raise ValueError(

--- a/src/cocotb/_deprecation.py
+++ b/src/cocotb/_deprecation.py
@@ -4,9 +4,9 @@
 
 import functools
 import warnings
-from typing import Any, Callable, Type, TypeVar
+from typing import Callable, Type, TypeVar
 
-AnyCallableT = TypeVar("AnyCallableT", bound=Callable[..., Any])
+AnyCallableT = TypeVar("AnyCallableT", bound=Callable[..., object])
 
 
 def deprecated(
@@ -27,7 +27,7 @@ def deprecated(
 
     def decorator(f: AnyCallableT) -> AnyCallableT:
         @functools.wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: object, **kwargs: object) -> object:
             warnings.warn(msg, category=category, stacklevel=2)
             return f(*args, **kwargs)
 

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -411,8 +411,8 @@ async def with_timeout(
     if res is timeout_timer:
         if not shielded:
             # shielded = False only when trigger is a Task created to wrap a Coroutine
-            task = cast(Task[object], trigger)
+            task = cast("Task[object]", trigger)
             task.cancel()
         raise SimTimeoutError
     else:
-        return cast(Union[T, TriggerT], res)
+        return cast("T | TriggerT", res)

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -12,7 +12,7 @@ import time
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, List, cast
+from typing import Callable, List, cast
 
 import cocotb
 import cocotb._profiling
@@ -94,7 +94,7 @@ def init_package_from_simulation(argv: List[str]) -> None:
     )
 
 
-def run_regression(_: Any) -> None:
+def run_regression(_: object) -> None:
     """Setup and run a regression."""
 
     _setup_regression_manager()

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -142,7 +142,7 @@ def _process_packages() -> None:
 
     for pkg in pkgs:
         handle = cast(
-            cocotb.handle.HierarchyObject, cocotb.handle._make_sim_object(pkg)
+            "cocotb.handle.HierarchyObject", cocotb.handle._make_sim_object(pkg)
         )
         name = handle._name
 

--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -84,30 +84,13 @@ if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from functools import update_wrapper
-    from typing import Any, Callable, Generic, Type, TypeVar, Union, overload
 
-    T_co = TypeVar("T_co", covariant=True)
-
-    class cached_property(Generic[T_co]):
-        def __init__(self, method: Callable[..., T_co]) -> None:
+    class cached_property:
+        def __init__(self, method):
             self._method = method
-            update_wrapper(self, method)  # type: ignore[arg-type]
+            update_wrapper(self, method)
 
-        @overload
-        def __get__(
-            self, instance: None, owner: Union[Type[Any], None] = None
-        ) -> "cached_property[T_co]": ...
-
-        @overload
-        def __get__(
-            self, instance: object, owner: Union[Type[Any], None] = None
-        ) -> T_co: ...
-
-        def __get__(
-            self,
-            instance: Union[object, None],
-            owner: Union[Type[Any], None] = None,
-        ) -> Union["cached_property[T_co]", T_co]:
+        def __get__(self, instance, owner=None):
             if instance is None:
                 return self
             res = self._method(instance)

--- a/src/cocotb/_test_factory.py
+++ b/src/cocotb/_test_factory.py
@@ -139,7 +139,7 @@ class TestFactory:
             Groups of options are now supported
         """
         if not isinstance(name, str):
-            optionlist = cast(Sequence[Sequence[object]], optionlist)
+            optionlist = cast("Sequence[Sequence[object]]", optionlist)
             for opt in optionlist:
                 if len(name) != len(opt):
                     raise ValueError(
@@ -240,7 +240,7 @@ class TestFactory:
             postfix = ""
 
         # trust the user puts a reasonable stacklevel in
-        glbs = cast(FrameType, inspect.stack()[stacklevel][0].f_back).f_globals
+        glbs = cast("FrameType", inspect.stack()[stacklevel][0].f_back).f_globals
 
         test_func_name = self.test_function.__qualname__ if name is None else name
 
@@ -254,18 +254,18 @@ class TestFactory:
             testoptions_split: Dict[str, Sequence[object]] = {}
             for optname, optvalue in testoptions.items():
                 if isinstance(optname, str):
-                    optvalue = cast(Sequence[object], optvalue)
+                    optvalue = cast("Sequence[object]", optvalue)
                     testoptions_split[optname] = optvalue
                 else:
                     # previously checked in add_option; ensure nothing has changed
-                    optvalue = cast(Sequence[Sequence[object]], optvalue)
+                    optvalue = cast("Sequence[Sequence[object]]", optvalue)
                     assert len(optname) == len(optvalue)
                     for n, v in zip(optname, optvalue):
                         testoptions_split[n] = v
 
             for optname, optvalue in testoptions_split.items():
                 if callable(optvalue):
-                    optvalue = cast(FunctionType, optvalue)
+                    optvalue = cast("FunctionType", optvalue)
                     if optvalue.__doc__ is None:
                         desc = "No docstring supplied"
                     else:

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -281,3 +281,14 @@ def pointer_str(obj: object) -> str:
     """
     full_repr = object.__repr__(obj)  # gives "<{type} object at {address}>"
     return full_repr.rsplit(" ", 1)[1][:-1]
+
+
+def safe_divide(a: float, b: float) -> float:
+    """Used when computing time ratios to ensure no exception is raised if either time is 0."""
+    try:
+        return a / b
+    except ZeroDivisionError:
+        if a == 0:
+            return float("nan")
+        else:
+            return float("inf")

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -179,7 +179,7 @@ class DocEnum(Enum):
     as recommended by the ``enum_tools`` documentation.
     """
 
-    def __new__(cls: Type[EnumT], value: Any, doc: Optional[str] = None) -> EnumT:
+    def __new__(cls: Type[EnumT], value: object, doc: Optional[str] = None) -> EnumT:
         # super().__new__() assumes the value is already an enum value
         # so we side step that and create a raw object and fill in _value_
         self = object.__new__(cls)

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -93,7 +93,9 @@ def remove_traceback_frames(
     if isinstance(tb_or_exc, BaseException):
         exc: BaseException = tb_or_exc
         return exc.with_traceback(
-            remove_traceback_frames(cast(TracebackType, exc.__traceback__), frame_names)
+            remove_traceback_frames(
+                cast("TracebackType", exc.__traceback__), frame_names
+            )
         )
     elif isinstance(tb_or_exc, tuple):
         exc_type, exc_value, exc_tb = tb_or_exc
@@ -105,7 +107,7 @@ def remove_traceback_frames(
         for frame_name in frame_names:
             # the assert and cast are there assuming the frame_names being removed are correct
             assert tb.tb_frame.f_code.co_name == frame_name
-            tb = cast(TracebackType, tb.tb_next)
+            tb = cast("TracebackType", tb.tb_next)
         return tb
 
 

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -893,10 +893,10 @@ class ValueObjectBase(SimHandleBase, Generic[ValueGetT, ValueSetT]):
             self._set_value(value.value, _GPISetAction.FORCE)
         elif isinstance(value, Freeze):
             # We assume that ValueSetT >= ValueGetT
-            self._set_value(cast(ValueSetT, self.get()), _GPISetAction.FORCE)
+            self._set_value(cast("ValueSetT", self.get()), _GPISetAction.FORCE)
         elif isinstance(value, Release):
             # We assume that ValueSetT >= ValueGetT
-            self._set_value(cast(ValueSetT, self.get()), _GPISetAction.RELEASE)
+            self._set_value(cast("ValueSetT", self.get()), _GPISetAction.RELEASE)
         elif isinstance(value, Immediate):
             self._set_value(value.value, _GPISetAction.NO_DELAY)
         else:
@@ -1071,7 +1071,7 @@ class ArrayObject(
             raise IndexError(f"{self._path} contains no object at index {index}")
         path = self._path + "[" + str(index) + "]"
         self._sub_handles[index] = cast(
-            ChildObjectT, _make_sim_object(new_handle, path)
+            "ChildObjectT", _make_sim_object(new_handle, path)
         )
         return self._sub_handles[index]
 

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -160,7 +160,7 @@ class SimHandleBase(ABC):
     def __hash__(self) -> int:
         return hash(self._handle)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, SimHandleBase):
             return NotImplemented
         return self._handle == other._handle
@@ -455,7 +455,7 @@ class HierarchyObject(_HierarchyObjectBase[str]):
     def __init__(self, handle: simulator.gpi_sim_hdl, path: Optional[str]) -> None:
         super().__init__(handle, path)
 
-    def __setattr__(self, name: str, value: Any) -> None:
+    def __setattr__(self, name: str, value: object) -> None:
         # private attributes pass through directly
         if name.startswith("_"):
             return object.__setattr__(self, name, value)
@@ -1350,7 +1350,7 @@ class LogicArrayObject(
     def _len(self) -> int:
         return self._handle.get_num_elems()
 
-    def __getitem__(self, _: Any) -> NoReturn:
+    def __getitem__(self, _: object) -> NoReturn:
         raise TypeError(
             "Packed objects, either arrays or structs, cannot be indexed.\n"
             "Try instead reading the whole value and slicing: `t = handle.value; t[0:3]`.\n"

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -423,7 +423,7 @@ class RegressionManager:
 
     def _score_test(
         self,
-        outcome: Outcome[Any],
+        outcome: Outcome[None],
         wall_time_s: float,
         sim_time_ns: float,
     ) -> None:

--- a/src/cocotb/result.py
+++ b/src/cocotb/result.py
@@ -2,10 +2,9 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import warnings
-from typing import Any
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> object:
     if name == "TestSuccess":
         warnings.warn(
             "`raise TestSuccess` is deprecated. Use `cocotb.pass_test()` instead.",

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -406,7 +406,7 @@ class Task(Generic[ResultType]):
         if self._state is _TaskState.CANCELLED:
             raise self._cancelled_error
         elif self._state is _TaskState.FINISHED:
-            return cast(Outcome[ResultType], self._outcome).get()
+            return cast("Outcome[ResultType]", self._outcome).get()
         else:
             raise InvalidStateError("result is not yet available")
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -11,7 +11,6 @@ from bdb import BdbQuit
 from enum import auto
 from types import CoroutineType
 from typing import (
-    Any,
     Callable,
     Coroutine,
     Generator,
@@ -100,7 +99,7 @@ class Task(Generic[ResultType]):
         self._state: _TaskState = _TaskState.UNSTARTED
         self._outcome: Union[Outcome[ResultType], None] = None
         self._trigger: Union[Trigger, None] = None
-        self._done_callbacks: List[Callable[[Task[ResultType]], Any]] = []
+        self._done_callbacks: List[Callable[[Task[ResultType]], None]] = []
         self._cancelled_msg: Union[str, None] = None
         self._must_cancel: bool = False
 
@@ -429,7 +428,9 @@ class Task(Generic[ResultType]):
         else:
             raise InvalidStateError("result is not yet available")
 
-    def _add_done_callback(self, callback: Callable[["Task[ResultType]"], Any]) -> None:
+    def _add_done_callback(
+        self, callback: Callable[["Task[ResultType]"], None]
+    ) -> None:
         """Add *callback* to the list of callbacks to be run once the Task becomes "done".
 
         Args:

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -2,7 +2,6 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import warnings
-from typing import Any
 
 from cocotb._base_triggers import Event, Lock, NullTrigger, Trigger
 from cocotb._extended_awaitables import (
@@ -55,7 +54,7 @@ for name in __all__:
     obj.__module__ = __name__
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> object:
     if name == "Join":
         warnings.warn(
             "Join has been moved to `cocotb.task`.",

--- a/src/cocotb/types/_array.py
+++ b/src/cocotb/types/_array.py
@@ -231,7 +231,7 @@ class Array(AbstractArray[T]):
     ) -> None:
         if isinstance(item, int):
             idx = self._translate_index(item)
-            self._value[idx] = cast(T, value)
+            self._value[idx] = cast("T", value)
         elif isinstance(item, slice):
             start = item.start if item.start is not None else self.left
             stop = item.stop if item.stop is not None else self.right
@@ -243,7 +243,7 @@ class Array(AbstractArray[T]):
                 raise IndexError(
                     f"slice [{start}:{stop}] direction does not match array direction [{self.left}:{self.right}]"
                 )
-            value = list(cast(Iterable[T], value))
+            value = list(cast("Iterable[T]", value))
             if len(value) != (stop_i - start_i + 1):
                 raise ValueError(
                     f"value of length {len(value)!r} will not fit in slice [{start}:{stop}]"

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -261,7 +261,7 @@ class LogicArray(AbstractArray[Logic]):
                 self._value_as_str = format(self._value_as_int, f"0{len(self)}b")
             else:
                 self._value_as_str = "".join(
-                    str(v) for v in cast(List[Logic], self._value_as_array)
+                    str(v) for v in cast("List[Logic]", self._value_as_array)
                 )
         return self._value_as_str
 
@@ -716,7 +716,7 @@ class LogicArray(AbstractArray[Logic]):
         self._value_as_int = None
         if isinstance(item, int):
             idx = self._translate_index(item)
-            array[idx] = Logic(cast(LogicConstructibleT, value))
+            array[idx] = Logic(cast("LogicConstructibleT", value))
         elif isinstance(item, slice):
             start = item.start if item.start is not None else self.left
             stop = item.stop if item.stop is not None else self.right
@@ -728,7 +728,7 @@ class LogicArray(AbstractArray[Logic]):
                 raise IndexError(
                     f"slice [{start}:{stop}] direction does not match array direction [{self.left}:{self.right}]"
                 )
-            value = cast(Union[str, Iterable[LogicConstructibleT], int], value)
+            value = cast("str | int | Iterable[LogicConstructibleT]", value)
             value_as_logics = LogicArray(value, stop_i - start_i + 1)
             array[start_i : stop_i + 1] = value_as_logics
         else:

--- a/src/cocotb_tools/_coverage.py
+++ b/src/cocotb_tools/_coverage.py
@@ -2,10 +2,9 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 import os
-from typing import Any
 
 
-def start_cocotb_library_coverage(_: Any) -> None:  # pragma: no cover
+def start_cocotb_library_coverage(_: object) -> None:  # pragma: no cover
     if "COCOTB_LIBRARY_COVERAGE" not in os.environ:
         return
     try:

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -4,7 +4,7 @@ from functools import reduce
 from typing import Any, Callable, List, Tuple, cast
 
 
-def load_entry(argv: List[str]) -> Any:
+def load_entry(argv: List[str]) -> None:
     """Gather entry point information by parsing :envvar:`PYGPI_USERS`."""
 
     entry_point_str = os.environ.get(
@@ -35,7 +35,7 @@ def load_entry(argv: List[str]) -> Any:
     # Expect failure to stop the loading of any additional entry points.
     for entry_module_str, entry_func_str in entry_points:
         entry_module = importlib.import_module(entry_module_str)
-        entry_func: Callable[[List[str]], Any] = reduce(
+        entry_func: Callable[[List[str]], object] = reduce(
             getattr, entry_func_str.split("."), cast(Any, entry_module)
         )
         entry_func(argv)

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -36,6 +36,6 @@ def load_entry(argv: List[str]) -> None:
     for entry_module_str, entry_func_str in entry_points:
         entry_module = importlib.import_module(entry_module_str)
         entry_func: Callable[[List[str]], object] = reduce(
-            getattr, entry_func_str.split("."), cast(Any, entry_module)
+            getattr, entry_func_str.split("."), cast("Any", entry_module)
         )
         entry_func(argv)


### PR DESCRIPTION
Depends upon #4750 and #4768. Closes #4740.

This removes as many instances of `Any` as possible, replacing them with `object` in the common case. There are still remaining uses of `Any` in parameterized types because those types (`Task`, `Outcome`, etc.) are invariant so using `object` or `Never` as the type does not work as it would with covariant or contravariant types, respectively.

Generally the rules are:

> Use `object` instead of `Any`.
> Unless this is a parameter in a parameterized type, then use `object` in output types and `Any` in input types.
> Use `Any` on parameters in parameterized types internally if the type's variance makes using `object` incorrect.
> Or if the type is being downcast from a `TypeVar`.