### PR TITLE
Change docs configs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,7 +118,7 @@ autoclass_content = "class"
 
 autodoc_typehints = "signature"  # show type hints in the list of parameters
 autodoc_typehints_description_target = "documented"
-maximum_signature_line_length = 80
+maximum_signature_line_length = 78
 
 # use short "a | b" syntax for Literal types
 python_display_short_literal_types = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,10 +114,11 @@ is_rtd_tag = 'READTHEDOCS' in os.environ and os.environ.get('READTHEDOCS_VERSION
 if is_rtd_tag:
     tags.add('is_release_build')
 
-autoclass_content = "both"
+autoclass_content = "class"
 
-autodoc_typehints = "description"  # show type hints in the list of parameters
+autodoc_typehints = "signature"  # show type hints in the list of parameters
 autodoc_typehints_description_target = "documented"
+maximum_signature_line_length = 80
 
 # use short "a | b" syntax for Literal types
 python_display_short_literal_types = True


### PR DESCRIPTION
https://cocotb--4922.org.readthedocs.build/en/4922/library_reference.html

* Use `class` for `autoclass_content` so that docstrings on `__init__` aren't used.
* Add limit the length of a signature, which is fairly unreadable otherwise when the signature is long.
* Move typehints back to signature both that they are split up.