### PR TITLE
Add `Bit` back

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -136,6 +136,9 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
 .. autoclass:: cocotb.types.Logic
     :members:
 
+.. autoclass:: cocotb.types.Bit
+    :members:
+
 .. autoclass:: cocotb.types.Range
     :members:
     :exclude-members: count, index

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -116,7 +116,6 @@ Deprecations and Removals
 - Support for generator-based coroutines, which used the ``cocotb.coroutine`` decorator and :keyword:`yield` syntax, has been removed. To update to the new syntax, remove all uses of the decorator and convert the function to a :term:`coroutine function` using the :keyword:`async` and :keyword:`await` syntax. (:pr:`3509`)
 - Removed the ``cocotb.memdebug`` module. (:pr:`3543`)
 - :external+cocotb19:class:`cocotb.utils.lazy_property` was removed. Use :func:`functools.cached_property` instead. (:pr:`3547`)
-- Removed :external+cocotb19:class:`cocotb.types.Bit`. (:pr:`3549`)
 - Removed ``cocotb.clock.BaseClock``. (:pr:`3550`)
 - The ``prefix`` and ``postfix`` arguments to :meth:`TestFactory.generate_tests() <cocotb.regression.TestFactory.generate_tests>` are deprecated in favor of the more flexible ``name`` argument. (:pr:`3578`)
 - Methods :external+cocotb19:meth:`~cocotb.simulator.gpi_sim_hdl.get_definition_name()` and :external+cocotb19:meth:`~cocotb.simulator.gpi_sim_hdl.get_definition_file()` of :class:`cocotb.handle.SimHandleBase` were removed in favor of :meth:`~cocotb.handle.SimHandleBase._def_name` and :meth:`~cocotb.handle.SimHandleBase._def_file`, respectively. (:pr:`3609`)

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -4,7 +4,7 @@
 from ._abstract_array import AbstractArray, AbstractMutableArray
 from ._array import Array
 from ._indexing import IndexingChangedWarning
-from ._logic import Logic
+from ._logic import Bit, Logic
 from ._logic_array import LogicArray
 from ._range import Range
 
@@ -18,6 +18,7 @@ __all__ = (
     "AbstractArray",
     "AbstractMutableArray",
     "Array",
+    "Bit",
     "IndexingChangedWarning",
     "Logic",
     "LogicArray",

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -19,11 +19,12 @@ from cocotb._deprecation import deprecated
 from cocotb._py_compat import Literal, TypeAlias
 from cocotb.types._abstract_array import AbstractMutableArray
 from cocotb.types._indexing import IndexingChangedWarning
-from cocotb.types._logic import Logic, LogicConstructibleT, _str_literals
+from cocotb.types._logic import Logic, LogicConstructibleT
 from cocotb.types._range import Range
 from cocotb.types._resolve import RESOLVE_X, ResolverLiteral, get_str_resolver
 
 _resolve_lh_table = str.maketrans({"L": "0", "H": "1"})
+_str_literals = frozenset("uUxX01zZwWlLhH-")
 
 
 ByteOrder: TypeAlias = Literal["big", "little"]

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -5,7 +5,7 @@ import copy
 
 import pytest
 
-from cocotb.types import Logic
+from cocotb.types import Bit, Logic
 
 
 def test_logic_conversions():
@@ -203,3 +203,39 @@ def test_copy() -> None:
     l = Logic("X")
     assert l == copy.copy(l)
     assert l == copy.deepcopy(l)
+
+
+def test_bit_constructor() -> None:
+    Bit(0)
+    Bit(False)
+    Bit("0")
+    Bit(Logic(0))
+    Bit(1)
+    Bit(True)
+    Bit("1")
+    Bit(Logic(1))
+    with pytest.raises(ValueError):
+        Bit("X")
+    with pytest.raises(ValueError):
+        Bit("L")
+    a = Logic("X")
+    with pytest.raises(ValueError):
+        Bit(a)
+
+
+def test_bit_ops() -> None:
+    assert Bit(1) | Bit(0) is Bit(1)
+    assert Bit(1) & Bit(0) is Bit(0)
+    assert Bit(1) ^ Bit(0) is Bit(1)
+    assert ~Bit(1) is Bit(0)
+
+
+def test_bit_with_logic_ops() -> None:
+    assert Logic(0) == Bit(0)
+    assert Bit(0) == Logic(0)
+    assert Logic(1) & Bit(1) is Logic(1)
+    assert Bit(1) & Logic(1) is Logic(1)
+    assert Logic(0) | Bit(1) is Logic(1)
+    assert Bit(0) | Logic(1) is Logic(1)
+    assert Logic(1) ^ Bit(1) is Logic(0)
+    assert Bit(1) ^ Logic(1) is Logic(0)


### PR DESCRIPTION
Re-adds `Bit` class. I plan on adding more types in the near future including `BitArray` and subtypes which can use this type.

### TODO
- [x] tests