### PR TITLE
tests: Test that multiple waits on First will catch coincident triggers

### DIFF
--- a/tests/test_cases/test_first_on_coincident_triggers/test_first_on_coincident_triggers.py
+++ b/tests/test_cases/test_first_on_coincident_triggers/test_first_on_coincident_triggers.py
@@ -4,10 +4,16 @@
 from __future__ import annotations
 
 import logging
+import os
 import unittest
 
 import cocotb
 from cocotb.triggers import First, RisingEdge, Timer
+from cocotb.utils import get_sim_time
+
+SIM_NAME = cocotb.SIM_NAME.lower()
+LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
+VHDL_INTF = os.environ.get("VHDL_GPI_INTERFACE", "fli").strip()
 
 
 @cocotb.test()
@@ -28,3 +34,56 @@ async def test_first_on_coincident_trigger(dut) -> None:
         assert (
             "No coroutines waiting on trigger that fired" not in logs.records[0].message
         )
+
+
+@cocotb.xfail(
+    SIM_NAME.startswith("nvc"),
+    reason="NVC doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
+)
+@cocotb.xfail(
+    SIM_NAME.startswith("verilator"),
+    reason="Verilator doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
+)
+@cocotb.xfail(
+    SIM_NAME.startswith("riviera"),
+    reason="Riviera doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
+)
+@cocotb.xfail(
+    SIM_NAME.startswith("xmsim") and LANGUAGE in ["vhdl"],
+    reason="xcelium doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
+)
+@cocotb.xfail(
+    SIM_NAME.startswith("modelsim") and LANGUAGE in ["vhdl"] and VHDL_INTF in ["vhpi"],
+    reason="Questa doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
+)
+@cocotb.skipif(
+    SIM_NAME.startswith("modelsim") and LANGUAGE in ["vhdl"] and VHDL_INTF in ["fli"],
+    reason="Questa will segfault",
+)
+@cocotb.xfail(
+    SIM_NAME.startswith("ghdl"),
+    reason="GHDL doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
+)
+# Setting timeout because even though GHDL fails the test correctly, it gets stuck and doesn't finish simulation (gh-4997)
+@cocotb.test(timeout_time=100, timeout_unit="ns")
+async def test_repeated_first_no_missed_edges(dut) -> None:
+    """Test that waiting on First() twice will catch both triggers that happen at the same simulation time."""
+    a_count = 0
+    b_count = 0
+
+    start_time = get_sim_time("ns")
+    end_time = start_time + 30
+
+    while True:
+        trigger = await First(RisingEdge(dut.a), RisingEdge(dut.b))
+        if get_sim_time("ns") > end_time:
+            break
+        signal = trigger.signal
+        cocotb.log.info(f"Fired: {signal._name} at {get_sim_time('ns')}")
+        if signal is dut.a:
+            a_count += 1
+        elif signal is dut.b:
+            b_count += 1
+
+    assert a_count == 2
+    assert b_count == 2


### PR DESCRIPTION
If two signals change value at the same time step, we should be able to get both of them if we wait on `First()` in a loop.
We wait on `First()` the second time before returning from the first callback, and should get the second one.

This probably won't work currently on some simulators,
as we register a new simulator value change callback rather than keeping a list of GPI user callbacks associated with a single simulator callback.