### PR TITLE
Link pygpi against libpython, remove find_libpython dependency

### DIFF
--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -15,7 +15,7 @@ this chapter shows the minimum settings to be done.
 
 For all simulators, the following environment variables need to be set:
 
-* Define :envvar:`LIBPYTHON_LOC` using ``$(cocotb-config --libpython)``.
+* Define :envvar:`GPI_USERS` using ``$(cocotb-config --pygpi-entry-point)``.
 * Define :envvar:`PYGPI_PYTHON_BIN` using ``$(cocotb-config --python-bin)``.
 * Define :envvar:`COCOTB_TEST_MODULES` with the name of the Python module(s) containing your testcases.
 

--- a/docs/source/library_reference_c.rst
+++ b/docs/source/library_reference_c.rst
@@ -38,12 +38,6 @@ Environment Variables
     You can get the default PyGPI entry point at other times by calling ``cocotb-config --pygpi-entry-point`` from the shell
     or :func:`cocotb_tools.config.pygpi_entry_point` from Python.
 
-.. envvar:: LIBPYTHON_LOC
-
-    The absolute path to the Python library associated with the current Python installation;
-    i.e. ``libpython.so`` or ``python.dll`` on Windows.
-    This is determined with ``cocotb-config --libpython`` during build.
-
 .. envvar:: GPI_EXTRA
 
     A comma-separated list of extra libraries that are dynamically loaded at runtime.

--- a/noxfile.py
+++ b/noxfile.py
@@ -465,9 +465,6 @@ def release_install(session: nox.Session) -> None:
     # Work around that by explicitly installing the dependencies first from
     # PyPi, and then installing cocotb itself from the local dist directory.
 
-    session.log("Installing cocotb dependencies from PyPi")
-    session.install("find_libpython")
-
     session.log(f"Installing cocotb from wheels in {dist_dir!r}")
     session.install(
         "--force-reinstall",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,7 @@ maintainers = [
     {name = "Colin Marquardt"},
     {name = "Philipp Wagner"},
 ]
-dependencies = [
-    "find_libpython",
-]
+dependencies = []
 requires-python = ">= 3.9"
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -236,17 +236,13 @@ static int gpi_load_users() {
                       func_name.c_str());
             entry_func();
             LOG_TRACE("User Init => [ GPI Init ]");
+        } else {
+            LOG_INFO("Loaded entry library: '%s'", lib_name.c_str());
         }
     }
 
     return 0;
 }
