### PR TITLE
Break out logging handler initialization

### DIFF
--- a/docs/source/newsfragments/4775.removal.rst
+++ b/docs/source/newsfragments/4775.removal.rst
@@ -1,0 +1,1 @@
+Removed ``cocotb.logging.SimBaseLog``. The class no longer did anything, so simply remove it.

--- a/docs/source/newsfragments/4775.removal.rst
+++ b/docs/source/newsfragments/4775.removal.rst
@@ -1,1 +1,1 @@
-Removed ``cocotb.logging.SimBaseLog``. The class no longer did anything, so simply remove it.
+Removed ``cocotb.logging.SimBaseLog`` as the class no longer did anything.

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -19,17 +19,14 @@ import cocotb._profiling
 import cocotb.handle
 import cocotb.simulator
 from cocotb._scheduler import Scheduler
-from cocotb.logging import _log_from_c, _setup_handler, _setup_loggers
 from cocotb.regression import RegressionManager, RegressionMode
 
 log: logging.Logger
 
 
 def _setup_logging() -> None:
-    _setup_loggers()
     cocotb.log = logging.getLogger("test")
     cocotb.log.setLevel(logging.INFO)
-    cocotb.simulator.initialize_logger(_log_from_c, logging.getLogger)
 
     global log
     log = logging.getLogger("cocotb")
@@ -49,11 +46,6 @@ def _shutdown_testbench() -> None:
     while _shutdown_callbacks:
         cb = _shutdown_callbacks.pop(0)
         cb()
-
-
-def init_logging(_: List[str]) -> None:
-    """Initialize the cocotb log handler and formatter."""
-    _setup_handler()
 
 
 def init_package_from_simulation(argv: List[str]) -> None:

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -19,14 +19,14 @@ import cocotb._profiling
 import cocotb.handle
 import cocotb.simulator
 from cocotb._scheduler import Scheduler
-from cocotb.logging import _log_from_c, default_config
+from cocotb.logging import _log_from_c, _setup_handler, _setup_loggers
 from cocotb.regression import RegressionManager, RegressionMode
 
 log: logging.Logger
 
 
 def _setup_logging() -> None:
-    default_config()
+    _setup_loggers()
     cocotb.log = logging.getLogger("test")
     cocotb.log.setLevel(logging.INFO)
     cocotb.simulator.initialize_logger(_log_from_c, logging.getLogger)
@@ -49,6 +49,11 @@ def _shutdown_testbench() -> None:
     while _shutdown_callbacks:
         cb = _shutdown_callbacks.pop(0)
         cb()
+
+
+def init_logging(_: List[str]) -> None:
+    """Initialize the cocotb log handler and formatter."""
+    _setup_handler()
 
 
 def init_package_from_simulation(argv: List[str]) -> None:

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -68,17 +68,18 @@ def default_config() -> None:
 
     .. versionadded:: 1.4
     """
-    # construct an appropriate handler
-    hdlr = logging.StreamHandler(sys.stdout)
-    hdlr.addFilter(SimTimeContextFilter())
-    if want_color_output():
-        hdlr.setFormatter(SimColourLogFormatter())
-    else:
-        hdlr.setFormatter(SimLogFormatter())
+    if not logging.getLogger().hasHandlers():
+        # construct an appropriate handler
+        hdlr = logging.StreamHandler(sys.stdout)
+        hdlr.addFilter(SimTimeContextFilter())
+        if want_color_output():
+            hdlr.setFormatter(SimColourLogFormatter())
+        else:
+            hdlr.setFormatter(SimLogFormatter())
 
-    logging.setLoggerClass(SimBaseLog)
-    logging.basicConfig()
-    logging.getLogger().handlers = [hdlr]  # overwrite default handlers
+        logging.setLoggerClass(SimBaseLog)
+        logging.basicConfig()
+        logging.getLogger().handlers = [hdlr]  # overwrite default handlers
 
     def set_level(logger_name: str, envvar: str, default_level: str) -> None:
         log_level = os.environ.get(envvar, default_level)

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -11,8 +11,9 @@ Everything related to logging
 import logging
 import os
 import sys
+from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
 from cocotb import _ANSI, simulator
 from cocotb._deprecation import deprecated
@@ -37,7 +38,6 @@ logging.addLevelName(5, "TRACE")
 
 
 __all__ = (
-    "SimBaseLog",
     "SimColourLogFormatter",
     "SimLog",
     "SimLogFormatter",
@@ -55,26 +55,16 @@ def default_config() -> None:
     :class:`SimTimeContextFilter` filter so that
     :attr:`~logging.LogRecord.created_sim_time` is available to the formatter.
 
-    The logging level for cocotb logs is set based on the
-    :envvar:`COCOTB_LOG_LEVEL` environment variable, which defaults to ``INFO``.
-
-    The logging level for GPI logs is set based on the
-    :envvar:`GPI_LOG_LEVEL` environment variable, which defaults to ``INFO``.
-
     If desired, this logging configuration can be overwritten by calling
     ``logging.basicConfig(..., force=True)`` (in Python 3.8 onwards), or by
     manually resetting the root logger instance.
     An example of this can be found in the section on :ref:`rotating-logger`.
 
     .. versionadded:: 1.4
+
+    .. versionchanged:: 2.0
+        No longer set the log level of the ``cocotb`` and ``gpi`` loggers.
     """
