### PR TITLE
Centralize and document debugging flag

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -441,6 +441,11 @@ Other Runtime Information
 
 .. autodata:: cocotb.is_simulation
 
+Debugging
+---------
+
+.. autodata:: cocotb.debug.DEBUG
+
 .. _combine-results:
 
 The ``combine_results`` script

--- a/src/cocotb/debug.py
+++ b/src/cocotb/debug.py
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+DEBUG: bool = bool(os.getenv("COCOTB_SCHEDULER_DEBUG"))
+"""Global flag to enable additional debugging functionality.
+
+Defaults to ``True`` if the :envvar:`COCOTB_SCHEDULER_DEBUG` environment variable is set,
+but can be programmatically set by the user afterwards.
+
+The ``"cocotb"`` logger should have its logging level set to :data:`logging.DEBUG`
+to see additional debugging information in the test log.
+This can be accomplished by setting the :envvar:`COCOTB_LOG_LEVEL` environment variable
+to ``DEBUG``,
+or using the following code.
+
+.. code-block:: python
+
+    import logging
+    logging.getLogger("cocotb").setLevel(logging.DEBUG)
+
+"""

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -4,7 +4,6 @@
 import collections.abc
 import inspect
 import logging
-import os
 import traceback
 from asyncio import CancelledError, InvalidStateError
 from bdb import BdbQuit
@@ -34,13 +33,6 @@ from cocotb._utils import DocEnum, extract_coro_stack, remove_traceback_frames
 if TYPE_CHECKING:
     from types import CoroutineType
 
-#: Task result type
-ResultType = TypeVar("ResultType")
-
-# Sadly the Python standard logging module is very slow so it's better not to
-# make any calls by testing a boolean flag first
-_debug = "COCOTB_SCHEDULER_DEBUG" in os.environ
-
 
 __all__ = (
     "Join",
@@ -54,6 +46,9 @@ __all__ = (
 # Set __module__ on re-exports
 bridge.__module__ = __name__
 resume.__module__ = __name__
+
+#: Task result type
+ResultType = TypeVar("ResultType")
 
 
 class _TaskState(DocEnum):

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,6 +7,7 @@
 # the site module.
 # Do not fail on DeprecationWarning caused by attrs dropping 3.6 support
 export PYTHONWARNINGS = error,ignore::DeprecationWarning:site,ignore::DeprecationWarning:attr
+export COCOTB_SCHEDULER_DEBUG = 1
 
 REGRESSIONS :=  $(shell ls test_cases/)
 


### PR DESCRIPTION
Replaces first commit of #4717. xref #4809.

Also tests the debugging logs without actually printing them. Should improve coverage a bit. Closes #3968.
