### PR TITLE
Fix color of generic admonitions to cocotb-blue

### DIFF
--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -139,6 +139,7 @@ blockquote {
 
 div.admonition {
     border-radius: 0 !important;
+    border-color: var(--color-cocotb-blue) !important;
     box-shadow: none !important;
     padding-bottom: 0 !important;
 }


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
