### PR TITLE
Remove coverage exclusions as they are now default

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ import nox
 nox.options.sessions = ["dev_test"]
 
 test_deps = ["pytest>=6"]
-coverage_deps = ["coverage[toml]>=5.0", "pytest-cov"]
+coverage_deps = ["coverage[toml]>=7.2", "pytest-cov"]
 # gcovr 5.1 has an issue parsing some gcov files, so pin to 5.0. See
 # https://github.com/gcovr/gcovr/issues/596
 # When using gcovr 5.0, deprecated jinja2.Markup was removed in 3.1, so an
@@ -21,7 +21,7 @@ coverage_deps = ["coverage[toml]>=5.0", "pytest-cov"]
 # See https://github.com/gcovr/gcovr/pull/576
 # gcovr 5.2 would solve these issues, but has dropped Python 3.6 support.
 # TODO: Switch to the latest gcovr version once we drop Python 3.6 support.
-coverage_report_deps = ["coverage[toml]>=5.0", "jinja2<3.1", "gcovr==5.0"]
+coverage_report_deps = ["coverage[toml]>=7.2", "jinja2<3.1", "gcovr==5.0"]
 
 dev_deps = [
     "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,11 @@ omit = [
     "*/_vendor/*",
 ]
 
+[tool.coverage.report]
+exclude_also = [
+    "@(typing\\.)?overload",
+]
+
 [tool.codespell]
 ignore-words-list = [
     "AFE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,15 +155,6 @@ omit = [
     "*/cocotb_tools/*",
     "*/_vendor/*",
 ]
-exclude_lines = [
-    "pragma: no cover",
-    # for excluding typing stubs
-    "\\.\\.\\.",
-    # for excluding abstractmethods
-    "raise\\s+NotImplementedError",
-    # excluding type checking blocks
-    "if (typing\\.)?TYPE_CHECKING:"
-]
 
 [tool.codespell]
 ignore-words-list = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,8 +155,6 @@ omit = [
     "*/cocotb_tools/*",
     "*/_vendor/*",
 ]
-
-[tool.coverage.report]
 exclude_also = [
     "@(typing\\.)?overload",
 ]


### PR DESCRIPTION
These rules are now default in coverage>=7.1.0. Also the `\.\.\.` rule wasn't correct and would cause entire functions to be excluded if it appeared in tuple type return annotation (whoops).

`exclude_also` was added in 7.2.0 and allows extending the default list. We include `@overload` to disable coverage on overload stubs.