### PR TITLE
Add doc section Available Triggers for Testbenches

### DIFF
--- a/docs/source/coroutines.rst
+++ b/docs/source/coroutines.rst
@@ -18,7 +18,7 @@ The coroutine uses the :keyword:`await` keyword to
 block on another coroutine's execution or pass control of execution back to the
 simulator, allowing simulation time to advance.
 
-Typically coroutines await a :class:`~cocotb.triggers.Trigger` object which
+Typically coroutines await a :doc:`Trigger <triggers>` object which
 pauses the task, and indicates to the simulator some event which will cause the task to resume execution.
 For example:
 

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -304,6 +304,9 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
 Triggers
 ========
 
+..
+   Please keep this section aligned with the table in triggers.rst
+
 .. module:: cocotb.triggers
 
 .. autofunction:: current_gpi_trigger

--- a/docs/source/triggers.rst
+++ b/docs/source/triggers.rst
@@ -3,15 +3,62 @@ Triggers
 ********
 
 Triggers are used to indicate when the cocotb scheduler should resume coroutine execution.
+
 To use a trigger, a coroutine should :keyword:`await` it.
 This will cause execution of the current coroutine to pause.
-When the trigger fires, execution of the paused coroutine will resume:
+When the trigger fires
+(:class:`~cocotb.triggers.RisingEdge` in the following example),
+execution of the paused coroutine will resume:
 
 .. code-block:: python
+
+    from cocotb.triggers import RisingEdge
 
     async def coro():
         print("Some time before a clock edge")
         await RisingEdge(clk)
         print("Immediately after the rising clock edge")
 
-See :ref:`triggers` for a list of available triggers.
+
+Available Triggers for Testbenches
+==================================
+
+Below is a table of triggers that are useful for writing testbenches and models.
+
+For a list of *all* available triggers,
+see the :ref:`triggers` section in the :doc:`Python Code Library Reference <library_reference>`.
+
+..
+   Please keep this table aligned with the content in library_reference.rst
+
++------------------------------------------+-------------------------------------------------------------------------------------------+
+| **Edge Triggers**                                                                                                                    |
++------------------------------------------+-------------------------------------------------------------------------------------------+
+| | :class:`~cocotb.triggers.RisingEdge`   | | Resume after a *rising* edge on a single-bit signal                                     |
+| | :class:`~cocotb.triggers.FallingEdge`  | | Resume after a *falling* edge on a single-bit signal                                    |
+| | :class:`~cocotb.triggers.ValueChange`  | | Resume after *any* edge on a signal                                                     |
+| | :class:`~cocotb.triggers.ClockCycles`  | | Resume after the specified number of transitions of a signal                            |
+| | :class:`~cocotb.triggers.Edge`         | | (deprecated, see :class:`~cocotb.triggers.ValueChange`)                                 |
++------------------------------------------+-------------------------------------------------------------------------------------------+
+| **Timing Triggers**                                                                                                                  |
++------------------------------------------+-------------------------------------------------------------------------------------------+
+| | :class:`~cocotb.triggers.Timer`        | | Resume after the specified time                                                         |
+| | :class:`~cocotb.triggers.ReadOnly`     | | Resume when the simulation timestep moves to the *read-only* phase                      |
+| | :class:`~cocotb.triggers.ReadWrite`    | | Resume when the simulation timestep moves to the *read-write* phase                     |
+| | :class:`~cocotb.triggers.NextTimeStep` | | Resume when the simulation timestep moves to the *next time step*                       |
++------------------------------------------+-------------------------------------------------------------------------------------------+
+| **Concurrency Triggers**                                                                                                             |
++------------------------------------------+-------------------------------------------------------------------------------------------+
+| | :func:`~cocotb.triggers.gather`        | | Resume after *all* given Tasks or Triggers                                              |
+| | :func:`~cocotb.triggers.select`        | | Resume after *any* given Tasks or Triggers                                              |
+| | :class:`~cocotb.triggers.Combine`      | | Resume after *all* given Triggers                                                       |
+| | :class:`~cocotb.triggers.First`        | | Resume after *any* given Triggers                                                       |
+| | :func:`~cocotb.triggers.wait`          | | Await on all given Tasks or Triggers concurrently and block until a condition is met    |
+| | :class:`~cocotb.triggers.NullTrigger`  | | Resume immediately                                                                      |
++------------------------------------------+-------------------------------------------------------------------------------------------+
+| **Synchronization Triggers**                                                                                                         |
++------------------------------------------+-------------------------------------------------------------------------------------------+
+| | :class:`~cocotb.triggers.Event`        | | A way to signal an event across Tasks                                                   |
+| | :class:`~cocotb.triggers.Lock`         | | A mutual exclusion lock                                                                 |
+| | :func:`~cocotb.triggers.with_timeout`  | | Resume latest at the specified timeout time                                             |
++------------------------------------------+-------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Closes #5191

Rendered page: https://cocotb--5197.org.readthedocs.build/en/5197/triggers.html

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
