### PR TITLE
[Upgrade 2.0 docs] Even more!

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -472,7 +472,7 @@ Adding Simulation Time to Logs
 
 .. attribute:: logging.LogRecord.created_sim_time
 
-    The result of :func:`.get_sim_time` at the point the log was created (in simulation time).
+    The result of :func:`~cocotb.simtime.get_sim_time` at the point the log was created (in simulation time).
     The formatter is responsible for converting this to something like nanoseconds via :func:`~cocotb.simtime.convert`.
 
     This is added by :class:`~cocotb.logging.SimTimeContextFilter`.

--- a/docs/source/library_reference_c.rst
+++ b/docs/source/library_reference_c.rst
@@ -7,7 +7,7 @@ that is an abstraction layer for the VPI, VHPI, and FLI simulator interfaces.
 
 .. image:: diagrams/svg/cocotb_overview.svg
 
-The interaction between cocotb's Python and GPI is via a Python extension module called the :ref:`PyGPI <_pygpi>`.
+The interaction between cocotb's Python and GPI is via a Python extension module called the :ref:`PyGPI <pygpi>`.
 
 Environment Variables
 =====================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -87,7 +87,6 @@ Bugfixes
 --------
 
 - Fixes handling of escaped identifiers containing characters that are special in regular expressions (e.g. dots). (:pr:`1610`)
-- Updated :meth:`.ValueObjectBase.setimmediatevalue` to use ``GPI_NO_DELAY`` to set values, so values are *actually* set immediately and can be read back immediately. (:pr:`4068`)
 - Support reading and writing all possible 9-state values in VHDL; ``W``, ``H``, and ``L`` were missing before. (Note that GHDL only supports 4-state values.) (:pr:`4299`)
 - Fixed several memory and callback leaks in the GPI. Simulations may use less memory and run slightly faster. (:pr:`4392`)
 - Passing no triggers to :class:`~cocotb.triggers.First` previously hung the simulation indefinitely. Now, doing so raises a :exc:`ValueError` exception. (:pr:`4409`)

--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -1108,6 +1108,53 @@ Many new users were confused on when to use one vs the other,
 so :func:`!cocotb.start` will be removed to prevent any confusion.
 
 
+*********************************************************************************
+Replace ``handle.setimmediatevalue(value)`` with ``handle.set(Immediate(value))``
+*********************************************************************************
+
+Change
+======
+
+:meth:`handle.setimmediatevalue() <cocotb.handle.ValueObjectBase.setimmediatevalue>` was deprecated.
+
+How To Upgrade
+==============
+
+Replace the call to :meth:`!handle.setimmediatevalue` with a value set using the :meth:`~cocotb.handle.Immediate` action wrapper.
+
+.. code-block:: python
+    :caption: Old way with ``handle.setimmediatevalue(value)``
+    :class: removed
+
+    cocotb.top.iface.valid.setimmediatevalue(0)
+
+.. code-block:: python
+    :caption: New way with ``handle.set(Immediate(value))``
+    :class: new
+
+    cocotb.top.iface.valid.set(Immediate(0))
+
+Rationale
+=========
+
+:meth:`!handle.setimmediatevalue` does not actually set the object's value immediately.
+It sets the value inertially, but immediately,
+without it being scheduled for the next :ref:`ReadWrite sync phase <values-settle>`.
+This means signals get their value at delta N+1 (N being where you currently are in the time step).
+This is unexpected and generally not useful.
+
+:class:`!Immediate` applies values immediately, such that they can be read back after writing.
+
+.. code-block:: python
+    :caption: Read back value written immediately
+    :class: new
+
+    assert cocotb.top.data.value == 100
+    cocotb.top.data.set(Immediate(0))
+    # new value can be read back immediately
+    assert cocotb.top.data.value == 0
+
+
 ********************************************************************
 Use :func:`!cocotb.pass_test` instead of raising :exc:`!TestSuccess`
 ********************************************************************

--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -1106,3 +1106,67 @@ Rationale
 
 Many new users were confused on when to use one vs the other,
 so :func:`!cocotb.start` will be removed to prevent any confusion.
+
+
+****************************************************************************************************
+Use ``sources`` argument in :meth:`Runner.build` instead of ``vhdl_sources`` and ``verilog_sources``
+****************************************************************************************************
+
+Change
+======
+
+The ``vhdl_sources`` and ``verilog_sources`` arguments to :meth:`.Runner.build` have been deprecated and replaced with the ``sources`` argument.
+
+How to Upgrade
+==============
+
+Instead of splitting your sources between the ``vhdl_sources`` and ``verilog_sources`` arguments,
+pass all sources via the ``sources`` argument.
+Sources will be compiled in the given order, left-to-right.
+
+.. code-block:: python
+    :caption: Old way with ``vhdl_sources`` and ``verilog_sources``
+    :class: removed
+
+    runner = get_runner()
+    runner.build(
+        vhdl_sources=["top.vhdl"],
+        verilog_sources=["ip_core.sv"],
+    )
+
+.. code-block:: python
+    :caption: New way with ``sources``
+    :class: new
+
+    runner = get_runner()
+    runner.build(
+        sources=["ip_core.sv", "top.vhdl"],
+    )
+
+.. note::
+    If you are unsure about the order the sources should be compiled in with mixed-language simulators,
+    prefer compiling all VHDL sources, then all Verilog sources.
+    This is the order of compilation when using separate ``vhdl_sources`` and ``verilog_sources`` arguments.
+
+Rationale
+=========
+
+Splitting the two types of sources made arbitrary build ordering of VHDL and Verilog sources impossible.
+This approach also reduces verbosity and hidden assumptions about compilation order.
+
+Additional Details
+==================
+
+Source files are judged to be either VHDL or Verilog sources and compiled appropriately for your simulator.
+The runner uses the file extension to determine whether the source file is VHDL or Verilog
+(see :meth:`.Runner.build` for details).
+If you use custom file extensions,
+you can use the :class:`~cocotb_tools.runner.VHDL` and :class:`~cocotb_tools.runner.Verilog` tag classes
+to mark the sources as either VHDL or Verilog, respectively.
+
+.. code-block:: python
+
+    runner = get_runner()
+    runner.build(
+        sources=[Verilog("ip_core.gen"), "top.vhdl"],
+    )

