### PR TITLE
Add compatability code path for setimmediatevalue

### DIFF
--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -309,7 +309,10 @@ class Clock:
                 Force: _GPISetAction.FORCE,
             }[self._set_action]
             clkobj.start(
-                self._period_steps, self._period_high_steps, start_high, set_action
+                self._period_steps,
+                self._period_high_steps,
+                start_high,
+                set_action.value,
             )
 
             async def drive() -> None:


### PR DESCRIPTION
Fix #4886. Gets `setimmediatevalue` working as it did in 1.9. In 1.9 `setimmediatevalue` was a normal deposit that was not scheduled with the write scheduler, but applied immediately.