### PR TITLE
Fallback on `set_trace` when no traceback available

### DIFF
--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -89,7 +89,10 @@ class RunningTest:
 
         # Break into pdb on test end before all Tasks are killed.
         if _pdb_on_exception and isinstance(outcome, Error):
-            pdb.post_mortem(outcome.error.__traceback__)
+            try:
+                pdb.post_mortem(outcome.error.__traceback__)
+            except BaseException:
+                pdb.set_trace()
 
         # Set outcome and cancel Tasks.
         self._outcome = outcome


### PR DESCRIPTION
Closes #4837.