### PR TITLE
CI: Disable VCS due to missing license

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 23
+        after_n_builds: 22
 
 coverage:
     status:

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -415,7 +415,7 @@ ENVS = [
         "os": "ubuntu-22.04",
         "self-hosted": True,
         "python-version": "3.9",
-        "group": "ci-licensed",
+        "group": "experimental",  # TODO: Move back to ci-licensed once we got new licenses.
     },
     {
         "lang": "vhdl",


### PR DESCRIPTION
Disable VCS in CI until we have a valid license again.