### PR TITLE
Support any `Awaitable` in `with_timeout`

### DIFF
--- a/docs/source/newsfragments/5205.feature.rst
+++ b/docs/source/newsfragments/5205.feature.rst
@@ -1,0 +1,1 @@
+:func:`.with_timeout` now supports being passed any :term:`awaitable`.

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -9,8 +9,8 @@ from asyncio import CancelledError
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 import cocotb
+from cocotb._base_triggers import Event
 from cocotb.task import Task
-from cocotb.triggers import Event
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable


### PR DESCRIPTION
Closes #5009. Reimplement `with_timeout` using `select`. Allows us to support any `Awaitable` and not just `Trigger`s, `Task`s and `Coroutine`s.
