### PR TITLE
Better split logging configuration

### DIFF
--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -17,6 +17,7 @@ from typing import Callable, List, cast
 import cocotb
 import cocotb._profiling
 import cocotb.handle
+import cocotb.logging
 import cocotb.simulator
 from cocotb._scheduler import Scheduler
 from cocotb.regression import RegressionManager, RegressionMode
@@ -62,6 +63,7 @@ def init_package_from_simulation(argv: List[str]) -> None:
     # Add it back because users expect to be able to import files in their test directory.
     sys.path.insert(0, "")
 
+    cocotb.logging._init()
     _setup_logging()
 
     # From https://www.python.org/dev/peps/pep-0565/#recommended-filter-settings-for-test-runners

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -1,7 +1,7 @@
 import importlib
+import operator
 import os
-from functools import reduce
-from typing import Any, Callable, List, Tuple, cast
+from typing import Callable, List, Tuple
 
 
 def load_entry(argv: List[str]) -> None:
@@ -12,8 +12,7 @@ def load_entry(argv: List[str]) -> None:
         ",".join(
             (
                 "cocotb_tools._coverage:start_cocotb_library_coverage",
-                "cocotb.logging:_init",
-                "cocotb.logging:_setup_formatter",
+                "cocotb.logging:_configure",
                 "cocotb._init:init_package_from_simulation",
                 "cocotb._init:run_regression",
             )
@@ -37,7 +36,7 @@ def load_entry(argv: List[str]) -> None:
     # Expect failure to stop the loading of any additional entry points.
     for entry_module_str, entry_func_str in entry_points:
         entry_module = importlib.import_module(entry_module_str)
-        entry_func: Callable[[List[str]], object] = reduce(
-            getattr, entry_func_str.split("."), cast("Any", entry_module)
+        entry_func: Callable[[List[str]], object] = operator.attrgetter(entry_func_str)(
+            entry_module
         )
         entry_func(argv)


### PR DESCRIPTION
This splits setting the log level into defaults in the overridable function and overriding them with the variables COCOTB_LOG_LEVEL and GPI_LOG_LEVEL in the non-overridable function. If neither envvar is supplied it won't affect whatever the user put in the override.

This spawned a larger refactor of `_init.py` which will come in a follow on.