### PR TITLE
Add plugin facility to extend RegressionManager

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -123,6 +123,7 @@ A test can spawn multiple coroutines, allowing for independent flows of executio
    custom_flows
    rotating_logger
    extensions
+   plugins
    upgrade-2.0
    update_indexing
 

--- a/docs/source/newsfragments/5013.feature.rst
+++ b/docs/source/newsfragments/5013.feature.rst
@@ -1,0 +1,1 @@
+Added plugin facility that will allow to extend or override the :class:`~cocotb.regression.RegressionManager` to fully support `pytest <https://docs.pytest.org>`_.

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,0 +1,106 @@
+**********************
+Writing cocotb Plugins
+**********************
+
+This guide explains how to write a custom Python plugin to extend existing cocotb capabilities.
+
+cocotb gives its users a framework to build Python testbenches for hardware designs.
+
+For example, it comes with default implementation of :class:`cocotb.regression.RegressionManager`
+that handles execution of test functions decorated with :func:`cocotb.test`.
+
+But Python world offers a wide choice of different testing frameworks with far more
+advanced features that can help boost quality and productivity of created tests.
+Like for example `pytest`_ with
+`fixtures support <https://docs.pytest.org/en/stable/explanation/fixtures.html>`_,
+`tests parametrization <https://docs.pytest.org/en/stable/example/parametrize.html>`_ and
+`large number of existing plugins <https://docs.pytest.org/en/stable/reference/plugin_list.html>`_
+that can be used in RTL verification as well.
+
+cocotb plugin facility allows to integrate and use these existing testing frameworks
+without sacrificing any of cocotb capabilities.
+
+Creating Plugin Project
+=======================
+
+The best way to create our custom cocotb plugin is to use Python entry points available with
+`package metadata <https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata>`_.
+
+For that, we need to create a small standalone Python project for our plugin.
+It requires only few files.
+
+Example tree structure of plugin project:
+
+.. code-block:: none
+
+    <plugin-project>
+    ├── pyproject.toml
+    └── src
+        └── <plugin-module-name>
+            ├── __init__.py
+            └── plugin.py
+
+    3 directories, 3 files
+
+Example content of ``pyproject.toml`` file:
+
+.. code-block:: toml
+
+    [project]
+    name = "<plugin-package-name>"
+    version = "0.1.0"
+    dependencies = ["cocotb"]
+
+    # https://packaging.python.org/en/latest/guides/tool-recommendations/#build-backends
+    [build-system]
+    requires = ["hatchling", "hatch-vcs"]
+    build-backend = "hatchling.build"
+
+Example content of ``plugin.py`` file:
+
+.. code-block:: python
+
+    """Plugin module."""
+
+    import cocotb.handle  # NOTE: workaround for cocotb circular dependency
+    from cocotb.regression import RegressionManager
+
+
+    class MyRegressionManager(RegressionManager):
+        def start_regression(self) -> None:
+            print("My own tests regression manager for cocotb! Start hacking...")
+
+            # Start default implementation of regression manager from cocotb or try to implement own
+            super().start_regression()
+
+
+    # cocotb_regression_manager function will be called automatically by cocotb plugin facility
+    def cocotb_regression_manager() -> type[RegressionManager]:
+        """Register new tests regression manager for cocotb."""
+        return MyRegressionManager
+
+
+Using Plugin in Projects
+========================
+
+To use cocotb plugin in our projects, we simple need to add it as dependency and
+define it as part of ``[project.entry-points.cocotb]`` entry in ``pyproject.toml`` file.
+
+Example content of ``pyproject.toml`` file in projects:
+
+.. code-block:: toml
+
+    [project]
+    name = "<my-awesome-project>"
+    version = "0.1.0"
+    dependencies = ["cocotb", "<plugin-package-name>"]
+
+    [project.entry-points.cocotb]
+    plugin-name = "<plugin-module-name>.plugin"
+
+List of Plugins
+===============
+
+* `pytest_cocotb <https://gitlab.com/tymonx/pytest-cocotb>`_ - Plugin to integrate `pytest`_ with cocotb.
+
+.. _pytest: https://docs.pytest.org

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from types import SimpleNamespace
 
     from cocotb._scheduler import Scheduler
