### PR TITLE
Force normal font for 'pre' to make docs look less busy

### DIFF
--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -244,6 +244,17 @@ strong.command {
     color: var(--color-cocotb-blue) !important;
 }
 
+/* normal font weight for .pre ... */
+.pre {
+    font-weight: normal;
+}
+/* ... but restore bold when .pre is in headings
+   (a check for "not in headings" does not really exist in CSS)
+*/
+h1:has(.pre) .pre, h2:has(.pre) .pre, h3:has(.pre) .pre, h4:has(.pre) .pre, h5:has(.pre) .pre, h6:has(.pre) .pre {
+    font-weight: bold;
+}
+
 /* apidoc "[source]" link */
 span.viewcode-link {
     font-weight: normal !important;


### PR DESCRIPTION
Compare these two:
* https://docs.cocotb.org/en/development/upgrade-2.0.html#id2
* https://cocotb--4786.org.readthedocs.build/en/4786/upgrade-2.0.html#id2

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
