### PR TITLE
Remove all ocurences of `handle._log` from examples

### DIFF
--- a/examples/analog_model/test_analog_model.py
+++ b/examples/analog_model/test_analog_model.py
@@ -51,7 +51,7 @@ async def test_analog_model(digital) -> None:
         # get the converted digital value
         afe_out = await afe_out_queue.get()
 
-        digital._log.info(f"AFE converted input value {in_V}V to {int(afe_out)}")
+        cocotb.log.info(f"AFE converted input value {in_V}V to {int(afe_out)}")
 
         # hand digital value over as "meas_val" to digital part (HDL)
         # "meas_val_valid" pulses for one clock cycle

--- a/examples/doc_examples/quickstart/test_my_design.py
+++ b/examples/doc_examples/quickstart/test_my_design.py
@@ -17,8 +17,8 @@ async def my_first_test(dut):
         dut.clk.value = 1
         await Timer(1, unit="ns")
 
-    dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)
-    assert dut.my_signal_2.value == 0, "my_signal_2 is not 0!"
+    cocotb.log.info("my_signal_1 is %s", dut.my_signal_1.value)
+    assert dut.my_signal_2.value == 0
 
 
 # test_my_design.py (extended)
@@ -46,5 +46,5 @@ async def my_second_test(dut):
     await Timer(5, unit="ns")  # wait a bit
     await FallingEdge(dut.clk)  # wait for falling edge/"negedge"
 
-    dut._log.info("my_signal_1 is %s", dut.my_signal_1.value)
-    assert dut.my_signal_2.value == 0, "my_signal_2 is not 0!"
+    cocotb.log.info("my_signal_1 is %s", dut.my_signal_1.value)
+    assert dut.my_signal_2.value == 0

--- a/examples/mixed_language/tests/test_mixed_language.py
+++ b/examples/mixed_language/tests/test_mixed_language.py
@@ -30,7 +30,7 @@ async def mixed_language_accessing_test(dut):
     await Timer(100, unit="ns")
 
     verilog = dut.i_swapper_sv
-    dut._log.info(f"Got: {verilog._name!r}")
+    cocotb.log.info(f"Got: {verilog._name!r}")
 
     # discover all attributes of the SV component
     # This is a workaround since SV modules are not discovered automatically
@@ -38,7 +38,7 @@ async def mixed_language_accessing_test(dut):
     verilog._discover_all()
 
     vhdl = dut.i_swapper_vhdl
-    dut._log.info(f"Got: {vhdl._name!r}")
+    cocotb.log.info(f"Got: {vhdl._name!r}")
 
     verilog.reset_n.value = 1
     await Timer(100, unit="ns")
@@ -67,10 +67,10 @@ async def mixed_language_functional_test(dut):
     await Timer(100, unit="ns")
 
     verilog = dut.i_swapper_sv
-    dut._log.info(f"Got: {verilog._name!r}")
+    cocotb.log.info(f"Got: {verilog._name!r}")
 
     vhdl = dut.i_swapper_vhdl
-    dut._log.info(f"Got: {vhdl._name!r}")
+    cocotb.log.info(f"Got: {vhdl._name!r}")
 
     # setup default values
     dut.reset_n.value = 0

--- a/examples/mixed_signal/tests/test_regulator_plot.py
+++ b/examples/mixed_signal/tests/test_regulator_plot.py
@@ -23,7 +23,7 @@ async def test_trim_vals(tb_hdl):
         await Timer(1, unit="ns")
         trimmed_volt = await get_voltage(tb_hdl, probed_node)
         actual_trim_val = tb_hdl.trim_val.value.to_signed()
-        tb_hdl._log.info(
+        cocotb.log.info(
             f"trim_val={actual_trim_val} results in {probed_node}={trimmed_volt:.4} V"
         )
         # sanity check: output voltage can not exceed supply
@@ -41,7 +41,7 @@ async def get_voltage(tb_hdl, node):
         tb_hdl.i_analog_probe.probe_voltage_toggle
     )
     await Timer(1, unit="ps")  # waiting time needed for the analog values to be updated