+    from cocotb.factory import Factory
     from cocotb.handle import SimHandleBase
     from cocotb.regression import RegressionManager
 
@@ -70,6 +71,9 @@ _scheduler_inst: "Scheduler"
 
 _regression_manager: "RegressionManager"
 """The global regression manager instance."""
+
+_factory: "Factory"
+"""The global factory instance to create other objects."""
 
 argv: List[str]
 """The argument list as seen by the simulator."""

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -21,6 +21,7 @@ import cocotb.logging
 import cocotb.simtime
 import cocotb.simulator
 from cocotb._scheduler import Scheduler
+from cocotb.factory import Factory
 from cocotb.regression import RegressionManager, RegressionMode
 
 log: logging.Logger
@@ -50,8 +51,15 @@ def _shutdown_testbench() -> None:
         cb()
 
 
+def _setup_factory() -> None:
+    """Setup factory instance."""
+    cocotb._factory = Factory()
+
+
 def init_package_from_simulation(argv: List[str]) -> None:
     """Initialize the cocotb package from a simulation context."""
+
+    _setup_factory()
 
     # register a callback to be called if the simulation fails
     cocotb.simulator.set_sim_event_callback(_sim_event)
@@ -270,7 +278,7 @@ def _setup_root_handle() -> None:
 
 
 def _setup_regression_manager() -> None:
-    cocotb._regression_manager = RegressionManager()
+    cocotb._regression_manager = cocotb._factory.create(RegressionManager)
 
     # discover tests
     module_str = os.getenv("COCOTB_TEST_MODULES", "")

--- a/src/cocotb/factory.py
+++ b/src/cocotb/factory.py
@@ -1,0 +1,121 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Factory to create other objects."""
+
+import logging
+import sys
+from importlib import import_module
+from typing import Any, Callable
+
+# https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata
+if sys.version_info < (3, 10):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
+
+
+_logger = logging.getLogger(__name__)
+
+
+class Factory:
+    """Object to create other objects."""
+
+    def __init__(self):
+        """Create new instance of factory."""
+        self._plugins = [
+            import_module(entry_point.value)
+            for entry_point in metadata.entry_points(group="cocotb")
+        ]
+
+    def create(self, cls, *args, plugin_function: str = "", **kwargs) -> object:
+        """Create new object of requested class type.
+
+        It can be overload by defining `cocotb` entry point in `pyproject.toml` file:
+
+        .. code-block:: toml
+
+            [project.entry-points.cocotb]
+            <plugin-name> = "<python-module-name>"
+
+        And by defining `plugin_function` in `<python-module-name>`
+        that will return new extended class of `cls`.
+
+        .. code-block:: python
+
+            import cocotb.handle
+            from cocotb.regression import RegressionManager
+
+
+            class MyRegressionManager(RegressionManager):
+                pass
+
+
+            def cocotb_regression_manager() -> type[RegressionManager]:
+                return MyRegressionManager
+
+        Args:
+            cls: Requested class type of object to be created by factory.
+
+            args: Additional positional argument(s) passed directory to class constructor.
+
+            plugin_function: Name of plugin function that returns requested class type used by factory to create object.
+                If not provided, default is combination of `cocotb_` prefix with snake case of class type name.
+                Example: `cocotb_regression_manager`.
+
+            kwargs: Additional named argument(s) passed directory to class constructor.
+
+        Returns:
+            New object of requested class type, default implementation or from plugin.
+        """
+        obj: Any = None
+
+        if not plugin_function:
+            # Compose plugin function name
+            # Example: RegressionManager -> cocotb_regression_manager
+            plugin_function = "cocotb" + "".join(
+                "_" + c.lower() if c.isupper() else c for c in cls.__name__
+            )
+
+        for plugin in self._plugins:
+            # Specific plugin function was not provided, try with next plugin
+            if not hasattr(plugin, plugin_function):
+                continue
+
+            # Get class type needed to create new object by calling plugin function
+            function: Callable[[], Any] = getattr(plugin, plugin_function)
+            class_type: Callable[..., Any] | type | None = function()
+
+            # Class was not provided, try with next plugin
+            if not class_type:
+                continue
+
+            # Create object using class constructor or assign it as object
+            if isinstance(class_type, type):
+                obj = class_type(*args, **kwargs)
+            else:
+                obj = class_type  # already created object, assign it as is
+
+            _logger.debug(
+                "Created new instance of %s from plugin function %s.%s",
+                type(obj),
+                plugin.__name__,
+                plugin_function,
+            )
+
+            if not isinstance(obj, cls):
+                _logger.fatal(
+                    "Plugin function %s.%s must return extended class from %s",
+                    plugin.__name__,
+                    plugin_function,
+                    cls,
+                )
+
+            break
+
+        if not obj:
+            obj = cls(*args, **kwargs)
+            _logger.debug("Created new instance of %s", type(obj))
+
+        return obj

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -176,7 +176,9 @@ class RegressionManager:
 
         self.xunit = XUnitReporter(filename=results_filename)
         self.xunit.add_testsuite(name=suite_name, package=package_name)
-        self.xunit.add_property(name="random_seed", value=str(cocotb.RANDOM_SEED))
+        self.xunit.add_property(
+            name="random_seed", value=str(getattr(cocotb, "RANDOM_SEED", 0))
+        )
 
     def discover_tests(self, *modules: str) -> None:
         """Discover tests in files automatically.
