### PR TITLE
Split `AbstractArray` into mutable and immutable versions

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -135,6 +135,13 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
     :members:
     :exclude-members: count, index
 
+.. autoclass:: cocotb.types.AbstractArray
+    :members:
+
+.. autoclass:: cocotb.types.AbstractMutableArray
+    :members:
+    :show-inheritance:
+
 .. autoclass:: cocotb.types.Array
     :members:
     :inherited-members:

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -1,7 +1,7 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
-from ._abstract_array import AbstractArray
+from ._abstract_array import AbstractArray, AbstractMutableArray
 from ._array import Array
 from ._logic import Logic
 from ._logic_array import LogicArray
@@ -13,7 +13,14 @@ from ._range import Range
 # and will evaluate this module first before running tests.
 from typing import Tuple  # noqa: F401
 
-__all__ = ("AbstractArray", "Array", "Logic", "LogicArray", "Range")
+__all__ = (
+    "AbstractArray",
+    "AbstractMutableArray",
+    "Array",
+    "Logic",
+    "LogicArray",
+    "Range",
+)
 
 # Set __module__ on re-exports
 for name in __all__:

--- a/src/cocotb/types/_array.py
+++ b/src/cocotb/types/_array.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from typing import Iterable, Iterator, List, TypeVar, Union, cast, overload
 
-from cocotb.types._abstract_array import AbstractArray
+from cocotb.types._abstract_array import AbstractMutableArray
 from cocotb.types._range import Range
 
 T = TypeVar("T")
 
 
-class Array(AbstractArray[T]):
+class Array(AbstractMutableArray[T]):
     r"""Fixed-size, arbitrarily-indexed, homogeneous collection type.
 
     Arrays are similar to, but different from Python :class:`list`\ s.

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -13,7 +13,7 @@ from typing import (
 
 from cocotb._deprecation import deprecated
 from cocotb._py_compat import Literal, TypeAlias
-from cocotb.types._abstract_array import AbstractArray
+from cocotb.types._abstract_array import AbstractMutableArray
 from cocotb.types._logic import Logic, LogicConstructibleT, _str_literals
 from cocotb.types._range import Range
 from cocotb.types._resolve import RESOLVE_X, ResolverLiteral, get_str_resolver
@@ -24,7 +24,7 @@ _resolve_lh_table = str.maketrans({"L": "0", "H": "1"})
 ByteOrder: TypeAlias = Literal["big", "little"]
 
 
-class LogicArray(AbstractArray[Logic]):
+class LogicArray(AbstractMutableArray[Logic]):
     r"""Fixed-sized, arbitrarily-indexed, Array of Logics.
 
     .. currentmodule:: cocotb.types
@@ -540,8 +540,6 @@ class LogicArray(AbstractArray[Logic]):
 
             .. deprecated:: 2.0
                 Use ``logic_array[:] = value`` instead.
-
-        :setter
         """
         return self.to_unsigned()
 


### PR DESCRIPTION
Because `AbstractArray` is mutable, the TypeVar must be invariant and that prevents `AbstractArray[int]` from being passed to `AbstractArray[float]` for example. Making a separate immutable version allows a covariant TypeVar to be used.