### PR TITLE
stable/2.0: Move VCS to experimental bucket

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,7 @@ codecov:
         #
         # [1] https://docs.codecov.io/docs/merging-reports#how-does-codecov-know-when-to-send-notifications
         # [2] https://docs.codecov.io/docs/notifications#preventing-notifications-until-after-n-builds
-        after_n_builds: 26
+        after_n_builds: 25
 
 coverage:
     status:

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -442,7 +442,7 @@ ENVS = [
         "os": "ubuntu-22.04",
         "self-hosted": True,
         "python-version": "3.9",
-        "group": "ci-licensed",
+        "group": "experimental",  # TODO: Move back to ci-licensed once we got new licenses.
     },
     {
         "lang": "vhdl",


### PR DESCRIPTION
We don't have licenses available at the moment. Move VCS to the experimental bucket until that gets fixed to avoid blocking the release pipeline.

Backport of #5126 for stable/2.0.