### PR TITLE
CI: Add test for VHDL integer signal value change trigger

### DIFF
--- a/tests/test_cases/test_vhdl_integer/Makefile
+++ b/tests/test_cases/test_vhdl_integer/Makefile
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+ifeq ($(TOPLEVEL_LANG),vhdl)
+
+ifneq ($(filter $(SIM),ius xcelium),)
+    COMPILE_ARGS += -v93
+endif
+
+COCOTB_TOPLEVEL := vhdl_integer
+COCOTB_TEST_MODULES := test_vhdl_integer
+VHDL_SOURCES := vhdl_integer.vhdl
+
+# cocotb inclusions
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+else
+all:
+	$(info Skipping simulation as only TOPLEVEL_LANG=vhdl is supported)
+
+clean::
+
+endif

--- a/tests/test_cases/test_vhdl_integer/test_vhdl_integer.py
+++ b/tests/test_cases/test_vhdl_integer/test_vhdl_integer.py
@@ -1,0 +1,43 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import cocotb
+from cocotb.triggers import Combine
+
+SIM_NAME = cocotb.SIM_NAME.lower()
+
+
+async def wait_value_change(signal, expected_value) -> None:
+    await signal.value_change
+    current_value = signal.value
+    assert current_value == expected_value, (
+        f"Signal {signal} current value {current_value} didn't match expected value {expected_value}"
+    )
+
+
+@cocotb.test(timeout_time=15, timeout_unit="ns")
+async def vhdl_integer_valuechange(dut) -> None:
+    dut.i_int.value = 0
+
+    await Combine(
+        cocotb.start_soon(wait_value_change(dut.o_int, 0)),
+        cocotb.start_soon(wait_value_change(dut.s_int, 1)),
+    )
+
+
+@cocotb.xfail(
+    SIM_NAME.startswith("ghdl"),
+    raises=AttributeError,
+    reason="GHDL is unable to access record signals (gh-2591)",
+)
+@cocotb.test(timeout_time=15, timeout_unit="ns")
+async def vhdl_record_integer_valuechange(dut) -> None:
+    a_val = dut.s_ints.a.value
+    b_val = dut.s_ints.b.value
+
+    await Combine(
+        cocotb.start_soon(wait_value_change(dut.s_ints.a, a_val + 1)),
+        cocotb.start_soon(wait_value_change(dut.s_ints.b, b_val + 1)),
+    )

--- a/tests/test_cases/test_vhdl_integer/vhdl_integer.vhdl
+++ b/tests/test_cases/test_vhdl_integer/vhdl_integer.vhdl
@@ -1,0 +1,37 @@
+-- Copyright cocotb contributors
+-- Licensed under the Revised BSD License, see LICENSE for details.
+-- SPDX-License-Identifier: BSD-3-Clause
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity vhdl_integer is
+  port(
+    i_int : in  integer;
+    o_int : out integer
+  );
+end entity vhdl_integer;
+
+architecture RTL of vhdl_integer is
+  signal s_int : integer := 0;
+
+  type ints is record
+    a : integer;
+    b : integer;
+  end record ints;
+
+  signal s_ints : ints := (1, 2);
+begin
+
+  process
+  begin
+    wait for 10 ns;
+    s_int <= s_int + 1;
+    s_ints.a <= s_ints.a + 1;
+    s_ints.b <= s_ints.b + 1;
+
+  end process;
+
+  o_int <= transport i_int after 10 ns;
+
+end architecture RTL;


### PR DESCRIPTION
I think I am seeing an issue with RivieraPRO not firing a `ValueChange` trigger on an integer signal, so adding a test to CI to check it.