### PR TITLE
Make 1st level Python objects stand out more against 2nd level objects in docs

### DIFF
--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -555,3 +555,10 @@ body.release-notes h3 {
   top: calc(3 * 48px);
   z-index: 970;
 }
+
+
+code.literal {
+  border: none;
+  background-color: unset;
+  padding: 0;
+}

--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -152,6 +152,7 @@ div.versionremoved {
     /* font-size: 0.75rem !important; */ /* TODO: decide on this */
     border-radius: 0 !important;
     box-shadow: none !important;
+    margin: 1.0rem auto;
 }
 
 .admonition.warning,
@@ -244,15 +245,64 @@ strong.command {
     color: var(--color-cocotb-blue) !important;
 }
 
-/* normal font weight for .pre ... */
-.pre {
-    font-weight: normal;
+code.xref {
+  background-color: transparent;
+  font-weight: normal;
 }
-/* ... but restore bold when .pre is in headings
-   (a check for "not in headings" does not really exist in CSS)
-*/
-h1:has(.pre) .pre, h2:has(.pre) .pre, h3:has(.pre) .pre, h4:has(.pre) .pre, h5:has(.pre) .pre, h6:has(.pre) .pre {
-    font-weight: bold;
+
+h1:has(code.xref) code.xref, h2:has(code.xref) code.xref, h3:has(code.xref) code.xref, h4:has(code.xref) code.xref, h5:has(code.xref) code.xref, h6:has(code.xref) code.xref {
+  font-weight: bold !important;
+}
+
+dl.py.class dt.sig.sig-object,
+dl.py.exception dt.sig.sig-object,
+dl.py.type dt.sig.sig-object,
+dl.py.data dt.sig.sig-object,
+dl.py.decorator dt.sig.sig-object,
+dl.py.function dt.sig.sig-object {
+  margin-top: 2.0rem !important;
+  font-size: 1.1rem !important;
+  font-weight: bold !important;
+}
+
+dl.py.attribute dt.sig.sig-object,
+dl.py.classmethod dt.sig.sig-object,
+dl.py.decoratormethod dt.sig.sig-object,
+dl.py.staticmethod dt.sig.sig-object,
+dl.py.method dt.sig.sig-object,
+dl.py.property dt.sig.sig-object {
+  margin-top: 0 !important;
+  font-size: 1.0rem !important;
+  /* font-weight: normal !important; */
+}
+
+dl.py.attribute dt.sig.sig-object .sig-name,
+dl.py.classmethod dt.sig.sig-object .sig-name,
+dl.py.decoratormethod dt.sig.sig-object .sig-name,
+dl.py.staticmethod dt.sig.sig-object .sig-name,
+dl.py.method dt.sig.sig-object .sig-name,
+dl.py.property dt.sig.sig-object .sig-name {
+  font-size: 1.0rem !important;
+  /* font-weight: normal !important; */
+}
+
+/* remove top margin if preceded by a heading, admonition or version modified */
+h1 + dl.py,
+h2 + dl.py,
+h3 + dl.py,
+h4 + dl.py,
+h5 + dl.py,
+h6 + dl.py,
+.admonition + dl.py,
+.versionadded + dl.py,
+.versionchanged + dl.py,
+.versionremoved + dl.py,
+.deprecated + dl.py {
+  margin-top: 0 !important;
+}
+
+dl[class]:not(.option-list, .field-list, .footnote, .glossary, .simple) {
+  margin-bottom: 1rem !important;
 }
 
 /* apidoc "[source]" link */
@@ -369,7 +419,6 @@ dl.py.exception,
 dl.py.function,
 dl.py.method,
 dl.py.property,
-dl.py.property,
 dl.py.staticmethod,
 dl.py.type {
     margin-bottom: 1rem;
@@ -388,7 +437,7 @@ dl.cpp.type,
 dl.cpp.union,
 dl.cpp.var,
 dl.cpp.macro {
-    margin-bottom: 1rem;
+    margin-bottom: 1rem !important;
 }
 
 dl.cpp.enumerator {


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