-
-#ifndef PYTHON_LIB
-#error "Name of Python library required"
-#else
-#define PYTHON_LIB_STR xstr(PYTHON_LIB)
-#endif
 
 void gpi_entry_point() {
     LOG_TRACE("=> [ GPI Init ]");
@@ -273,21 +269,7 @@ void gpi_entry_point() {
         gpi_load_libs(to_load);
     }
 
-    // preload Python library
-    char const *libpython_path = getenv("LIBPYTHON_LOC");
-    if (!libpython_path) {
-        // default to libpythonX.X.so
-        libpython_path = PYTHON_LIB_STR;
-    }
-    auto loaded = utils_dyn_open(libpython_path);
-    // LCOV_EXCL_START
-    if (!loaded) {
-        LOG_ERROR("Failed to preload Python library: %s", libpython_path);
-        return;
-    }
-    // LCOV_EXCL_STOP
-
-    /* Finally embed Python */
+    // Load users
     if (!gpi_load_users()) {
         return;
     }

--- a/src/cocotb/share/lib/gpi/dynload.cpp
+++ b/src/cocotb/share/lib/gpi/dynload.cpp
@@ -19,7 +19,7 @@ void *utils_dyn_open(const char *lib_name) {
     SetErrorMode(0);
     ret = static_cast<void *>(LoadLibrary(lib_name));
     if (!ret) {
-        const char *log_fmt = "Unable to open lib %s%s%s";
+        const char *log_fmt = "Unable to open lib '%s'%s%s";
         LPSTR msg_ptr;
         if (FormatMessageA(
                 FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER,
@@ -38,7 +38,7 @@ void *utils_dyn_open(const char *lib_name) {
 
     ret = dlopen(lib_name, RTLD_LAZY | RTLD_GLOBAL);
     if (!ret) {
-        LOG_ERROR("Unable to open lib %s: %s", lib_name, dlerror());
+        LOG_ERROR("Unable to open lib '%s': %s", lib_name, dlerror());
     }
 #endif
     return ret;
@@ -50,7 +50,7 @@ void *utils_dyn_sym(void *handle, const char *sym_name) {
     entry_point = reinterpret_cast<void *>(
         GetProcAddress(static_cast<HMODULE>(handle), sym_name));
     if (!entry_point) {
-        const char *log_fmt = "Unable to find symbol %s%s%s";
+        const char *log_fmt = "Unable to find symbol '%s'%s%s";
         LPSTR msg_ptr;
         if (FormatMessageA(
                 FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER,
@@ -66,7 +66,7 @@ void *utils_dyn_sym(void *handle, const char *sym_name) {
 #else
     entry_point = dlsym(handle, sym_name);
     if (!entry_point) {
-        LOG_ERROR("Unable to find symbol %s: %s", sym_name, dlerror());
+        LOG_ERROR("Unable to find symbol '%s': %s", sym_name, dlerror());
     }
 #endif
     return entry_point;

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -25,8 +25,6 @@ import sys
 import textwrap
 from pathlib import Path
 
-import find_libpython
-
 import cocotb_tools
 
 base_tools_dir = Path(cocotb_tools.__file__).parent.resolve()
@@ -68,7 +66,6 @@ def _help_vars_text() -> str:
         COCOTB_ENABLE_PROFILING   Performance analysis of the Python portion of cocotb
         COCOTB_LOG_LEVEL          Default logging level (default INFO)
         COCOTB_RESOLVE_X          How to resolve X, Z, U, W, - on integer conversion
-        LIBPYTHON_LOC             Absolute path to libpython
 
         Regression Manager
         ------------------
@@ -191,11 +188,6 @@ def _get_parser() -> argparse.ArgumentParser:
         help="Print help about supported Makefile variables",
     )
     group.add_argument(
-        "--libpython",
-        action="store_true",
-        help="Print the absolute path to the libpython associated with the current Python installation",
-    )
-    group.add_argument(
         "--lib-dir",
         action="store_true",
         help="Print the absolute path to the interface libraries location",
@@ -238,11 +230,6 @@ def main() -> None:
         print(Path(sys.executable).as_posix())
     elif args.help_vars:
         print(_help_vars_text())
-    elif args.libpython:
-        libpython_path = find_libpython.find_libpython()
-        if libpython_path is None:
-            sys.exit(1)
-        print(Path(libpython_path).as_posix())
     elif args.lib_dir:
         print(libs_dir.as_posix())
     elif args.lib_name:

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -87,33 +87,8 @@ endif
 
 endif
 
-define find_libpython_errmsg =
-
-
-find_libpython was not able to find a libpython in the current Python environment. Ensure
-the Python development packages are installed. If they are installed and find_libpython
-is not finding the path to libpython, file an upstream bug in find_libpython; then
-manually override the LIBPYTHON_LOC make variable with the absolute path to libpython.so
-(or python.dll on Windows).
-
-endef
-
-ifndef LIBPYTHON_LOC
-
-# get the path to libpython and the return code from the script
-# adapted from https://stackoverflow.com/a/24658961/6614127
-FIND_LIBPYTHON_RES := $(shell $(PYTHON_BIN) -m cocotb_tools.config --libpython; echo $$?)
-FIND_LIBPYTHON_RC := $(lastword $(FIND_LIBPYTHON_RES))
-LIBPYTHON_LOC := $(strip $(subst $(FIND_LIBPYTHON_RC)QQQQ,,$(FIND_LIBPYTHON_RES)QQQQ))
-
-# complain if libpython isn't found, and export otherwise
-ifneq ($(FIND_LIBPYTHON_RC),0)
-    $(error $(find_libpython_errmsg))
-endif
-
-endif
-
-export LIBPYTHON_LOC
+GPI_USERS ?= $(shell $(PYTHON_BIN) -m cocotb_tools.config --pygpi-entry-point)
+export GPI_USERS
 
 define check_vhdl_sources
 if [ "$(VHDL_SOURCES_$(LIB))" == "" ]; then \
@@ -139,9 +114,6 @@ else
 endif
 
 export COCOTB_TRUST_INERTIAL_WRITES
-
-GPI_USERS ?= $(shell $(PYTHON_BIN) -m cocotb_tools.config --pygpi-entry-point)
-export GPI_USERS
 
 
 # Universal

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -32,8 +32,6 @@ from typing import (
     Union,
 )
 
-import find_libpython
-
 import cocotb_tools.config
 from cocotb_tools.check_results import get_results
 from cocotb_tools.sim_versions import NvcVersion
@@ -229,14 +227,6 @@ class Runner(ABC):
         # TODO: Remove this. Why are Xcelium and VCS loading VPI during build?
 
         self.env.update(os.environ)
-
-        if "LIBPYTHON_LOC" not in self.env:
-            libpython_path = find_libpython.find_libpython()
-            if not libpython_path:
-                raise ValueError(
-                    "Unable to find libpython, please make sure the appropriate libpython is installed"
-                )
-            self.env["LIBPYTHON_LOC"] = libpython_path
 
         # TODO the following line reappends the path on every call to build() or test(). This needs to not be an attribute.
         # Most of the stuff on this class really shouldn't be an attribute, but that's a non-trivial and API-breaking refactor.


### PR DESCRIPTION
Embedding libraries should link against libpython. The path to the libpython is not used to set up sys.path, so it doesn't matter if we choose the simulator's libpython over the system's or environments. As long as the Python version matches it should be good.

### TODO
- [ ] newsfrag for removing `--libpython` from `cocotb-config`
- [ ] newsfrag for mooting `LIBPYTHON_LOC`

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
