### PR TITLE
Move project description to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,46 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "cocotb"
+description = "Python-based chip (RTL) verification"
+readme = "README.md"
+license = "BSD-3-Clause"
+license-files = [
+    "LICENSE"
+]
+authors = [
+    {name = "Chris Higgs"},
+    {name = "Stuart Hodgson"},
+]
+maintainers = [
+    {name = "Kaleb Barrett"},
+    {name = "Tomasz Hemperek"},
+    {name = "Marlon James"},
+    {name = "Colin Marquardt"},
+    {name = "Philipp Wagner"},
+]
+dependencies = [
+    "find_libpython",
+]
+requires-python = ">= 3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Framework :: cocotb",
+]
+dynamic = ["version"]
+
+[project.scripts]
+cocotb-config = "cocotb_tools.config:main"
+
+[project.urls]
+Homepage = "https://www.cocotb.org"
+Documentation = "https://docs.cocotb.org"
+Repository = "https://github.com/cocotb/cocotb"
+Issues = "https://github.com/cocotb/cocotb/issues"
+
+
 [tool.towncrier]
     package = "cocotb"
     directory = "docs/source/newsfragments"

--- a/setup.py
+++ b/setup.py
@@ -65,21 +65,8 @@ log.setLevel(logging.INFO)
 log.addHandler(handler)
 
 setup(
-    name="cocotb",
     cmdclass={"build_ext": build_ext},
     version=__version__,
-    description="cocotb is a coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python.",
-    url="https://www.cocotb.org",
-    license="BSD-3-Clause",
-    long_description=read_file("README.md"),
-    long_description_content_type="text/markdown",
-    author="Chris Higgs, Stuart Hodgson",
-    maintainer="cocotb contributors",
-    maintainer_email="cocotb@lists.librecores.org",
-    install_requires=[
-        "find_libpython",
-    ],
-    python_requires=">=3.9",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     package_data={
@@ -91,28 +78,6 @@ setup(
         "cocotb_tools": (package_files("src/cocotb_tools/makefiles")),
     },
     ext_modules=get_ext(),
-    entry_points={
-        "console_scripts": [
-            "cocotb-config=cocotb_tools.config:main",
-        ]
-    },
-    platforms="any",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
-        "Framework :: cocotb",
-    ],
-    # these appear in the sidebar on PyPI
-    project_urls={
-        "Bug Tracker": "https://github.com/cocotb/cocotb/issues",
-        "Source Code": "https://github.com/cocotb/cocotb",
-        "Documentation": "https://docs.cocotb.org",
-    },
 )
 
 print(log_stream.getvalue())


### PR DESCRIPTION
This PR moves the static parts of the cocotb project configuration from setup.py to pyproject.toml. This should allow us to use uv going forward.

Also while working on this I discovered that our package data file spec was a mess and it was just including everything in the final wheels. This was fixed by:
* Remove the `MANIFEST.in` and setting `include_package_data=False` which when `True` turns off `package_data`.
* Correct the specification of `package_data`.