### PR TITLE
Remove `InternalError`

### DIFF
--- a/src/cocotb/_bridge.py
+++ b/src/cocotb/_bridge.py
@@ -20,7 +20,6 @@ from typing import (
 import cocotb
 from cocotb import debug
 from cocotb._base_triggers import Event, Trigger
-from cocotb._exceptions import InternalError
 from cocotb._outcomes import Error, Outcome, Value, capture
 
 if sys.version_info >= (3, 10):
@@ -128,7 +127,7 @@ class external_waiter(Generic[Result]):
     @property
     def result(self) -> Result:
         if self._outcome is None:
-            raise InternalError("Got result of external before it finished")
+            raise RuntimeError("Got result of external before it finished")
         return self._outcome.get()
 
     def _propagate_state(self, new_state: external_state) -> None:

--- a/src/cocotb/_exceptions.py
+++ b/src/cocotb/_exceptions.py
@@ -1,8 +1,0 @@
-# Copyright cocotb contributors
-# Licensed under the Revised BSD License, see LICENSE for details.
-# SPDX-License-Identifier: BSD-3-Clause
-from __future__ import annotations
-
-
-class InternalError(BaseException):
-    """An error internal to scheduler. If you see this, report a bug!"""

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -16,7 +16,6 @@ import cocotb
 import cocotb._event_loop
 from cocotb._base_triggers import NullTrigger, Trigger
 from cocotb._deprecation import deprecated
-from cocotb._exceptions import InternalError
 from cocotb._outcomes import Error, Outcome, Value
 from cocotb._test_functions import TestSuccess
 from cocotb.task import ResultType, Task
@@ -72,7 +71,7 @@ class RunningTest:
 
     def result(self) -> Outcome[None]:
         if self._outcome is None:  # pragma: no cover
-            raise InternalError("Getting result before test is completed")
+            raise RuntimeError("Getting result before test is completed")
 
         if not isinstance(self._outcome, Error) and self._shutdown_errors:
             return self._shutdown_errors[0]


### PR DESCRIPTION
Users will no longer be able to catch these exceptions, so there's no reason to make it a different type.
