### PR TITLE
Add docs and features to warn about changing indexes in 2.0

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -124,6 +124,7 @@ A test can spawn multiple coroutines, allowing for independent flows of executio
    rotating_logger
    extensions
    upgrade-2.0
+   update_indexing
 
 .. todo::
    - Add IPython section

--- a/docs/source/update_indexing.rst
+++ b/docs/source/update_indexing.rst
@@ -1,0 +1,158 @@
+.. _update-indexing:
+
+******************************
+Update Indexing for cocotb 2.0
+******************************
+
+cocotb 2.0 changes what types are returned when getting a value from a
+:ref:`Logic-like <logic-handle-value-changes>` or :ref:`Array-like <array-handle-value-changes>` simulator object.
+This can require a change to the testbench code in how those values are indexed.
+Because this change breaks backwards compatibility silently,
+this document and the following set of features were added to assist users in updating the indexing in their existing tests built against cocotb 1.x.
+
+.. autoclass:: cocotb.types.IndexingChangedWarning
+
+.. envvar:: COCOTB_INDEXING_CHANGED_WARNING
+
+    Set this environment variable to ``1`` to cause a warning to be emitted on all :class:`.LogicArray` and :class:`.Array` indexing and slicing operations
+    if the indexing would have changed between cocotb 1.x and 2.x.
+
+How to Find Indexing Changes
+============================
+
+Set the :envvar:`!COCOTB_INDEXING_CHANGED_WARNING` environment variable to ``1`` and run your test.
+You should see warnings emitted on every line of your testbench that indices or slices a :class:`.LogicArray` or :class:`.Array` where the indexing has changed.
+The warning will tell you what index you used and what the new index should be.
+
+.. code-block:: console
+
+    $ export COCOTB_INDEXING_CHANGED_WARNING=1
+    $ make
+    ...
+    /home/user/project/tests/unit_tests.py:160: IndexingChangedWarning: Index 0 is now 7
+      left_bit = dut.signal.value[0]
+    ...
+    /home/user/project/tests/unit_tests.py:543: IndexingChangedWarning: Index 0 is now 3
+      if handle.value[i]:
+    /home/user/project/tests/unit_tests.py:543: IndexingChangedWarning: Index 1 is now 2
+      if handle.value[i]:
+    /home/user/project/tests/unit_tests.py:543: IndexingChangedWarning: Index 2 is now 1
+      if handle.value[i]:
+    /home/user/project/tests/unit_tests.py:543: IndexingChangedWarning: Index 3 is now 0
+      if handle.value[i]:
+    ...
+    /home/user/project/tests/unit_tests.py:232: IndexingChangedWarning: Slice 0:3 is now 7:4
+      field = dut.signal.value[:3]
+
+
+How to Update Indexing
+======================
+
+For static indices or slices, simply change the index or slice to the new value.
+
+.. code-block:: verilog
+    :caption: Signal definition
+
+    logic [3:0] signal;
+    logic [3:0] array [1:4];
+
+.. code-block:: python
+    :caption: Old 0-based indexing
+    :class: removed
+
+    dut.signal.value = "1010"
+    ...
+    assert dut.signal.value[0] == 1  # index 0 is always left-most
+
+    dut.array.value = [100, 101, 102, 103]
+    ...
+    assert dut.array.value[0] == 100  # index 0 is always left-most
+
+.. code-block:: python
+    :caption: New HDL-based indexing (packed object / logic array)
+    :class: new
+
+    dut.signal.value = "1010"
+    ...
+    assert dut.signal.value[3] == 1  # index 3 is now the left-most
+
+    dut.array.value = [100, 101, 102, 103]
+    ...
+    assert dut.array.value[1] == 100  # index 1 is now the left-most
+
+.. note::
+
+    If you previously used the static indices ``0`` or ``-1`` to refer to the first or last element in an array,
+    ``array[array.left]`` or ``array[array.right]``, respectively, may be a better spelling.
+
+When dealing with loops involving indices, there are several options, depending on your needs.
+If you are looping over the indices to then index each element, you can instead iterate over the array directly.
+This can be combined with :func:`enumerate` to get the ``0``-based index of each element, if needed.
+
+.. code-block:: python
+    :caption: Looping over indices
+    :class: removed
+
+    for i in range(len(dut.signal.value)):
+        bit = dut.signal.value[i]
+        ...
+
+.. code-block:: python
+    :caption: Looping over elements directly
+    :class: new
+
+    for i, bit in enumerate(dut.signal.value):
+        ...
+
+If you need to use the index value, you can loop over the ``array.range`` object to get the indices in left-to-right order.
+
+.. code-block:: verilog
+    :caption: HDL signal being used
+
+    // Two arrays using the same indices
+    logic [3:0] array [1:4];
+    logic [4:0] doubled_array [1:4];
+
+.. code-block:: python
+    :caption: Looping over indices
+    :class: removed
+
+    for i in range(len(dut.array.value)):  # 0, 1, 2, 3
+        dut.doubled_array[i].value = 2 * dut.array.value[i]
+
+.. code-block:: python
+    :caption: Looping over ``range``
+    :class: new
+
+    array_value = dut.array.value
+    for i in array_value.range:  # 1, 2, 3, 4
+        dut.doubled_array[i].value = 2 * array_value[i]
+
+
+You can also use the ``array.range`` object to translate ``0`` to ``len()-1`` indexing to the one used by :class:`!LogicArray` and :class:`!Array`.
+Use this as a last resort, as it is less readable and has runtime overhead compared to the other options.
+
+.. code-block:: python
+    :class: new
+
+    val = LogicArray("1010", Range(3, 0))
+    assert val[0] == 0      # index 0 is right-most
+    ind = val.range[0]      # 0th range value is 3
+    assert val[ind] == "1"  # index 3 is left-most
+
+
+Gradual Update
+==============
+
+The recommended approach is to update one module at a time.
+This is done by using the :envvar:`PYTHONWARNINGS` environment variable to limit which modules can emit an :class:`!IndexingChangedWarning`.
+The :envvar:`!PYTHONWARNINGS` value below will ignore all :class:`!IndexingChangedWarning` except those from the ``unit_tests`` module.
+
+.. code-block:: console
+
+    $ export PYTHONWARNINGS=ignore::cocotb.types.IndexingChangedWarning,default::cocotb.types.IndexingChangedWarning:unit_tests
+    $ export COCOTB_INDEXING_CHANGED_WARNING=1
+    $ make
+
+After eliminating all warnings from one module, update the :envvar:`!PYTHONWARNINGS` environment variable to the next module and repeat until all modules are updated.
+Then rerun all tests with :envvar:`!PYTHONWARNINGS` unset to ensure all warnings are gone.

