### PR TITLE
Document envvars GUI, WAVES, COCOTB_WAVEFORM_VIEWER

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -27,7 +27,7 @@ Make Phases
 ===========
 
 Typically the makefiles provided with cocotb for various simulators use a separate ``compile`` and ``run`` target.
-This allows for a rapid re-running of a simulator if none of the :term:`RTL` source files have changed and therefore the simulator does not need to recompile the :term:`RTL`.
+This allows for a rapid re-running of a simulator if none of the :term:`RTL` source files have changed and therefore the simulator does not need to recompile the RTL.
 
 Make Variables
 ==============
@@ -57,7 +57,7 @@ Make Variables
 .. make:var:: TOPLEVEL_LANG
 
     Used to inform the makefile scripts which :term:`HDL` language the top-level design element is written in.
-    Currently it supports the values ``verilog`` for Verilog or SystemVerilog tops, and ``vhdl`` for VHDL tops.
+    Currently it supports the values ``verilog`` for Verilog or SystemVerilog toplevels, and ``vhdl`` for VHDL toplevels.
     This is used by simulators that support more than one interface (:term:`VPI`, :term:`VHPI`, or :term:`FLI`) to select the appropriate interface to start cocotb.
 
 .. make:var:: VHDL_GPI_INTERFACE
@@ -103,7 +103,7 @@ Make Variables
 .. make:var:: RUN_ARGS
 
       Any argument to be passed to the "first" invocation of a simulator that runs via a TCL script.
-      One motivating usage is to pass `-noautoldlibpath` to Questa to prevent it from loading the out-of-date libraries it ships with.
+      One motivating usage is to pass ``-noautoldlibpath`` to Questa to prevent it from loading the out-of-date libraries it ships with.
       Used by the Riviera-PRO and Questa simulators.
 
 .. make:var:: EXTRA_ARGS

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -85,7 +85,7 @@ Glossary
       :term:`Depositing <deposit>` a value on a signal or variable immediately.
 
    driving
-      Continuously :term:`depositing <deposit>` a value to a signal. cocotb cannot drive signals.
+      Continuously :term:`depositing <deposit>` a value to a signal. cocotb cannot drive signals, only deposit or force values.
 
    deposit
       Setting the value of a signal or variable once. May be :term:`inertial <inertial deposit>` or :term:`no-delay <no-delay deposit>`.

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -39,6 +39,23 @@ Python Test Runner
 
 .. autodata:: MAX_PARALLEL_BUILD_JOBS
 
+.. envvar:: GUI
+
+    Set this to 1 to enable the GUI mode in the simulator (if supported).
+
+.. envvar:: WAVES
+
+    Set this to 1 to enable wave traces dump for the
+    Aldec Riviera-PRO, Mentor Graphics Questa, and Icarus Verilog simulators.
+    To get wave traces in Verilator see :ref:`sim-verilator-waveforms`.
+
+.. envvar:: COCOTB_WAVEFORM_VIEWER
+
+    The name of the waveform viewer executable to use (like ``surfer``) when GUI mode is enabled
+    for simulators that do not have a built-in waveform viewer (like Verilator).
+    The executable name will be called with the name of the waveform file as the argument.
+
+
 .. _api-runner-sim:
 
 Simulator Runners

--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -85,9 +85,9 @@ Generate waveforms
 ==================
 
 For many simulators it is possible to generate simulation waveforms.
-This can be done by setting the *waves* argument to True in the
+This can be done by setting the *waves* argument to ``True`` in the
 :meth:`Runner.build <cocotb_tools.runner.Runner.build>` and :meth:`Runner.test <cocotb_tools.runner.Runner.test>` functions.
-It is also possible to set the environment variable ``WAVES`` to
+It is also possible to set the environment variable :envvar:`WAVES` to
 a non-zero value to generate waveform files at run-time without modifying the test code, e.g.,
 
 .. code-block:: bash
@@ -102,16 +102,16 @@ Starting in GUI mode/viewing waveforms
 
 To start the simulator GUI or, for simulators not having a GUI, view
 the waveform file in a waveform viewer after the simulation, it is possible
-to set the *gui* argument to True in :meth:`Runner.test <cocotb_tools.runner.Runner.test>`.
-It is also possible to set the ``GUI`` environment variable to a non-zero value, e.g.,
+to set the *gui* argument to ``True`` in :meth:`Runner.test <cocotb_tools.runner.Runner.test>`.
+It is also possible to set the :envvar:`GUI` environment variable to a non-zero value, e.g.,
 
 .. code-block:: bash
 
     GUI=1 pytest examples/simple_dff/test_dff.py
 
 For simulators without a GUI, cocotb will open a waveform viewer. Either `Surfer <https://surfer-project.org/>`_
-or `GTKWave <https://gtkwave.github.io/gtkwave/>`, in that order, if available in the system path.
-To specify preferred waveform viewer, the ``COCOTB_WAVEFORM_VIEWER`` environment variable
+or `GTKWave <https://gtkwave.github.io/gtkwave/>`_, in that order, if available in the system path.
+To specify preferred waveform viewer, the :envvar:`COCOTB_WAVEFORM_VIEWER` environment variable
 can be used. This can also be used to set, e.g., the ``surfer.sh`` startup script for WSL.
 
 API

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -277,7 +277,7 @@ class Runner(ABC):
             clean: Delete *build_dir* before building.
             verbose: Enable verbose messages.
             timescale: Tuple containing time unit and time precision for simulation.
-            waves: Record signal traces. Overridden by the ``WAVES`` environment variable.
+            waves: Record signal traces. Overridden by the :envvar:`WAVES` environment variable.
             log_file: File to write the build log to.
 
         .. deprecated:: 2.0
@@ -370,14 +370,14 @@ class Runner(ABC):
             test_args: A list of extra arguments for the simulator.
             plusargs: 'plusargs' to set for the simulator.
             extra_env: Extra environment variables to set.
-            waves: Record signal traces. Overridden by the ``WAVES`` environment variable.
-            gui: Run with simulator GUI. Overridden by the ``GUI`` environment variable.
+            waves: Record signal traces. Overridden by the :envvar:`WAVES` environment variable.
+            gui: Run with simulator GUI. Overridden by the :envvar:`GUI` environment variable.
             parameters: Verilog parameters or VHDL generics.
             build_dir: Directory the build step has been run in.
             test_dir: Directory to run the tests in.
             results_xml: Name of xUnit XML file to store test results in.
                 If an absolute path is provided it will be used as-is,
-                ``{build_dir}/results.xml`` otherwise.
+                :file:`{build_dir}/results.xml` otherwise.
                 This argument should not be set when run with ``pytest``.
             verbose: Enable verbose messages.
             pre_cmd: Commands to run before simulation begins.


### PR DESCRIPTION
Fix more markup inconsistencies.

Closes #4967

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
