### PR TITLE
Remove reporting DeprecationWarnings by default

### DIFF
--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -67,12 +67,6 @@ def init_package_from_simulation(argv: List[str]) -> None:
     cocotb.logging._init()
     _setup_logging()
 
-    # From https://www.python.org/dev/peps/pep-0565/#recommended-filter-settings-for-test-runners
-    # If the user doesn't want to see these, they can always change the global
-    # warning settings in their test module.
-    if not sys.warnoptions:
-        warnings.simplefilter("default")
-
     cocotb.SIM_NAME = cocotb.simulator.get_simulator_product().strip()
     cocotb.SIM_VERSION = cocotb.simulator.get_simulator_version().strip()
 


### PR DESCRIPTION
The rationale is suspect. cocotb is a library. We don't need to inform the user of deprecations on every run. The intended way to deal with deprecations is to switch on warnings only when you intend to upgrade. We should only set this for our own internal testing, which we are by setting `PYTHONWARNINGS=error`.