### PR TITLE
Add `COCOTB_LOG_PREFIX` to customize the default log Formatter's appearance

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -130,19 +130,25 @@ Cocotb
     Logs will include simulation time, message type (``INFO``, ``WARNING``, ``ERROR``, ...), logger name, and the log message itself.
     If the value is set to ``0``, the filename and line number where a log function was called will be added between the logger name and the log message.
 
-.. envvar:: COCOTB_ATTACH
+.. envvar:: COCOTB_LOG_PREFIX
 
-    In order to give yourself time to attach a debugger to the simulator process before it starts to run,
-    you can set the environment variable :envvar:`COCOTB_ATTACH` to a pause time value in seconds.
-    If set, cocotb will print the process ID (PID) to attach to and wait the specified time before
-    actually letting the simulator run.
+    Customize the log message prefix.
+    The value of this variable should be in Python f-string syntax.
+    It has access to the following variables:
 
-.. envvar:: COCOTB_ENABLE_PROFILING
+    - ``record``: The :class:`~logging.LogRecord` being formatted. This includes the attribute ``created_sim_time``, which is the simulation time in steps.
+    - ``time``: The Python :mod:`time` module.
+    - ``simtime``: The cocotb :mod:`cocotb.simtime` module.
+    - ``ansi``: The cocotb :mod:`cocotb.ANSI` module, which contains ANSI escape codes for coloring the output.
 
-    Enable performance analysis of the Python portion of cocotb. When set, a file :file:`test_profile.pstat`
-    will be written which contains statistics about the cumulative time spent in the functions.
+    The following example is a color-less version of the default log prefix.
 
-    From this, a callgraph diagram can be generated with `gprof2dot <https://github.com/jrfonseca/gprof2dot>`_ and ``graphviz``.
+    .. code-block:: shell
+
+        COCOTB_LOG_PREFIX="{simtime.convert(record.created_sim_time, 'step', to='ns'):>9}ns {record.levelname:<8} {record.name[-34:]:<34} "
+
+    .. note::
+        If this variable is set, :envvar:`COCOTB_REDUCED_LOG_FMT` has no effect.
 
 .. envvar:: COCOTB_LOG_LEVEL
 
@@ -164,6 +170,20 @@ Cocotb
     This behaves similarly to ``INFO``.
 
     .. versionadded:: 2.0
+
+.. envvar:: COCOTB_ATTACH
+
+    In order to give yourself time to attach a debugger to the simulator process before it starts to run,
+    you can set the environment variable :envvar:`COCOTB_ATTACH` to a pause time value in seconds.
+    If set, cocotb will print the process ID (PID) to attach to and wait the specified time before
+    actually letting the simulator run.
+
+.. envvar:: COCOTB_ENABLE_PROFILING
+
+    Enable performance analysis of the Python portion of cocotb. When set, a file :file:`test_profile.pstat`
+    will be written which contains statistics about the cumulative time spent in the functions.
+
+    From this, a callgraph diagram can be generated with `gprof2dot <https://github.com/jrfonseca/gprof2dot>`_ and ``graphviz``.
 
 .. envvar:: COCOTB_RESOLVE_X
 
@@ -223,7 +243,6 @@ Cocotb
             make simulator_test SIM=<your simulator here> TOPLEVEL_LANG=<vhdl or verilog>
 
         If the tests pass, your simulator and version apply inertial writes as expected and you can turn on :envvar:`COCOTB_TRUST_INERTIAL_WRITES`.
-
 
 Regression Manager
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -318,8 +318,6 @@ Logging
 .. module:: cocotb.logging
     :synopsis: Classes for logging messages from cocotb during simulation.
 
-.. autodata:: strip_ansi
-
 .. autofunction:: default_config
 
 .. autofunction:: SimLog
@@ -336,6 +334,8 @@ Logging
     :show-inheritance:
     :no-members:
 
+.. autodata:: strip_ansi
+
 .. currentmodule:: None
 
 .. attribute:: logging.LogRecord.created_sim_time
@@ -344,6 +344,12 @@ Logging
     The formatter is responsible for converting this to something like nanoseconds via :func:`~cocotb.utils.get_time_from_sim_steps`.
 
     This is added by :class:`~cocotb.logging.SimTimeContextFilter`.
+
+Log Coloring
+------------
+
+.. automodule:: cocotb.ANSI
+    :synopsis: ANSI escape codes for coloring log output.
 
 
 Simulator Objects

