### PR TITLE
Hardcode parallelism in Windows CI build jobs

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -179,7 +179,7 @@ jobs:
         git reset --hard ${{matrix.sim-version}}
         bash ./autoconf.sh
         bash ./configure --host=x86_64-w64-mingw32 --prefix=/c/iverilog
-        make -j $(nproc) install
+        make -j 2 install
         echo "C:\iverilog\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Set up Icarus (MacOS - homebrew --HEAD)
       if: startsWith(matrix.os, 'macos') && matrix.sim == 'icarus' && matrix.sim-version == 'homebrew-HEAD'


### PR DESCRIPTION
I have a feeling the reason this job randomly fails due to timeout is that `nproc` is returning nothing and so `make -j $(nproc)` uses the default behavior for argument-less `-j` which is maximum parallelism, one job per target. That often has the effect of blowing up any computer.

I don't feel like trying out different stuff to see what the analogue to `nproc` is on Windows.