### PR TITLE
Updated Runner.test arg testcase behaviour

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -513,7 +513,7 @@ class Runner(ABC):
                 names = [s.strip() for s in testcase.split(",") if s.strip()]
             else:
                 names = list(testcase)
-            regex = "\.(" + "|".join(rf".*{re.escape(name)}" for name in names) + ")$"
+            regex = r"\.(" + "|".join(rf".*{re.escape(name)}" for name in names) + ")$"
             self.env["COCOTB_TEST_FILTER"] = regex
 
         if test_filter is not None:


### PR DESCRIPTION
Modified file
src/cocotb_tools/runner.py

Runner.test() argument testcase to
remove deprecated use of COCOTB_TESTCASE
and rather update COCOTB_TEST_FILTER

Fixes #5080

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