--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -374,17 +374,7 @@ Change bit indexing and slicing to use the indexing provided by the ``range`` ar
     assert val[3] == 1
     assert val[0] == 0
 
-.. note::
-    You can also use the :attr:`.LogicArray.range` object to translate ``0`` to ``len()-1`` indexing to the one used by :class:`!LogicArray`,
-    but this is rather inefficient.
-
-    .. code-block:: python
-        :class: new
-
-        val = LogicArray("1010", Range(3, 0))
-        assert val[0] == 0      # index 0 is right-most
-        ind = val.range[0]      # 0th range value is 3
-        assert val[ind] == "1"  # index 3 is left-most
+See :ref:`update-indexing` for more details on how to update indexing and slicing.
 
 ----
 
@@ -619,6 +609,8 @@ Integer representation is provided when converting to and from an integer.
     but assumes an unsigned and two's complement representation, respectively.
 
 
+.. _logic-handle-value-changes:
+
 **************************************************************************************************************************************
 Expect :class:`!LogicArray` and :class:`!Logic` instead of :class:`!BinaryValue` when getting values from logic-like simulator objects
 **************************************************************************************************************************************
@@ -628,39 +620,16 @@ Change
 
 Handles to logic-like simulator objects now return :class:`.LogicArray` or :class:`.Logic` instead of :external+cocotb19:py:class:`~cocotb.binary.BinaryValue`
 when getting their value with the :attr:`value <cocotb.handle.ValueObjectBase.value>` getter.
-Scalar logic-like simulator objects return :class:`!Logic`, and array logic-like simulator objects return :class:`!LogicArray`.
+Scalar logic-like simulator objects return :class:`!Logic`, and array-of-logic-like simulator objects return :class:`!LogicArray`.
 
 How to Upgrade
 ==============
 
