### PR TITLE
Improvements around runner

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -433,7 +433,11 @@ The following variables are makefile variables, not environment variables.
 
 .. make:var:: SIM
 
-      Selects which simulator Makefile to use.  Attempts to include a simulator specific makefile from :file:`src/cocotb/share/makefiles/simulators/makefile.$(SIM)`
+      In the makefile flow, selects which simulator Makefile to use.
+      Attempts to include a simulator specific makefile from :file:`src/cocotb/share/makefiles/simulators/makefile.$(SIM)`
+
+      In the :ref:`Python Runner <howto-python-runner>` flow,
+      selects the :ref:`Simulator Runner <api-runner-sim>` to use.
 
 .. make:var:: WAVES
 

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -41,6 +41,8 @@ Python Test Runner
 
 .. autodata:: MAX_PARALLEL_BUILD_JOBS
 
+.. _api-runner-sim:
+
 Simulator Runners
 -----------------
 

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -54,8 +54,8 @@ To redirect the wave file to a different location, use the plusarg `dumpfile_pat
 
 .. _sim-icarus-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:icarus <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Aicarus>`_
 
@@ -134,8 +134,8 @@ The resulting file will be :file:`dump.fst` and can be opened by ``gtkwave dump.
 
 .. _sim-verilator-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:verilator <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Averilator>`_
 
@@ -162,8 +162,8 @@ cocotb currently only supports :term:`VPI` for Synopsys VCS, not :term:`VHPI`.
 
 .. _sim-vcs-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:vcs <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Avcs>`_
 
@@ -202,8 +202,8 @@ this setting will be mirrored in the TCL ``license_queue`` variable to control r
 
 .. _sim-aldec-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:riviera <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Ariviera>`_
 
@@ -237,8 +237,8 @@ see :class:`cocotb_tools.runner.ActiveHdl`.
 
 .. _sim-activehdl-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:activehdl <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Aactivehdl>`_
 
@@ -289,8 +289,8 @@ For more information, see :ref:`sim-modelsim`.
 
 .. _sim-questa-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:questa <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Aquesta>`_
 
@@ -327,8 +327,8 @@ If you have previously launched a test without this setting, you might have to d
 
 .. _sim-modelsim-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:modelsim <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Amodelsim>`_
 
@@ -354,8 +354,8 @@ For more information, see :ref:`sim-xcelium`.
 
 .. _sim-incisive-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:ius <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Aius>`_
 
@@ -384,8 +384,8 @@ Testing designs with VHDL toplevels is only supported with Xcelium 23.09.004 and
 
 .. _sim-xcelium-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:xcelium <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Axcelium>`_
 
@@ -422,8 +422,8 @@ To specify a VHDL architecture to simulate, set the ``ARCH`` make variable to th
 
 .. _sim-ghdl-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:ghdl <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Aghdl>`_
 
@@ -476,8 +476,8 @@ see :class:`cocotb_tools.runner.Nvc`.
 
 .. _sim-nvc-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:nvc <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Anvc>`_
 
@@ -537,8 +537,8 @@ Note that cocotb's makefile is using CVC's interpreted mode.
 
 .. _sim-cvc-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:cvc <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Acvc>`_
 
@@ -584,8 +584,8 @@ To enable VCD tracing, set :make:var:`WAVES` to ``1``.
 
 .. _sim-dsim-issues:
 
-Issues for this simulator
--------------------------
+Reported Issues for this Simulator
+----------------------------------
 
 * `All issues with label category:simulators:dsim <https://github.com/cocotb/cocotb/issues?q=is%3Aissue+-label%3Astatus%3Aduplicate+label%3Acategory%3Asimulators%3Adsim>`_
 

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -24,6 +24,8 @@ In order to use this simulator, set :make:var:`SIM` to ``icarus``:
 .. code-block:: bash
 
     make SIM=icarus
