### PR TITLE
Make headings in Release Notes sticky on top

### DIFF
--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -187,7 +187,6 @@ div.versionremoved {
     break-inside: avoid;
     border-left: 0.2rem solid;
     border-color: var(--pst-color-info);
-    border-radius: $admonition-border-radius;
     background-color: var(--pst-color-on-background);
     /* @include box-shadow; */
     position: relative;
@@ -474,4 +473,35 @@ a[href*="docs.cocotb.org"][href*="v1.2"]::after {
 }
 a[href*="docs.cocotb.org"][href*="v1.1"]::after {
     content: "v1.1";
+}
+
+
+/*
+Sticky headings for Release Notes only (where we know the heading text spans only one line).
+The "release-notes" class on "body" is dynamically set in cocotb.js
+*/
+body.release-notes h1,
+body.release-notes h2,
+body.release-notes h3 {
+  position: sticky;
+  /* top: 48px; */
+  height: 48px;
+  display: flex;
+  align-items: center;
+  background-color: var(--pst-color-background);
+}
+
+body.release-notes h1 {
+  top: calc(1 * 48px);
+  z-index: 990;
+}
+
+body.release-notes h2 {
+  top: calc(2 * 48px);
+  z-index: 980;
+}
+
+body.release-notes h3 {
+  top: calc(3 * 48px);
+  z-index: 970;
 }

--- a/docs/source/_static/cocotb.js
+++ b/docs/source/_static/cocotb.js
@@ -1,0 +1,5 @@
+document.addEventListener("DOMContentLoaded", function () {
+    if (window.location.href.includes("release_notes")) {
+        document.body.classList.add("release-notes");
+    }
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -252,6 +252,7 @@ html_favicon = "_static/cocotb-favicon.svg"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 html_css_files = ["cocotb.css"]
+html_js_files = ["cocotb.js"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
I found it a bit hard to know what version I am looking at in the Release Notes, especially when I ended up there via a search. This PR fixes that by making the headings sticky, but *only* for the Release Notes. With a bit more effort this could be extended to all pages, but random headings might be two or more lines high, so it needs to be measured instead of hardcoded, and that is only possible with JS.

Showcase: https://cocotb--4810.org.readthedocs.build/en/4810/release_notes.html#id19

**EDIT**: doesn't work so nicely on phones, but who does that anyway...

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
