### PR TITLE
Clarify str vs range length mismatch when initializing LogicArray

### DIFF
--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -257,7 +257,7 @@ class LogicArray(AbstractMutableArray[Logic]):
             if range is not None:
                 if len(self._value_as_array) != len(range):
                     raise ValueError(
-                        f"Value of length {len(self._value_as_array)} will not fit in {range!r}"
+                        f"Value of length {len(self._value_as_array)} does not match bounds: {range!r}"
                     )
                 self._range = range
             else:


### PR DESCRIPTION
The exception message makes it seem that it should be possible to initialize a LogicArray
with a string as long as it fits within the range, but they need to have matching lengths.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
