### PR TITLE
Small Fixes

### DIFF
--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -559,7 +559,8 @@ GpiObjHdl *VpiImpl::get_root_handle(const char *name) {
     for (root = vpi_scan(iterator); root != NULL; root = vpi_scan(iterator)) {
         if (to_gpi_objtype(vpi_get(vpiType, root)) != GPI_MODULE) continue;
 
-        if (name == NULL || !strcmp(name, vpi_get_str(vpiFullName, root)))
+        const char *obj_name = vpi_get_str(vpiFullName, root);
+        if ((!name && obj_name[0] != '\\') || (name && !strcmp(name, obj_name)))
             break;
     }
 

--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -559,7 +559,8 @@ GpiObjHdl *VpiImpl::get_root_handle(const char *name) {
     for (root = vpi_scan(iterator); root != NULL; root = vpi_scan(iterator)) {
         if (to_gpi_objtype(vpi_get(vpiType, root)) != GPI_MODULE) continue;
 
-        // prevents finding virtual classes (which Xcelium puts at the top-level scope) when looking for objects with get_root_handle.
+        // prevents finding virtual classes (which Xcelium puts at the top-level
+        // scope) when looking for objects with get_root_handle.
         const char *obj_name = vpi_get_str(vpiFullName, root);
         if ((!name && obj_name[0] != '\\') || (name && !strcmp(name, obj_name)))
             break;

--- a/src/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -559,6 +559,7 @@ GpiObjHdl *VpiImpl::get_root_handle(const char *name) {
     for (root = vpi_scan(iterator); root != NULL; root = vpi_scan(iterator)) {
         if (to_gpi_objtype(vpi_get(vpiType, root)) != GPI_MODULE) continue;
 
+        // prevents finding virtual classes (which Xcelium puts at the top-level scope) when looking for objects with get_root_handle.
         const char *obj_name = vpi_get_str(vpiFullName, root);
         if ((!name && obj_name[0] != '\\') || (name && !strcmp(name, obj_name)))
             break;

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -28,8 +28,8 @@ import find_libpython
 import cocotb_tools
 
 base_tools_dir = Path(cocotb_tools.__file__).parent.resolve()
-base_cocotb_dir = base_tools_dir.parent.joinpath("cocotb").resolve()
-if not base_cocotb_dir.exists():
+base_cocotb_dir = (base_tools_dir.parent / "cocotb").resolve()
+if not (base_cocotb_dir.exists() and (base_cocotb_dir / "libs").exists()):
     import cocotb
 
     base_cocotb_dir = Path(cocotb.__file__).parent.resolve()


### PR DESCRIPTION
Upstreaming some small fixes.

The first commit prevents finding virtual classes (which Xcelium puts at the top-level scope) when looking for objects with `get_root_handle`.

The second commit ensures that the cocotb directory found has the libraries built which can be an issue if cocotb_tools is run from the source directory and cocotb isn't built yet or is installed elsewhere.
