### PR TITLE
Spread envvars docs to related reference sections

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -1,17 +1,18 @@
 .. _building:
 
-***************************************
-Build Options and Environment Variables
-***************************************
+*******************************************
+Makefile-based Build System and Test Runner
+*******************************************
 
-Make System
-===========
+cocotb has traditionally provided a Makefile-based design build system and test runner.
+The build system should be *sufficient*, but may not be easy to use for more serious projects.
 
-Makefiles are provided for a variety of simulators in :file:`src/cocotb/share/makefiles/simulators`.
-The common Makefile :file:`src/cocotb/share/makefiles/Makefile.sim` includes the appropriate simulator Makefile based on the contents of the :make:var:`SIM` variable.
+Makefiles are provided for a variety of simulators in :file:`src/cocotb-tools/makefiles/simulators`.
+
+The common Makefile :file:`src/cocotb-tools/makefiles/Makefile.sim` includes the appropriate simulator Makefile based on the contents of the :make:var:`SIM` variable.
 
 Make Targets
-------------
+============
 
 Makefiles defines the targets ``regression`` and ``sim``, the default target is ``sim``.
 
@@ -23,423 +24,16 @@ In addition, the target ``clean`` can be used to remove build and simulation art
 The target ``help`` lists these available targets and the variables described below.
 
 Make Phases
------------
+===========
 
 Typically the makefiles provided with cocotb for various simulators use a separate ``compile`` and ``run`` target.
 This allows for a rapid re-running of a simulator if none of the :term:`RTL` source files have changed and therefore the simulator does not need to recompile the :term:`RTL`.
 
-
-Variables
-=========
-
-The following sections document environment variables and makefile variables according to their owner/consumer.
-
-Of the environment variables, only :envvar:`COCOTB_TEST_MODULES` is mandatory to be set
-(typically done in a makefile or run script), all others are optional.
+Make Variables
+==============
 
 ..
