### PR TITLE
Prevent pytest from picking up cocotb.test decorator as a test

### DIFF
--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -381,6 +381,10 @@ def test(
     return wrapper
 
 
+# Prevent pytest from picking up the test decorator as a test
+test.__test__ = False  # type: ignore[attr-defined]
+
+
 def parametrize(
     *options_by_tuple: tuple[str, Sequence[object]]
     | tuple[Sequence[str], Sequence[Sequence[object]]],


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
