### PR TITLE
chore(pytest-plugin): setup/teardown random seed per test

### DIFF
--- a/src/cocotb_tools/pytest/_init.py
+++ b/src/cocotb_tools/pytest/_init.py
@@ -48,6 +48,8 @@ def run_regression(argv: list[str]) -> None:
         reporter_address=env.as_str("COCOTB_PYTEST_REPORTER_ADDRESS"),
         # Name of HDL top level design
         toplevel=env.as_str("COCOTB_TOPLEVEL"),
+        # Initialization value for the random generator
+        seed=cocotb.RANDOM_SEED,
     )
 
     cocotb._regression_manager = cast("cocotb.regression.RegressionManager", manager)


### PR DESCRIPTION
Align handling random seed in the same way like in the built-in regression manager.

Random seed will be set and restore per test.

Closes #5228

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