-  If you edit the following sections, please also update the "helpmsg" text in ../../src/cocotb_tools/config.py
-
-Cocotb
-------
-
-.. envvar:: COCOTB_TOPLEVEL
-
-    Use this to indicate the instance in the hierarchy to use as the :term:`DUT`.
-    If this isn't defined then the first root instance is used.
-    Leading and trailing whitespace are automatically discarded.
-
-    The DUT is available in cocotb tests as a Python object at :data:`cocotb.top`;
-    and is also passed to all cocotb tests as the :ref:`first and only parameter <quickstart_creating_a_test>`.
-
-    .. versionchanged:: 1.6 Strip leading and trailing whitespace
-
-    .. versionchanged:: 2.0
-
-        :envvar:`TOPLEVEL` is renamed to :envvar:`COCOTB_TOPLEVEL`.
-
-    .. deprecated:: 2.0
-
-        :envvar:`TOPLEVEL` is a deprecated alias and will be removed.
-
-.. envvar:: COCOTB_RANDOM_SEED
-
-    Seed the Python random module to recreate a previous test stimulus.
-    At the beginning of every test a message is displayed with the seed used for that execution:
-
-    .. code-block:: bash
-
-        INFO     cocotb.gpi                                  __init__.py:89   in _initialise_testbench           Seeding Python random module with 1377424946
-
-
-    To recreate the same stimuli use the following:
-
-    .. code-block:: bash
-
-       make COCOTB_RANDOM_SEED=1377424946
-
-    See also: :envvar:`COCOTB_PLUSARGS`
-
-    .. versionchanged:: 2.0
-
-        :envvar:`RANDOM_SEED` is renamed to :envvar:`COCOTB_RANDOM_SEED`.
-
-    .. deprecated:: 2.0
-
-        :envvar:`RANDOM_SEED` is a deprecated alias and will be removed.
-
-.. envvar:: COCOTB_PLUSARGS
-
-      "Plusargs" are options that are starting with a plus (``+``) sign.
-      They are passed to the simulator and are also available within cocotb as :data:`cocotb.plusargs`.
-      In the simulator, they can be read by the Verilog/SystemVerilog system functions
-      ``$test$plusargs`` and ``$value$plusargs``.
-
-      The special plusargs ``+ntb_random_seed`` and ``+seed``, if present, are evaluated
-      to set the random seed value if :envvar:`COCOTB_RANDOM_SEED` is not set.
-      If both ``+ntb_random_seed`` and ``+seed`` are set, ``+ntb_random_seed`` is used.
-
-    .. versionchanged:: 2.0
-
-        :envvar:`PLUSARGS` is renamed to :envvar:`COCOTB_PLUSARGS`.
-
-    .. deprecated:: 2.0
-
-        :envvar:`PLUSARGS` is a deprecated alias and will be removed.
-
-.. envvar:: COCOTB_ANSI_OUTPUT
-
-    Use this to override the default behavior of annotating cocotb output with
-    ANSI color codes if the output is a terminal (``isatty()``).
-
-    ``COCOTB_ANSI_OUTPUT=1``
-       forces output to be ANSI-colored regardless of the type of ``stdout`` or the presence of :envvar:`NO_COLOR`
-    ``COCOTB_ANSI_OUTPUT=0``
-       suppresses the ANSI color output in the log messages
-
-.. envvar:: NO_COLOR
-
-    From http://no-color.org,
-
-        All command-line software which outputs text with ANSI color added should check for the presence
-        of a ``NO_COLOR`` environment variable that, when present (regardless of its value), prevents the addition of ANSI color.
-
-.. envvar:: COCOTB_REDUCED_LOG_FMT
-
-    Defaults to ``1``.
-    Logs will include simulation time, message type (``INFO``, ``WARNING``, ``ERROR``, ...), logger name, and the log message itself.
-    If the value is set to ``0``, the filename and line number where a log function was called will be added between the logger name and the log message.
-
-.. envvar:: COCOTB_LOG_PREFIX
-
-    Customize the log message prefix.
-    The value of this variable should be in Python f-string syntax.
-    It has access to the following variables:
-
-    - ``record``: The :class:`~logging.LogRecord` being formatted. This includes the attribute ``created_sim_time``, which is the simulation time in steps.
-    - ``time``: The Python :mod:`time` module.
-    - ``simtime``: The cocotb :mod:`cocotb.simtime` module.
-    - ``ANSI``: The cocotb :class:`cocotb.logging.ANSI` enum, which contains ANSI escape codes for coloring the output.
-
-    The following example is a color-less version of the default log prefix.
-
-    .. code-block:: shell
-
-        COCOTB_LOG_PREFIX="{simtime.convert(record.created_sim_time, 'step', to='ns'):>9}ns {record.levelname:<8} {record.name[-34:]:<34} "
-
-    .. note::
-        If this variable is set, :envvar:`COCOTB_REDUCED_LOG_FMT` has no effect.
-
-.. envvar:: COCOTB_LOG_LEVEL
-
-    The default log level of all ``"cocotb"`` Python loggers.
-    Valid values are ``TRACE``, ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``.
-    The default is unset, which means that the log level is inherited from the root logger.
-    This behaves similarly to ``INFO``.
-
-    .. versionchanged:: 2.0
-        The root ``"gpi"`` logger level is no longer set when this environment variable is used.
-        Use :envvar:`GPI_LOG_LEVEL` instead.
-
-.. envvar:: GPI_LOG_LEVEL
-
-    The default log level of all ``"gpi"`` (the low-level simulator interface) loggers,
-    including both Python and the native GPI logger.
-    Valid values are ``TRACE``, ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``.
-    The default is unset, which means that the log level is inherited from the root logger.
-    This behaves similarly to ``INFO``.
-
-    .. versionadded:: 2.0
-
-.. envvar:: COCOTB_ATTACH
-
-    In order to give yourself time to attach a debugger to the simulator process before it starts to run,
-    you can set the environment variable :envvar:`COCOTB_ATTACH` to a pause time value in seconds.
-    If set, cocotb will print the process ID (PID) to attach to and wait the specified time before
-    actually letting the simulator run.
-
-.. envvar:: COCOTB_ENABLE_PROFILING
-
-    Enable performance analysis of the Python portion of cocotb. When set, a file :file:`test_profile.pstat`
-    will be written which contains statistics about the cumulative time spent in the functions.
-
-    From this, a callgraph diagram can be generated with `gprof2dot <https://github.com/jrfonseca/gprof2dot>`_ and ``graphviz``.
-
-.. envvar:: COCOTB_RESOLVE_X
-
-    Defines how to resolve bits with a value of ``X``, ``Z``, ``U``, ``W``, or ``-`` when being converted to integer.
-    Valid settings are:
-
-    ``error``
-        Resolves nothing.
-    ``weak``
-        Resolves ``L`` to ``0`` and ``H`` to ``1``.
-    ``zeros``
-        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values to ``0``.
-    ``ones``
-        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values to ``1``.
-    ``random``
-        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values randomly to either ``0`` or ``1``.
-
-    There is also a slight difference in behavior of ``bool(logic)`` when this environment variable is set.
-    When this variable is set, ``bool(logic)`` treats all non-\ ``0``\ /\ ``1`` values as equivalent to ``0``.
-    When this variable is *not* set, ``bool(logic)`` will fail on non-\ ``0``\ /\ ``1`` values.
-
-    .. warning::
-        Using this feature is *not* recommended.
-
-    .. deprecated:: 2.0
-        The previously accepted values ``VALUE_ERROR``, ``ZEROS``, ``ONES``, and ``RANDOM`` are deprecated.
-
-.. envvar:: LIBPYTHON_LOC
-
-    The absolute path to the Python library associated with the current Python installation;
-    i.e. ``libpython.so`` or ``python.dll`` on Windows.
-    This is determined with ``cocotb-config --libpython`` in cocotb's makefiles.
-
-
-.. envvar:: COCOTB_TRUST_INERTIAL_WRITES
-
-    Defining this variable enables a mode which allows cocotb to trust that VPI/VHPI/FLI inertial writes are applied properly according to the respective standards.
-    This mode can lead to noticeable performance improvements,
-    and also includes some behavioral difference that are considered by the cocotb maintainers to be "better".
-    Not all simulators handle inertial writes properly, so use with caution.
-
-    This is achieved by *not* scheduling writes to occur at the beginning of the ``ReadWrite`` mode,
-    but instead trusting that the simulator's inertial write mechanism is correct.
-    This allows cocotb to avoid a VPI callback into Python to apply writes.
-
-    .. note::
-        This flag is enabled by default for the GHDL, NVC and Verilator simulators.
-        More simulators may enable this flag by default in the future as they are gradually updated to properly apply inertial writes according to the respective standard.
-
-    .. note::
-        To test if your simulator behaves correctly with your simulator and version,
-        first clone the cocotb github repo and run:
-
-        .. code-block::
-
-            cd tests/test_cases/test_inertial_writes
-            make simulator_test SIM=<your simulator here> TOPLEVEL_LANG=<vhdl or verilog>
-
-        If the tests pass, your simulator and version apply inertial writes as expected and you can turn on :envvar:`COCOTB_TRUST_INERTIAL_WRITES`.
-
-Regression Manager
-~~~~~~~~~~~~~~~~~~
-
-.. envvar:: COCOTB_TEST_MODULES
-
-    The name of the Python module(s) to search for test functions -
-    if your tests are in a file called ``test_mydesign.py``, ``COCOTB_TEST_MODULES`` would be set to ``test_mydesign``.
-    Multiple modules can be specified using a comma-separated string.
-    For example: ``COCOTB_TEST_MODULES="directed_tests,random_tests,error_injection_tests"``.
-    All tests will be run from each specified module in order of the module's appearance in this list.
-
-    The is the only environment variable that is **required** for cocotb, all others are optional.
-
-    .. versionchanged:: 2.0
-
-        :envvar:`MODULE` is renamed to :envvar:`COCOTB_TEST_MODULES`.
-
-    .. deprecated:: 2.0
-
-        :envvar:`MODULE` is a deprecated alias and will be removed.
-
-.. _testcase:
-
-.. envvar:: COCOTB_TESTCASE
-
-    A comma-separated list of tests to run.
-    Does an exact match on the test name.
-
-    .. versionchanged:: 2.0
-
-        :envvar:`TESTCASE` is renamed to :envvar:`COCOTB_TESTCASE`.
-
-    .. deprecated:: 2.0
-
-        :envvar:`TESTCASE` is a deprecated alias and will be removed.
-
-    .. deprecated:: 2.0
-
-        Use :envvar:`COCOTB_TEST_FILTER` instead.
-
-        If matching only the exact test name is desired, use the regular expression anchor character ``$``.
-        For example, ``my_test$`` will match ``my_test``, but not ``my_test_2``.
-
-        To run multiple tests, use regular expression alternations.
-        For example, ``my_test|my_other_test``.
-
-    .. versionchanged:: 2.0
-
-        Previously, if more than one test matched a test name in the :envvar:`TESTCASE` list,
-        only the first test that matched that test name in the :envvar:`COCOTB_TEST_MODULES` list was run.
-        Now, all tests that match the test name across all :envvar:`COCOTB_TEST_MODULES`\ s are run.
-
-    .. warning::
-
-        Only one of :envvar:`COCOTB_TESTCASE` or :envvar:`COCOTB_TEST_FILTER` should be used.
-
-
-.. envvar:: COCOTB_TEST_FILTER
-
-    A regular expression matching names of test function(s) to run.
-    If this variable is not defined cocotb discovers and executes all functions decorated with the :class:`cocotb.test` decorator in the supplied :envvar:`COCOTB_TEST_MODULES` list.
-
-    .. versionadded:: 2.0
-
-    .. warning::
-
-        Only one of :envvar:`COCOTB_TESTCASE` or :envvar:`COCOTB_TEST_FILTER` should be used.
-
-.. envvar:: COCOTB_RESULTS_FILE
-
-    The file name where xUnit XML tests results are stored. If not provided, the default is :file:`results.xml`.
-
-    .. versionadded:: 1.3
-
-.. envvar:: COCOTB_USER_COVERAGE
-
-    Enable to collect Python coverage data for user code.
-    For some simulators, this will also report :term:`HDL` coverage.
-    If :envvar:`COVERAGE_RCFILE` is not set, branch coverage is collected
-    and files in the cocotb package directory are excluded.
-
-    This needs the :mod:`coverage` Python module to be installed.
-
-    .. versionchanged:: 2.0
-
-        :envvar:`COVERAGE` is renamed to :envvar:`COCOTB_USER_COVERAGE`.
-
-    .. deprecated:: 2.0
-
-        :envvar:`COVERAGE` is a deprecated alias and will be removed.
-
-.. envvar:: COVERAGE_RCFILE
-
-    Location of a configuration file for coverage collection of Python user code
-    using the the :mod:`coverage` module.
-    See https://coverage.readthedocs.io/en/latest/config.html for documentation of this file.
-
-    If this environment variable is set,
-    cocotb will *not* apply its own default coverage collection settings,
-    like enabling branch coverage and excluding files in the cocotb package directory.
-
-    .. versionadded:: 1.7
-
-.. envvar:: COCOTB_PDB_ON_EXCEPTION
-
-   If defined, cocotb will drop into the Python debugger (:mod:`pdb`) if a test fails with an exception.
-   See also the :ref:`troubleshooting-attaching-debugger-python` subsection of :ref:`troubleshooting-attaching-debugger`.
-
-
-.. envvar:: COCOTB_REWRITE_ASSERTION_FILES
-
-    Select the Python files to apply ``pytest``'s assertion rewriting to.
-    This is useful to get more informative assertion error messages in cocotb tests.
-    Specify using a space-separated list of file globs, e.g. ``test_*.py testbench_common/**/*.py``.
-    Set to the empty string to disable assertion rewriting.
-    Defaults to ``*.py`` (all Python files, even third-party modules like ``scipy``).
-
-
-Scheduler
-~~~~~~~~~
-
-.. envvar:: COCOTB_SCHEDULER_DEBUG
-
-    Enable additional log output of the coroutine scheduler.
-
-    This will default the value of :data:`~cocotb.debug.debug`,
-    which can later be modified.
-
-
-GPI
----
-
-.. envvar:: GPI_EXTRA
-
-    A comma-separated list of extra libraries that are dynamically loaded at runtime.
-    A function from each of these libraries will be called as an entry point prior to elaboration,
-    allowing these libraries to register system functions and callbacks.
-    Note that :term:`HDL` objects cannot be accessed at this time.
-    An entry point function must be named following a ``:`` separator,
-    which follows an existing simulator convention.
-
-    For example:
-
-    * ``GPI_EXTRA=libnameA.so:entryA,libnameB.so:entryB`` will first load ``libnameA.so`` with entry point ``entryA`` , then load ``libnameB.so`` with entry point ``entryB``.
-
-    .. versionchanged:: 1.4
-        Support for the custom entry point via ``:`` was added.
-        Previously ``:`` was used as a separator between libraries instead of ``,``.
-
-    .. versionchanged:: 1.5
-        Library name must be fully specified.
-        This allows using relative or absolute paths in library names,
-        and loading from libraries that `aren't` prefixed with "lib".
-        Paths `should not` contain commas.
-
-PyGPI
------
-
-.. envvar:: PYGPI_PYTHON_BIN
-
-    The Python binary in the Python environment to use with cocotb.
-    This is set to the result of ``cocotb-config --python-bin`` in the Makefiles and :ref:`Python Runner <howto-python-runner>`.
-    You will likely only need to set this variable manually if
-    you are using a Python environment other than the currently activated environment,
-    or if you are using a :ref:`custom flow <custom-flows>`.
-
-.. envvar:: PYGPI_USERS
-
-    The Python module and callable that starts up the Python cosimulation environment.
-    User overloads can be used to enter alternative Python frameworks or to hook existing cocotb functionality.
-    The variable is formatted as ``path.to.entry.module:entry_point.function,other_module:other_func``.
-    The string before the colon is the Python module to import
-    and the string following the colon is the object to call as the entry function.
-    Multiple entry points can be specified by separating them with a comma.
-
-    The entry function must be a callable matching this form:
-
-    * ``entry_function(argv: List[str]) -> None``
-
-    .. versionchanged:: 1.8
-        ``level`` argument to ``_sim_event`` is no longer passed, it is assumed to be `SIM_FAIL` (2).
-
-    .. versionchanged:: 2.0
-        The entry-module-level functions ``_sim_event``, ``_log_from_c``, and ``_filter_from_c`` are no longer required.
-
-    .. versionchanged:: 2.0
-        Multiple entry points can be specified by separating them with a comma.
-
-    .. versionchanged:: 2.0
-        Renamed from ``PYGPI_ENTRY_POINT``.
-
-
-Makefile-based Test Scripts
----------------------------
-
-The following variables are makefile variables, not environment variables.
+  If you edit the following sections, please also update the "helpmsg" text in src/cocotb_tools/config.py
 
 .. make:var:: GUI
 
