### PR TITLE
Makefile.icarus: fix $WAVES to not override the default simulation behaviour

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.icarus
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.icarus
@@ -42,7 +42,7 @@ ifeq ($(WAVES), 1)
     VERILOG_SOURCES += $(SIM_BUILD)/cocotb_iverilog_dump.v
     COMPILE_ARGS += -s cocotb_iverilog_dump
     FST = -fst
-else
+else ifeq ($(WAVES), disable)
     # Disable waveform output
     FST = -none
 endif

--- a/src/cocotb_tools/makefiles/simulators/Makefile.icarus
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.icarus
@@ -42,7 +42,7 @@ ifeq ($(WAVES), 1)
     VERILOG_SOURCES += $(SIM_BUILD)/cocotb_iverilog_dump.v
     COMPILE_ARGS += -s cocotb_iverilog_dump
     FST = -fst
-else ifeq ($(WAVES), disable)
+else ifeq ($(WAVES),0)
     # Disable waveform output
     FST = -none
 endif


### PR DESCRIPTION
Previously this would inhibit any $dumpvar because -none was always appended to the end of the command line.  Which overrides $RUN_ARGS or any other user configuration (such as verilog $dumpfunc usage).

This does provide an undocumented $WAVES=disable which is not document because it is only relevant to this one simulation and not a feature I require to use.  But it allows anyone relying on the previous behaviour to restore it via undocumented configuration.  Although $RUN_ARGS=-none might also work for them as well.

Why this change: it breaks 1.9x behaviour, it did not seem possible to get any output VCD unless WAVES=1 which is not a feature I require to use and seems very limited in nature, useful for quick start example but the moment you want to configure something different you are stuck.
