### PR TITLE
Build release bdists for Mac against ARM and x86

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -34,7 +34,8 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-2022
-          - macos-13
+          - macos-13  # x86_64
+          - macos-14  # ARM64
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ known-third-party = [
 # - CPython on Linux i686 and x86_64 with glibc
 # - CPython on Windows i686 and x86_64
 # - CPython on macOS x86_64
-build = "cp*-manylinux_x86_64 cp*-manylinux_i686 cp*-win_amd64 cp*-win32 cp*-macosx_x86_64"
+build = "cp*-manylinux_x86_64 cp*-manylinux_i686 cp*-win_amd64 cp*-win32 cp*-macosx_x86_64 cp*-macosx_arm64"
 
 # Build with optimizations and debugging
 # -O2   Enables reasonable optimizations. -O3 is unnecessary with the virtual-call-heavy code in the GPI and may bloat binary size.


### PR DESCRIPTION
Build against both ARM64 and x86 for Mac release builds. xref #2930.

We are only testing the ARM image since we are only testing against macos-14 in the regression right now. We should also test against an x86 image (such as the large images, but they cost money, or macos-13 for this release) if we plan to do this. Alternatively we only do release builds for ARM.
