### PR TITLE
verilator.cpp: create trace after top

### DIFF
--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -77,12 +77,13 @@ int main(int argc, char** argv) {
 #else
     const char* traceFile = "dump.vcd";
 #endif
+    bool traceOn = false;
 
     for (int i = 1; i < argc; i++) {
         std::string arg = std::string(argv[i]);
         if (arg == "--trace") {
 #if VM_TRACE
-            tfp = new verilated_trace_t;
+            traceOn = true;
 #else
             fprintf(stderr,
                     "Error: --trace requires the design to be built with trace "
@@ -124,7 +125,8 @@ int main(int argc, char** argv) {
 
 #if VM_TRACE
     Verilated::traceEverOn(true);
-    if (tfp) {
+    if (traceOn) {
+        tfp = new verilated_trace_t;
         top->trace(tfp, 99);
         tfp->open(traceFile);
     }


### PR DESCRIPTION
This fixes a bug I introduced with #4758, where the trace has the wrong scale. The trace object constructor gets the time scale/unit from a global context, which is initialized with Vtop construction, so move back the trace initialization back after Vtop.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
