### PR TITLE
Make reason_to_string() static class method

### DIFF
--- a/src/cocotb/share/lib/fli/FliImpl.cpp
+++ b/src/cocotb/share/lib/fli/FliImpl.cpp
@@ -435,10 +435,6 @@ GpiObjHdl *FliImpl::get_child_by_index(int32_t index, GpiObjHdl *parent) {
     }
 }
 
-const char *FliImpl::reason_to_string(int) {
-    return "Who can explain it, who can tell you why?";
-}
-
 /**
  * @name    Get current simulation time
  * @brief   Get current simulation time

--- a/src/cocotb/share/lib/fli/FliImpl.h
+++ b/src/cocotb/share/lib/fli/FliImpl.h
@@ -443,9 +443,6 @@ class FliImpl : public GpiImplInterface {
                                           void *cb_data) override;
 
     /* Method to provide strings from operation types */
-    const char *reason_to_string(int reason) override;
-
-    /* Method to provide strings from operation types */
     GpiObjHdl *create_gpi_obj_from_handle(void *hdl, const std::string &name,
                                           const std::string &fq_name,
                                           int accType, int accFullType);

--- a/src/cocotb/share/lib/gpi/gpi_priv.h
+++ b/src/cocotb/share/lib/gpi/gpi_priv.h
@@ -253,9 +253,6 @@ class GPI_EXPORT GpiImplInterface {
     virtual GpiCbHdl *register_readwrite_callback(int (*gpi_function)(void *),
                                                   void *gpi_cb_data) = 0;
 
-    /* Method to provide strings from operation types */
-    virtual const char *reason_to_string(int reason) = 0;
-
   private:
     std::string m_name;
 

--- a/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -311,8 +311,7 @@ int VhpiSignalObjHdl::initialise(const std::string &name,
     LOG_DEBUG(
         "VHPI: Found %s of format type %s (%d) format object with %d elems "
         "buffsize %d size %d",
-        name.c_str(),
-        ((VhpiImpl *)GpiObjHdl::m_impl)->format_to_string(m_value.format),
+        name.c_str(), VhpiImpl::format_to_string(m_value.format),
         m_value.format, m_value.numElems, m_value.bufSize,
         vhpi_get(vhpiSizeP, handle));
 
@@ -342,9 +341,7 @@ int VhpiSignalObjHdl::initialise(const std::string &name,
         default: {
             LOG_ERROR(
                 "VHPI: Unable to determine property for %s (%d) format object",
-                ((VhpiImpl *)GpiObjHdl::m_impl)
-                    ->format_to_string(m_value.format),
-                m_value.format);
+                VhpiImpl::format_to_string(m_value.format), m_value.format);
             return -1;
         }
     }
@@ -458,7 +455,7 @@ int VhpiCbHdl::arm() {
         LOG_ERROR(
             "VHPI: Unable to register a callback handle for VHPI type "
             "%s(%d)",
-            m_impl->reason_to_string(cb_data.reason), cb_data.reason);
+            VhpiImpl::reason_to_string(cb_data.reason), cb_data.reason);
         check_vhpi_error();
         return -1;
     }
@@ -660,8 +657,7 @@ int VhpiSignalObjHdl::set_signal_value(int32_t value, gpi_set_action action) {
 
         default: {
             LOG_ERROR("VHPI: Unable to handle this format type %s",
-                      ((VhpiImpl *)GpiObjHdl::m_impl)
-                          ->format_to_string(m_value.format));
+                      VhpiImpl::format_to_string(m_value.format));
             return -1;
         }
     }
@@ -684,8 +680,7 @@ int VhpiSignalObjHdl::set_signal_value(double value, gpi_set_action action) {
 
         default: {
             LOG_ERROR("VHPI: Unable to set a Real handle with format type %s",
-                      ((VhpiImpl *)GpiObjHdl::m_impl)
-                          ->format_to_string(m_value.format));
+                      VhpiImpl::format_to_string(m_value.format));
             return -1;
         }
     }
@@ -733,8 +728,7 @@ int VhpiSignalObjHdl::set_signal_value_binstr(std::string &value,
 
         default: {
             LOG_ERROR("VHPI: Unable to handle this format type: %s",
-                      ((VhpiImpl *)GpiObjHdl::m_impl)
-                          ->format_to_string(m_value.format));
+                      VhpiImpl::format_to_string(m_value.format));
             return -1;
         }
     }
