### PR TITLE
Explicitly support MacOS arm64

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 25
+        after_n_builds: 26
 
 coverage:
     status:

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -279,7 +279,7 @@ ENVS = [
         "group": "extended",
     },
     # Test other OSes
-    # Icarus homebrew
+    # Icarus homebrew (ARM64)
     {
         "lang": "verilog",
         "sim": "icarus",
@@ -288,7 +288,7 @@ ENVS = [
         "python-version": "3.9",
         "group": "ci-free",
     },
-    # Icarus homebrew (HEAD/master)
+    # Icarus homebrew (ARM64) (HEAD/master)
     {
         "lang": "verilog",
         "sim": "icarus",
@@ -297,7 +297,7 @@ ENVS = [
         "python-version": "3.9",
         "group": "experimental",
     },
-    # Verilator macOS HEAD
+    # Verilator macOS (ARM64) HEAD
     {
         "lang": "verilog",
         "sim": "verilator",
@@ -306,12 +306,21 @@ ENVS = [
         "python-version": "3.9",
         "group": "experimental",
     },
-    # Verilator macOS latest release
+    # Verilator macOS (ARM64) latest release
     {
         "lang": "verilog",
         "sim": "verilator",
         "sim-version": "v5.038",  # not latest, but v5.040 is broken on MacOS
         "os": "macos-14",
+        "python-version": "3.9",
+        "group": "ci-free",
+    },
+    # Icarus homebrew (x86)
+    {
+        "lang": "verilog",
+        "sim": "icarus",
+        "sim-version": "homebrew-stable",
+        "os": "macos-15-intel",
         "python-version": "3.9",
         "group": "ci-free",
     },

--- a/docs/source/newsfragments/5056.feature.rst
+++ b/docs/source/newsfragments/5056.feature.rst
@@ -1,0 +1,1 @@
+Support MacOS ARM64 builds and provide pre-built wheels.

--- a/docs/source/platform_support.rst
+++ b/docs/source/platform_support.rst
@@ -70,13 +70,15 @@ Supported Windows Versions
 * **Windows 10 x86_64**
 * **Windows 11 x86_64**
 
-
 Supported macOS Versions
 ========================
 
 * **macOS 13 (Ventura) x86_64**
 * **macOS 14 (Sonoma) x86_64**
 * **macOS 15 (Sequoia) x86_64**
+* **macOS 13 (Ventura) ARM64**
+* **macOS 14 (Sonoma) ARM64**
+* **macOS 15 (Sequoia) ARM64**
 
 .. _platform-support-policy:
 


### PR DESCRIPTION
2.0.0 release provides builds for both ARM64 and x86_64 on Mac, but we don't mention that in the docs,or test it in CI. Turns out Github Actions has a free MacOS x86 runner, so we use that. Also we fix up the docs to explicitly mention we support MacOS ARM64.
