### PR TITLE
Fix typos in Upgrade to 2.0 docs

### DIFF
--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -99,7 +99,7 @@ that exception would be thrown back to the caller of :func:`!cocotb.fork` and th
     :caption: Set up example...
 
     async def has_exception():
-        if variable_does_not_exit:  # throws NameError
+        if variable_does_not_exist:  # throws NameError
             await Timer(1, 'ns')
 
 .. code-block:: python
@@ -138,7 +138,7 @@ How to Upgrade
 ==============
 
 * Remove the :deco:`!cocotb.coroutine` decorator.
-* Add :keyword:`!async` keyword directly before the :keyword:`def` keyword in the function definition.
+* Add :keyword:`async` keyword directly before the :keyword:`def` keyword in the function definition.
 * Replace any ``yield [triggers, ...]`` with :class:`await First(triggers, ...) <cocotb.triggers.First>`.
 * Replace all ``yield``\ s in the function with :keyword:`await`\ s.
 * Remove all imports of the :deco:`!cocotb.coroutine` decorator
@@ -165,7 +165,7 @@ Rationale
 
 These existed to support defining coroutines in Python 2 and early versions of Python 3 before :term:`coroutine functions <coroutine function>`
 using the :keyword:`!async`\ /:keyword:`!await` syntax was added in Python 3.5.
-We no longer support versions of Python that don't support :keyword:`!async`\ /:keyword:`!await`,
+We no longer support versions of Python that don't support :keyword:`!async`\ /:keyword:`!await`.
 Python coroutines are noticeably faster than :deco:`!cocotb.coroutine`'s implementation,
 and the behavior of :deco:`!cocotb.coroutine` would have had to be changed to support changes to the scheduler.
 For all those reasons the :deco:`!cocotb.coroutine` decorator and generator-based coroutine support was removed.
@@ -394,7 +394,7 @@ Change expected type of single indexes to :class:`.Logic` and slices to :class:`
     assert isinstance(val[0:3], LogicArray)
 
 .. note::
-    :class:`Logic` supports usage in condition expressions (e.g. ``if val: ...``),
+    :class:`Logic` supports usage in conditional expressions (e.g. ``if val: ...``),
     equality with :class:`!str`, :class:`!bool`, or :class:`!int`,
     and casting to :class:`!str`, :class:`!bool`, or :class:`!int`;
     so many behaviors overlap with :class:`!LogicArray`


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
