### PR TITLE
Fix handling of `directories` argument to `combine_results.py`

### DIFF
--- a/src/cocotb_tools/combine_results.py
+++ b/src/cocotb_tools/combine_results.py
@@ -29,7 +29,7 @@ def _find_all(name: Pattern, path: Path) -> Iterable[Path]:
 def _existing_path(path_str: str) -> Path:
     path = Path(path_str)
     if not path.exists():
-        raise argparse.ArgumentTypeError(f"Path '{path_string}' does not exist.")
+        raise argparse.ArgumentTypeError(f"Path '{path_str}' does not exist.")
     return path
 
 


### PR DESCRIPTION
Closes #5186. When supporting multiple args, the `type` argument applies to each passed element, not the whole array of arguments.