@@ -508,7 +102,7 @@ The following variables are makefile variables, not environment variables.
 
       Any argument to be passed to the "first" invocation of a simulator that runs via a TCL script.
       One motivating usage is to pass `-noautoldlibpath` to Questa to prevent it from loading the out-of-date libraries it ships with.
-      Used by Aldec Riviera-PRO and Mentor Graphics Questa simulator.
+      Used by Riviera-PRO and Questa simulator.
 
 .. make:var:: EXTRA_ARGS
 
@@ -579,25 +173,10 @@ The following variables are makefile variables, not environment variables.
     The name of the library that contains the :envvar:`COCOTB_TOPLEVEL` module/entity.
     Only supported by the Aldec Riviera-PRO, Aldec Active-HDL, and Siemens EDA Questa simulators.
 
-
 .. make:var:: PYTHON_BIN
 
     The path to the Python binary.
     Set to the result of ``cocotb-config --python-bin`` if ``cocotb-config`` is present on the ``PATH``.
     Otherwise defaults to ``python3``.
 
-
-Library Build Process
----------------------
-
-You can pass additional options to the library build process
-(which is usually happening as part of the installation with ``pip``) using the
-`conventional variables <https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html>`_
-for C and C++ compilation and linking:
-`CFLAGS`,
-`CPPFLAGS`,
-and
-`LDFLAGS`.
-
-..
-   `CXXFLAGS`, `LDLIBS` are not supported by distutils/pip
+The :envvar:`COCOTB_TOPLEVEL` variable is also often used by the Makefile-based build and runner system.

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -102,7 +102,7 @@ Make Variables
 
       Any argument to be passed to the "first" invocation of a simulator that runs via a TCL script.
       One motivating usage is to pass `-noautoldlibpath` to Questa to prevent it from loading the out-of-date libraries it ships with.
