### PR TITLE
Add optimization and debugging flags to release builds

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -376,23 +376,11 @@ def release_build_bdist(session: nox.Session) -> None:
     # Pin a version to ensure reproducible builds.
     session.run("pip", "install", f"cibuildwheel=={cibuildwheel_version}")
 
-    flags = " ".join(
-        [
-            "-O2",  # O3 is unnecessary with the virtual-call-heavy code in the GPI and may bloat binary size
-            "-g",  # Include debug information so users can debug
-        ],
-    )
-
-    env = session.env.copy()
-    env["CFLAGS"] = flags
-    env["CXXFLAGS"] = flags
-
     session.log("Building binary distribution (wheels)")
     session.run(
         "cibuildwheel",
         "--output-dir",
         dist_dir,
-        env=env,
     )
 
     session.log(f"Binary distribution in release mode built into {dist_dir!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,10 +114,24 @@ known-third-party = [
 # - CPython on macOS x86_64
 build = "cp*-manylinux_x86_64 cp*-manylinux_i686 cp*-win_amd64 cp*-win32 cp*-macosx_x86_64"
 
+# Build with optimizations and debugging
+# -O2   Enables reasonable optimizations. -O3 is unnecessary with the virtual-call-heavy code in the GPI and may bloat binary size.
+# -g    Generate standard debugging info.
+# -flto Enable LTO which can reduce binary size and improve inlining.
+environment = {CFLAGS = "-O2 -g -flto", CXXFLAGS = "-02 -g -flto", LDFLAGS = "-O2 -g -flto"}
+
 # By default, build on manylinux2014 for compatibility with CentOS/RHEL 7+ (once
 # the user updates Python) and Ubuntu 20.04+ (with system Python).
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
+
+# Build with optimizations and debugging (Windows)
+# /O2   Enables reasonable optimizations.
+# /Z7   Enables debugging and places info in the binary (/Zi puts debug info in a different file).
+# /Zo   Improves debugging when optimizations are also enabled.
+# /LTCG Enables LTO which can reduce binary size and improve inlining.
+[tool.cibuildwheel.windows]
+environment = {CL = "/O2 /Z7 /Zo /LTCG"}
 
 [[tool.cibuildwheel.overrides]]
 # Build CPython 3.6 wheels on manylinux1 to support Ubuntu 18.04, CentOS/RHEL 7


### PR DESCRIPTION
This was moved to pyproject.toml because it wasn't being applied to all runs of cibuildwheel. Also added flags for Windows builds.