### PR TITLE
Add format specifier support to LogicArray

### DIFF
--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -462,3 +462,37 @@ def test_copy() -> None:
     d = copy.deepcopy(l)
     assert l == d
     assert l.range == d.range
+
+
+def test_format():
+    l = LogicArray("01XZ")
+    assert f"{l}" == "01XZ"
+    assert f"{l!s}" == "01XZ"
+    assert f"{l!r}" == "LogicArray('01XZ', Range(3, 'downto', 0))"
+    with pytest.raises(ValueError):
+        f"{l:d}"
+    with pytest.raises(ValueError):
+        f"{l:b}"
+    with pytest.raises(ValueError):
+        f"{l:x}"
+    with pytest.raises(ValueError):
+        f"{l:X}"
+    with pytest.raises(ValueError):
+        f"{l:o}"
+
+    l = LogicArray("1010")
+    assert f"{l:d}" == "10"
+    assert f"{l:b}" == "1010"
+    assert f"{l:x}" == "a"
+    assert f"{l:X}" == "A"
+    assert f"{l:o}" == "12"
+
+    with pytest.raises(ValueError):
+        f"{l:Q}"
+
+    l = LogicArray("00001101001")
+    assert f"{l:#_b}" == "0b000_0110_1001"
+    assert f"{l:#x}" == "0x069"
+    assert f"{l:#_X}" == "0X069"
+    assert f"{l:#_o}" == "0o0_0151"
+    assert f"{l:#,d}" == "0d0,105"


### PR DESCRIPTION
Closes #4887. Adds binary, octal, decimal, and hexadecimal format specifiers that 0 pad to the appropriate length.