### PR TITLE
Remove blurb about cocotb-bus from docs

### DIFF
--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -26,30 +26,8 @@ Assuming an extension named ``EXTNAME`` (all lower-case),
 - the package is in the ``cocotbext.EXTNAME`` namespace, and
 - the distribution (package) name is prefixed with ``cocotbext-EXTNAME``.
 
-Example:
-An SPI bus extension might be packaged as ``cocotbext-spi``, and its functionality would live in the ``cocotbext.spi`` namespace.
+For example, a SPI bus extension might be packaged as ``cocotbext-spi``, and its functionality would live in the ``cocotbext.spi`` namespace.
 The module can then be installed with ``pip3 install cocotbext-spi``, and used with ``import cocotbext.spi``.
-
-Types of cocotb extensions
-==========================
-
-For some types of cocotb extensions we have developed conventions which go beyond naming.
-These conventions help to achieve a consistent behavior across extensions of the same type.
-
-Bus extensions
---------------
-
-A cocotb extension which interacts with a bus or an interface (such as SPI or AXI) should build on top of a common set of classes to provide a uniform interface for its users.
-Typically, a bus extension provides three pieces of functionality:
-an abstraction of the bus itself, a bus driver, and a bus monitor.
-
-A bus driver is the "active" part, it drives the signals that make up the bus to request reads or writes from the bus.
-A bus monitor is the "passive" part, it observes signal changes on the bus and assigns meaning to them.
-Monitors can also check the bus behavior against a standard to ensure no invalid states are being observed.
-
-The signals which make up the bus should be grouped in a class inheriting from :class:`cocotb_bus.bus.Bus`.
-Bus drivers should inherit from the :class:`cocotb_bus.drivers.BusDriver` class.
-Bus monitors should inherit from the :class:`cocotb_bus.monitors.BusMonitor` class.
 
 Packaging extensions
 ====================


### PR DESCRIPTION
We don't want people using it, so we should stop mentioning it.