### PR TITLE
Refactor Finalization/Initialization (part 1/N)

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -1054,7 +1054,7 @@ The Regression Manager
 .. module:: cocotb.regression
     :synopsis: Regression test suite manager.
 
-.. autodata:: cocotb._regression_manager
+.. autodata:: _manager_inst
 
 .. autoclass:: Test
 

--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -12,7 +12,6 @@ from cocotb._decorators import parametrize, skipif, test, xfail
 from cocotb._test import create_task, start, start_soon
 from cocotb._test_functions import pass_test
 from cocotb.handle import SimHandleBase
-from cocotb.regression import RegressionManager
 
 from ._version import __version__ as _version
 
@@ -63,9 +62,6 @@ This logger defaults to the :data:`logging.INFO` log level.
     This was previously the ``"cocotb"`` Logger.
     It is now a Logger under the ``"test"`` namespace.
 """
-
-_regression_manager: RegressionManager
-"""The global regression manager instance."""
 
 argv: list[str]
 """The argument list as seen by the simulator."""

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -7,113 +7,57 @@ from __future__ import annotations
 
 import logging
 import random
-import sys
+import time
 import warnings
 from pathlib import Path
-from time import time
 from types import SimpleNamespace
-from typing import Callable, cast
+from typing import cast
 
 import cocotb
 import cocotb._profiling
+import cocotb._shutdown
 import cocotb.handle
 import cocotb.logging
 import cocotb.simtime
 import cocotb.simulator
-from cocotb.regression import RegressionManager, RegressionMode
 from cocotb_tools import _env
 
 log: logging.Logger
 
 
-def _setup_logging() -> None:
-    cocotb.log = logging.getLogger("test")
-    cocotb.log.setLevel(logging.INFO)
-
-    global log
-    log = logging.getLogger("cocotb")
-
-
-_shutdown_callbacks: list[Callable[[], None]] = []
-"""List of callbacks to be called when cocotb shuts down."""
-
-
-def _register_shutdown_callback(cb: Callable[[], None]) -> None:
-    """Register a callback to be called when cocotb shuts down."""
-    _shutdown_callbacks.append(cb)
-
-
-def _shutdown_testbench() -> None:
-    """Call all registered shutdown callbacks."""
-    while _shutdown_callbacks:
-        cb = _shutdown_callbacks.pop(0)
-        cb()
-
-
 def init_package_from_simulation(argv: list[str]) -> None:
     """Initialize the cocotb package from a simulation context."""
 
-    # register a callback to be called if the simulation fails
-    cocotb.simulator.set_sim_event_callback(_sim_event)
-
-    cocotb.is_simulation = True
-
-    cocotb.argv = argv
-
-    # sys.path normally includes "" (the current directory), but does not appear to when python is embedded.
-    # Add it back because users expect to be able to import files in their test directory.
-    sys.path.insert(0, "")
-
+    # Initialize subsystems
+    cocotb._shutdown._init()
     cocotb.logging._init()
-    _setup_logging()
-
-    # From https://www.python.org/dev/peps/pep-0565/#recommended-filter-settings-for-test-runners
-    # If the user doesn't want to see these, they can always change the global
-    # warning settings in their test module.
-    if not sys.warnoptions:
-        warnings.simplefilter("default")
-
-    cocotb.SIM_NAME = cocotb.simulator.get_simulator_product().strip()
-    cocotb.SIM_VERSION = cocotb.simulator.get_simulator_version().strip()
-
-    log.info("Running on %s version %s", cocotb.SIM_NAME, cocotb.SIM_VERSION)
-
-    cocotb._profiling.initialize()
-    _register_shutdown_callback(cocotb._profiling.finalize)
-
-    _process_plusargs()
-    _process_packages()
-    _setup_random_seed()
-    _setup_root_handle()
-    _start_user_coverage()
-
+    cocotb._profiling._init()
     cocotb.simtime._init()
 
+    # Set up local "cocotb" logger
+    global log
+    log = logging.getLogger("cocotb.initialize")
+
+    # setup cocotb global variables
+    cocotb.is_simulation = True
+    cocotb.argv = argv
+    cocotb.log = logging.getLogger("test")
+    cocotb.log.setLevel(logging.INFO)
+    cocotb.SIM_NAME = cocotb.simulator.get_simulator_product().strip()
+    cocotb.SIM_VERSION = cocotb.simulator.get_simulator_version().strip()
+    _process_plusargs()
+    _setup_random_seed()
+    _setup_root_handle()
+    _process_packages()
+    _start_user_coverage()
+
+    # log info about the simulation
     log.info(
         "Initialized cocotb v%s from %s",
         cocotb.__version__,
         Path(__file__).parent.absolute(),
     )
-
-
-def run_regression(_: object) -> None:
-    """Setup and run a regression."""
-
-    _setup_regression_manager()
-
-    # start Regression Manager
-    log.info("Running tests")
-    cocotb._regression_manager.start_regression()
-
-
-def _sim_event() -> None:
-    """Function that can be called externally to signal an event."""
-    # We simply return here as the simulator will exit
-    # so no cleanup is needed
-    if hasattr(cocotb, "_regression_manager"):
-        cocotb._regression_manager._on_sim_end()
-    else:
-        _shutdown_testbench()
+    log.info("Running on %s version %s", cocotb.SIM_NAME, cocotb.SIM_VERSION)
 
 
 def _process_plusargs() -> None:
@@ -199,11 +143,11 @@ def _start_user_coverage() -> None:
                 log.debug("Writing user coverage data")
                 user_coverage.save()
 
-            _register_shutdown_callback(stop_user_coverage)
+            cocotb._shutdown.register(stop_user_coverage)
 
 
 def _setup_random_seed() -> None:
-    seed: int = int(time())
+    seed: int = int(time.time())
 
     if _env.exists("COCOTB_RANDOM_SEED"):
         seed = _env.as_int("COCOTB_RANDOM_SEED", seed)
@@ -250,35 +194,3 @@ def _setup_root_handle() -> None:
         raise RuntimeError(f"Can not find root handle {root_name!r}")
 
     cocotb.top = cocotb.handle._make_sim_object(handle)
-
-
-def _setup_regression_manager() -> None:
-    cocotb._regression_manager = RegressionManager()
-
-    # discover tests
-    modules: list[str] = _env.as_list("COCOTB_TEST_MODULES")
-    if not modules:
-        raise RuntimeError(
-            "Environment variable COCOTB_TEST_MODULES, which defines the module(s) to execute, is not defined or empty."
-        )
-    cocotb._regression_manager.setup_pytest_assertion_rewriting()
-    cocotb._regression_manager.discover_tests(*modules)
-
-    # filter tests
-    testcases: list[str] = _env.as_list("COCOTB_TESTCASE")
-    test_filter: str = _env.as_str("COCOTB_TEST_FILTER")
-
-    if testcases and test_filter:
-        raise RuntimeError("Specify only one of COCOTB_TESTCASE or COCOTB_TEST_FILTER")
-    elif testcases:
-        warnings.warn(
-            "COCOTB_TESTCASE is deprecated in favor of COCOTB_TEST_FILTER",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        filters: list[str] = [f"{testcase}$" for testcase in testcases]
-        cocotb._regression_manager.add_filters(*filters)
-        cocotb._regression_manager.set_mode(RegressionMode.TESTCASE)
-    elif test_filter:
-        cocotb._regression_manager.add_filters(test_filter)
-        cocotb._regression_manager.set_mode(RegressionMode.TESTCASE)

--- a/src/cocotb/_shutdown.py
+++ b/src/cocotb/_shutdown.py
@@ -1,0 +1,27 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import Callable
+
+_callbacks: list[Callable[[], None]] = []
+"""List of callbacks to be called when cocotb shuts down."""
+
+
+def register(cb: Callable[[], None]) -> None:
+    """Register a callback to be called when cocotb shuts down."""
+    _callbacks.append(cb)
+
+
+def _shutdown() -> None:
+    """Call all registered shutdown callbacks."""
+    while _callbacks:
+        cb = _callbacks.pop(0)
+        cb()
+
+
+def _init() -> None:
+    from cocotb import simulator  # noqa: PLC0415
+
+    simulator.set_sim_event_callback(_shutdown)

--- a/src/cocotb/_test.py
+++ b/src/cocotb/_test.py
@@ -230,7 +230,7 @@ def create_task(
         return coro
     elif isinstance(coro, Coroutine):
         task = Task[ResultType](coro, name=name)
-        cocotb._regression_manager._running_test.add_task(task)
+        _current_test.add_task(task)
         return task
     elif inspect.iscoroutinefunction(coro):
         raise TypeError(
@@ -246,3 +246,17 @@ def create_task(
             f"Attempt to add an object of type {type(coro)} to the scheduler, "
             f"which isn't a coroutine: {coro!r}\n"
         )
+
+
+_current_test: RunningTest
+"""The currently executing test's state."""
+
+
+def set_current_test(running_test: RunningTest) -> None:
+    """Set the currently executing test's state.
+
+    Args:
+        running_test: The :class:`~cocotb._test.RunningTest` instance to set as current.
+    """
+    global _current_test
+    _current_test = running_test