-:ref:`logic-array-over-binary-value` when dealing with array logic-like simulator objects.
-Also, change indexing assumptions from always being ``0`` to ``length-1`` left-to-right, to following the arbitrary indexing scheme of the logic array as defined in HDL.
-
-.. code-block:: verilog
-    :caption: HDL signal being used
-
-    logic [7:0] signal;
-
-.. code-block:: python
-    :caption: Old way with :class:`!BinaryValue`\ s
-    :class: removed
-
-    dut.signal.value = "1010"
-    ...
-    val = dut.signal.value
-    assert val[0] == 1  # always left-most
-
-.. code-block:: python
-    :caption: New way with :class:`!LogicArray`\ s
-    :class: new
-
-    dut.signal.value = "1010"
-    ...
-    val = dut.signal.value
-    assert val[0] == 0  # uses HDL indexing, index 0 is right-most
-
-
+:ref:`logic-array-over-binary-value` when dealing with array-of-logic-like simulator objects.
 Change code when dealing with scalar logic-like simulator objects to work with :class:`!Logic`.
+
+Change indexing assumptions from always being ``0`` to ``length-1`` left-to-right, to following the arbitrary indexing scheme of the logic array as defined in HDL.
+See :ref:`update-indexing` for more details on how to update indexing and slicing.
 
 Rationale
 =========
@@ -695,6 +664,8 @@ while also providing a common API to enable writing backwards-compatible and hig
     dut.signal.value = True
 
 
+.. _array-handle-value-changes:
+
 ***************************************************************************************************
 Expect :class:`!Array` instead of :class:`!list` when getting values from arrayed simulator objects
 ***************************************************************************************************
@@ -708,33 +679,7 @@ How to Upgrade
 ==============
 
 Change indexing assumptions from always being ``0`` to ``length-1`` left-to-right, to following the arbitrary indexing scheme of the array as defined in HDL.
-For example, if the HDL defines an array with the indexing scheme ``[15:0]``, index ``15`` will be the left-most element of the array rather than the right-most.
-Change all negative indexing to use positive indexing.
-
-.. code-block:: verilog
-    :caption: HDL signal being used
-
-    integer array[1:-2];
-
-.. code-block:: python
-    :caption: Old way with :class:`!list`\ s
-    :class: removed
-
-    dut.array.value = [1, 2, 3, 4]
-    ...
-    val = dut.array.value
-    assert val[0] == 1  # always left-most
-    assert val[-1] == 4  # always right-most
-
-.. code-block:: python
-    :caption: New way with :class:`!Array`\ s
-    :class: new
-
-    dut.array.value = [1, 2, 3, 4]
-    ...
-    val = dut.array.value
-    assert val[0] == 2  # uses HDL indexing, index 0 is second element
-    assert val[-1] == 3  # uses HDL indexing, index -1 is third element
+See :ref:`update-indexing` for more details on how to update indexing and slicing.
 
 Rationale
 =========

--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -350,8 +350,6 @@ Change bit indexing and slicing to use the indexing provided by the ``range`` ar
     This means index ``0`` will be the rightmost bit and not the leftmost bit like in :class:`BinaryValue`.
     Pass ``Range(0, range-1)`` when constructing :class:`!LogicArray` to retain the old indexing scheme, or update the indexing and slicing usage.
 
-Change all negative indexing to use positive indexing.
-
 .. code-block:: python
     :caption: Old way with :class:`!BinaryValue`
     :class: removed
@@ -359,7 +357,6 @@ Change all negative indexing to use positive indexing.
     val = BinaryValue(10, 4)
     assert val[0] == 1
     assert val[3] == 0
-    assert val[-2] == 1
 
 .. code-block:: python
     :caption: New way with :class:`!LogicArray`, specifying an ascending range
@@ -368,7 +365,6 @@ Change all negative indexing to use positive indexing.
     val = LogicArray(10, Range(0, 3))
     assert val[0] == 1
     assert val[3] == 0
-    assert val[3] == 1
 
 .. code-block:: python
     :caption: New way with :class:`!LogicArray`, changing indexing
@@ -377,7 +373,6 @@ Change all negative indexing to use positive indexing.
     val = LogicArray(10, 4)
     assert val[3] == 1
     assert val[0] == 0
-    assert val[1] == 1
 
 .. note::
     You can also use the :attr:`.LogicArray.range` object to translate ``0`` to ``len()-1`` indexing to the one used by :class:`!LogicArray`,
