### PR TITLE
Overhaul sources and build_args to maintain tag and value separately

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -37,6 +37,8 @@ Python Test Runner
 
 .. autoclass:: Verilog
 
+.. autoclass:: VerilatorControlFile
+
 .. autodata:: MAX_PARALLEL_BUILD_JOBS
 
 .. envvar:: GUI

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -294,7 +294,8 @@ class Runner(ABC):
         followed by *vhdl_sources* and *verilog_sources*, respectively.
 
         If your source files use an atypical file extension,
-        use :class:`VHDL` and :class:`Verilog` to tag the path as a VHDL or Verilog source file, respectively.
+        use :class:`VHDL`, :class:`Verilog`, or :class:`VerilatorControlFile`
+        to tag the path as a VHDL, Verilog, or Verilator control file source file, respectively.
         If the filepaths aren't tagged, the extension is used to determine if they are VHDL or Verilog files.
 
         +----------+------------------------------------+


### PR DESCRIPTION
Closes #5016. 

This re-implements the logic for tagging across all runners so that the tag and the value are kept separately. This should avoid any destruction of the tags as was reported in #5016. I can imagine this might need to spread to `elab_args`, `analysis_args`, etc. But we will cross that bridge when we get there.