### PR TITLE
Make `cocotb.RANDOM_SEED` the current test seed

### DIFF
--- a/docs/source/newsfragments/5082.change.rst
+++ b/docs/source/newsfragments/5082.change.rst
@@ -1,0 +1,1 @@
+The value of :data:`cocotb.RANDOM_SEED` is now modified for the duration of a test to be that tests's seed, rather than the regression-wide seed.

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -89,11 +89,13 @@ SIM_VERSION: str
 """The version of the running simulator."""
 
 RANDOM_SEED: int
-"""
-The value passed to the Python global random number generator.
+"""The last value used to seed the global PRNG.
 
-See :envvar:`COCOTB_RANDOM_SEED` for details on how the value is computed.
-This is guaranteed to hold a value at test time.
+During test collection, this is set to the value provided by :envvar:`COCOTB_RANDOM_SEED`,
+if given, or a random value based on the state of the operating system.
+
+During test run, this is set to a new value computed by combining the value used during test collection,
+with the full test name (e.g. ``my_test_module.my_test``).
 """
 
 top: SimHandleBase


### PR DESCRIPTION
Closes #5066.

This is done to ensure that anyone who grabs `cocotb.RANDOM_SEED` in a test for seeding a new PRNG is using the current test's random seed and not the regression-wide random seed to prevent random sequences from being the same on similar tests.