@@ -714,6 +709,7 @@ How to Upgrade
 
 Change indexing assumptions from always being ``0`` to ``length-1`` left-to-right, to following the arbitrary indexing scheme of the array as defined in HDL.
 For example, if the HDL defines an array with the indexing scheme ``[15:0]``, index ``15`` will be the left-most element of the array rather than the right-most.
+Change all negative indexing to use positive indexing.
 
 .. code-block:: verilog
     :caption: HDL signal being used
@@ -728,6 +724,7 @@ For example, if the HDL defines an array with the indexing scheme ``[15:0]``, in
     ...
     val = dut.array.value
     assert val[0] == 1  # always left-most
+    assert val[-1] == 4  # always right-most
 
 .. code-block:: python
     :caption: New way with :class:`!Array`\ s
@@ -737,6 +734,7 @@ For example, if the HDL defines an array with the indexing scheme ``[15:0]``, in
     ...
     val = dut.array.value
     assert val[0] == 2  # uses HDL indexing, index 0 is second element
+    assert val[-1] == 3  # uses HDL indexing, index -1 is third element
 
 Rationale
 =========

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -45,6 +45,7 @@ from cocotb._py_compat import cached_property, insertion_ordered_dict
 from cocotb._utils import DocIntEnum
 from cocotb.task import Task
 from cocotb.types import Array, Logic, LogicArray, Range
