### PR TITLE
docs: Fix links and log formatter docstrings

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -134,6 +134,7 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
 .. versionadded:: 1.6
 
 .. autoclass:: cocotb.types.Logic
+    :members:
 
 .. autoclass:: cocotb.types.Range
     :members:

--- a/docs/source/newsfragments/4871.feature.rst
+++ b/docs/source/newsfragments/4871.feature.rst
@@ -1,1 +1,1 @@
-Added ``color`` and ``reduced_log_fmt`` parameters to :func:`default_config` to control log formatting.
+Added ``color`` and ``reduced_log_fmt`` parameters to :func:`.default_config` to control log formatting.

--- a/docs/source/newsfragments/4871.removal.rst
+++ b/docs/source/newsfragments/4871.removal.rst
@@ -1,1 +1,1 @@
-Deprecated :class:`SimColourLogFormatter`. Use :class:`SimLogFormatter` with ``color=True`` instead.
+Deprecated :class:`.SimColourLogFormatter`. Use :class:`.SimLogFormatter` with ``color=True`` instead.

--- a/docs/source/newsfragments/4872.feature.rst
+++ b/docs/source/newsfragments/4872.feature.rst
@@ -1,1 +1,1 @@
-Added ``period_high`` argument to :class:`Clock` to allow the user to control the duty cycle of the generated clock.
+Added ``period_high`` argument to :class:`.Clock` to allow the user to control the duty cycle of the generated clock.

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -196,6 +196,11 @@ class SimLogFormatter(logging.Formatter):
         reduced_log_fmt: bool = True,
         color: bool = False,
     ) -> None:
+        """
+        Args:
+            reduced_log_fmt: Use less verbose log format.
+            color: Use ANSI color codes in log output.
+        """
         self._reduced_log_fmt = reduced_log_fmt
         self.color = color
 


### PR DESCRIPTION
For `SimLogFormatter` and `SimColourLogFormatter`, sphinx was pulling in Python's `logging.Formatter` `__init__()` docstring. Fix that by documenting parameters.

Before:
<img width="806" height="433" alt="image" src="https://github.com/user-attachments/assets/51880e84-8496-4c6e-85f0-72c6fa00bd24" />

After:
<img width="813" height="341" alt="image" src="https://github.com/user-attachments/assets/6787d9cc-a6fd-4d1c-b637-03d428ebf07a" />
