### PR TITLE
Fixed typo in _determine_file_type

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -153,7 +153,7 @@ def _determine_file_type(
         return Verilog
     elif ext in _vhdl_extensions:
         return VHDL
-    elif ext == "vlt":
+    elif ext == ".vlt":
         return VerilatorControlFile
     else:
         raise ValueError(


### PR DESCRIPTION
Very minor bug fix for typo in _determine_file_type func in runner.py