-    tb_hdl._log.debug(
+    cocotb.log.debug(
         f"Voltage on node {node} is {tb_hdl.i_analog_probe.voltage.value:.4} V"
     )
     return tb_hdl.i_analog_probe.voltage.value
@@ -79,5 +79,5 @@ def plot_data(tb_hdl, datasets, graphfile="cocotb_plot.png"):
     fig.tight_layout()
     fig.set_size_inches(11, 6)
 
-    tb_hdl._log.info(f"Writing file {graphfile}")
+    cocotb.log.info(f"Writing file {graphfile}")
     fig.savefig(graphfile)

--- a/examples/mixed_signal/tests/test_regulator_trim.py
+++ b/examples/mixed_signal/tests/test_regulator_trim.py
@@ -34,7 +34,7 @@ class Regulator_TB:
         await Timer(
             1, unit="ps"
         )  # waiting time needed for the analog values to be updated
-        self.tb_hdl._log.debug(
+        cocotb.log.debug(
             "trim value={}: {}={:.4} V".format(
                 self.tb_hdl.trim_val.value,
                 self.analog_probe.node_to_probe.value.decode("ascii"),
@@ -71,12 +71,12 @@ class Regulator_TB:
         await Timer(self.settling_time_ns, unit="ns")
         volt_max = await self.get_voltage(probed_node)
         if target_volt > volt_max:
-            self.tb_hdl._log.debug(
+            cocotb.log.debug(
                 f"target_volt={target_volt} > volt_max={volt_max}, returning minimum trim value {trim_val_max}"
             )
             return trim_val_max
         if target_volt < volt_min:
-            self.tb_hdl._log.debug(
+            cocotb.log.debug(
                 f"target_volt={target_volt} < volt_min={volt_min}, returning maximum trim value {trim_val_min}"
             )
             return trim_val_min
@@ -99,9 +99,7 @@ async def run_test(tb_hdl):
 
     # show automatic trimming
     target_volt = 3.013
-    tb_py.tb_hdl._log.info(
-        f"Running trimming algorithm for target voltage {target_volt:.4} V"
-    )
+    cocotb.log.info(f"Running trimming algorithm for target voltage {target_volt:.4} V")
     best_trim_float = await tb_py.find_trim_val(
         probed_node=node, target_volt=target_volt, trim_val_node=tb_py.tb_hdl.trim_val
     )
@@ -109,7 +107,7 @@ async def run_test(tb_hdl):
     tb_py.tb_hdl.trim_val.value = best_trim_rounded
     await Timer(tb_py.settling_time_ns, unit="ns")
     trimmed_volt = await tb_py.get_voltage(node)
-    tb_py.tb_hdl._log.info(
+    cocotb.log.info(
         f"Best trimming value is {best_trim_rounded} "
         f"--> voltage is {trimmed_volt:.4} V (difference to target is {trimmed_volt - target_volt:.4} V)"
     )

--- a/examples/mixed_signal/tests/test_rescap.py
+++ b/examples/mixed_signal/tests/test_rescap.py
@@ -36,7 +36,7 @@ class ResCap_TB:
             voltage=self.analog_probe.voltage.value,
             current=self.analog_probe.current.value * 1000.0,  # in mA
         )
-        self.tb_hdl._log.debug(
+        cocotb.log.debug(
             "{}={:.4} V, {:.4} mA".format(
                 self.analog_probe.node_to_probe.value.decode("ascii"),
                 dataset.voltage,
@@ -118,7 +118,7 @@ class ResCap_TB:
         fig.set_size_inches(11, 6)
         fig.legend(loc="upper right", bbox_to_anchor=(0.8, 0.9), frameon=False)
 
-        self.tb_hdl._log.info(f"Writing file {graphfile}")
+        cocotb.log.info(f"Writing file {graphfile}")
         fig.savefig(graphfile)
 
 
@@ -136,14 +136,14 @@ async def run_test(tb_hdl):
     vdd = 0.0
     tb_py.tb_hdl.vdd_val.value = vdd
     tb_py.tb_hdl.vss_val.value = 0.0
-    tb_py.tb_hdl._log.info(f"Setting vdd={vdd:.4} V")
+    cocotb.log.info(f"Setting vdd={vdd:.4} V")
     # dummy read appears to be necessary for the analog solver
     _ = await tb_py.get_sample_data(nodes=nodes_to_probe)
 
     for vdd in [5.55, -3.33]:
         tb_py.tb_hdl.vdd_val.value = vdd
         tb_py.tb_hdl.vss_val.value = 0.0
-        tb_py.tb_hdl._log.info(f"Setting vdd={vdd:.4} V")
+        cocotb.log.info(f"Setting vdd={vdd:.4} V")
         data = await tb_py.get_sample_data(num=60, delay_ns=5, nodes=nodes_to_probe)
         for node in nodes_to_probe:
             probedata[node].extend(data[node])

--- a/examples/mixed_signal/tests/test_rescap_minimalist.py
+++ b/examples/mixed_signal/tests/test_rescap_minimalist.py
@@ -20,7 +20,7 @@ async def rescap_minimalist_test(tb_hdl):
         await Timer(
             1, unit="ps"
         )  # waiting time needed for the analog values to be updated
-        tb_hdl._log.info(
+        cocotb.log.info(
             "tb_hdl.i_analog_probe@{}={:.4} V  {:.4} A".format(
                 tb_hdl.i_analog_probe.node_to_probe.value.decode("ascii"),
                 tb_hdl.i_analog_probe.voltage.value,

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -20,12 +20,14 @@ async def dff_simple_test(dut):
     # Set initial input value to prevent it from floating
     dut.d.value = 0
 
-    clock = Clock(dut.clk, 10, unit="us")  # Create a 10us period clock on port clk
+    # Create a 10us period clock driver on port `clk``
+    clock = Clock(dut.clk, 10, unit="us")
     # Start the clock. Start it low to avoid issues on the first RisingEdge
-    cocotb.start_soon(clock.start(start_high=False))
+    clock.start(start_high=False)
 
-    # Synchronize with the clock. This will regisiter the initial `d` value
+    # Synchronize with the clock. This will register the initial `d` value
     await RisingEdge(dut.clk)
+
     expected_val = 0  # Matches initial input value
     for i in range(10):
         val = random.randint(0, 1)

--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -20,7 +20,7 @@ async def dff_simple_test(dut):
     # Set initial input value to prevent it from floating
     dut.d.value = 0
 
-    # Create a 10us period clock driver on port `clk``
+    # Create a 10us period clock driver on port `clk`
     clock = Clock(dut.clk, 10, unit="us")
     # Start the clock. Start it low to avoid issues on the first RisingEdge
     clock.start(start_high=False)


### PR DESCRIPTION
This was deprecated in 2.0. Replaced with `cocotb.log` which is the user's new "print" function.