--- a/src/cocotb_tools/_coverage.py
+++ b/src/cocotb_tools/_coverage.py
@@ -30,6 +30,6 @@ def start_cocotb_library_coverage(_: object) -> None:  # pragma: no cover
 
         # This must come after `library_coverage.start()` to ensure coverage is being
         # collected on the cocotb library before importing from it.
-        from cocotb._init import _register_shutdown_callback  # noqa: PLC0415
+        import cocotb._shutdown  # noqa: PLC0415
 
-        _register_shutdown_callback(stop_library_coverage)
+        cocotb._shutdown.register(stop_library_coverage)

--- a/src/cocotb_tools/pytest/plugin.py
+++ b/src/cocotb_tools/pytest/plugin.py
@@ -53,7 +53,14 @@ from cocotb_tools.pytest.option import (
 )
 from cocotb_tools.runner import Runner, get_runner
 
-ENTRY_POINT: str = "cocotb_tools.pytest._init:run_regression"
+ENTRY_POINT: str = ",".join(
+    (
+        "cocotb_tools._coverage:start_cocotb_library_coverage",
+        "cocotb.logging:_configure",
+        "cocotb._init:init_package_from_simulation",
+        "cocotb_tools.pytest._init:run_regression",
+    )
+)
 
 
 def to_timescale(value: str) -> tuple[str, str]:

--- a/src/cocotb_tools/pytest/regression.py
+++ b/src/cocotb_tools/pytest/regression.py
@@ -42,6 +42,8 @@ from pytest import (
 )
 
 import cocotb
+import cocotb._shutdown
+import cocotb._test
 from cocotb import simulator
 from cocotb._extended_awaitables import with_timeout
 from cocotb._gpi_triggers import Timer
@@ -814,6 +816,7 @@ class RegressionManager:
             running_test: Test to run.
         """
         self._running_test = running_test
+        cocotb._test.set_current_test(running_test)
 
         if self._scheduled:
             self._timer1._register(self._running_test.start)
@@ -822,11 +825,7 @@ class RegressionManager:
             self._running_test.start()
 
     def _shutdown(self) -> None:
-        # TODO refactor initialization and finalization into their own module
-        # to prevent circular imports requiring local imports
-        from cocotb._init import _shutdown_testbench  # noqa: PLC0415
-
-        _shutdown_testbench()
+        cocotb._shutdown._shutdown()
 
         # Setup simulator finalization
         simulator.stop_simulator()

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -16,7 +16,7 @@ def load_entry(argv: list[str]) -> None:
             "cocotb_tools._coverage:start_cocotb_library_coverage",
             "cocotb.logging:_configure",
             "cocotb._init:init_package_from_simulation",
-            "cocotb._init:run_regression",
+            "cocotb.regression:_run_regression",
         ),
     )
 

--- a/tests/pytest/test_env.py
+++ b/tests/pytest/test_env.py
@@ -20,6 +20,7 @@ from pytest import MonkeyPatch, raises
 import cocotb
 import cocotb._init
 import cocotb._profiling
+import cocotb.regression
 import cocotb.types._resolve
 from cocotb.handle import SimHandleBase
 from cocotb_tools import _env
@@ -223,7 +224,7 @@ def test_env_cocotb_testcase_deprecated(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("COCOTB_TESTCASE", "dummy")
 
     with pytest.deprecated_call():
-        cocotb._init._setup_regression_manager()
+        cocotb.regression._setup_regression_manager()
 
 
 def test_env_cocotb_test_modules_empty(monkeypatch: MonkeyPatch) -> None:
@@ -237,7 +238,7 @@ def test_env_cocotb_test_modules_empty(monkeypatch: MonkeyPatch) -> None:
             "Environment variable COCOTB_TEST_MODULES, which defines the module(s) to execute, is not defined or empty."
         ),
     ):
-        cocotb._init._setup_regression_manager()
+        cocotb.regression._setup_regression_manager()
 
 
 def test_env_cocotb_test_modules_undefined(monkeypatch: MonkeyPatch) -> None:
@@ -251,7 +252,7 @@ def test_env_cocotb_test_modules_undefined(monkeypatch: MonkeyPatch) -> None:
             "Environment variable COCOTB_TEST_MODULES, which defines the module(s) to execute, is not defined or empty."
         ),
     ):
-        cocotb._init._setup_regression_manager()
+        cocotb.regression._setup_regression_manager()
 
 
 def test_env_cocotb_testcase_with_cocotb_test_filter(monkeypatch: MonkeyPatch) -> None:
@@ -265,7 +266,7 @@ def test_env_cocotb_testcase_with_cocotb_test_filter(monkeypatch: MonkeyPatch) -
         RuntimeError,
         match="Specify only one of COCOTB_TESTCASE or COCOTB_TEST_FILTER",
     ):
-        cocotb._init._setup_regression_manager()
+        cocotb.regression._setup_regression_manager()
 
 
 def test_env_cocotb_random_seed(monkeypatch: MonkeyPatch) -> None:
@@ -323,12 +324,10 @@ def test_env_cocotb_enable_profiling(monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setenv("COCOTB_ENABLE_PROFILING", value)
         reload(cocotb._profiling)
 
-        cocotb._profiling.initialize()
+        cocotb._profiling._init()
 
         with cocotb._profiling.profiling_context:
             pass
-
-        cocotb._profiling.finalize()
 
 
 def test_env_cocotb_resolve_x_weak(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -24,6 +24,7 @@ import pytest
 from common import MyException, assert_takes
 
 import cocotb
+import cocotb.regression
 from cocotb.clock import Clock
 from cocotb.task import Task, current_task
 from cocotb.triggers import (
@@ -510,7 +511,7 @@ async def test_test_repr(_):
     """Test RunningTest.__repr__"""
     log = logging.getLogger("cocotb.test")
 
-    current_test = cocotb._regression_manager._running_test._main_task
+    current_test = cocotb._test._current_test._main_task
     log.info(repr(current_test))
     assert re.match(
         r"<Test test_test_repr running coro=test_test_repr\(\)>", repr(current_test)
@@ -528,7 +529,7 @@ class TestClassRepr(Coroutine):
     async def check_repr(self, dut):
         log = logging.getLogger("cocotb.test")
 
-        current_test = cocotb._regression_manager._running_test._main_task
+        current_test = cocotb._test._current_test._main_task
         log.info(repr(current_test))
         assert re.match(
             r"<Test TestClassRepr running coro=TestClassRepr\(\)>", repr(current_test)

--- a/tests/test_cases/test_cocotb/test_testfactory.py
+++ b/tests/test_cases/test_cocotb/test_testfactory.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Coroutine
 
 import cocotb
+import cocotb.regression
 
 testfactory_test_names = set()
 testfactory_test_args = set()
@@ -20,7 +21,7 @@ testfactory_test_args = set()
     ("arg1", ["a1v1", "a1v2"]), (("arg2", "arg3"), [("a2v1", "a3v1"), ("a2v2", "a3v2")])
 )
 async def run_testfactory_test(dut, arg1, arg2, arg3):
-    testfactory_test_names.add(cocotb._regression_manager._test.name)
+    testfactory_test_names.add(cocotb.regression._manager_inst._test.name)
     testfactory_test_args.add((arg1, arg2, arg3))
 
 
@@ -70,7 +71,7 @@ p_testfactory_test_args = set()
 @cocotb.parametrize(arg1=["a1v1", "a1v2"])
 @cocotb.parametrize(arg2=["a2v1", "a2v2"])
 async def p_run_testfactory_test(dut, arg1, arg2):
-    p_testfactory_test_names.add(cocotb._regression_manager._test.name)
+    p_testfactory_test_names.add(cocotb.regression._manager_inst._test.name)
     p_testfactory_test_args.add((arg1, arg2))
 
 

--- a/tests/test_cases/test_select_testcase/Makefile
+++ b/tests/test_cases/test_select_testcase/Makefile
@@ -4,12 +4,12 @@
 
 # select only y_tests from all MODULEs
 
-include ../../designs/sample_module/Makefile
-
 COCOTB_TEST_MODULES := x_tests,y_tests,y_tests_again
 COCOTB_TESTCASE := y_test
 
 # override PYTHONWARNINGS to prevent DeprecationWarning causing an error with use of COCOTB_TESTCASE
 ifdef PYTHONWARNINGS
-override PYTHONWARNINGS += ignore::DeprecationWarning:cocotb._init,
+override PYTHONWARNINGS := $(PYTHONWARNINGS),ignore::DeprecationWarning:cocotb.regression
 endif
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_select_testcase_error/Makefile
+++ b/tests/test_cases/test_select_testcase_error/Makefile
@@ -9,9 +9,9 @@ TESTCASE := y_test
 
 # TESTCASE filtering out all tests results in a warning
 
-include ../../designs/sample_module/Makefile
-
-# override PYTHONWARNINGS to prevent DeprecationWarning causing an error with use of TESTCASE
+# override PYTHONWARNINGS to prevent DeprecationWarning causing an error with use of COCOTB_TESTCASE
 ifdef PYTHONWARNINGS
-override PYTHONWARNINGS += ignore::DeprecationWarning:cocotb._init,
+override PYTHONWARNINGS := $(PYTHONWARNINGS),ignore::DeprecationWarning:cocotb.regression
 endif
+
+include ../../designs/sample_module/Makefile


### PR DESCRIPTION
Step 1 of N of refactoring cocotb initialization and finalization. xref #4585, xref #4584. Breaking the dependency between RunningTest and RegressionManager will also enable refactoring RunningTest to use TaskManager.

This gets us to the point where we don't see the following part of the stacktrace when initialization raises.
```
Traceback (most recent call last):
  File "/home/csushma/anaconda3/lib/python3.12/site-packages/cocotb/_init.py", line 117, in _sim_event
    cocotb._regression_manager._fail_simulation(msg)
  File "/home/csushma/anaconda3/lib/python3.12/site-packages/cocotb/regression.py", line 895, in _fail_simulation
    self._running_test.abort(self._sim_failure)
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'RegressionManager' object has no attribute '_running_test'
```

Follow-on commits will:
* Expose a Startup and Shutdown trigger
* Move Pythonland initialization to module initialization time instead of time 0.
* Split handling pre-mature shutdown to the new Shutdown trigger
* Refactor `sim_event` to be finalization which is consistently called