### PR TITLE
Don't set scheduler log level if debug.DEBUG is set

### DIFF
--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -108,8 +108,6 @@ class Scheduler:
 
     def __init__(self) -> None:
         self.log = logging.getLogger("cocotb.scheduler")
-        if debug.DEBUG:
-            self.log.setLevel(logging.DEBUG)
 
         # A dictionary of pending tasks for each trigger,
         # indexed by trigger


### PR DESCRIPTION
Tests are failing because the log outputs are now too long. This should resolve the issue and preserve the intent of #4867.