### PR TITLE
Always use the lowercase spelling of 'cocotb'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Cocotb Contribution Guidelines
+# cocotb Contribution Guidelines
 
 cocotb welcomes contributions from anyone!
 Please have a look at the [Development & Community](https://docs.cocotb.org/en/development/contributing.html) section of the cocotb documentation for an in-depth contribution guide.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-Cocotb documentation
+cocotb documentation
 ====================
 
 This directory contains the documentation of cocotb, which is built with Doxygen and Sphinx.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,7 +97,7 @@ release = cocotb.__version__
 # The short X.Y version.
 v_major, v_minor = LooseVersion(release).version[:2]
 version = "{}.{}".format(v_major, v_minor)
-# Cocotb commit ID
+# cocotb commit ID
 try:
     commit_id = (
         subprocess.check_output(["git", "rev-parse", "HEAD"]).strip().decode("ascii")

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -10,16 +10,16 @@ All processes in this document are designed to streamline the development effort
 Feeling lost?
 =============
 
-Cocotb is a diverse and challenging project to contribute to.
+cocotb is a diverse and challenging project to contribute to.
 If you ever feel lost, out of your depth, or simply want to know more, the `cocotb Gitter channel <https://gitter.im/cocotb/Lobby>`__ is actively watched by many cocotb users, contributors, and maintainers.
 It is a good idea if you are unsure whether your problem or question is worthy of a Github Issue to first post it to the Gitter channel.
 You may also ask questions in `Github issues <https://github.com/cocotb/cocotb/issues>`_.
 If you don't receive any response on the Gitter channel or a Github issue, or you want help privately, you may directly contact a maintainer.
 
-Architecture and Scope of Cocotb
+Architecture and Scope of cocotb
 ================================
 
-Cocotb has seen adoption in a wide variety of scenarios with sometimes conflicting requirements.
+cocotb has seen adoption in a wide variety of scenarios with sometimes conflicting requirements.
 To foster experimentation and to decentralize the development process the architecture of cocotb is highly modular.
 A solid core forms the foundation upon which extensions can provide higher-level functionality.
 
@@ -47,14 +47,14 @@ They including the following:
 -  Managing Github issues and the Gitter channel
 -  Testing and coverage improvements
 
-Cocotb is still not perfect.
+cocotb is still not perfect.
 There are plenty of `bug fixes <https://github.com/cocotb/cocotb/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3Abug>`__ and `features <https://github.com/cocotb/cocotb/issues?q=is%3Aopen+is%3Aissue+label%3Atype%3Afeature>`__ that can be worked on.
 Most of these are recorded as Github issues.
 
 Documentation
 -------------
 
-Cocotb's documentation is always open to improvements.
+cocotb's documentation is always open to improvements.
 Improving documentation will help users better understand and use cocotb;
 and may decrease the number of questions the Gitter channel and Github issue page.
 Updating documentation requires knowledge of:
@@ -109,14 +109,14 @@ If you can duplicate the bug or confirm the bug report is invalid, that helps ma
 Tests and Coverage
 ------------------
 
-Cocotb has a suite of unit tests (located in the ``tests`` directory) and examples (located in the ``examples`` directory) which are functional acceptance tests.
+cocotb has a suite of unit tests (located in the ``tests`` directory) and examples (located in the ``examples`` directory) which are functional acceptance tests.
 If a pull request cannot pass *all* of these tests, it will likely be rejected.
 To ensure cocotb only includes the highest quality code, these test should be exhaustive.
 We use code coverage as a quantifiable metric of the "exhaustiveness" of these tests, and wish to improve this metric.
 
 Working on this task requires a familiarity with:
 
--  Cocotb's core functionality
+-  cocotb's core functionality
 -  How to write Verilog and VHDL
 -  How to write cocotb tests in Python
 -  (Optionally) `codecov <https://docs.codecov.io/docs>`__; coverage aggregator and Github bot
@@ -124,7 +124,7 @@ Working on this task requires a familiarity with:
 -  (Optionally) `gcov <https://gcc.gnu.org/onlinedocs/gcc/Gcov.html>`__, for C++ code coverage
 -  (Optionally) `Github Actions <https://docs.github.com/en/free-pro-team@latest/actions>`__, for automatic acceptance testing
 
-Cocotb's regression tests can be improved by:
+cocotb's regression tests can be improved by:
 
 -  Testing more of cocotb's core functionality
 -  Testing corner cases left out of the current set of tests (identified by looking at code coverage)
@@ -136,9 +136,9 @@ Please see the `guidelines on submitting pull requests <#patch-requirements>`__.
 Features
 --------
 
-Cocotb is still in development and new features are still welcome and appreciated;
-as long as they stay `in scope <#Architecture-and-Scope-of-Cocotb>`__.
-Cocotb is comprised of several major codebases, each requiring different sets of skills and development process.
+cocotb is still in development and new features are still welcome and appreciated;
+as long as they stay `in scope <#Architecture-and-Scope-of-cocotb>`__.
+cocotb is comprised of several major codebases, each requiring different sets of skills and development process.
 Instead of including that breakdown here, it is done in the `internal documentation <https://github.com/cocotb/cocotb/wiki/cocotb-Internals>`__.
 
 Small improvements to existing features generally do not require maintainer pre-approval.
@@ -213,7 +213,7 @@ Details on how to debug cocotb can be found on the `Wiki <https://github.com/coc
 Deprecations and Removals
 -------------------------
 
-Cocotb's treatment of deprecations and removal follows guidelines laid out `here <https://symfony.com/doc/current/setup/upgrade_major.html#1-make-your-code-deprecation-free>`__.
+cocotb's treatment of deprecations and removal follows guidelines laid out `here <https://symfony.com/doc/current/setup/upgrade_major.html#1-make-your-code-deprecation-free>`__.
 Deprecations serve the following purposes:
 
 -  Remove legacy code that has been deemed out of scope
@@ -246,7 +246,7 @@ How to Get Changes Merged
 =========================
 
 Have you fixed a bug in cocotb, or want to add new functionality to it?
-Cocotb follows the typical `GitHub flow <https://guides.github.com/introduction/flow/>`__ and makes use of pull requests and reviews.
+cocotb follows the typical `GitHub flow <https://guides.github.com/introduction/flow/>`__ and makes use of pull requests and reviews.
 Follow the steps below to get your changes merged, i.e. integrated into the main cocotb codebase.
 
 1. Create an issue ticket on `cocotb's GitHub issue tracker <https://github.com/cocotb/cocotb/issues>`__ describing the problem.

--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -21,7 +21,7 @@ legal and administrative support, and holds cocotb assets.
 Maintainers
 ===========
 
-Cocotb uses a shared maintainer model.
+cocotb uses a shared maintainer model.
 Most maintainers are experts in part of the cocotb codebase, and are primarily responsible for reviews in this area.
 
 - Kaleb Barrett (@ktbarrett)

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -4,7 +4,7 @@ Writing cocotb Extensions
 
 This guide explains how to write cocotb extensions, with a focus on the conventions that should be followed.
 
-Cocotb gives its users a framework to build Python testbenches for hardware designs.
+cocotb gives its users a framework to build Python testbenches for hardware designs.
 But sometimes the functionality provided by cocotb is too low-level.
 One common example are bus drivers and monitors:
 instead of creating a bus adapter from scratch for each new project, wouldn't it be nice to share this component, and build on top it?
@@ -19,7 +19,7 @@ Additionally, the cocotb community has agreed on a set of conventions to make ex
 Naming conventions
 ==================
 
-Cocotb extensions are normal Python modules which follow these naming conventions.
+cocotb extensions are normal Python modules which follow these naming conventions.
 
 Assuming an extension named ``EXTNAME`` (all lower-case),
 

--- a/docs/source/library_reference_c.rst
+++ b/docs/source/library_reference_c.rst
@@ -2,7 +2,7 @@
 GPI Library Reference
 *********************
 
-Cocotb contains a native library called :term:`GPI` (Generic Procedural Interface)
+cocotb contains a native library called :term:`GPI` (Generic Procedural Interface)
 that is an abstraction layer for the VPI, VHPI, and FLI simulator interfaces.
 
 .. image:: diagrams/svg/cocotb_overview.svg

--- a/docs/source/maintaining.rst
+++ b/docs/source/maintaining.rst
@@ -93,7 +93,7 @@ cocotb explicitly uses no priority labels, as experience indicates that they pro
 Issues and pull requests which are invalid, or where feedback is lacking for four weeks, should be closed.
 
 
-Cocotb Releases
+cocotb Releases
 ===============
 
 cocotb aims to keep the ``master`` branch always in a releasable state.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -327,7 +327,7 @@ Features
 - Add support for :class:`fractions.Fraction` and :class:`decimal.Decimal` to the ``period`` argument of :external+cocotb18:class:`cocotb.clock.Clock`. (:pr:`3045`)
 - This release adds the :external+cocotb18:ref:`Python Test Runner <howto-python-runner>`, an experimental replacement for the traditional Makefile-based build and run flow. (:pr:`3103`)
 - Incisive now supports compilation into a named VHDL library ``lib`` using ``VHDL_SOURCES_<lib>``. (:pr:`3261`)
-- Cocotb can now correctly drive Verilator when its new ``--timing`` flag is used. (:pr:`3316`)
+- cocotb can now correctly drive Verilator when its new ``--timing`` flag is used. (:pr:`3316`)
 - Creating an FST waveform dump in Icarus Verilog can now be done by setting the :external+cocotb18:make:var:`WAVES` environment variable. Icarus-specific Verilog code is no longer required. (:pr:`3324`)
 
 
@@ -625,7 +625,7 @@ Features
 - Add support for distinguishing between ``net`` (``vpiNet``) and ``reg`` (``vpiReg``) type when using the VPI interface. (:pr:`1107`)
 - Support for dropping into :mod:`pdb` upon failure, via the new :external+cocotb14:envvar:`COCOTB_PDB_ON_EXCEPTION` environment variable. (:pr:`1180`)
 - Simulators run through a Tcl script (Aldec Riviera Pro and Mentor simulators) now support a new :external+cocotb14:make:var:`RUN_ARGS` Makefile variable, which is passed to the first invocation of the tool during runtime. (:pr:`1244`)
-- Cocotb now supports the following example of forking a *non-decorated* :external+cocotb14:ref:`async coroutine <async_functions>`.
+- cocotb now supports the following example of forking a *non-decorated* :external+cocotb14:ref:`async coroutine <async_functions>`.
 
   .. code-block:: python
 
@@ -655,7 +655,7 @@ Features
   .. consume the towncrier issue number on this line. (:pr:`1266`)
 - Support for ``vpiRealNet``. (:pr:`1282`)
 - The colored output can now be disabled by the :external+cocotb14:envvar:`NO_COLOR` environment variable. (:pr:`1309`)
-- Cocotb now supports deposit/force/release/freeze actions on simulator handles, exposing functionality similar to the respective Verilog/VHDL assignments.
+- cocotb now supports deposit/force/release/freeze actions on simulator handles, exposing functionality similar to the respective Verilog/VHDL assignments.
 
   .. code-block:: python
 
@@ -747,7 +747,7 @@ Deprecations and Removals
 Changes
 -------
 
-- Cocotb no longer supports Python 2, at least Python 3.5 is now required.
+- cocotb no longer supports Python 2, at least Python 3.5 is now required.
   Users of Python 2.7 can still use cocotb 1.3, but are heavily encouraged to update.
   It is recommended to use the latest release of Python 3 for improved performance over older Python 3 versions. (:pr:`767`)
 - Mentor Questa, Aldec Riviera-PRO and GHDL are now started in the directory containing the Makefile and also save :file:`results.xml` there, bringing them in line with the behavior used by other simulators. (:pr:`1598`) (:pr:`1599`) (:pr:`1063`)
@@ -756,7 +756,7 @@ Changes
   The interface libraries ``libcocotbvpi`` and ``libcocotbvhpi`` have been renamed to have a ``_simulator_name`` postfix.
   The ``simulator`` module has moved to :external+cocotb14:mod:`cocotb.simulator`.
   The ``LD_LIBRARY_PATH`` environment variable no longer needs to be set by the makefiles, as the libraries now discover each other via ``RPATH`` settings. (:pr:`1425`)
-- Cocotb must now be :external+cocotb14:ref:`installed <installation-via-pip>` before it can be used. (:pr:`1445`)
+- cocotb must now be :external+cocotb14:ref:`installed <installation-via-pip>` before it can be used. (:pr:`1445`)
 - ``cocotb.handle.NonHierarchyIndexableObject.value`` is now a list in left-to-right range order of the underlying simulation object.
   Previously the list was always ordered low-to-high. (:pr:`1507`)
 - Various binary representations have changed type from :class:`str` to :class:`bytes`. These include:

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -274,7 +274,7 @@ see :class:`cocotb_tools.runner.Questa`.
 
     A working installation of the simulator itself is required.
 
-Cocotb implements two flows for Questa.
+cocotb implements two flows for Questa.
 The most suitable flow is chosen based on the Questa version being used.
 
 The newer **QIS/Qrun flow** uses the Questa Information System (QIS) together with the ``qrun`` command.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -208,7 +208,7 @@ Users of cocotb with more than one installation of a single Python version (incl
 must take care not to reuse cached versions of the installed cocotb package.
 If this isn't done, running simulations fails with errors like ``libpython3.7m.so.1.0: cannot open shared object file: No such file or directory``.
 
-Cocotb builds binary libraries during its installation process.
+cocotb builds binary libraries during its installation process.
 These libraries are tailored to the installation of Python used when installing cocotb.
 When switching between Python installations, cocotb needs to be re-installed without using cached build artifacts, e.g. with ``pip install --no-cache-dir cocotb``.
 

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -8,7 +8,7 @@ Writing Testbenches
 Logging
 =======
 
-Cocotb uses Python's :mod:`logging` library, with the configuration described in :ref:`logging-reference-section` to provide some sensible defaults.
+cocotb uses Python's :mod:`logging` library, with the configuration described in :ref:`logging-reference-section` to provide some sensible defaults.
 ``cocotb.log.info`` is a good stand-in for :func:`print`,
 but user are encouraged to create their own loggers and logger hierarchy by calling :func:`logging.getLogger` and/or :meth:`.Logger.getChild`.
 
@@ -121,7 +121,7 @@ Signed and unsigned values
 --------------------------
 
 Both signed and unsigned values can be assigned to signals using a Python int.
-Cocotb makes no assumptions regarding the signedness of the signal. It only
+cocotb makes no assumptions regarding the signedness of the signal. It only
 considers the width of the signal, so it will allow values in the range from
 the minimum negative value for a signed number up to the maximum positive
 value for an unsigned number: ``-2**(Nbits - 1) <= value <= 2**Nbits - 1``
@@ -180,7 +180,7 @@ The Python type of a value depends on the handle's HDL type:
 Identifying tests
 =================
 
-Cocotb tests are identified using the :deco:`cocotb.test` decorator.
+cocotb tests are identified using the :deco:`cocotb.test` decorator.
 Using this decorator will tell cocotb that this function is a special type of coroutine that is meant
 to either pass or fail.
 The :deco:`cocotb.test` decorator supports several keyword arguments (see section :ref:`writing-tests`).

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
                 stderr,
                 "usage: %s [--trace] [--trace-flush] [--trace-file TRACEFILE]\n"
                 "\n"
-                "Cocotb + Verilator sim\n"
+                "cocotb + Verilator sim\n"
                 "\n"
                 "options:\n"
                 "  --trace       Enable tracing (VCD or FST)\n"

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -56,7 +56,7 @@ def _help_vars_text() -> str:
         """\
         The following variables are environment variables:
 
-        Cocotb
+        cocotb
         ------
         COCOTB_TOPLEVEL           Instance in the hierarchy to use as the DUT
         COCOTB_RANDOM_SEED        Random seed, to recreate a previous test stimulus

--- a/tests/pytest/test_timescale.py
+++ b/tests/pytest/test_timescale.py
@@ -33,7 +33,7 @@ async def check_timescale(dut):
 @pytest.mark.simulator_required
 @pytest.mark.skipif(
     os.getenv("SIM", "icarus") not in ["icarus", "ghdl", "verilator", "dsim"],
-    reason="Currently only Icarus, GHDL, Verilator, and Dsim support timescale setting when using Cocotb runner",
+    reason="Currently only Icarus, GHDL, Verilator, and Dsim support timescale setting when using cocotb runner",
 )
 @pytest.mark.parametrize("precision", ["fs", "ps", "ns", "us", "ms", "s"])
 def test_precision(precision):

--- a/tests/test_cases/test_vhdl_zerovector/Makefile
+++ b/tests/test_cases/test_vhdl_zerovector/Makefile
@@ -12,7 +12,7 @@ COCOTB_TOPLEVEL := vhdl_zerovector
 COCOTB_TEST_MODULES := test_vhdl_zerovector
 VHDL_SOURCES := vhdl_zerovector.vhdl
 
-# Cocotb inclusions
+# cocotb inclusions
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 else


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
