### PR TITLE
Implement verbose option in Questa runner

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -946,6 +946,10 @@ class Questa(Runner):
 
         cmds.append(["vlib", _as_tcl_value(self.hdl_library)])
 
+        verbosity_opts = []
+        if not self.verbose:
+            verbosity_opts += ["-quiet"]
+
         vhdl_args = [
             _as_tcl_value(arg.value)
             for arg in self._build_args
@@ -965,6 +969,7 @@ class Questa(Runner):
                 cmds.append(
                     [
                         "vcom",
+                        *verbosity_opts,
                         "-work",
                         hdl_library,
                         *vhdl_args,
@@ -975,6 +980,7 @@ class Questa(Runner):
                 cmds.append(
                     [
                         "vlog",
+                        *verbosity_opts,
                         *([] if self.always else ["-incr"]),
                         "-work",
                         hdl_library,
@@ -992,6 +998,10 @@ class Questa(Runner):
 
     def _test_command(self) -> list[_Command]:
         cmds = []
+
+        verbosity_opts = []
+        if not self.verbose:
+            verbosity_opts += ["-quiet"]
 
         if self.pre_cmd is not None:
             pre_cmd = ["-do", *self.pre_cmd]
@@ -1033,6 +1043,7 @@ class Questa(Runner):
 
         cmds.append(
             ["vsim"]
+            + verbosity_opts
             + ["-gui" if self.gui else "-c"]
             + ["-onfinish", "stop" if self.gui else "exit"]
             + lib_opts


### PR DESCRIPTION
Pretty minor change: Adds support for the `verbose` option for the Questa runner.

For consistency, I mirrored the style already being used in the Xcelium and VCS runners

# verbose=False
```
Errors: 0, Warnings: 1
Reading pref.tcl

# 2024.1

# vsim -quiet -c -onfinish exit -pli "/home/alex/dev/cocotb/src/cocotb/libs/libcocotbvpi_modelsim.so" -suppress 13314 -vcddump out.vcd top.my_design -do "run -all; quit"
# Start time: 09:24:36 on Oct 26,2025
# ** Note: (vsim-3812) Design is being optimized...
# ** Warning: (vsim-3865) Due to PLI being present, global +acc is being enabled automatically. This will cause your simulation to run very slowly. Please use vsim -no_autoacc to disable this feature. This feature is now deprecated and will be removed from future releases.
# ** Warning: (vopt-10587) Some optimizations are turned off because the +acc switch is in effect. This will cause your simulation to run slowly. Please use -access/-debug to maintain needed visibility.
# ** Note: (vsim-12126) Error and warning message counts have been restored: Errors=0, Warnings=2.
# //  Questa Intel Starter FPGA Edition-64
# //  Version 2024.1 linux_x86_64 Apr 19 2024
# //
# // Unpublished work. Copyright 2024 Siemens
# //
# // This material contains trade secrets or otherwise confidential information
# // owned by Siemens Industry Software Inc. or its affiliates (collectively,
# // "SISW"), or its licensors. Access to and use of this information is strictly
# // limited as set forth in the Customer's applicable agreements with SISW.
# //
# // This material may not be copied, distributed, or otherwise disclosed outside
# // of the Customer's facilities without the express written permission of SISW,
# // and may not be used in any way not expressly authorized by SISW.
# //
#      -.--ns INFO     gpi                                ..mbed/gpi_embed.cpp:93   in _embed_init_python              Using Python 3.10.12 interpreter at /home/alex/dev/cocotb_test/.venv/bin/python3
#      -.--ns INFO     gpi                                ../gpi/GpiCommon.cpp:79   in gpi_print_registered_impl       VPI registered
#      -.--ns INFO     gpi                                ../gpi/GpiCommon.cpp:79   in gpi_print_registered_impl       FLI registered
# run -all
#      0.00ns INFO     cocotb                             Running on ModelSim for QuestaIntel Starter FPGA Edition-64 version 2024.1 2024.04
#      0.00ns INFO     cocotb                             Seeding Python random module with 1761495877
#      0.00ns INFO     cocotb                             Initialized cocotb v2.1.0.dev0+6b39b126 from /home/alex/dev/cocotb/src/cocotb
#      0.00ns INFO     cocotb                             Running tests
#      0.00ns INFO     cocotb.regression                  running test_my_design.my_second_test (1/1)
#                                                             Try accessing the design.
#     23.00ns INFO     cocotb.regression                  test_my_design.my_second_test passed
#     23.00ns INFO     cocotb.regression                  ***************************************************************************************
#                                                         ** TEST                           STATUS  SIM TIME (ns)  REAL TIME (s)  RATIO (ns/s) **
#                                                         ***************************************************************************************
#                                                         ** test_my_design.my_second_test   PASS          23.00           0.05        489.36  **
#                                                         ***************************************************************************************
#                                                         ** TESTS=1 PASS=1 FAIL=0 SKIP=0                  23.00           0.05        451.48  **
#                                                         ***************************************************************************************
# ** Note: $finish    : UNKNOWN(-1)
#    Time: 23 ns  Iteration: 2  Instance: /my_design File: /home/alex/dev/cocotb_test/my_design.sv
# End time: 09:24:37 on Oct 26,2025, Elapsed time: 0:00:01
# Errors: 0, Warnings: 2, Suppressed Warnings: 1
```

# verbose=True
```
** Warning: (vlib-34) Library already exists at "top".
Errors: 0, Warnings: 1
Questa Intel Starter FPGA Edition-64 vlog 2024.1 Compiler 2024.04 Apr 19 2024
Start time: 09:26:51 on Oct 26,2025
vlog -incr -work top -sv /home/alex/dev/cocotb_test/my_design.sv
-- Compiling package foo
** Warning: /home/alex/dev/cocotb_test/my_design.sv(12): (vlog-13314) Defaulting port 'hwif' kind to 'var' rather than 'wire' due to default compile option setting of -svinputport=relaxed.
-- Compiling module my_design

Top level modules:
	my_design
End time: 09:26:51 on Oct 26,2025, Elapsed time: 0:00:00
Errors: 0, Warnings: 1
Reading pref.tcl

# 2024.1

# vsim -c -onfinish exit -pli "/home/alex/dev/cocotb/src/cocotb/libs/libcocotbvpi_modelsim.so" -suppress 13314 -vcddump out.vcd top.my_design -do "run -all; quit"
# Start time: 09:26:52 on Oct 26,2025
# ** Note: (vsim-3812) Design is being optimized...
# ** Warning: (vsim-3865) Due to PLI being present, global +acc is being enabled automatically. This will cause your simulation to run very slowly. Please use vsim -no_autoacc to disable this feature. This feature is now deprecated and will be removed from future releases.
# ** Warning: (vopt-10587) Some optimizations are turned off because the +acc switch is in effect. This will cause your simulation to run slowly. Please use -access/-debug to maintain needed visibility.
# ** Note: (vsim-12126) Error and warning message counts have been restored: Errors=0, Warnings=2.
# //  Questa Intel Starter FPGA Edition-64
# //  Version 2024.1 linux_x86_64 Apr 19 2024
# //
# // Unpublished work. Copyright 2024 Siemens
# //
# // This material contains trade secrets or otherwise confidential information
# // owned by Siemens Industry Software Inc. or its affiliates (collectively,
# // "SISW"), or its licensors. Access to and use of this information is strictly
# // limited as set forth in the Customer's applicable agreements with SISW.
# //
# // This material may not be copied, distributed, or otherwise disclosed outside
# // of the Customer's facilities without the express written permission of SISW,
# // and may not be used in any way not expressly authorized by SISW.
# //
# Loading sv_std.std
# Loading work.foo(fast)
# Loading work.my_design(fast)
# Loading /home/alex/dev/cocotb/src/cocotb/libs/libcocotbvpi_modelsim.so
#      -.--ns INFO     gpi                                ..mbed/gpi_embed.cpp:93   in _embed_init_python              Using Python 3.10.12 interpreter at /home/alex/dev/cocotb_test/.venv/bin/python3
#      -.--ns INFO     gpi                                ../gpi/GpiCommon.cpp:79   in gpi_print_registered_impl       VPI registered
#      -.--ns INFO     gpi                                ../gpi/GpiCommon.cpp:79   in gpi_print_registered_impl       FLI registered
# run -all
#      0.00ns INFO     cocotb                             Running on ModelSim for QuestaIntel Starter FPGA Edition-64 version 2024.1 2024.04
#      0.00ns INFO     cocotb                             Seeding Python random module with 1761496013
#      0.00ns INFO     cocotb                             Initialized cocotb v2.1.0.dev0+6b39b126 from /home/alex/dev/cocotb/src/cocotb
#      0.00ns INFO     cocotb                             Running tests
#      0.00ns INFO     cocotb.regression                  running test_my_design.my_second_test (1/1)
#                                                             Try accessing the design.
#     23.00ns INFO     cocotb.regression                  test_my_design.my_second_test passed
#     23.00ns INFO     cocotb.regression                  ***************************************************************************************
#                                                         ** TEST                           STATUS  SIM TIME (ns)  REAL TIME (s)  RATIO (ns/s) **
#                                                         ***************************************************************************************
#                                                         ** test_my_design.my_second_test   PASS          23.00           0.03        727.37  **
#                                                         ***************************************************************************************
#                                                         ** TESTS=1 PASS=1 FAIL=0 SKIP=0                  23.00           0.04        645.23  **
#                                                         ***************************************************************************************
# ** Note: $finish    : UNKNOWN(-1)
#    Time: 23 ns  Iteration: 2  Instance: /my_design File: /home/alex/dev/cocotb_test/my_design.sv
# End time: 09:26:53 on Oct 26,2025, Elapsed time: 0:00:01
# Errors: 0, Warnings: 2, Suppressed Warnings: 1
```
