### PR TITLE
Use simulator-only registration function in xcelium

### DIFF
--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -144,31 +144,23 @@ Cadence Incisive and Xcelium
 * The ``xrun`` call (or ``xmelab`` in multi-step mode) needs the ``-access +rwc``
   (or equivalent, e.g. :samp:`-afile {afile}`) option set to allow cocotb to access values in the design.
 
-.. tab-set::
+* The ``xrun`` call (or ``xmsim`` in multi-step mode) needs the VPI library and entry point via the option
+  ``-loadvpisim $(cocotb-config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap``.
+  Alternatively, it is possible to specify the same during elaboration in multi-step mode with
+  ``-loadvpi $(cocotb-config --lib-name-path vpi xcelium):.vlog_startup_routines_bootstrap``.
+  The syntax is ``-loadvpi library:elab_functions[.sim_functions]``, taking two comma separated lists of
+  methods. The first list is invoked during elaboration and then simulation, while the second only applies
+  to simulation and it is the one to use to register callbacks. Specifying the entry point in ``elab_functions``
+  works but has the downside of initializing cocotb during elaboration, not only simulation.
 
-   .. tab-item:: Design with a VHDL Toplevel
+* If the design contains any VHDL modules, set the :envvar:`GPI_EXTRA` environment variable to
+  ``$(cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point``.
+  This is because directly loading the VHPI library causes an error in Xcelium,
+  so always load the VPI library and supply VHPI via ``GPI_EXTRA``.
 
-      For a design with a VHDL toplevel, call the ``xrun`` or ``xmelab`` executable with the options
-      ``-NEW_VHPI_PROPAGATE_DELAY -loadvpi $(cocotb-config --lib-name-path vpi xcelium):.vlog_startup_routines_bootstrap``.
-
-      Set the :envvar:`GPI_EXTRA` environment variable to
-      ``$(cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point``.
-      This is because directly loading the VHPI library causes an error in Xcelium,
-      so always load the VPI library and supply VHPI via ``GPI_EXTRA``.
-
-   .. tab-item:: Design with a (System)Verilog Toplevel
-
-      For a design with a (System)Verilog toplevel, call the ``xrun`` or ``xmelab`` executable with the option
-      ``-loadvpi $(cocotb-config --lib-name-path vpi xcelium):.vlog_startup_routines_bootstrap``.
-      The syntax is ``-loadvpi library:elab_functions[.sim_functions]``, taking two comma separated lists of methods.
-      The first list is invoked during elaboration and then simulation, while the second only applies to simulation
-      and it is the one to use to register callbacks. Specifying the entry point in ``elab_functions`` works but has
-      the downside of initializing cocotb during elaboration, not only simulation.
-      As of Xcelium 25.09, ``-loadvpi`` must be given at elaboration time, even if it applies only to simulation.
-
-      Set the :envvar:`GPI_EXTRA` environment variable to
-      ``$(cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point``
-      if there are also VHDL modules in the design.
+.. note::
+  For a design with a VHDL toplevel, call the ``xrun`` or ``xmelab`` executable with the option
+  ``-NEW_VHPI_PROPAGATE_DELAY ``.
 
 .. _custom-flows-ghdl:
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.xcelium
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.xcelium
@@ -54,7 +54,7 @@ endif
 # GPI_EXTRA=$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi xcelium) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if VPI library name is libvpi.so
-GPI_ARGS = -loadvpi $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi xcelium):.vlog_startup_routines_bootstrap
+GPI_ARGS = -loadvpisim $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap
 ifeq ($(TOPLEVEL_LANG),verilog)
     HDL_SOURCES = $(VERILOG_SOURCES)
     ROOT_LEVEL = $(COCOTB_TOPLEVEL)

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1761,12 +1761,6 @@ class Xcelium(Runner):
             + verbosity_opts
             # + ["-vpicompat 1800v2005"]  # <1364v1995|1364v2001|1364v2005|1800v2005> Specify the IEEE VPI
             + ["-access +rwc"]
-            + ["-loadvpi"]
-            # always start with VPI on Xcelium
-            + [
-                cocotb_tools.config.lib_name_path("vpi", "xcelium").as_posix()
-                + ":.vlog_startup_routines_bootstrap"
-            ]
             + vhpi_opts
             + [f"-work {self.hdl_library}"]
             + (
@@ -1843,6 +1837,9 @@ class Xcelium(Runner):
                 f"xrun_{self.current_test_name}.log",
                 "-xmlibdirname",
                 f"{self.build_dir}/xrun_snapshot",
+                "-loadvpisim",
+                cocotb_tools.config.lib_name_path("vpi", "xcelium").as_posix()
+                + ":vlog_startup_routines_bootstrap",
                 "-cds_implicit_tmpdir",
                 tmpdir,
                 "-licqueue",


### PR DESCRIPTION
This syntax ensures that `vlog_startup_routines_bootstrap()` is called only during simulation and not elaboration when using xcelium.
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