@@ -892,5 +894,8 @@ class RegressionManager:
 
     def _fail_simulation(self, msg: str) -> None:
         self._sim_failure = Error(SimFailure(msg))
-        self._running_test.abort(self._sim_failure)
+
+        if hasattr(self, "_running_test"):
+            self._running_test.abort(self._sim_failure)
+
         cocotb._scheduler_inst._event_loop()

--- a/tests/pytest/test_factory.py
+++ b/tests/pytest/test_factory.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+import cocotb.handle  # noqa: F401 TODO: workaround for cocotb circular dependency
 from cocotb.factory import Factory
 from cocotb.regression import RegressionManager
 

--- a/tests/pytest/test_factory.py
+++ b/tests/pytest/test_factory.py
@@ -1,0 +1,128 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from cocotb.factory import Factory
+from cocotb.regression import RegressionManager
+
+# https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata
+if sys.version_info < (3, 10):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
+
+TEST: Path = Path(__file__).resolve()
+
+
+class MyRegressionManager(RegressionManager):
+    pass
+
+
+class InvalidRegressionManager:
+    pass
+
+
+def cocotb_regression_manager() -> type[RegressionManager]:
+    """Register new regression manager for cocotb."""
+    return MyRegressionManager
+
+
+def cocotb_regression_manager_none() -> None:
+    """Register new regression manager for cocotb."""
+
+
+def cocotb_regression_manager_object() -> RegressionManager:
+    """Register new regression manager for cocotb."""
+    return MyRegressionManager()
+
+
+def cocotb_regression_manager_invalid() -> InvalidRegressionManager:
+    """Register new regression manager for cocotb."""
+    return InvalidRegressionManager
+
+
+@pytest.fixture(name="mock_entry_points")
+def mock_entry_points_fixture() -> None:
+    # Setup
+    entry_points = metadata.entry_points
+    pythonpath = os.environ.get("PYTHONPATH", "")
+    os.environ["PYTHONPATH"] = str(TEST.parent)
+
+    def mock(**params) -> metadata.EntryPoints:
+        return metadata.EntryPoints(
+            (metadata.EntryPoint(name="myplugin", group="cocotb", value=TEST.stem),),
+        ).select(**params)
+
+    metadata.entry_points = mock
+
+    # Test
+    yield None
+
+    # Teardown
+    metadata.entry_points = entry_points
+    os.environ["PYTHONPATH"] = pythonpath
+
+
+def test_factory_create_default() -> None:
+    """Test cocotb factory to create other objects."""
+    obj = Factory().create(RegressionManager)
+
+    assert obj is not None
+    assert isinstance(obj, RegressionManager)
+    assert not isinstance(obj, MyRegressionManager)
+
+
+def test_factory_create_from_plugin_custom(mock_entry_points) -> None:
+    """Test cocotb factory to create other objects using plugin facility."""
+    obj = Factory().create(RegressionManager)
+
+    assert obj is not None
+    assert isinstance(obj, MyRegressionManager)
+
+
+def test_factory_create_from_plugin_none(mock_entry_points) -> None:
+    """Test cocotb factory to create other objects where plugin function returns None."""
+    obj = Factory().create(
+        RegressionManager, plugin_function="cocotb_regression_manager_none"
+    )
+
+    assert obj is not None
+    assert isinstance(obj, RegressionManager)
+    assert not isinstance(obj, MyRegressionManager)
+
+
+def test_factory_create_from_plugin_missing(mock_entry_points) -> None:
+    """Test cocotb factory to create other objects where plugin function is not available."""
+    obj = Factory().create(
+        RegressionManager, plugin_function="no_cocotb_regression_manager"
+    )
+
+    assert obj is not None
+    assert isinstance(obj, RegressionManager)
+    assert not isinstance(obj, MyRegressionManager)
+
+
+def test_factory_create_from_plugin_object(mock_entry_points) -> None:
+    """Test cocotb factory to create other objects where plugin function returns created object."""
+    obj = Factory().create(
+        RegressionManager, plugin_function="cocotb_regression_manager_object"
+    )
+
+    assert obj is not None
+    assert isinstance(obj, MyRegressionManager)
+
+
+def test_factory_create_from_plugin_invalid(mock_entry_points) -> None:
+    """Test cocotb factory to create other objects where plugin function returns invalid class type."""
+    obj = Factory().create(
+        RegressionManager, plugin_function="cocotb_regression_manager_invalid"
+    )
+
+    assert obj is not None
+    assert isinstance(obj, InvalidRegressionManager)


