### PR TITLE
`cocotb.logging` refactor

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -324,7 +324,7 @@ Logging
     The result of :func:`~cocotb.utils.get_sim_time` at the point the log was created (in simulation time).
     The formatter is responsible for converting this to something like nanoseconds via :func:`~cocotb.utils.get_time_from_sim_steps`.
 
-    This is added by :class:`cocotb.log.SimTimeContextFilter`.
+    This is added by :class:`~cocotb.logging.SimTimeContextFilter`.
 
 
 Simulator Objects

--- a/docs/source/newsfragments/4871.feature.rst
+++ b/docs/source/newsfragments/4871.feature.rst
@@ -1,0 +1,1 @@
+Added ``color`` and ``reduced_log_fmt`` parameters to :func:`default_config` to control log formatting.

--- a/docs/source/newsfragments/4871.removal.rst
+++ b/docs/source/newsfragments/4871.removal.rst
@@ -1,0 +1,1 @@
+Deprecated :class:`SimColourLogFormatter`. Use :class:`SimLogFormatter` with ``color=True`` instead.


### PR DESCRIPTION
xref #4808. Will be the basis for in-progress addition of `COCOTB_LOG_PREFIX` which allows users to customize the logging prefix.

This is a general refactor for performance/flexibility:
* Adds ability to pass `color` and `reduced_log_fmt` to callers of `default_config` so that function isn't dependent upon private globals or environment variables
* Refactors `SimLogFormatter` and `SimColourLogFormatter` into one class, `SimColourLogFormatter` is deprecated.
* Refactors the implementation of `formatMessage` in cocotb's formatter to use f-strings and other performance-minded refactors