--- a/docs/source/newsfragments/4900.feature.rst
+++ b/docs/source/newsfragments/4900.feature.rst
@@ -1,0 +1,1 @@
+Added :envvar:`COCOTB_LOG_PREFIX` environment variable to allow users to customize the log message prefix.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -137,7 +137,6 @@ Deprecations and Removals
 - ``Event.fired`` attribute was made private. Use :meth:`.Event.is_set`. (:pr:`3851`)
 - Removed ``cocotb.triggers.PythonTrigger``. Use ``not isinstance(trigger, cocotb.triggers.GPITrigger)`` instead. (:pr:`3851`)
 - Made ``cocotb.triggers.Trigger.primed``, ``cocotb.triggers.GPITrigger.cbhdl``, and ``cocotb.triggers.Timer.sim_steps`` private. (:pr:`3851`)
-- Made ``cocotb.ANSI`` module private. (:pr:`3852`)
 - ``cocotb.result.TestComplete`` was removed. (:pr:`3864`)
 - ``cocotb.result.ExternalException`` was removed. (:pr:`3864`)
 - ``cocotb.triggers.Join.retval`` was removed. (:pr:`3931`)

--- a/src/cocotb/ANSI.py
+++ b/src/cocotb/ANSI.py
@@ -4,11 +4,18 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""
-Some constants for doing ANSI stuff.
+"""ANSI escape codes for coloring output.
+
+Variables that end in ``_FG`` will color the character or symbol ("foreground")
+and variables that end in ``_BG`` will color the background.
+
+Foreground and background colors can be combined together.
+Setting a new foreground color will override the previous foreground, likewise with background colors.
+
+Use ``DEFAULT_FG`` and ``DEFAULT_BG`` to reset the coloring to the default colors for the foreground and background, respectively.
+Or use ``DEFAULT`` to reset both.
 """
 
-# flake8: noqa (skip this file for flake8: pypi.python.org/pypi/flake8)
 _ESCAPE = "\033["
 
 # see https://en.wikipedia.org/wiki/ANSI_escape_code#Colors

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Optional, Tuple, Union
 
 import cocotb.utils
-from cocotb import _ANSI, simulator
+from cocotb import ANSI, simulator
 from cocotb._deprecation import deprecated
 from cocotb.utils import get_sim_time, get_time_from_sim_steps
 
@@ -228,15 +228,15 @@ class SimLogFormatter(logging.Formatter):
         logging.TRACE: "",  # type: ignore[attr-defined]  # type checkers don't like adding module attributes after the fact
         logging.DEBUG: "",
         logging.INFO: "",
