### PR TITLE
Add removal newsfrag for `TestFailure`, `TestError`, and `TestComplete`

### DIFF
--- a/docs/source/newsfragments/4960.removal.rst
+++ b/docs/source/newsfragments/4960.removal.rst
@@ -1,0 +1,1 @@
+Removed the deprecated :external+cocotb19:py:class:`cocotb.result.TestComplete`, :external+cocotb19:py:class:`cocotb.result.TestError`, and :external+cocotb19:py:class:`cocotb.result.TestFailure`.


### PR DESCRIPTION
I realized when doing the documentation nothing mentioned they were removed. So I added deprecation shims instead.