-      Used by Riviera-PRO and Questa simulator.
+      Used by the Riviera-PRO and Questa simulators.
 
 .. make:var:: EXTRA_ARGS
 

--- a/docs/source/install_devel.rst
+++ b/docs/source/install_devel.rst
@@ -90,3 +90,24 @@ The development version of cocotb can be installed by running
 
 After installation, you should be able to execute ``cocotb-config``.
 If it is not found, you need to append its location to the ``PATH`` environment variable.
+
+
+Passing Flags to cocotb Library Build
+=====================================
+
+You may want to pass additional flags when building cocotb's C++ libraries.
+These libraries are built during the ``pip install`` call when installing from a source distribution,
+e.g. a local clone, from Github directly, or from an sdist tarball.
+
+You can pass additional options to the library build process using the
+`conventional variables <https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html>`_
+for C and C++ compilation and linking: ``CFLAGS``, ``CPPFLAGS``, and ``LDFLAGS`` when building with GCC or Clang,
+and `CL <https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables>`_ when building with MSVC.
+
+.. code-block:: shell
+
+    $ CFLAGS="-O2 -g" LDFLAGS="-O2 -g" pip install git+https://github.com/cocotb/cocotb@master
+
+.. note::
+
+    `CXXFLAGS`, `LDLIBS` are not supported by the distutils/pip build system.

