### PR TITLE
Cleanup uses of `dut._log` in tests

### DIFF
--- a/tests/test_cases/issue_588/issue_588.py
+++ b/tests/test_cases/issue_588/issue_588.py
@@ -9,7 +9,7 @@ from cocotb.utils import get_sim_time
 async def sample_coroutine(dut):
     """Very simple coroutine that waits 5 ns."""
     await Timer(5, "ns")
-    dut._log.info("Sample coroutine yielded.")
+    cocotb.log.info("Sample coroutine yielded.")
 
 
 @cocotb.test()

--- a/tests/test_cases/test_async_bridge/test_async_bridge.py
+++ b/tests/test_cases/test_async_bridge/test_async_bridge.py
@@ -25,7 +25,7 @@ async def await_two_clock_edges(dut):
     await RisingEdge(dut.clk)
     await RisingEdge(dut.clk)
     await Timer(1, unit="ns")
-    dut._log.info("Returning from await_two_clock_edges")
+    cocotb.log.info("Returning from await_two_clock_edges")
     return 2
 
 
@@ -111,11 +111,11 @@ async def test_consecutive_bridges(dut):
     Test that multiple @bridge functions can be called in the same test
     """
     value = await bridge(return_two)(dut)
-    dut._log.info("First one completed")
+    cocotb.log.info("First one completed")
     assert value == 2
 
     value = await bridge(return_two)(dut)
-    dut._log.info("Second one completed")
+    cocotb.log.info("Second one completed")
     assert value == 2
 
 
@@ -126,7 +126,7 @@ async def test_bridge_from_readonly(dut):
     can be called from ReadOnly state
     """
     await ReadOnly()
-    dut._log.info("In readonly")
+    cocotb.log.info("In readonly")
     value = await bridge(return_two)(dut)
     assert value == 2
 
@@ -140,7 +140,7 @@ async def test_resume_from_readonly(dut):
     cocotb.start_soon(Clock(dut.clk, 100, unit="ns").start())
 
     await ReadOnly()
-    dut._log.info("In readonly")
+    cocotb.log.info("In readonly")
     value = await bridge(calls_resume)(dut)
     assert value == 2
 
@@ -194,13 +194,13 @@ async def test_bridge_from_start_soon(dut):
     coro1 = cocotb.start_soon(run_function(dut))
     value = await coro1
     assert value == 2
-    dut._log.info("Back from join 1")
+    cocotb.log.info("Back from join 1")
 
     value = 0
     coro2 = cocotb.start_soon(run_bridge(dut))
     value = await coro2
     assert value == 2
-    dut._log.info("Back from join 2")
+    cocotb.log.info("Back from join 2")
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_edge_triggers.py
+++ b/tests/test_cases/test_cocotb/test_edge_triggers.py
@@ -40,15 +40,15 @@ async def count_edges_cycles(signal, edges):
     edge = RisingEdge(signal)
     for i in range(edges):
         await edge
-        signal._log.info("Rising edge %d detected", i)
-    signal._log.info("Finished, returning %d", edges)
+        cocotb.log.info("Rising edge %d detected", i)
+    cocotb.log.info("Finished, returning %d", edges)
     return edges
 
 
 async def do_single_edge_check(dut, level):
     """Do test for rising edge"""
     old_value = dut.clk.value
-    dut._log.info("Value of %s is %d", dut.clk._path, old_value)
+    cocotb.log.info("Value of %s is %d", dut.clk._path, old_value)
     assert old_value != level
     if level == 1:
         await RisingEdge(dut.clk)
@@ -129,7 +129,7 @@ async def test_fork_and_monitor(dut, period=1000, clocks=6):
         result = await First(timer, task)
         assert count <= expect, "Task didn't complete in expected time"
         if result is timer:
-            dut._log.info("Count %d: Task still running", count)
+            cocotb.log.info("Count %d: Task still running", count)
             count += 1
         else:
             break

--- a/tests/test_cases/test_cocotb/test_logging.py
+++ b/tests/test_cases/test_cocotb/test_logging.py
@@ -56,18 +56,18 @@ class StrCallCounter:
 @cocotb.test()
 async def test_logging_with_args(dut):
     counter = StrCallCounter()
