### PR TITLE
Lowercase `debug.DEBUG` to signal its not a constant

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -350,6 +350,9 @@ Scheduler
 
     Enable additional log output of the coroutine scheduler.
 
+    This will default the value of :data:`~cocotb.debug.debug`,
+    which can later be modified.
+
 
 GPI
 ---

--- a/docs/source/newsfragments/4867.feature.rst
+++ b/docs/source/newsfragments/4867.feature.rst
@@ -1,0 +1,1 @@
+Added :data:`~cocotb.debug.debug` to allow users to programmatically control the collection of additional debugging information.

--- a/src/cocotb/_bridge.py
+++ b/src/cocotb/_bridge.py
@@ -132,7 +132,7 @@ class external_waiter(Generic[Result]):
 
     def _propagate_state(self, new_state: external_state) -> None:
         with self.cond:
-            if debug.DEBUG:
+            if debug.debug:
                 self._log.debug(
                     f"Changing state from {self.state} -> {new_state} from {threading.current_thread()}"
                 )
@@ -140,7 +140,7 @@ class external_waiter(Generic[Result]):
             self.cond.notify()
 
     def thread_done(self) -> None:
-        if debug.DEBUG:
+        if debug.debug:
             self._log.debug(f"Thread finished from {threading.current_thread()}")
         self._propagate_state(external_state.EXITED)
 
@@ -159,7 +159,7 @@ class external_waiter(Generic[Result]):
         self._propagate_state(external_state.RUNNING)
 
     def thread_wait(self) -> external_state:
-        if debug.DEBUG:
+        if debug.debug:
             self._log.debug(
                 f"Waiting for the condition lock {threading.current_thread()}"
             )
@@ -168,7 +168,7 @@ class external_waiter(Generic[Result]):
             while self.state == external_state.RUNNING:
                 self.cond.wait()
 
-            if debug.DEBUG:
+            if debug.debug:
                 if self.state == external_state.EXITED:
                     self._log.debug(
                         f"Thread {self.thread} has exited from {threading.current_thread()}"

--- a/src/cocotb/_scheduler.py
+++ b/src/cocotb/_scheduler.py
@@ -150,7 +150,7 @@ class Scheduler:
 
         Finds all Tasks waiting on the Trigger that fired and queues them.
         """
-        if debug.DEBUG:
+        if debug.debug:
             self.log.debug("Trigger fired: %s", trigger)
 
         # find all tasks waiting on trigger that fired
@@ -166,11 +166,11 @@ class Scheduler:
             # For Python triggers this isn't actually an error - we might do
             # event.set() without knowing whether any tasks are actually
             # waiting on this event, for example
-            elif debug.DEBUG:
+            elif debug.debug:
                 self.log.debug("No tasks waiting on trigger that fired: %s", trigger)
             return
 
-        if debug.DEBUG:
+        if debug.debug:
             debugstr = "\n\t".join([str(task) for task in scheduling])
             if len(scheduling) > 0:
                 debugstr = "\n\t" + debugstr
@@ -201,10 +201,10 @@ class Scheduler:
         while self._scheduled_tasks:
             task, exc = self._scheduled_tasks.popitem(last=False)
 
-            if debug.DEBUG:
+            if debug.debug:
                 self.log.debug("Scheduling task %s", task)
             self._resume_task(task, exc)
-            if debug.DEBUG:
+            if debug.debug:
                 self.log.debug("Scheduled task %s", task)
 
             # remove our reference to the objects at the end of each loop,
@@ -214,14 +214,14 @@ class Scheduler:
 
             # Schedule may have queued up some events so we'll burn through those
             while self._pending_events:
-                if debug.DEBUG:
+                if debug.debug:
                     self.log.debug(
                         "Scheduling pending event %s", self._pending_events[0]
                     )
                 self._pending_events.pop(0).set()
 
         # no more pending tasks
-        if debug.DEBUG:
+        if debug.debug:
             self.log.debug("All tasks scheduled, handing control back to simulator")
 
     def _unschedule(self, task: Task[Any]) -> None:
@@ -357,7 +357,7 @@ class Scheduler:
 
         def execute_external() -> None:
             waiter._outcome = capture(func, *args, **kwargs)
-            if debug.DEBUG:
+            if debug.debug:
                 self.log.debug(
                     "Execution of external routine done %s", threading.current_thread()
                 )
@@ -400,13 +400,13 @@ class Scheduler:
             trigger = task._advance(exc)
 
             if task.done():
-                if debug.DEBUG:
+                if debug.debug:
                     self.log.debug("%s completed with %s", task, task._outcome)
                 assert trigger is None
                 self._unschedule(task)
 
             if not task.done():
-                if debug.DEBUG:
+                if debug.debug:
                     self.log.debug("%r yielded %s", task, trigger)
                 if not isinstance(trigger, Trigger):
                     e = TypeError(
@@ -424,14 +424,14 @@ class Scheduler:
             if self._main_thread is threading.current_thread():
                 for ext in self._pending_threads:
                     ext.thread_start()
-                    if debug.DEBUG:
+                    if debug.debug:
                         self.log.debug(
                             "Blocking from %s on %s",
                             threading.current_thread(),
                             ext.thread,
                         )
                     state = ext.thread_wait()
-                    if debug.DEBUG:
+                    if debug.debug:
                         self.log.debug(
                             "Back from wait on self %s with newstate %s",
                             threading.current_thread(),

--- a/src/cocotb/debug.py
+++ b/src/cocotb/debug.py
@@ -4,7 +4,7 @@
 
 import os
 
-DEBUG: bool = bool(os.getenv("COCOTB_SCHEDULER_DEBUG"))
+debug: bool = bool(os.getenv("COCOTB_SCHEDULER_DEBUG"))
 """Global flag to enable additional debugging functionality.
 
 Defaults to ``True`` if the :envvar:`COCOTB_SCHEDULER_DEBUG` environment variable is set,


### PR DESCRIPTION
Was told it was weird that it was uppercase since it's intended to be modified. Fair...
