### PR TITLE
Add missing "verilator" to supported_sims variable

### DIFF
--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -106,6 +106,7 @@ def lib_name(interface: str, simulator: str) -> str:
     simulator_name = simulator.lower()
     supported_sims = [
         "icarus",
+        "verilator",
         "questa",
         "modelsim",
         "ius",


### PR DESCRIPTION
This bug prevented `cocotb-config --lib-name-path vpi verilator` from working.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