-    dut._log.setLevel(
+    cocotb.log.setLevel(
         logging.INFO
     )  # To avoid logging debug message, to make next line run without error
-    dut._log.debug("%s", counter)
+    cocotb.log.debug("%s", counter)
     assert counter.str_counter == 0
 
-    dut._log.info("%s", counter)
+    cocotb.log.info("%s", counter)
     assert counter.str_counter == 1
 
-    dut._log.info("No substitution")
+    cocotb.log.info("No substitution")
 
-    dut._log.warning("Testing multiple line\nmessage")
+    cocotb.log.warning("Testing multiple line\nmessage")
 
 
 @cocotb.test()

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -146,7 +146,7 @@ async def recursive_discover(dut):
         if not isinstance(obj, (HierarchyObject, HierarchyArrayObject, ArrayObject)):
             return
         for thing in obj:
-            dut._log.debug("Found %s (%s)", thing._name, type(thing))
+            cocotb.log.debug("Found %s (%s)", thing._name, type(thing))
             _discover(thing)
 
     _discover(dut)
@@ -489,7 +489,7 @@ async def discover_all_in_component_vhdl(dut):
         count = 0
         for thing in obj:
             count += 1
-            dut._log.info("Found %s (%s)", thing._path, type(thing))
+            cocotb.log.info("Found %s (%s)", thing._path, type(thing))
             count += _discover(thing)
         return count
 

--- a/tests/test_cases/test_dumpfile_verilator/test_dumpfile_verilator.py
+++ b/tests/test_cases/test_dumpfile_verilator/test_dumpfile_verilator.py
@@ -14,7 +14,7 @@ async def reset_dut(reset_n, duration_ns):
     reset_n.value = 0
     await Timer(duration_ns)
     reset_n.value = 1
-    reset_n._log.debug("Reset complete")
+    cocotb.log.debug("Reset complete")
 
 
 @cocotb.test()

--- a/tests/test_cases/test_iteration_verilog/test_iteration_es.py
+++ b/tests/test_cases/test_iteration_verilog/test_iteration_es.py
@@ -54,7 +54,7 @@ async def recursive_discovery(dut):
 
 async def iteration_loop(dut):
     for thing in dut:
-        thing._log.info("Found something: %s", thing._path)
+        cocotb.log.info("Found something: %s", thing._path)
 
 
 @cocotb.test()

--- a/tests/test_cases/test_iteration_vhdl/test_iteration.py
+++ b/tests/test_cases/test_iteration_vhdl/test_iteration.py
@@ -71,19 +71,14 @@ async def recursive_discovery(dut):
     assert total == pass_total
 
 
-# GHDL unable to access signals in generate loops (gh-2594)
-@cocotb.test(
-    expect_error=IndexError if cocotb.SIM_NAME.lower().startswith("ghdl") else ()
-)
+@cocotb.test
 async def discovery_all(dut):
     """Discover everything on top-level."""
-    dut._log.info("Iterating over top-level to discover objects")
+    cocotb.log.info("Iterating over top-level to discover objects")
     for thing in dut:
-        thing._log.info("Found something: %s", thing._path)
+        cocotb.log.info("Found something: %s", thing._path)
 
-    dut._log.info("length of dut.inst_acs is %d", len(dut.gen_acs))
-    item = dut.gen_acs[3]
-    item._log.info("this is item")
+    cocotb.log.info("length of dut.inst_acs is %d", len(dut.gen_acs))
 
 
 @cocotb.test()
@@ -92,7 +87,7 @@ async def dual_iteration(dut):
 
     async def iteration_loop():
         for thing in dut:
-            thing._log.info("Found something: %s", thing._path)
+            cocotb.log.info("Found something: %s", thing._path)
             await Timer(1)
 
     loop_one = cocotb.start_soon(iteration_loop())

--- a/tests/test_cases/test_select_testcase_error/x_tests.py
+++ b/tests/test_cases/test_select_testcase_error/x_tests.py
@@ -7,4 +7,4 @@ import cocotb
 
 @cocotb.test()
 async def x_test(dut):
-    dut._log.info("x_test")
+    cocotb.log.info("x_test")


### PR DESCRIPTION
This was "made private" in 2.0 but we are still giving users bad ideas.