--- a/docs/source/install_devel.rst
+++ b/docs/source/install_devel.rst
@@ -110,4 +110,4 @@ and `CL <https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-va
 
 .. note::
 
-    `CXXFLAGS`, `LDLIBS` are not supported by the distutils/pip build system.
+    ``CXXFLAGS``, ``LDLIBS`` are not supported by the distutils/pip build system.

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -96,6 +96,91 @@ Marking and Generating Tests
 
 .. autoclass:: cocotb.regression.SimFailure
 
+
+Discovering Tests
+=================
+
+.. envvar:: COCOTB_TEST_MODULES
+
+    The name of the Python module(s) to search for test functions -
+    if your tests are in a file called ``test_mydesign.py``, ``COCOTB_TEST_MODULES`` would be set to ``test_mydesign``.
+    Multiple modules can be specified using a comma-separated string.
+    For example: ``COCOTB_TEST_MODULES="directed_tests,random_tests,error_injection_tests"``.
+    All tests will be run from each specified module in order of the module's appearance in this list.
+
+    The is the only environment variable that is **required** for cocotb, all others are optional.
+
+    .. versionchanged:: 2.0
+
+        :envvar:`MODULE` is renamed to :envvar:`COCOTB_TEST_MODULES`.
+
+    .. deprecated:: 2.0
+
+        :envvar:`MODULE` is a deprecated alias and will be removed.
+
+.. _testcase:
+
+.. envvar:: COCOTB_TESTCASE
+
+    A comma-separated list of tests to run.
+    Does an exact match on the test name.
+
+    .. versionchanged:: 2.0
+
+        :envvar:`TESTCASE` is renamed to :envvar:`COCOTB_TESTCASE`.
+
+    .. deprecated:: 2.0
+
+        :envvar:`TESTCASE` is a deprecated alias and will be removed.
+
+    .. deprecated:: 2.0
+
+        Use :envvar:`COCOTB_TEST_FILTER` instead.
+
+        If matching only the exact test name is desired, use the regular expression anchor character ``$``.
+        For example, ``my_test$`` will match ``my_test``, but not ``my_test_2``.
+
+        To run multiple tests, use regular expression alternations.
+        For example, ``my_test|my_other_test``.
+
+    .. versionchanged:: 2.0
+
+        Previously, if more than one test matched a test name in the :envvar:`TESTCASE` list,
+        only the first test that matched that test name in the :envvar:`COCOTB_TEST_MODULES` list was run.
+        Now, all tests that match the test name across all :envvar:`COCOTB_TEST_MODULES`\ s are run.
+
+    .. warning::
+
+        Only one of :envvar:`COCOTB_TESTCASE` or :envvar:`COCOTB_TEST_FILTER` should be used.
+
+
+.. envvar:: COCOTB_TEST_FILTER
+
+    A regular expression matching names of test function(s) to run.
+    If this variable is not defined cocotb discovers and executes all functions decorated with the :class:`cocotb.test` decorator in the supplied :envvar:`COCOTB_TEST_MODULES` list.
+
+    .. versionadded:: 2.0
+
+    .. warning::
+
+        Only one of :envvar:`COCOTB_TESTCASE` or :envvar:`COCOTB_TEST_FILTER` should be used.
+
+.. envvar:: COCOTB_RESULTS_FILE
+
+    The file name where xUnit XML tests results are stored. If not provided, the default is :file:`results.xml`.
+
+    .. versionadded:: 1.3
+
+.. envvar:: COCOTB_REWRITE_ASSERTION_FILES
+
+    Select the Python files to apply ``pytest``'s assertion rewriting to.
+    This is useful to get more informative assertion error messages in cocotb tests.
+    Specify using a space-separated list of file globs, e.g. ``test_*.py testbench_common/**/*.py``.
+    Set to the empty string to disable assertion rewriting.
+    Defaults to ``*.py`` (all Python files, even third-party modules like ``scipy``).
+
+    .. versionadded:: 2.0
+
 Test Management
 ===============
 
@@ -117,6 +202,7 @@ Task Management
 .. autofunction:: cocotb.create_task
 
 .. module:: cocotb.task
+    :synopsis: Tools for concurrency.
 
 .. autoclass:: ResultType
 
@@ -141,6 +227,7 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
 .. versionadded:: 1.6
 
 .. module:: cocotb.types
+    :synopsis: Types for dealing with digital signal values.
 
 .. autoclass:: Logic
     :members:
@@ -166,6 +253,32 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
 .. autoclass:: LogicArray
     :members:
     :inherited-members:
+
+.. envvar:: COCOTB_RESOLVE_X
+
+    Defines how to resolve bits with a value of ``X``, ``Z``, ``U``, ``W``, or ``-`` when being converted to integer.
+    Valid settings are:
+
+    ``error``
+        Resolves nothing.
+    ``weak``
+        Resolves ``L`` to ``0`` and ``H`` to ``1``.
+    ``zeros``
+        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values to ``0``.
+    ``ones``
+        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values to ``1``.
+    ``random``
+        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values randomly to either ``0`` or ``1``.
+
+    There is also a slight difference in behavior of ``bool(logic)`` when this environment variable is set.
+    When this variable is set, ``bool(logic)`` treats all non-\ ``0``\ /\ ``1`` values as equivalent to ``0``.
+    When this variable is *not* set, ``bool(logic)`` will fail on non-\ ``0``\ /\ ``1`` values.
+
+    .. warning::
+        Using this feature is *not* recommended.
+
+    .. deprecated:: 2.0
+        The previously accepted values ``VALUE_ERROR``, ``ZEROS``, ``ONES``, and ``RANDOM`` are deprecated.
 
 .. _triggers:
 
@@ -327,20 +440,26 @@ Logging
 
 .. autofunction:: default_config
 
-Log Coloring
-------------
+.. envvar:: COCOTB_LOG_LEVEL
 
-.. autodata:: strip_ansi
+    The default log level of all ``"cocotb"`` Python loggers.
+    Valid values are ``TRACE``, ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``.
+    The default is unset, which means that the log level is inherited from the root logger.
+    This behaves similarly to ``INFO``.
 
-.. autodata:: ANSI
+    .. versionchanged:: 2.0
+        The root ``"gpi"`` logger level is no longer set when this environment variable is used.
+        Use :envvar:`GPI_LOG_LEVEL` instead.
 
-.. autoclass:: SimLogFormatter
-    :show-inheritance:
-    :no-members:
+.. envvar:: GPI_LOG_LEVEL
 
-.. autoclass:: SimColourLogFormatter
-    :show-inheritance:
-    :no-members:
+    The default log level of all ``"gpi"`` (the low-level simulator interface) loggers,
+    including both Python and the native GPI logger.
+    Valid values are ``TRACE``, ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``.
+    The default is unset, which means that the log level is inherited from the root logger.
+    This behaves similarly to ``INFO``.
+
+    .. versionadded:: 2.0
 
 Adding Simulation Time to Logs
 ------------------------------
@@ -353,10 +472,73 @@ Adding Simulation Time to Logs
 
 .. attribute:: logging.LogRecord.created_sim_time
 
-    The result of :func:`~cocotb.utils.get_sim_time` at the point the log was created (in simulation time).
-    The formatter is responsible for converting this to something like nanoseconds via :func:`~cocotb.utils.get_time_from_sim_steps`.
+    The result of :func:`.get_sim_time` at the point the log was created (in simulation time).
+    The formatter is responsible for converting this to something like nanoseconds via :func:`~cocotb.simtime.convert`.
 
     This is added by :class:`~cocotb.logging.SimTimeContextFilter`.
+
+.. currentmodule:: cocotb.logging
+
+Log Formatting
+--------------
+
+.. autoclass:: SimLogFormatter
+    :show-inheritance:
+    :no-members:
+
+.. autoclass:: SimColourLogFormatter
+    :show-inheritance:
+    :no-members:
+
+.. envvar:: COCOTB_REDUCED_LOG_FMT
+
+    Defaults to ``1``.
+    Logs will include simulation time, message type (``INFO``, ``WARNING``, ``ERROR``, ...), logger name, and the log message itself.
+    If the value is set to ``0``, the filename and line number where a log function was called will be added between the logger name and the log message.
+
+.. envvar:: COCOTB_LOG_PREFIX
+
+    Customize the log message prefix.
+    The value of this variable should be in Python f-string syntax.
+    It has access to the following variables:
+
+    - ``record``: The :class:`~logging.LogRecord` being formatted. This includes the attribute ``created_sim_time``, which is the simulation time in steps.
+    - ``time``: The Python :mod:`time` module.
+    - ``simtime``: The cocotb :mod:`cocotb.simtime` module.
+    - ``ANSI``: The cocotb :class:`cocotb.logging.ANSI` enum, which contains ANSI escape codes for coloring the output.
+
+    The following example is a color-less version of the default log prefix.
+
+    .. code-block:: shell
+
+        COCOTB_LOG_PREFIX="{simtime.convert(record.created_sim_time, 'step', to='ns'):>9}ns {record.levelname:<8} {record.name[-34:]:<34} "
+
+    .. note::
+        If this variable is set, :envvar:`COCOTB_REDUCED_LOG_FMT` has no effect.
+
+Log Coloring
+------------
+
+.. autodata:: strip_ansi
+
+.. autodata:: ANSI
+
+.. envvar:: COCOTB_ANSI_OUTPUT
+
+    Use this to override the default behavior of annotating cocotb output with
+    ANSI color codes if the output is a terminal (``isatty()``).
+
+    ``COCOTB_ANSI_OUTPUT=1``
+       forces output to be ANSI-colored regardless of the type of ``stdout`` or the presence of :envvar:`NO_COLOR`
+    ``COCOTB_ANSI_OUTPUT=0``
+       suppresses the ANSI color output in the log messages
+
+.. envvar:: NO_COLOR
+
+    From http://no-color.org,
+
+        All command-line software which outputs text with ANSI color added should check for the presence
+        of a ``NO_COLOR`` environment variable that, when present (regardless of its value), prevents the addition of ANSI color.
 
 
 Simulator Objects
@@ -367,6 +549,7 @@ Simulator Objects
     A better term is :term:`simulator object`.
 
 .. module:: cocotb.handle
+    :synopsis: Tools for discovering and manipulating :term:`simulator objects <simulator object>`.
 
 .. autoclass:: SimHandleBase
     :members:
@@ -429,6 +612,32 @@ Simulator Objects
     :member-order: bysource
     :inherited-members: SimHandleBase, ValueObjectBase
 
+.. envvar:: COCOTB_TRUST_INERTIAL_WRITES
+
+    Defining this variable enables a mode which allows cocotb to trust that VPI/VHPI/FLI inertial writes are applied properly according to the respective standards.
+    This mode can lead to noticeable performance improvements,
+    and also includes some behavioral difference that are considered by the cocotb maintainers to be "better".
+    Not all simulators handle inertial writes properly, so use with caution.
+
+    This is achieved by *not* scheduling writes to occur at the beginning of the ``ReadWrite`` mode,
+    but instead trusting that the simulator's inertial write mechanism is correct.
+    This allows cocotb to avoid a VPI callback into Python to apply writes.
+
+    .. note::
+        This flag is enabled by default for the GHDL, NVC and Verilator simulators.
+        More simulators may enable this flag by default in the future as they are gradually updated to properly apply inertial writes according to the respective standard.
+
+    .. note::
+        To test if your simulator behaves correctly with your simulator and version,
+        first clone the cocotb github repo and run:
+
+        .. code-block::
+
+            cd tests/test_cases/test_inertial_writes
+            make simulator_test SIM=<your simulator here> TOPLEVEL_LANG=<vhdl or verilog>
+
+        If the tests pass, your simulator and version apply inertial writes as expected and you can turn on :envvar:`COCOTB_TRUST_INERTIAL_WRITES`.
+
 .. _assignment-methods:
 
 Assignment Methods
@@ -458,7 +667,41 @@ Other Runtime Information
 
 .. autodata:: cocotb.plusargs
 
+.. envvar:: COCOTB_PLUSARGS
+
+      "Plusargs" are options that are starting with a plus (``+``) sign.
+      They are passed to the simulator and are also available within cocotb as :data:`cocotb.plusargs`.
+      In the simulator, they can be read by the Verilog/SystemVerilog system functions
+      ``$test$plusargs`` and ``$value$plusargs``.
+
+    .. versionchanged:: 2.0
+
+        :envvar:`PLUSARGS` is renamed to :envvar:`COCOTB_PLUSARGS`.
+
+    .. deprecated:: 2.0
+
+        :envvar:`PLUSARGS` is a deprecated alias and will be removed.
+
 .. autodata:: cocotb.top
+
+.. envvar:: COCOTB_TOPLEVEL
+
+    Use this to indicate the instance in the hierarchy to use as the :term:`DUT`.
+    If this isn't defined then the first root instance is used.
+    Leading and trailing whitespace are automatically discarded.
+
+    The DUT is available in cocotb tests as a Python object at :data:`cocotb.top`;
+    and is also passed to all cocotb tests as the :ref:`first and only parameter <quickstart_creating_a_test>`.
+
+    .. versionchanged:: 1.6 Strip leading and trailing whitespace
+
+    .. versionchanged:: 2.0
+
+        :envvar:`TOPLEVEL` is renamed to :envvar:`COCOTB_TOPLEVEL`.
+
+    .. deprecated:: 2.0
+
+        :envvar:`TOPLEVEL` is a deprecated alias and will be removed.
 
 .. autodata:: cocotb.packages
 
@@ -467,6 +710,39 @@ Other Runtime Information
 .. autodata:: cocotb.SIM_VERSION
 
 .. autodata:: cocotb.RANDOM_SEED
+
+.. envvar:: COCOTB_RANDOM_SEED
+
+    Seed the Python random module to recreate a previous test stimulus.
+    At the beginning of every test a message is displayed with the seed used for that execution:
+
+    .. code-block:: bash
+
+             0.00ns INFO     cocotb                             Seeding Python random module with 1756566114
+
+
+    To recreate the same stimuli use the following:
+
+    .. code-block:: bash
+
+       make COCOTB_RANDOM_SEED=1377424946
+
+    The special :data:`cocotb.plusargs` ``+ntb_random_seed`` and ``+seed``, if present,
+    are evaluated to set the random seed value if :envvar:`!COCOTB_RANDOM_SEED` is not set.
+    ``+ntb_random_seed`` takes precedence over ``+seed``.
+
+    .. versionchanged:: 2.0
+
+        :envvar:`RANDOM_SEED` is renamed to :envvar:`COCOTB_RANDOM_SEED`.
+
+    .. deprecated:: 2.0
+
+        :envvar:`RANDOM_SEED` is a deprecated alias and will be removed.
+
+    .. deprecated:: 2.0
+
+        The setting of :envvar:`!COCOTB_RANDOM_SEED` using ``+ntb_random_seed`` and ``+seed`` :data:`!cocotb.plusargs`.
+
 
 .. autodata:: cocotb.is_simulation
 
@@ -477,6 +753,61 @@ Debugging
     :members:
     :member-order: bysource
     :synopsis: Features for debugging cocotb's concurrency system.
+
+.. envvar:: COCOTB_SCHEDULER_DEBUG
+
+    Enable additional log output of the coroutine scheduler.
+
+    This will default the value of :data:`~cocotb.debug.debug`,
+    which can later be modified.
+
+.. envvar:: COCOTB_PDB_ON_EXCEPTION
+
+   If defined, cocotb will drop into the Python debugger (:mod:`pdb`) if a test fails with an exception.
+   See also the :ref:`troubleshooting-attaching-debugger-python` subsection of :ref:`troubleshooting-attaching-debugger`.
+
+.. envvar:: COCOTB_ATTACH
+
+    In order to give yourself time to attach a debugger to the simulator process before it starts to run,
+    you can set the environment variable :envvar:`COCOTB_ATTACH` to a pause time value in seconds.
+    If set, cocotb will print the process ID (PID) to attach to and wait the specified time before
+    actually letting the simulator run.
+
+.. envvar:: COCOTB_ENABLE_PROFILING
+
+    Enable performance analysis of the Python portion of cocotb. When set, a file :file:`test_profile.pstat`
+    will be written which contains statistics about the cumulative time spent in the functions.
+
+    From this, a callgraph diagram can be generated with `gprof2dot <https://github.com/jrfonseca/gprof2dot>`_ and ``graphviz``.
+
+.. envvar:: COCOTB_USER_COVERAGE
+
+    Enable to collect Python coverage data for user code.
+    For some simulators, this will also report :term:`HDL` coverage.
+    If :envvar:`COVERAGE_RCFILE` is not set, branch coverage is collected
+    and files in the cocotb package directory are excluded.
+
+    This needs the :mod:`coverage` Python module to be installed.
+
+    .. versionchanged:: 2.0
+
+        :envvar:`COVERAGE` is renamed to :envvar:`COCOTB_USER_COVERAGE`.
+
+    .. deprecated:: 2.0
+
+        :envvar:`COVERAGE` is a deprecated alias and will be removed.
+
+.. envvar:: COVERAGE_RCFILE
+
+    Location of a configuration file for coverage collection of Python user code
+    using the the :mod:`coverage` module.
+    See https://coverage.readthedocs.io/en/latest/config.html for documentation of this file.
+
+    If this environment variable is set,
+    cocotb will *not* apply its own default coverage collection settings,
+    like enabling branch coverage and excluding files in the cocotb package directory.
+
+    .. versionadded:: 1.7
 
 .. _combine-results:
 