-    _setup_handler()
-    _setup_loggers()
-
-
-def _setup_handler() -> None:
-    """Apply the default cocotb log formatting to the root logger."""
-    # construct an appropriate handler
     hdlr = logging.StreamHandler(sys.stdout)
     hdlr.addFilter(SimTimeContextFilter())
     if want_color_output():
@@ -82,14 +72,29 @@ def _setup_handler() -> None:
     else:
         hdlr.setFormatter(SimLogFormatter())
 
-    logging.setLoggerClass(SimBaseLog)
     logging.basicConfig()
     logging.getLogger().handlers = [hdlr]  # overwrite default handlers
 
 
-def _setup_loggers() -> None:
-    """Set up the `cocotb` and `gpi` loggers."""
+def _init(_: object) -> None:
+    """Set cocotb and pygpi log levels."""
 
+    # Monkeypatch "gpi" logger with function that also sets a PyGPI-local logger level
+    # as an optimization.
+    gpi_logger = logging.getLogger("gpi")
+    old_setLevel = gpi_logger.setLevel
+
+    @wraps(old_setLevel)
+    def setLevel(level: Union[int, str]) -> None:
+        old_setLevel(level)
+        simulator.set_gpi_log_level(gpi_logger.getEffectiveLevel())
+
+    gpi_logger.setLevel = setLevel  # type: ignore[method-assign]
+
+    # Initialize PyGPI logging
+    simulator.initialize_logger(_log_from_c, logging.getLogger)
+
+    # Set "cocotb" and "gpi" logger based on environment variables
     def set_level(logger_name: str, envvar: str, default_level: str) -> None:
         log_level = os.environ.get(envvar, default_level)
         log_level = log_level.upper()
@@ -112,19 +117,9 @@ def _setup_loggers() -> None:
     set_level("cocotb", "COCOTB_LOG_LEVEL", "INFO")
 
 
