### PR TITLE
Introduce deprecated `__len__` for `Logic`

### DIFF
--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -1187,6 +1187,9 @@ class LogicObject(_NonIndexableValueObjectBase[Logic, Union[Logic, int, str]]):
             raise TypeError("Can't get FallingEdge on immutable signal")
         return FallingEdge._make(self)
 
+    @deprecated(
+        '`len(logic_scalar_handle)` has been deprecated. A scalar handle\'s "length" is always 1.'
+    )
     def __len__(self) -> int:
         return 1
 

--- a/src/cocotb/types/_logic.py
+++ b/src/cocotb/types/_logic.py
@@ -9,6 +9,7 @@ from typing import (
     Union,
 )
 
+from cocotb._deprecation import deprecated
 from cocotb._py_compat import TypeAlias
 from cocotb.types._resolve import RESOLVE_X, ResolverLiteral, get_str_resolver
 
@@ -289,3 +290,7 @@ class Logic:
             TypeError: Unsupported *value* type.
         """
         return Logic(get_str_resolver(resolver)(str(self)))
+
+    @deprecated('`len(logic)` is deprecated. A Logic\'s "length" is always 1.')
+    def __len__(self) -> int:
+        return 1


### PR DESCRIPTION
Due to the split between `LogicObject` and `LogicArrayObject`, code that used to get the length of the resulting value no longer works since `Logic` doesn't support `len`.

```python
len(dut.obj.value)
```

This adds the method deprecated for backwards compatibility's sake, as well as deprecates the operator on the handle object that was missing.