### PR TITLE
Mention Verilator uses COCOTB_TRUST_INERTIAL_WRITES=1 by default

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -210,7 +210,7 @@ Cocotb
     This allows cocotb to avoid a VPI callback into Python to apply writes.
 
     .. note::
-        This flag is enabled by default for GHDL and NVC simulators.
+        This flag is enabled by default for the GHDL, NVC and Verilator simulators.
         More simulators may enable this flag by default in the future as they are gradually updated to properly apply inertial writes according to the respective standard.
 
     .. note::

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -129,6 +129,9 @@ define check_lib_order
   fi;
 endef
 
+# NOTE: if the following simulator list is modified, update the sentence
+# "This flag is enabled by default for the GHDL, NVC and Verilator simulators."
+# in docs/source/building.rst accordingly.
 ifneq ($(filter $(SIM),nvc ghdl verilator),)
   COCOTB_TRUST_INERTIAL_WRITES ?= 1
 else


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
