### PR TITLE
Fix logging in Pythons <3.11

### DIFF
--- a/src/cocotb/_py_compat.py
+++ b/src/cocotb/_py_compat.py
@@ -144,4 +144,5 @@ else:
     from enum import Enum
 
     class StrEnum(str, Enum):
-        pass
+        def __str__(self) -> str:
+            return self.value


### PR DESCRIPTION
`StrEnum.__str__` behaves weird in Python <3.11 and was messing up logs.