### PR TITLE
Remove warnings about 2.0 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,3 @@
 * Join the discussion in the [Gitter chat room](https://gitter.im/cocotb/Lobby)
 * [Ask a question](https://github.com/cocotb/cocotb/discussions)
 * [Raise a bug / request an enhancement](https://github.com/cocotb/cocotb/issues/new)
-
-**Note: The current `master` branch of the cocotb repository is expected to be released as cocotb 2.0, which contains API-breaking changes from previous 1.x releases.**


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