### PR DESCRIPTION
This feature allows to extend or replace default implementation of `RegressionManager` using plugin facility.

New plugin can be created as standalone Python project.

With this feature, it is now possible to integrate and use any kind of existing testing framework like [pytest](https://docs.pytest.org) with cocotb test functions.

Related issues:
- https://github.com/cocotb/cocotb/issues/4642
- https://github.com/cocotb/cocotb/issues/494

Using [pytest](https://docs.pytest.org) with `cocotb` test functions will be possible via Pytest/Cocotb plugin `pytest_cocotb`:
- https://gitlab.com/tymonx/pytest-cocotb

Above plugin will allow to use **ALL** [pytest](https://docs.pytest.org) capabilities like [fixtures support](https://docs.pytest.org/en/stable/explanation/fixtures.html), [tests parametrization](https://docs.pytest.org/en/stable/example/parametrize.html) and using any kind of existing [pytest plugins](https://docs.pytest.org/en/stable/reference/plugin_list.html). 

GitLab CI job examples:
- https://gitlab.com/tymonx/pytest-cocotb/-/jobs/11543337062

Remarks:
- Almost imperceptible changes in existing cocotb codebase
- Documentation `Writing cocotb Plugins`
- Unit tests with 100% code coverage for `cocotb.factory.Factory` class
- Moving support for [pytest](https://docs.pytest.org)  to separate project (shifting responsibilities)
- Possible to integrate and use other Python testing framework with cocotb test functions

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
