### PR TITLE
Update license format in pyproject.toml to work with setuptools <v77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "cocotb"
 description = "Python-based chip (RTL) verification"
 readme = "README.md"
-license = "BSD-3-Clause"
-license-files = [
-    "LICENSE"
-]
+license = { file = "LICENSE" }
 authors = [
     {name = "Chris Higgs"},
     {name = "Stuart Hodgson"},


### PR DESCRIPTION
Resolves dual licensing error and references license files with PEP 621 specs.

Error:
```configuration error: `project.license` must be valid exactly by one definition (2 matches found):```
