### PR TITLE
Remove ccache from Mac CI

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -81,11 +81,11 @@ jobs:
 
     - name: setup ccache
       uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2
-      if: ${{ !startsWith(matrix.os, 'windows') }}
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       with:
         key: ${{ matrix.os }}-${{matrix.cc || 'gcc'}}
     - name: setup ccache path
-      if: ${{ !startsWith(matrix.os, 'windows') }}
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |
         echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
 


### PR DESCRIPTION
I have no proof this will fix things, but the ccache and Mac CI updates did happen at the same time so we might have missed what running them together looked like.

It'd be unfortunate to remove them since the macos-14 runners are by far the slowest.