### PR TITLE
Docs: linewrapping etc. fixes

### DIFF
--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -421,6 +421,11 @@ simple li p:first-child, .simple dd p:first-child {
     display: block;
 }
 
+/* add space between consecutive paragraphs */
+p + p {
+    margin-top: 0.5rem !important;
+}
+
 /* reduce distance after paragraphs a bit */
 p {
     margin-bottom: 0.5rem !important;

--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -411,9 +411,14 @@ dl > dd > dl:not(.field-list.simple) {
 }
 
 /* fix for extra linebreak in apidoc (https://github.com/pydata/pydata-sphinx-theme/issues/2098) */
-dl.field-list.simple > dd > p,
-dl.field-list.simple > dd > ul.simple > li > p {
-    display: inline !important;
+simple li p:first-child, .simple dd p:first-child {
+    display: inline;
+}
+.simple li p:first-child + p, .simple dd p:first-child + p {
+    display: inline;
+}
+.simple li p + p + p, .simple dd p + p + p {
+    display: block;
 }
 
 /* reduce distance after paragraphs a bit */

--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -604,3 +604,19 @@ dl.std.envvar > dt::before {
 dl.std.envvar > dt {
     margin-top: 1.5rem;
 }
+
+/* Make sure typewriter text has the same font size as the surrounding headings */
+h1 .pre,
+h2 .pre,
+h3 .pre,
+h4 .pre,
+h5 .pre,
+h6 .pre,
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+    font-size: inherit;
+}

--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -592,3 +592,15 @@ code.literal {
   background-color: unset;
   padding: 0;
 }
+
+
+/* add text "envvar" before environment variable definitions */
+dl.std.envvar > dt::before {
+    content: "envvar ";
+    color: var(--color-cocotb-blue);
+    font-style: italic;
+}
+
+dl.std.envvar > dt {
+    margin-top: 1.5rem;
+}

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -529,9 +529,9 @@ Log Coloring
     ANSI color codes if the output is a terminal (``isatty()``).
 
     ``COCOTB_ANSI_OUTPUT=1``
-       forces output to be ANSI-colored regardless of the type of ``stdout`` or the presence of :envvar:`NO_COLOR`
+       Forces output to be ANSI-colored regardless of the type of ``stdout`` or the presence of :envvar:`NO_COLOR`.
     ``COCOTB_ANSI_OUTPUT=0``
-       suppresses the ANSI color output in the log messages
+       Suppresses the ANSI color output in the log messages.
 
 .. envvar:: NO_COLOR
 

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -641,7 +641,7 @@ _ValueT = TypeVar("_ValueT")
 
 
 class Deposit(Generic[_ValueT]):
-    r""":term:`Inertially deposits <inertial deposit>` the given value on a simulator object.
+    r""":term:`Inertially deposit <inertial deposit>` the given value on a simulator object.
 
     If another :term:`deposit` comes after this deposit, the newer deposit overwrites the old value.
     If an HDL process is :term:`driving` the signal/net/register where a deposit from cocotb is made,
@@ -1072,9 +1072,9 @@ class ArrayObject(
         Raises:
             TypeError: If *value* is of a type that can't be assigned to the simulation object.
 
-            .. warning::
-                Exceptions from array element :meth:`.ValueObjectBase.set` calls will be propagated up,
-                so the actual set of exceptions possible is greater than this list.
+        .. warning::
+            Exceptions from array element :meth:`.ValueObjectBase.set` calls will be propagated up,
+            so the actual set of exceptions possible is greater than this list.
         """
         super().set(value)
 

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -421,7 +421,7 @@ class HierarchyObject(_HierarchyObjectBase[str]):
 
     - the name cannot start with a number
     - the name cannot start with a ``_`` character
-    - the name can only contain ASCII letters, numbers, and the ``_`` character
+    - the name can only contain ASCII letters, numbers, and the ``_`` character.
 
     Any possible name of an object is supported with the index syntax,
     but it can be more verbose.
@@ -947,7 +947,7 @@ class ValueObjectBase(SimHandleBase, Generic[ValueGetT, ValueSetT]):
         Passing :class:`Deposit`\ s and unwrapped values is equivalent to passing an :class:`Immediate` to :meth:`set`.
 
         .. deprecated:: 2.0
-            "Use `handle.set(Immediate(...))` or `handle.value = Immediate(...)` instead.
+            Use ``handle.set(Immediate(...))`` or ``handle.value = Immediate(...)`` instead.
             This could result in a change in behavior because prior to 2.0 this function did not set values immediately.
         """
         if isinstance(value, Deposit):

--- a/src/cocotb/types/_logic.py
+++ b/src/cocotb/types/_logic.py
@@ -263,11 +263,12 @@ class Logic:
         return int(self)
 
     def resolve(self, resolver: ResolverLiteral) -> Self:
-        """Resolves non-0/1 values to 0/1.
+        """Resolve non-``0``/``1`` values to ``0``/``1``.
 
         The possible values of the *resolver* argument are:
 
-        * ``"weak"``: Weak values are resolved to their strong-valued equivalents.
+        * ``"weak"``:
+            Weak values are resolved to their strong-valued equivalents.
 
         * ``"zeros"``:
             ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.

--- a/src/cocotb/types/_range.py
+++ b/src/cocotb/types/_range.py
@@ -41,7 +41,7 @@ class Range(Sequence[int]):
 
     :class:`Range` supports "null" ranges as seen in VHDL.
     "null" ranges occur when a left bound cannot reach a right bound with the given direction.
-    They have a length of 0, but the :attr:`left`, :attr:`right`, and :attr:`direction` values remain as given.
+    They have a length of ``0``, but the :attr:`left`, :attr:`right`, and :attr:`direction` values remain as given.
 
     .. code-block:: pycon3
 
@@ -62,9 +62,9 @@ class Range(Sequence[int]):
     The typical use case of this type is in conjunction with :class:`~cocotb.types.Array`.
 
     Args:
-        left: leftmost bound of range
-        direction: ``'to'`` if values are ascending, ``'downto'`` if descending
-        right: rightmost bound of range (inclusive)
+        left: Leftmost bound of range.
+        direction: ``'to'`` if values are ascending, ``'downto'`` if descending.
+        right: Rightmost bound of range (inclusive).
     """
 
     @overload


### PR DESCRIPTION
Showcase:
https://docs.cocotb.org/en/development/library_reference.html#cocotb.simtime.convert
vs.
https://cocotb--4961.org.readthedocs.build/en/4961/library_reference.html#cocotb.simtime.convert

Also, warnings in the "Raises:" section are apparently not supported:
https://docs.cocotb.org/en/development/library_reference.html#cocotb.handle.ArrayObject.set
https://cocotb--4961.org.readthedocs.build/en/4961/library_reference.html#cocotb.handle.ArrayObject.set

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
