### PR TITLE
Better split cocotb-required and user-overridable logging configuration

### DIFF
--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -61,23 +61,31 @@ def default_config() -> None:
     An example of this can be found in the section on :ref:`rotating-logger`.
 
     .. versionadded:: 1.4
-
-    .. versionchanged:: 2.0
-        No longer set the log level of the ``cocotb`` and ``gpi`` loggers.
     """
+    logging.basicConfig()
+
     hdlr = logging.StreamHandler(sys.stdout)
     hdlr.addFilter(SimTimeContextFilter())
     if want_color_output():
         hdlr.setFormatter(SimColourLogFormatter())
     else:
         hdlr.setFormatter(SimLogFormatter())
-
-    logging.basicConfig()
     logging.getLogger().handlers = [hdlr]  # overwrite default handlers
 
+    logging.getLogger("cocotb").setLevel(logging.INFO)
+    logging.getLogger("gpi").setLevel(logging.INFO)
 
-def _init(_: object) -> None:
-    """Set cocotb and pygpi log levels."""
+
+def _setup_cocotb(_: object) -> None:
+    """cocotb-specific logging setup.
+
+    Initializes the GPI logger and sets up the GPI logging optimization.
+    Sets the log level of the ``"cocotb"`` and ``"gpi"`` loggers based on
+    :envvar:`COCOTB_LOG_LEVEL` and :envvar:`GPI_LOG_LEVEL`, respectively.
+
+    Not intended to be overridden by the user.
+    Should be run after basic logging configuration.
+    """
 
     # Monkeypatch "gpi" logger with function that also sets a PyGPI-local logger level
     # as an optimization.
@@ -95,8 +103,11 @@ def _init(_: object) -> None:
     simulator.initialize_logger(_log_from_c, logging.getLogger)
 
     # Set "cocotb" and "gpi" logger based on environment variables
-    def set_level(logger_name: str, envvar: str, default_level: str) -> None:
-        log_level = os.environ.get(envvar, default_level)
+    def set_level(logger_name: str, envvar: str) -> None:
+        log_level = os.environ.get(envvar)
+        if log_level is None:
+            return
+
         log_level = log_level.upper()
 
         logger = logging.getLogger(logger_name)
@@ -113,12 +124,15 @@ def _init(_: object) -> None:
                 f"levels: {valid_levels}"
             ) from None
 
-    set_level("gpi", "GPI_LOG_LEVEL", "INFO")
-    set_level("cocotb", "COCOTB_LOG_LEVEL", "INFO")
+    set_level("gpi", "GPI_LOG_LEVEL")
+    set_level("cocotb", "COCOTB_LOG_LEVEL")
 
 
-def _setup_formatter(_: object) -> None:
-    """Setup cocotb's logging formatter."""
+def _configure(_: object) -> None:
+    """Configure logging.
+
+    May be overridden by the user.
+    """
     default_config()
 
 

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -12,8 +12,8 @@ def load_entry(argv: List[str]) -> None:
         ",".join(
             (
                 "cocotb_tools._coverage:start_cocotb_library_coverage",
-                "cocotb.logging:_init",
-                "cocotb.logging:_setup_formatter",
+                "cocotb.logging:_configure",
+                "cocotb.logging:_setup_cocotb",
                 "cocotb._init:init_package_from_simulation",
                 "cocotb._init:run_regression",
             )


### PR DESCRIPTION
This splits setting the log level into defaults in the overridable function and overriding them with the variables `COCOTB_LOG_LEVEL` and `GPI_LOG_LEVEL` in the non-overridable function. If neither envvar is supplied it won't affect whatever the user put in the override.

Also changes the function names. Maybe they are better?

Potential part 1 of more logging configuration changes (if I can find a way that doesn't suck).