@@ -762,8 +756,7 @@ int VhpiSignalObjHdl::set_signal_value_str(std::string &value,
 
         default: {
             LOG_ERROR("VHPI: Unable to handle this format type: %s",
-                      ((VhpiImpl *)GpiObjHdl::m_impl)
-                          ->format_to_string(m_value.format));
+                      VhpiImpl::format_to_string(m_value.format));
             return -1;
         }
     }
@@ -781,8 +774,7 @@ const char *VhpiSignalObjHdl::get_signal_value_binstr() {
     switch (m_value.format) {
         case vhpiRealVal:
             LOG_INFO("VHPI: get_signal_value_binstr not supported for %s",
-                     ((VhpiImpl *)GpiObjHdl::m_impl)
-                         ->format_to_string(m_value.format));
+                     VhpiImpl::format_to_string(m_value.format));
             return "";
         default: {
             /* Some simulators do not support BinaryValues so we fake up here
@@ -795,8 +787,7 @@ const char *VhpiSignalObjHdl::get_signal_value_binstr() {
                     "VHPI: Size of m_binvalue.value.str was not large enough: "
                     "req=%d have=%d for type %s",
                     ret, m_binvalue.bufSize,
-                    ((VhpiImpl *)GpiObjHdl::m_impl)
-                        ->format_to_string(m_value.format));
+                    VhpiImpl::format_to_string(m_value.format));
             }
 
             return m_binvalue.value.str;
@@ -815,8 +806,7 @@ const char *VhpiSignalObjHdl::get_signal_value_str() {
                     "VHPI: Size of m_value.value.str was not large enough: "
                     "req=%d have=%d for type %s",
                     ret, m_value.bufSize,
-                    ((VhpiImpl *)GpiObjHdl::m_impl)
-                        ->format_to_string(m_value.format));
+                    VhpiImpl::format_to_string(m_value.format));
             }
             break;
         }

--- a/src/cocotb/share/lib/vhpi/VhpiImpl.h
+++ b/src/cocotb/share/lib/vhpi/VhpiImpl.h
@@ -284,8 +284,8 @@ class VhpiImpl : public GpiImplInterface {
     GpiObjHdl *get_child_by_index(int32_t index, GpiObjHdl *parent) override;
     GpiObjHdl *get_child_from_handle(void *raw_hdl, GpiObjHdl *parent) override;
 
-    const char *reason_to_string(int reason) override;
-    const char *format_to_string(int format);
+    static const char *reason_to_string(int reason);
+    static const char *format_to_string(int format);
 
     GpiObjHdl *create_gpi_obj_from_handle(vhpiHandleT new_hdl,
                                           const std::string &name,

--- a/src/cocotb/share/lib/vpi/VpiCbHdl.cpp
+++ b/src/cocotb/share/lib/vpi/VpiCbHdl.cpp
@@ -83,7 +83,7 @@ int VpiCbHdl::arm() {
     if (!new_hdl) {
         LOG_ERROR(
             "VPI: Unable to register a callback handle for VPI type %s(%d)",
-            m_impl->reason_to_string(cb_data.reason), cb_data.reason);
+            VpiImpl::reason_to_string(cb_data.reason), cb_data.reason);
         check_vpi_error();
         return -1;
     }

--- a/src/cocotb/share/lib/vpi/VpiImpl.h
+++ b/src/cocotb/share/lib/vpi/VpiImpl.h
@@ -303,7 +303,7 @@ class VpiImpl : public GpiImplInterface {
                                  GpiObjHdl *parent) override;
     GpiObjHdl *get_child_by_index(int32_t index, GpiObjHdl *parent) override;
     GpiObjHdl *get_child_from_handle(void *raw_hdl, GpiObjHdl *parent) override;
-    const char *reason_to_string(int reason) override;
+    static const char *reason_to_string(int reason);
     GpiObjHdl *create_gpi_obj_from_handle(vpiHandle new_hdl,
                                           const std::string &name,
                                           const std::string &fq_name);


### PR DESCRIPTION
It's not dependent on an object, and it's only used inside each implementation.
I'm also planning on using it inside the sim callback for GPI tracing, where I might not have a valid GPI object anyway.