-if TYPE_CHECKING:
-    LoggerClass = logging.Logger
-else:
-    LoggerClass = logging.getLoggerClass()
-
-
-class SimBaseLog(LoggerClass):
-    # For hooking setLevel to inform the GPI's local log level
-
-    def setLevel(self, level: Union[int, str]) -> None:
-        super().setLevel(level)
-        if self.name == "gpi":
-            simulator.set_gpi_log_level(self.getEffectiveLevel())
+def _setup_formatter(_: object) -> None:
+    """Setup cocotb's logging formatter."""
+    default_config()
 
 
 @deprecated('Use `logging.getLogger(f"{name}.0x{ident:x}")` instead')

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -68,18 +68,27 @@ def default_config() -> None:
 
     .. versionadded:: 1.4
     """
-    if not logging.getLogger().hasHandlers():
-        # construct an appropriate handler
-        hdlr = logging.StreamHandler(sys.stdout)
-        hdlr.addFilter(SimTimeContextFilter())
-        if want_color_output():
-            hdlr.setFormatter(SimColourLogFormatter())
-        else:
-            hdlr.setFormatter(SimLogFormatter())
+    _setup_handler()
+    _setup_loggers()
 
-        logging.setLoggerClass(SimBaseLog)
-        logging.basicConfig()
-        logging.getLogger().handlers = [hdlr]  # overwrite default handlers
+
+def _setup_handler() -> None:
+    """Apply the default cocotb log formatting to the root logger."""
+    # construct an appropriate handler
+    hdlr = logging.StreamHandler(sys.stdout)
+    hdlr.addFilter(SimTimeContextFilter())
+    if want_color_output():
+        hdlr.setFormatter(SimColourLogFormatter())
+    else:
+        hdlr.setFormatter(SimLogFormatter())
+
+    logging.setLoggerClass(SimBaseLog)
+    logging.basicConfig()
+    logging.getLogger().handlers = [hdlr]  # overwrite default handlers
+
+
+def _setup_loggers() -> None:
+    """Set up the `cocotb` and `gpi` loggers."""
 
     def set_level(logger_name: str, envvar: str, default_level: str) -> None:
         log_level = os.environ.get(envvar, default_level)

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -12,7 +12,8 @@ def load_entry(argv: List[str]) -> None:
         ",".join(
             (
                 "cocotb_tools._coverage:start_cocotb_library_coverage",
-                "cocotb._init:init_logging",
+                "cocotb.logging:_init",
+                "cocotb.logging:_setup_formatter",
                 "cocotb._init:init_package_from_simulation",
                 "cocotb._init:run_regression",
             )

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -12,6 +12,7 @@ def load_entry(argv: List[str]) -> None:
         ",".join(
             (
                 "cocotb_tools._coverage:start_cocotb_library_coverage",
+                "cocotb._init:init_logging",
                 "cocotb._init:init_package_from_simulation",
                 "cocotb._init:run_regression",
             )

--- a/tests/test_cases/test_cocotb/test_logging.py
+++ b/tests/test_cases/test_cocotb/test_logging.py
@@ -6,12 +6,8 @@ Tests for the cocotb logger
 """
 
 import logging
-import os
-
-import pytest
 
 import cocotb
-import cocotb.logging
 
 
 class StrCallCounter:
@@ -38,44 +34,6 @@ async def test_logging_with_args(dut):
     dut._log.info("No substitution")
 
     dut._log.warning("Testing multiple line\nmessage")
-
-
-@cocotb.test()
-async def test_logging_default_config(dut):
-    cocotb_log = logging.getLogger("cocotb")
-
-    # Save pre-test configuration
-    log_level_prev = cocotb_log.level
-    os_environ_prev = os.environ.copy()
-
-    try:
-        # Set a valid log level
-        os.environ["COCOTB_LOG_LEVEL"] = "DEBUG"
-        cocotb.logging.default_config()
-        assert cocotb_log.level == logging.DEBUG, cocotb_log.level
-
-        # Try to set log level to an invalid log level
-        os.environ["COCOTB_LOG_LEVEL"] = "INVALID_LOG_LEVEL"
-        with pytest.raises(ValueError):
-            cocotb.logging.default_config()
-
-        # Try to set log level to a valid log level with wrong capitalization
-        os.environ["COCOTB_LOG_LEVEL"] = "error"
-        cocotb.logging.default_config()
-        assert cocotb_log.level == logging.ERROR, cocotb_log.level
-
-        # Set custom TRACE log level
-        os.environ["COCOTB_LOG_LEVEL"] = "TRACE"
-        cocotb.logging.default_config()
-        assert cocotb_log.level == logging.TRACE, cocotb_log.level
-
-    finally:
-        # Restore pre-test configuration
-        os.environ.clear()
-        os.environ.update(os_environ_prev)
-        cocotb_log.level = log_level_prev
-
-        logging.getLogger("gpi").setLevel(logging.INFO)
 
 
 @cocotb.test()


### PR DESCRIPTION
This makes it possible to set up a custom handler early via PYGPI_USERS,
allowing the cocotb logs to conform to the rest of the application early on
(except the initial messages from C++).

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
