### PR TITLE
Bump required version of setuptools in build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
setuptools is removing support for PEP621 style license fields in pyproject.toml in February 2026. Supersedes #5139.