+    # or
+    SIM=icarus [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.Icarus`.
@@ -74,6 +76,8 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
 .. code-block:: bash
 
     make SIM=verilator
+    # or
+    SIM=verilator [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.Verilator`.
@@ -150,6 +154,8 @@ In order to use this simulator, set :make:var:`SIM` to ``vcs``:
 .. code-block:: bash
 
     make SIM=vcs
+    # or
+    SIM=vcs [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.Vcs`.
@@ -179,6 +185,8 @@ In order to use this simulator, set :make:var:`SIM` to ``riviera``:
 .. code-block:: bash
 
     make SIM=riviera
+    # or
+    SIM=riviera [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.Riviera`.
@@ -219,8 +227,7 @@ In order to use this simulator, set :make:var:`SIM` to ``activehdl``:
 
     make SIM=activehdl
 
-For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
-see :class:`cocotb_tools.runner.ActiveHdl`.
+This simulator is not currently supported in the :ref:`Python Runner <howto-python-runner>` flow.
 
 .. note::
 
@@ -253,6 +260,8 @@ In order to use this simulator, set :make:var:`SIM` to ``questa``:
 .. code-block:: bash
 
     make SIM=questa
+    # or
+    SIM=questa [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.Questa`.
@@ -370,6 +379,8 @@ In order to use this simulator, set :make:var:`SIM` to ``xcelium``:
 .. code-block:: bash
 
     make SIM=xcelium
+    # or
+    SIM=xcelium [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.Xcelium`.
@@ -406,6 +417,8 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
 .. code-block:: bash
 
     make SIM=ghdl
+    # or
+    SIM=ghdl [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.Ghdl`.
@@ -470,6 +483,8 @@ In order to use this simulator, set :make:var:`SIM` to ``nvc``:
 .. code-block:: bash
 
     make SIM=nvc
+    # or
+    SIM=nvc [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.Nvc`.
@@ -558,6 +573,8 @@ In order to use this simulator, set :make:var:`SIM` to ``dsim``:
 .. code-block:: bash
 
     make SIM=dsim
+    # or
+    SIM=dsim [...] pytest [...]
 
 For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
 see :class:`cocotb_tools.runner.DSim`.

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -25,6 +25,9 @@ In order to use this simulator, set :make:var:`SIM` to ``icarus``:
 
     make SIM=icarus
 
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.Icarus`.
+
 .. note::
 
     A working installation of `Icarus Verilog <https://github.com/steveicarus/iverilog>`_ is required.
@@ -71,6 +74,9 @@ In order to use this simulator, set :make:var:`SIM` to ``verilator``:
 .. code-block:: bash
 
     make SIM=verilator
+
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.Verilator`.
 
 .. note::
 
@@ -145,6 +151,13 @@ In order to use this simulator, set :make:var:`SIM` to ``vcs``:
 
     make SIM=vcs
 
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.Vcs`.
+
+.. note::
+
+    A working installation of the simulator itself is required.
+
 cocotb currently only supports :term:`VPI` for Synopsys VCS, not :term:`VHPI`.
 
 .. _sim-vcs-issues:
@@ -166,6 +179,13 @@ In order to use this simulator, set :make:var:`SIM` to ``riviera``:
 .. code-block:: bash
 
     make SIM=riviera
+
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.Riviera`.
+
+.. note::
+
+    A working installation of the simulator itself is required.
 
 .. note::
 
@@ -199,6 +219,13 @@ In order to use this simulator, set :make:var:`SIM` to ``activehdl``:
 
     make SIM=activehdl
 
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.ActiveHdl`.
+
+.. note::
+
+    A working installation of the simulator itself is required.
+
 .. warning::
 
     cocotb does not work with some versions of Active-HDL (see :issue:`1494`).
@@ -226,6 +253,13 @@ In order to use this simulator, set :make:var:`SIM` to ``questa``:
 .. code-block:: bash
 
     make SIM=questa
+
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.Questa`.
+
+.. note::
+
+    A working installation of the simulator itself is required.
 
 Cocotb implements two flows for Questa.
 The most suitable flow is chosen based on the Questa version being used.
@@ -272,6 +306,12 @@ In order to use this simulator, set :make:var:`SIM` to ``modelsim``:
 
     make SIM=modelsim
 
+This simulator is not currently supported in the :ref:`Python Runner <howto-python-runner>` flow.
+
+.. note::
+
+    A working installation of the simulator itself is required.
+
 Any ModelSim PE or ModelSim PE derivatives (like the ModelSim Microsemi, Intel, Lattice Editions) do not support the VHDL :term:`FLI` feature.
 If you try to use them with :term:`FLI`, you will see a ``vsim-FLI-3155`` error:
 
@@ -304,6 +344,12 @@ In order to use this simulator, set :make:var:`SIM` to ``ius``:
 
     make SIM=ius
 
+This simulator is not currently supported in the :ref:`Python Runner <howto-python-runner>` flow.
+
+.. note::
+
+    A working installation of the simulator itself is required.
+
 For more information, see :ref:`sim-xcelium`.
 
 .. _sim-incisive-issues:
@@ -324,6 +370,13 @@ In order to use this simulator, set :make:var:`SIM` to ``xcelium``:
 .. code-block:: bash
 
     make SIM=xcelium
+
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.Xcelium`.
+
+.. note::
+
+    A working installation of the simulator itself is required.
 
 The simulator automatically loads :term:`VPI` even when only :term:`VHPI` is requested.
 
@@ -353,6 +406,9 @@ In order to use this simulator, set :make:var:`SIM` to ``ghdl``:
 .. code-block:: bash
 
     make SIM=ghdl
+
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.Ghdl`.
 
 .. note::
 
@@ -415,6 +471,9 @@ In order to use this simulator, set :make:var:`SIM` to ``nvc``:
 
     make SIM=nvc
 
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.Nvc`.
+
 .. _sim-nvc-issues:
 
 Issues for this simulator
@@ -468,6 +527,12 @@ set :make:var:`SIM` to ``cvc``:
 
     make SIM=cvc
 
+This simulator is not currently supported in the :ref:`Python Runner <howto-python-runner>` flow.
+
+.. note::
+
+    A working installation of the simulator itself is required.
+
 Note that cocotb's makefile is using CVC's interpreted mode.
 
 .. _sim-cvc-issues:
@@ -493,6 +558,9 @@ In order to use this simulator, set :make:var:`SIM` to ``dsim``:
 .. code-block:: bash
 
     make SIM=dsim
+
+For simulator-specific limitations when running with the :ref:`Python Runner <howto-python-runner>` flow,
+see :class:`cocotb_tools.runner.DSim`.
 
 .. note::
 

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -656,7 +656,7 @@ def is_verilog_source(source: PathLike) -> bool:
 
 
 class Icarus(Runner):
-    """Implementation of :class:`Runner` for Icarus.
+    """Implementation of :class:`Runner` for Icarus Verilog.
 
     * ``hdl_toplevel`` argument to :meth:`.build` is *required*.
     * ``waves=True`` *must* be given to :meth:`.build` if either ``waves`` or ``gui`` are to be used during :meth:`.test`.
@@ -803,7 +803,7 @@ class Icarus(Runner):
 
 
 class Questa(Runner):
-    """Implementation of :class:`Runner` for Questa.
+    """Implementation of :class:`Runner` for Siemens Questa.
 
     * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
@@ -1154,7 +1154,7 @@ class Nvc(Runner):
 
 
 class Riviera(Runner):
-    """Implementation of :class:`Runner` for Riviera-PRO.
+    """Implementation of :class:`Runner` for Aldec Riviera-PRO.
 
     * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     * Does not support the ``gui`` argument to :meth:`.test`.
@@ -1365,7 +1365,7 @@ class Verilator(Runner):
 
         if self.hdl_toplevel is None:
             raise ValueError(
-                f"{type(self).__qualname__} requires the hdl_toplevel parameter to be specified"
+                f"{type(self).__qualname__} requires the hdl_toplevel parameter to be specified."
             )
 
         # TODO: set "--debug" if self.verbose
@@ -1439,8 +1439,9 @@ class Verilator(Runner):
 
 
 class Xcelium(Runner):
-    """Implementation of :class:`Runner` for Xcelium.
+    """Implementation of :class:`Runner` for Cadence Xcelium.
 
+    * Does not support the ``waves`` argument to :meth:`.build` (must be set in :meth:`.test` instead).
     * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     * Does not support the ``timescale`` argument to :meth:`.test`.
     """
@@ -1622,7 +1623,7 @@ class Xcelium(Runner):
 
 
 class Vcs(Runner):
-    """Implementation of :class:`Runner` for VCS.
+    """Implementation of :class:`Runner` for Synopsys VCS.
 
     * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     * Does not support VHDL.
@@ -1710,7 +1711,7 @@ class Vcs(Runner):
 
 
 class Dsim(Runner):
-    """Implementation of :class:`Runner` for DSim.
+    """Implementation of :class:`Runner` for Siemens DSim.
 
     * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     """
@@ -1746,14 +1747,15 @@ class Dsim(Runner):
         return "file.vcd"
 
     def _test_command(self) -> List[_Command]:
+        if self.pre_cmd is not None:
+            raise RuntimeError("pre_cmd is not implemented for DSim.")
+
         plusargs = self.plusargs
         if self.waves or self.gui:
             plusargs += [f"-waves {self._waves_file()}"]
 
         if self.timescale:
             plusargs += ["-timescale {}/{}".format(*self.timescale)]
-        if self.pre_cmd is not None:
-            raise ValueError("WARNING: pre_cmd is not implemented for DSim.")
 
         return [
             [

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1442,7 +1442,7 @@ class Xcelium(Runner):
     """Implementation of :class:`Runner` for Xcelium.
 
     * Does not support the ``pre_cmd`` argument to :meth:`.test`.
-    * Does not support the ``timescale`` argument to :meth:`.build` and :meth:`.test`.
+    * Does not support the ``timescale`` argument to :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["vhpi"]}
@@ -1524,6 +1524,11 @@ class Xcelium(Runner):
             ]
             + vhpi_opts
             + [f"-work {self.hdl_library}"]
+            + (
+                ["-timescale", "{}/{}".format(*self.timescale)]
+                if self.timescale is not None
+                else []
+            )
             + self.build_args
             + self._get_include_options(self.includes)
             + self._get_define_options(self.defines)

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1482,6 +1482,11 @@ class Xcelium(Runner):
     def _build_command(self) -> List[_Command]:
         self.env["CDS_AUTO_64BIT"] = "all"
 
+        if self.waves:
+            raise RuntimeError(
+                "waves is not supported in the build step. Please set it in the test step."
+            )
+
         assert self.hdl_toplevel, "A HDL toplevel is required in all Xcelium compiles."
 
         verbosity_opts = []

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -658,10 +658,12 @@ def is_verilog_source(source: PathLike) -> bool:
 class Icarus(Runner):
     """Implementation of :class:`Runner` for Icarus Verilog.
 
-    * ``hdl_toplevel`` argument to :meth:`.build` is *required*.
-    * ``waves=True`` *must* be given to :meth:`.build` if either ``waves`` or ``gui`` are to be used during :meth:`.test`.
-    * ``timescale`` argument to :meth:`.build` must be given to support dumping the command file.
-    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * ``hdl_toplevel`` argument to :meth:`.build` is *required*.
+       * ``waves=True`` *must* be given to :meth:`.build` if either ``waves`` or ``gui`` are to be used during :meth:`.test`.
+       * ``timescale`` argument to :meth:`.build` must be given to support dumping the command file.
+       * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}
@@ -805,7 +807,9 @@ class Icarus(Runner):
 class Questa(Runner):
     """Implementation of :class:`Runner` for Siemens Questa.
 
-    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["fli", "vhpi"]}
@@ -934,7 +938,9 @@ class Questa(Runner):
 class Ghdl(Runner):
     """Implementation of :class:`Runner` for GHDL.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"vhdl": ["vpi"]}
@@ -1057,8 +1063,10 @@ class Ghdl(Runner):
 class Nvc(Runner):
     """Implementation of :class:`Runner` for NVC.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
-    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+       * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"vhdl": ["vhpi"]}
@@ -1156,9 +1164,11 @@ class Nvc(Runner):
 class Riviera(Runner):
     """Implementation of :class:`Runner` for Aldec Riviera-PRO.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
-    * Does not support the ``gui`` argument to :meth:`.test`.
-    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+       * Does not support the ``gui`` argument to :meth:`.test`.
+       * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["vhpi"]}
@@ -1313,8 +1323,10 @@ class Riviera(Runner):
 class Verilator(Runner):
     """Implementation of :class:`Runner` for Verilator.
 
-    * ``waves=True`` *must* be given to :meth:`.build` if either ``waves`` or ``gui`` are to be used during :meth:`.test`.
-    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * ``waves=True`` *must* be given to :meth:`.build` if either ``waves`` or ``gui`` are to be used during :meth:`.test`.
+       * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}
@@ -1441,9 +1453,11 @@ class Verilator(Runner):
 class Xcelium(Runner):
     """Implementation of :class:`Runner` for Cadence Xcelium.
 
-    * Does not support the ``waves`` argument to :meth:`.build` (must be set in :meth:`.test` instead).
-    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
-    * Does not support the ``timescale`` argument to :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * Does not support the ``waves`` argument to :meth:`.build` (must be set in :meth:`.test` instead).
+       * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+       * Does not support the ``timescale`` argument to :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"], "vhdl": ["vhpi"]}
@@ -1630,9 +1644,11 @@ class Xcelium(Runner):
 class Vcs(Runner):
     """Implementation of :class:`Runner` for Synopsys VCS.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
-    * Does not support VHDL.
-    * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+       * Does not support VHDL.
+       * Does not support the ``timescale`` argument to :meth:`.build` or :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}
@@ -1718,7 +1734,9 @@ class Vcs(Runner):
 class Dsim(Runner):
     """Implementation of :class:`Runner` for Siemens DSim.
 
-    * Does not support the ``pre_cmd`` argument to :meth:`.test`.
+    .. admonition:: Simulator-specific Usage
+
+       * Does not support the ``pre_cmd`` argument to :meth:`.test`.
     """
 
     supported_gpi_interfaces = {"verilog": ["vpi"]}

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -84,7 +84,7 @@ def test_cocotb():
         test_module=module_name,
         gpi_interfaces=gpi_interfaces,
         test_args=sim_args,
-        timescale=timescale,
+        timescale=None if sim in ("xcelium",) else timescale,
     )
 
 

--- a/tests/pytest/test_parallel_cocotb.py
+++ b/tests/pytest/test_parallel_cocotb.py
@@ -59,5 +59,5 @@ def test_cocotb_parallel(seed):
         test_module=module_name,
         test_args=sim_args,
         build_dir=sim_build,
-        timescale=timescale,
+        timescale=None if sim in ("xcelium",) else timescale,
     )

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -45,7 +45,7 @@ def run_simulation(sim, test_args=None):
         build_dir=sim_build,
         build_args=compile_args,
         defines={"NODUMPFILE": 1},
-        waves=True,
+        waves=False if sim in ("xcelium",) else True,
     )
 
     _test_args = sim_args


### PR DESCRIPTION
* Adds support for timescale for Xcelium in runner
* Raise exception when waves is set in build step for Xcelium (closes #4814)
* Improve docstrings and Simulator Support section for all simulators

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
