### PR TITLE
Error out if unsupported version of Python is used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,10 @@ from cocotb_build_libs import build_ext, get_ext
 
 __version__ = "2.1.0.dev0"
 
-max_python = (3, 14)
-max_python_str = ".".join(map(str, max_python))
-if sys.version_info > max_python:
+max_python3_minor_version = 14
+if sys.version_info >= (3, max_python3_minor_version + 1):
     raise RuntimeError(
-        f"cocotb {__version__} only supports a maximum Python version of {max_python_str}"
+        f"cocotb {__version__} only supports a maximum Python version of 3.{max_python3_minor_version}"
     )
 
 


### PR DESCRIPTION
This should solve the issue of `pip` choosing to use a version of cocotb incompatible with the user's version of Python. Since changing the upper bound in `requires-python` causes issues with the resolver, we add an error so if a version of cocotb is chosen with normal resolver methods that isn't compatible, the user will get a very explicit error. I would have preferred a warning, but `pip` squashes all output when not in verbose mode. This works for us because we only produce wheels for versions of Python we support and in other cases the sdist is used which will trigger this error.