@@ -527,12 +858,49 @@ The Regression Manager
     :members:
     :member-order: bysource
 
-The ``cocotb.simulator`` module (Internals)
--------------------------------------------
 
-This module is a Python wrapper to libgpi.
-It should not be considered public API, but is documented here for developers
-of cocotb.
+.. _pygpi:
+
+PyGPI and the ``cocotb.simulator`` module
+-----------------------------------------
+
+The PyGPI is a Python wrapper around the GPI.
+
+.. envvar:: PYGPI_PYTHON_BIN
+
+    The Python binary in the Python environment to use with cocotb.
+    This is set to the result of ``cocotb-config --python-bin`` in the Makefiles and :ref:`Python Runner <howto-python-runner>`.
+    You will likely only need to set this variable manually if
+    you are using a Python environment other than the currently activated environment,
+    or if you are using a :ref:`custom flow <custom-flows>`.
+
+.. envvar:: PYGPI_USERS
+
+    The Python module and callable that starts up the Python cosimulation environment.
+    User overloads can be used to enter alternative Python frameworks or to hook existing cocotb functionality.
+    The variable is formatted as ``path.to.entry.module:entry_point.function,other_module:other_func``.
+    The string before the colon is the Python module to import
+    and the string following the colon is the object to call as the entry function.
+    Multiple entry points can be specified by separating them with a comma.
+
+    The entry function must be a callable matching this form:
+
+    * ``entry_function(argv: List[str]) -> None``
+
+    .. versionchanged:: 1.8
+        ``level`` argument to ``_sim_event`` is no longer passed, it is assumed to be `SIM_FAIL` (2).
+
+    .. versionchanged:: 2.0
+        The entry-module-level functions ``_sim_event``, ``_log_from_c``, and ``_filter_from_c`` are no longer required.
+
+    .. versionchanged:: 2.0
+        Multiple entry points can be specified by separating them with a comma.
+
+    .. versionchanged:: 2.0
+        Renamed from ``PYGPI_ENTRY_POINT``.
+
+The ``cocotb.simulator`` module is the Python :keyword:`import`-able interface to the PyGPI.
+It should not be considered public API, but is documented here for developers of cocotb.
 
 .. automodule:: cocotb.simulator
     :members:

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -864,7 +864,7 @@ The Regression Manager
 PyGPI and the ``cocotb.simulator`` module
 -----------------------------------------
 
