### PR TITLE
Cleanup pragmas

### DIFF
--- a/examples/adder/hdl/adder.sv
+++ b/examples/adder/hdl/adder.sv
@@ -13,10 +13,4 @@ module adder #(
 
   assign X = A + B;
 
-  // Dump waves
-  initial begin
-    $dumpfile("dump.vcd");
-    $dumpvars(1, adder);
-  end
-
 endmodule

--- a/examples/matrix_multiplier/hdl/matrix_multiplier.sv
+++ b/examples/matrix_multiplier/hdl/matrix_multiplier.sv
@@ -6,9 +6,9 @@
 
 `ifdef VERILATOR  // make parameter readable from VPI
   `define VL_RD /*verilator public_flat_rd*/
-`else
+`else  // `ifdef VERILATOR
   `define VL_RD
-`endif
+`endif  // `ifdef VERILATOR
 
 module matrix_multiplier #(
   parameter int DATA_WIDTH `VL_RD = 8,

--- a/examples/matrix_multiplier/hdl/matrix_multiplier.sv
+++ b/examples/matrix_multiplier/hdl/matrix_multiplier.sv
@@ -57,28 +57,4 @@ module matrix_multiplier #(
     end
   end
 
-  // Dump waves
-`ifndef VERILATOR
-  initial begin
-    integer idx;
-    $dumpfile("dump.vcd");
-    $dumpvars(1, matrix_multiplier);
-  `ifdef __ICARUS__
-      for (idx = 0; idx < (A_ROWS * A_COLUMNS_B_ROWS); idx++) begin
-        $dumpvars(1, a_i[idx]);
-      end
-      for (idx = 0; idx < (A_COLUMNS_B_ROWS * B_COLUMNS); idx++) begin
-        $dumpvars(1, b_i[idx]);
-      end
-      for (idx = 0; idx < (A_ROWS * B_COLUMNS); idx++) begin
-        $dumpvars(1, c_o[idx]);
-      end
-  `else
-    $dumpvars(1, a_i);
-    $dumpvars(1, b_i);
-    $dumpvars(1, c_o);
-  `endif
-  end
-`endif
-
 endmodule

--- a/examples/mixed_language/hdl/endian_swapper.sv
+++ b/examples/mixed_language/hdl/endian_swapper.sv
@@ -153,12 +153,4 @@ always @(posedge clk or negedge reset_n) begin
     end
 end
 
-`ifndef VERILATOR // traced differently
-initial begin
-  $dumpfile ("waveform.vcd");
-  $dumpvars (0,endian_swapper_sv);
-  #1;
-end
-`endif
-
 endmodule

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -6,7 +6,7 @@
 
 `ifndef NOTIMESCALE
 `timescale 1 ps / 1 ps
-`endif
+`endif  // `ifndef NOTIMESCALE
 
 `ifndef __ICARUS__
 
@@ -23,8 +23,7 @@ typedef struct packed
     logic value;
 } test_struct_packed;
 
-
-`endif
+`endif  // `ifndef __ICARUS__
 
 interface TestInterface ();
 
@@ -57,7 +56,7 @@ module sample_module #(
     input  test_struct_unpacked                 inout_if,
     input  test_struct_packed                   my_struct,
     input  string                               stream_in_string,
-`endif
+`endif  // `ifndef __ICARUS__
     input  [7:0]                                stream_in_data,
     input  [31:0]                               stream_in_data_dword,
     input  [38:0]                               stream_in_data_39bit,
@@ -77,7 +76,7 @@ localparam string STRING_LOCALPARAM = "TESTING_LOCALPARAM";
 
 var   string STRING_VAR   = "TESTING_VAR";
 const string STRING_CONST = "TESTING_CONST";
-`endif
+`endif  // `ifndef __ICARUS__
 
 always @(posedge clk)
     stream_out_data_registered <= stream_in_data;
@@ -192,7 +191,7 @@ reg _underscore_name;
     // to be visible to VPI in Icarus Verilog.
     // See https://github.com/steveicarus/iverilog/issues/322
     assign _underscore_name = 0;
-`endif
+`endif  // `ifdef __ICARUS__
 
 bit mybit;
 bit [1:0] mybits;

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -119,13 +119,6 @@ test_struct_unpacked struct_var;
 
 and test_and_gate(and_output, stream_in_ready, stream_in_valid);
 
-`ifndef NODUMPFILE
-initial begin
-    $dumpfile("waveform.vcd");
-    $dumpvars(0,sample_module);
-end
-`endif
-
 parameter NUM_OF_MODULES /*verilator public_flat_rd*/ = 4;
 reg[NUM_OF_MODULES-1:0] temp;
 genvar idx;

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -10,13 +10,11 @@
 
 `ifndef __ICARUS__
 
-`ifndef VERILATOR
 typedef struct
 {
     logic a_in;
     logic b_out;
 } test_struct_unpacked;
-`endif // `ifndef VERILATOR
 
 typedef struct packed
 {
@@ -56,9 +54,7 @@ module sample_module #(
     input  integer                              stream_in_int,
     output real                                 stream_out_real,
     output integer                              stream_out_int,
-    `ifndef VERILATOR
     input  test_struct_unpacked                 inout_if,
-    `endif
     input  test_struct_packed                   my_struct,
     input  string                               stream_in_string,
 `endif
@@ -118,9 +114,7 @@ always @(stream_in_string) begin
 end
 `endif //  `ifndef _VCP
 
-`ifndef VERILATOR
 test_struct_unpacked struct_var;
-`endif
 `endif //  `ifndef __ICARUS__
 
 and test_and_gate(and_output, stream_in_ready, stream_in_valid);

--- a/tests/pytest/test_logs.py
+++ b/tests/pytest/test_logs.py
@@ -48,7 +48,6 @@ def run_simulation(sim, log_dir):
         hdl_toplevel=hdl_toplevel,
         build_dir=sim_build,
         build_args=compile_args,
-        defines={"NODUMPFILE": 1},
         log_file=log_dir / "build.log",
     )
 

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -44,7 +44,6 @@ def run_simulation(sim, test_args=None):
         hdl_toplevel=hdl_toplevel,
         build_dir=sim_build,
         build_args=compile_args,
-        defines={"NODUMPFILE": 1},
         waves=False if sim in ("xcelium",) else True,
     )
 

--- a/tests/test_cases/test_3316/test_3316.sv
+++ b/tests/test_cases/test_3316/test_3316.sv
@@ -5,7 +5,7 @@
 module test_3316 (
 `ifdef TEST_CLK_EXTERNAL
     input  logic clk,
-`endif
+`endif  // `ifdef TEST_CLK_EXTERNAL
     input  logic d,
     output logic q
 );
@@ -15,7 +15,7 @@ module test_3316 (
   bit clk;
   initial clk = 0;
   always #5 clk = ~clk;
-`endif
+`endif  // `ifndef TEST_CLK_EXTERNAL
 
   always_ff @(posedge clk) begin : proc_dff
     q <= d;

--- a/tests/test_cases/test_iteration_verilog/endian_swapper.sv
+++ b/tests/test_cases/test_iteration_verilog/endian_swapper.sv
@@ -153,12 +153,4 @@ always @(posedge clk or negedge reset_n) begin
     end
 end
 
-`ifndef VERILATOR // traced differently
-initial begin
-  $dumpfile ("waveform.vcd");
-  $dumpvars (0,endian_swapper_sv);
-  #1;
-end
-`endif
-
 endmodule


### PR DESCRIPTION
Various cleanup around SV pragmas.
* Verilator supports unpacked structs in all versions we support
* Remove unnecessary dumpfile/dumpvars in SV sources