-        logging.WARNING: _ANSI.COLOR_WARNING,
-        logging.ERROR: _ANSI.COLOR_ERROR,
-        logging.CRITICAL: _ANSI.COLOR_CRITICAL,
+        logging.WARNING: ANSI.COLOR_WARNING,
+        logging.ERROR: ANSI.COLOR_ERROR,
+        logging.CRITICAL: ANSI.COLOR_CRITICAL,
     }
 
     prefix_func_globals = {
         "time": time,
         "simtime": cocotb.utils,
-        "ansi": _ANSI,
+        "ansi": ANSI,
     }
 
     def __init__(
@@ -314,7 +314,7 @@ class SimLogFormatter(logging.Formatter):
             highlight_end = ""
         else:
             highlight_start = self.loglevel2colour.get(record.levelno, "")
-            highlight_end = _ANSI.COLOR_DEFAULT
+            highlight_end = ANSI.COLOR_DEFAULT
 
         if self._prefix_func is not None:
             prefix = self._prefix_func(record)
@@ -338,7 +338,7 @@ class SimLogFormatter(logging.Formatter):
             msg = self._ansi_escape_pattern.sub("", msg)
         else:
             highlight_start = self.loglevel2colour.get(record.levelno, "")
-            highlight_end = _ANSI.COLOR_DEFAULT
+            highlight_end = ANSI.COLOR_DEFAULT
 
         msg = f"{highlight_start}{msg}{highlight_end}"
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -28,7 +28,7 @@ from typing import (
 import cocotb
 import cocotb._gpi_triggers
 import cocotb.handle
-from cocotb import _ANSI, simulator
+from cocotb import ANSI, simulator
 from cocotb import logging as cocotb_logging
 from cocotb._decorators import Parameterized, Test
 from cocotb._extended_awaitables import SimTimeoutError, with_timeout
@@ -547,8 +547,8 @@ class RegressionManager:
 
     def _log_test_start(self) -> None:
         """Called by :meth:`_execute` to log that a test is starting."""
-        hilight_start = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_TEST
-        hilight_end = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_DEFAULT
+        hilight_start = "" if cocotb_logging.strip_ansi else ANSI.COLOR_TEST
+        hilight_end = "" if cocotb_logging.strip_ansi else ANSI.COLOR_DEFAULT
         self.log.info(
             "%srunning%s %s (%d/%d)%s",
             hilight_start,
@@ -581,8 +581,8 @@ class RegressionManager:
         """Called by :meth:`_execute` when a test is skipped."""
 
         # log test results
-        hilight_start = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_SKIPPED
-        hilight_end = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_DEFAULT
+        hilight_start = "" if cocotb_logging.strip_ansi else ANSI.COLOR_SKIPPED
+        hilight_end = "" if cocotb_logging.strip_ansi else ANSI.COLOR_DEFAULT
         self.log.info(
             "%sskipping%s %s (%d/%d)%s",
             hilight_start,
@@ -624,8 +624,8 @@ class RegressionManager:
         """Called by :meth:`_execute` when a test initialization fails."""
 
         # log test results
-        hilight_start = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_FAILED
-        hilight_end = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_DEFAULT
+        hilight_start = "" if cocotb_logging.strip_ansi else ANSI.COLOR_FAILED
+        hilight_end = "" if cocotb_logging.strip_ansi else ANSI.COLOR_DEFAULT
         self.log.exception(
             "%sFailed to initialize%s %s! (%d/%d)%s",
             hilight_start,
@@ -670,8 +670,8 @@ class RegressionManager:
         result: Union[Exception, None],
         msg: Union[str, None],
     ) -> None:
-        start_hilight = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_PASSED
-        stop_hilight = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_DEFAULT
+        start_hilight = "" if cocotb_logging.strip_ansi else ANSI.COLOR_PASSED
+        stop_hilight = "" if cocotb_logging.strip_ansi else ANSI.COLOR_DEFAULT
         if msg is None:
             rest = ""
         else:
@@ -723,8 +723,8 @@ class RegressionManager:
         result: Union[BaseException, None],
         msg: Union[str, None],
     ) -> None:
-        start_hilight = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_FAILED
-        stop_hilight = "" if cocotb_logging.strip_ansi else _ANSI.COLOR_DEFAULT
+        start_hilight = "" if cocotb_logging.strip_ansi else ANSI.COLOR_FAILED
+        stop_hilight = "" if cocotb_logging.strip_ansi else ANSI.COLOR_DEFAULT
         if msg is None:
             rest = ""
         else:
@@ -833,18 +833,18 @@ class RegressionManager:
             if result.passed is None:
                 ratio = "-.--"
                 pass_fail_str = "SKIP"
-                hilite = _ANSI.COLOR_SKIPPED
-                lolite = _ANSI.COLOR_DEFAULT
+                hilite = ANSI.COLOR_SKIPPED
+                lolite = ANSI.COLOR_DEFAULT
             elif result.passed:
                 ratio = format(result.ratio, "0.2f")
                 pass_fail_str = "PASS"
-                hilite = _ANSI.COLOR_PASSED
-                lolite = _ANSI.COLOR_DEFAULT
+                hilite = ANSI.COLOR_PASSED
+                lolite = ANSI.COLOR_DEFAULT
             else:
                 ratio = format(result.ratio, "0.2f")
                 pass_fail_str = "FAIL"
-                hilite = _ANSI.COLOR_FAILED
-                lolite = _ANSI.COLOR_DEFAULT
+                hilite = ANSI.COLOR_FAILED
+                lolite = ANSI.COLOR_DEFAULT
 
             if cocotb_logging.strip_ansi:
                 hilite = ""

--- a/tests/test_cases/test_cocotb/test_logging.py
+++ b/tests/test_cases/test_cocotb/test_logging.py
@@ -11,7 +11,7 @@ import warnings
 from typing import Generator, Union
 
 import cocotb
-import cocotb._ANSI as ansi
+import cocotb.ANSI as ansi
 import cocotb.logging as cocotb_logging
 
 

--- a/tests/test_cases/test_log_prefix/Makefile
+++ b/tests/test_cases/test_log_prefix/Makefile
@@ -1,0 +1,7 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+.PHONY: all
+all:
+	pytest -s

--- a/tests/test_cases/test_log_prefix/log_prefix_tests.py
+++ b/tests/test_cases/test_log_prefix/log_prefix_tests.py
@@ -1,0 +1,47 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import contextlib
+import logging
+from typing import Generator, List
+
+import cocotb
+import cocotb.ANSI as ansi
+
+
+class LogCaptureData:
+    def __init__(self) -> None:
+        self.records: List[logging.LogRecord] = []
+        self.msgs: List[str] = []
+
+
+@contextlib.contextmanager
+def capture_logs(handler: logging.Handler) -> Generator[LogCaptureData, None, None]:
+    data = LogCaptureData()
+
+    old_emit = handler.emit
+
+    def emit(record: logging.LogRecord) -> None:
+        data.records.append(record)
+        data.msgs.append(handler.format(record))
+        old_emit(record)
+
+    handler.emit = emit  # type: ignore[method-assign]
+    try:
+        yield data
+    finally:
+        handler.emit = old_emit  # type: ignore[method-assign]
+
+
+@cocotb.test
+async def test_log_prefix(_: object) -> None:
+    logger = logging.getLogger("example")
+    logger.setLevel(logging.INFO)
+    with capture_logs(logging.getLogger().handlers[0]) as logs:
+        logger.info("Test log message")
+    assert (
+        logs.msgs[0]
+        == f"{ansi.YELLOW_FG}abc{ansi.DEFAULT_FG} INFO 0       exam Test log message{ansi.DEFAULT}"
+    )

--- a/tests/test_cases/test_log_prefix/test_log_prefix.py
+++ b/tests/test_cases/test_log_prefix/test_log_prefix.py
@@ -1,0 +1,45 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+from pathlib import Path
+
+import pytest
+
+from cocotb_tools.runner import get_runner
+
+LANG = os.getenv("TOPLEVEL_LANG", "verilog")
+
+
+@pytest.mark.skipif(LANG != "verilog", reason="This test only supports Verilog")
+def test_indexing_warning() -> None:
+    sim = os.getenv("SIM", "icarus")
+    runner = get_runner(sim)
+
+    pwd = Path(__file__).parent.absolute()
+
+    # select args
+    build_args = []
+    test_args = []
+    if sim == "questa":
+        build_args = ["+acc"]
+        test_args = ["-t", "ps"]
+    elif sim == "xcelium":
+        build_args = ["-v93"]
+
+    runner.build(
+        sources=[pwd / "top.sv"],
+        hdl_toplevel="top",
+        build_args=build_args,
+    )
+
+    runner.test(
+        test_module="log_prefix_tests",
+        hdl_toplevel="top",
+        hdl_toplevel_lang=LANG,
+        test_args=test_args,
+        extra_env={
+            "COCOTB_LOG_PREFIX": "{ansi.YELLOW_FG}abc{ansi.DEFAULT_FG} {record.levelname} {record.created_sim_time} {record.name[:4]:>10} "
+        },
+    )

--- a/tests/test_cases/test_log_prefix/top.sv
+++ b/tests/test_cases/test_log_prefix/top.sv
@@ -1,0 +1,11 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+`timescale 1 ps / 1 ps
+
+module top (
+    input logic placeholder
+);
+
+endmodule


### PR DESCRIPTION
Depends on #4909. Closes #4808.

In lieu of of using the half-baked `logging.fileConfig` I've added `COCOTB_LOG_PREFIX` envvar to allow users to customize their logging prefix using an f-string.

Example usage:
```bash
# no prefix
COCOTB_LOG_PREFIX=
# [COCOTB] 12.035ns My Message!
COCOTB_LOG_PREFIX="{ansi.YELLOW_FG}[COCOTB]{ansi.DEFAULT_FG {simtime.get_time_from_sim_steps(record.created_sim_time, 'ns')}ns "
# This is the non-color default log format for cocotb -ish
COCOTB_LOG_PREFIX="{simtime.get_time_from_sim_steps(record.created_sim_time, 'ns'):>9}ns {record.levelname:<8} {record.name[-34:]:<34}"
```

Pros:
* Allows customization the prefix with very little hassle (`fileConfig` is half-baked and has a few limitations and requires some additional code to run to be able to use custom formatters).
* No noticeable affect on performance compared to the default logger.

Cons:
* Must keep a curated list of variables to use in evaluation, this may mean on-going feature requests.
* Limited in evaluation logic since it isn't full Python, just f-string.

### TODO
- [x] docs
- [x] test
- [x] newsfrag
- [x] ~~factor ljust and rjust out so they can be used in expressions?~~