-The PyGPI is a Python wrapper around the GPI.
+The PyGPI is a Python wrapper around the :term:`GPI` (Generic Procedural Interface).
 
 .. envvar:: PYGPI_PYTHON_BIN
 

--- a/docs/source/library_reference_c.rst
+++ b/docs/source/library_reference_c.rst
@@ -16,7 +16,7 @@ Environment Variables
 
     The absolute path to the Python library associated with the current Python installation;
     i.e. ``libpython.so`` or ``python.dll`` on Windows.
-    This is determined with ``cocotb-config --libpython`` in cocotb's makefiles.
+    This is determined with ``cocotb-config --libpython`` during build.
 
 .. envvar:: GPI_EXTRA
 

--- a/docs/source/library_reference_c.rst
+++ b/docs/source/library_reference_c.rst
@@ -2,14 +2,47 @@
 GPI Library Reference
 *********************
 
-Cocotb contains a library called ``GPI`` (in directory :file:`src/cocotb/share/lib/gpi/`) written in C++
+Cocotb contains a native library called :term:`GPI` (Generic Procedural Interface)
 that is an abstraction layer for the VPI, VHPI, and FLI simulator interfaces.
 
 .. image:: diagrams/svg/cocotb_overview.svg
 
-The interaction between Python and GPI is via a Python extension module called ``simulator``
-(in directory :file:`src/cocotb/share/lib/simulator/`) which provides routines for
-traversing the hierarchy, getting/setting an object's value, registering callbacks etc.
+The interaction between cocotb's Python and GPI is via a Python extension module called the :ref:`PyGPI <_pygpi>`.
+
+Environment Variables
+=====================
+
+.. envvar:: LIBPYTHON_LOC
+
+    The absolute path to the Python library associated with the current Python installation;
+    i.e. ``libpython.so`` or ``python.dll`` on Windows.
+    This is determined with ``cocotb-config --libpython`` in cocotb's makefiles.
+
+.. envvar:: GPI_EXTRA
+
+    A comma-separated list of extra libraries that are dynamically loaded at runtime.
+    A function from each of these libraries will be called as an entry point prior to elaboration,
+    allowing these libraries to register system functions and callbacks.
+    Note that :term:`HDL` objects cannot be accessed at this time.
+    An entry point function must be named following a ``:`` separator,
+    which follows an existing simulator convention.
+
+    For example:
+
+    * ``GPI_EXTRA=libnameA.so:entryA,libnameB.so:entryB`` will first load ``libnameA.so`` with entry point ``entryA`` , then load ``libnameB.so`` with entry point ``entryB``.
+
+    .. versionchanged:: 1.4
+        Support for the custom entry point via ``:`` was added.
+        Previously ``:`` was used as a separator between libraries instead of ``,``.
+
+    .. versionchanged:: 1.5
+        Library name must be fully specified.
+        This allows using relative or absolute paths in library names,
+        and loading from libraries that `aren't` prefixed with "lib".
+        Paths `should not` contain commas.
+
+C API
+=====
 
 .. doxygenfile:: gpi.h
    :sections: brief detaileddescription define typedef enum

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -47,11 +47,11 @@ def _get_version() -> str:
 
 def _help_vars_text() -> str:
     if "dev" in _get_version():
-        doclink = "https://docs.cocotb.org/en/development/building.html"
+        doclink = "https://docs.cocotb.org/en/development/library_reference.html"
     else:
-        doclink = f"https://docs.cocotb.org/en/v{_get_version()}/building.html"
+        doclink = f"https://docs.cocotb.org/en/v{_get_version()}/library_reference.html"
 
-    # NOTE: make sure to keep "helpmsg" aligned with ../../docs/source/building.rst
+    # NOTE: make sure to keep "helpmsg" aligned with docs/source/library_reference.rst
     helpmsg = textwrap.dedent(
         """\
         The following variables are environment variables:


### PR DESCRIPTION
Make the `building.rst` file specifically about the Makefile runner by moving the section about library building to the `install_dev.rst` spreading the envvars amongst the appropriate sections in the master reference doc.

A follow-on should split the "Python library reference" into multiple documents.