--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -1152,6 +1152,43 @@ However, neither of these implied behaviors is actually supported.
 It also parallels the design of :func:`sys.exit`.
 
 
+*******************************************************************
+Fail tests using :keyword:`!assert` rather than :exc:`!TestFailure`
+*******************************************************************
+
+Change
+======
+
+:external+cocotb19:py:exc:`~cocotb.result.TestFailure` was removed.
+
+How to Upgrade
+==============
+
+Replace ``raise TestFailure(msg)`` with an :keyword:`assert` statement.
+Move any exception message to the optional message clause of the :keyword:`!assert` statement.
+
+.. code-block:: python
+    :caption: Old way with :exc:`!TestFailure`
+    :class: removed
+
+    if cocotb.top.error.value != 0:
+        raise TestFailure("DUT errored")
+
+.. code-block:: python
+    :caption: New way with :keyword:`!assert`
+    :class: new
+
+    assert cocotb.top.error.value == 0, "DUT errored"
+
+Rationale
+=========
+
+cocotb had far too many competing ways to fail a test, so they were reduced to one.
+:keyword:`assert` is already familiar to those who have ever used :mod:`pytest`,
+and :mod:`!pytest` functionality can be leveraged to rewrite the :exc:`AssertionError`\ s coming from failing :keyword:`!assert`\ s
+with more contextual information as to why the :keyword:`!assert` failed.
+
+
 ****************************************************************************************************
 Use ``sources`` argument in :meth:`Runner.build` instead of ``vhdl_sources`` and ``verilog_sources``
 ****************************************************************************************************

--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -1108,6 +1108,50 @@ Many new users were confused on when to use one vs the other,
 so :func:`!cocotb.start` will be removed to prevent any confusion.
 
 
+********************************************************************
+Use :func:`!cocotb.pass_test` instead of raising :exc:`!TestSuccess`
+********************************************************************
+
+Change
+======
+
+:external+cocotb19:py:exc:`~cocotb.result.TestSuccess` was deprecated and replaced with :func:`cocotb.pass_test`.
+
+How To Upgrade
+==============
+
+Replace ``raise TestSuccess(msg)`` with a call to :func:`!cocotb.pass_test`.
+
+.. code-block:: python
+    :caption: Old way with :exc:`!TestSuccess`
+    :class: removed
+
+    if cocotb.top.error.value == 0:
+        raise TestSuccess("Test finished without DUT erroring")
+
+.. code-block:: python
+    :caption: New way with :func:`!cocotb.pass_test`
+    :class: new
+
+    if cocotb.top.error.value == 0:
+        cocotb.pass_test("Test finished without DUT erroring")
+
+Rationale
+=========
+
+cocotb needs a way to end a test with a pass from any Task, not just the main test Task.
+:exc:`!TestSuccess` was created for that purpose.
+But being an exception, it has an additional implied interface:
+
+- It is acceptable to catch it.
+- It will propagate through Tasks like other exceptions do.
+
+However, neither of these implied behaviors is actually supported.
+
+:func:`!cocotb.pass_test` being a function call avoids these implicit interfaces.
+It also parallels the design of :func:`sys.exit`.
+
+
 ****************************************************************************************************
 Use ``sources`` argument in :meth:`Runner.build` instead of ``vhdl_sources`` and ``verilog_sources``
 ****************************************************************************************************

--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -1189,6 +1189,45 @@ and :mod:`!pytest` functionality can be leveraged to rewrite the :exc:`Assertion
 with more contextual information as to why the :keyword:`!assert` failed.
 
 
+*********************************
+Replace uses of :exc:`!TestError`
+*********************************
+
+Change
+======
+
+:external+cocotb19:py:exc:`~cocotb.result.TestError` was removed.
+
+How to Upgrade
+==============
+
+Replace :exc:`!TestError` with an :external+python:ref:`exception of the appropriate type <concrete-exceptions>`.
+
+.. code-block:: python
+    :caption: Old way with :exc:`!TestError`
+    :class: removed
+
+    def drive(pkt):
+        if not isinstance(pkt, bytes):
+            raise TestError("packet must be bytes")
+        ...
+
+.. code-block:: python
+    :caption: New way with more appropriate exception type
+    :class: new
+
+    def drive(pkt):
+        if not isinstance(pkt, bytes):
+            raise TypeError("packet must be bytes")
+        ...
+
+Rationale
+=========
+
+:exc:`TestError` is unnecessarily cocotb-specific and another redundant way to fail the test with an error,
+so it was removed.
+
+
 ****************************************************************************************************
 Use ``sources`` argument in :meth:`Runner.build` instead of ``vhdl_sources`` and ``verilog_sources``
 ****************************************************************************************************


### PR DESCRIPTION
xref #3674. Some small fixes for the release + Upgrade to 2.0 for...

* `TestSuccess`
* `TestFailure`
* `TestError`
* `setimmediatevalue`
* `Runner.build(sources=)`
