### PR TITLE
chore(pytest-plugin): use RunningTest class

### DIFF
--- a/docs/source/pytest.rst
+++ b/docs/source/pytest.rst
@@ -351,16 +351,23 @@ Example clock generation for all tests using the ``conftest.py`` file:
 
 .. code:: python
 
+    from collections.abc import AsyncGenerator
+
     import pytest
     from cocotb.clock import Clock
 
 
     @pytest.fixture(scope="session", autouse=True)
-    async def clock_generation(dut) -> None:
+    async def clock_generation(dut) -> AsyncGenerator[None, None]:
         """Generate clock for all tests using session scope."""
+        # Test setup (executed before test), create and start clock generation
         dut.clk.value = 0
 
         Clock(dut.clk, 10, unit="ns").start(start_high=False)
+
+        yield  # Calling test, yield is needed to keep clock generation alive
+
+        # Test teardown (executed after test), clock generation will be finished here
 
 
 Example set up and tear down fixture:

--- a/src/cocotb_tools/pytest/_init.py
+++ b/src/cocotb_tools/pytest/_init.py
@@ -48,6 +48,8 @@ def run_regression(argv: list[str]) -> None:
         reporter_address=env.as_str("COCOTB_PYTEST_REPORTER_ADDRESS"),
         # Name of HDL top level design
         toplevel=env.as_str("COCOTB_TOPLEVEL"),
+        # Initialization value for the random generator
+        seed=cocotb.RANDOM_SEED,
     )
 
     cocotb._regression_manager = cast("cocotb.regression.RegressionManager", manager)

--- a/src/cocotb_tools/pytest/test.py
+++ b/src/cocotb_tools/pytest/test.py
@@ -1,0 +1,29 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Extend cocotb test module."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from cocotb._test import RunningTest
+from cocotb.task import Task
+
+
+class RunningTestSetup(RunningTest):
+    """Running test setup without cancelling added sub-tasks."""
+
+    def __init__(
+        self, test_complete_cb: Callable[[], None], main_task: Task[None]
+    ) -> None:
+        """Create new instance of running test setup."""
+        super().__init__(test_complete_cb=test_complete_cb, main_task=main_task)
+
+        self.subtasks: list[Task[Any]] = []
+        """Sub-tasks that must be keep alive during test setup, call and teardown."""
+
+    def add_task(self, task: Task[Any]) -> None:
+        """Add task to test setup."""
+        self.subtasks.append(task)

--- a/tests/pytest_plugin/conftest.py
+++ b/tests/pytest_plugin/conftest.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from pathlib import Path
+from typing import Any
 
 from pytest import FixtureRequest, Parser, PytestPluginManager, fixture, hookimpl
 
@@ -88,8 +90,13 @@ def sample_module_fixture(hdl: HDL, request: FixtureRequest) -> HDL:
 
 
 @fixture(name="clock_generation", scope="session", autouse=True)
-async def clock_generation_fixture(dut) -> None:
+async def clock_generation_fixture(dut: Any) -> AsyncGenerator[None, None]:
     """Generate clock for all tests using session scope."""
+    # Test setup (executed before test), create and start clock generation
     dut.clk.value = 0
 
     Clock(dut.clk, 10, unit="ns").start(start_high=False)
+
+    yield  # Calling test, yield is needed to keep clock generation alive
+
+    # Test teardown (executed after test), clock generation will be finished here


### PR DESCRIPTION
- Using the `RunningTest` class
- Added more docstrings and comments
- Removed dependency to `cocotb.regression`
- Added own `SimFailure` exception instead relying on `cocotb.regression.SimFailure`
- Added `RunningTestSetup` class for pytest `setup` - `teardown`. Added sub-tasks in test setup like clock generators cannot be cancelled, they must survive test `setup` abort, test `call` abort but be aborted in test `teardown`
- Code refactoring that should simplify and help understanding pytest flow `setup` -> `call` -> `teardown`
- ~Align handling random seed in the same way like in the built-in regression manager~
  - See https://github.com/cocotb/cocotb/pull/5230)
- ~Added `error` in `PYTHONWARNINGS` environment variable was... hanging pytest after refactoring :open_mouth: Related with the latest pytest `9.0.2` :thinking:~ 

~@ktbarrett there is some regression in the latest code changes in VPI/VHPI functions.~

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