+from cocotb.types._indexing import do_indexing_changed_warning, indexing_changed
 
 __all__ = (
     "ArrayObject",
@@ -1018,7 +1019,12 @@ class ArrayObject(
         | ``arr[7:4]`` | ``arr(7 downto 4)`` | ``Array([arr[7].value, arr[6].value, arr[5].value, arr[4].value], range=Range(7, 'downto', 4))`` |
         +--------------+---------------------+--------------------------------------------------------------------------------------------------+
         """
-        return Array._from_handle([self[i].value for i in self.range], self.range)
+        r = self.range
+        return Array._from_handle(
+            value=[self[i].value for i in r],
+            range=r,
+            warn_indexing=indexing_changed(r) if do_indexing_changed_warning else False,
+        )
 
     def set(
         self,
@@ -1297,7 +1303,12 @@ class LogicArrayObject(
     def get(self) -> LogicArray:
         """Return the current value of the simulation object as a :class:`.LogicArray`."""
         binstr = self._handle.get_signal_val_binstr()
-        return LogicArray._from_handle(binstr)
+        return LogicArray._from_handle(
+            value=binstr,
+            warn_indexing=indexing_changed(self.range)
+            if do_indexing_changed_warning
+            else False,
+        )
 
     def set(
         self,

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from ._abstract_array import AbstractArray, AbstractMutableArray
 from ._array import Array
+from ._indexing import IndexingChangedWarning
 from ._logic import Logic
 from ._logic_array import LogicArray
 from ._range import Range
@@ -17,6 +18,7 @@ __all__ = (
     "AbstractArray",
     "AbstractMutableArray",
     "Array",
+    "IndexingChangedWarning",
     "Logic",
     "LogicArray",
     "Range",

--- a/src/cocotb/types/_indexing.py
+++ b/src/cocotb/types/_indexing.py
@@ -1,0 +1,17 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from cocotb.types._range import Range
+
+do_indexing_changed_warning = os.environ.get("COCOTB_INDEXING_CHANGED_WARNING")
+
+
+def indexing_changed(range: Range) -> bool:
+    return not (range.left == 0 and range.direction == "to")
+
+
+class IndexingChangedWarning(UserWarning):
+    """Warning issued when a value is indexed in a way that is different between cocotb 1.x and 2.x."""

--- a/tests/test_cases/test_fatal/Makefile
+++ b/tests/test_cases/test_fatal/Makefile
@@ -1,7 +1,6 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
-# SPDX-License-Identifier: BSD-3-Clause USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# SPDX-License-Identifier: BSD-3-Clause
 
 TOPLEVEL_LANG ?= verilog
 COCOTB_TOPLEVEL := fatal

--- a/tests/test_cases/test_fatal/fatal.sv
+++ b/tests/test_cases/test_fatal/fatal.sv
@@ -1,8 +1,7 @@
 //-----------------------------------------------------------------------------
 // Copyright cocotb contributors
 // Licensed under the Revised BSD License, see LICENSE for details.
-// SPDX-License-Identifier: BSD-3-Clause USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// SPDX-License-Identifier: BSD-3-Clause
 //-----------------------------------------------------------------------------
 
 `timescale 1 ps / 1 ps

--- a/tests/test_cases/test_fatal/fatal.vhd
+++ b/tests/test_cases/test_fatal/fatal.vhd
@@ -1,7 +1,6 @@
 -- Copyright cocotb contributors
 -- Licensed under the Revised BSD License, see LICENSE for details.
--- SPDX-License-Identifier: BSD-3-Clause USE OF THIS
--- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-- SPDX-License-Identifier: BSD-3-Clause
 
 entity fatal is
 end entity fatal;

--- a/tests/test_cases/test_fatal/test_fatal.py
+++ b/tests/test_cases/test_fatal/test_fatal.py
@@ -1,7 +1,6 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
-# SPDX-License-Identifier: BSD-3-Clause USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# SPDX-License-Identifier: BSD-3-Clause
 
 import cocotb
 from cocotb.regression import SimFailure

--- a/tests/test_cases/test_indexing_warning/Makefile
+++ b/tests/test_cases/test_indexing_warning/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	pytest -s

--- a/tests/test_cases/test_indexing_warning/indexing_warning_tests.py
+++ b/tests/test_cases/test_indexing_warning/indexing_warning_tests.py
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from typing import Any
+
+import pytest
+
+import cocotb
+from cocotb.types import IndexingChangedWarning
+
+
+@cocotb.test
+async def test_indexing_warnings(dut: Any) -> None:
+    with pytest.warns(IndexingChangedWarning, match="Update index 0 to 7"):
+        dut.vec.value[0]
+    with pytest.raises(IndexError):  # 3:7 is TO, but the HDL 7:0 is DOWNTO
+        with pytest.warns(IndexingChangedWarning, match="Update slice 3:7 to 4:0"):
+            dut.vec.value[3:7]
+
+    with pytest.raises(IndexError):  # 0 is out of range of the HDL's 1:4
+        with pytest.warns(IndexingChangedWarning, match="Update index 0 to 1"):
+            dut.arr.value[0]
+    with pytest.warns(IndexingChangedWarning, match="Update slice 1:2 to 2:3"):
+        dut.arr.value[1:2]

--- a/tests/test_cases/test_indexing_warning/test_indexing_warning.py
+++ b/tests/test_cases/test_indexing_warning/test_indexing_warning.py
@@ -1,0 +1,43 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+from pathlib import Path
+
+import pytest
+
+from cocotb_tools.runner import get_runner
+
+LANG = os.getenv("TOPLEVEL_LANG", "verilog")
+
+
+@pytest.mark.skipif(LANG != "verilog", reason="This test only supports Verilog")
+def test_indexing_warning() -> None:
+    sim = os.getenv("SIM", "icarus")
+    runner = get_runner(sim)
+
+    pwd = Path(__file__).parent.absolute()
+
+    # select args
+    build_args = []
+    test_args = []
+    if sim == "questa":
+        build_args = ["+acc"]
+        test_args = ["-t", "ps"]
+    elif sim == "xcelium":
+        build_args = ["-v93"]
+
+    runner.build(
+        sources=[pwd / "top.sv"],
+        hdl_toplevel="top",
+        build_args=build_args,
+    )
+
+    runner.test(
+        test_module="indexing_warning_tests",
+        hdl_toplevel="top",
+        hdl_toplevel_lang=LANG,
+        test_args=test_args,
+        extra_env={"COCOTB_INDEXING_CHANGED_WARNING": "1"},
+    )

--- a/tests/test_cases/test_indexing_warning/top.sv
+++ b/tests/test_cases/test_indexing_warning/top.sv
@@ -1,0 +1,12 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+`timescale 1 ps / 1 ps
+
+module top (
+    input logic [7:0] vec,
+    input logic [7:0] arr [1:4]
+);
+
+endmodule


### PR DESCRIPTION
Adds a new nevvar `COCOTB_INDEXING_CHANGED_WARNING` to emit a warning whenever it detects that the user is indexing or slicing an Array or LogicArray that would have changed indexes between 1.x and 2.x.

Adds a document which discusses how to use the flag, how to approach updating, and how to fix some common usages.
These sections were moved from the "Upgrading to 2.0" doc.

### TODO
- [x] Manually created Arrays are not effected, only Arrays that come from handles.
- [x] Only LogicArrays that use and int for the `range` argument (that were upgraded from BinaryValue) and LogicArrays that come from handles are affected.
- [x] Add test
- [x] Proofread
