### PR TITLE
Introduce and use `cached_no_args_method`

### DIFF
--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -9,7 +9,6 @@ import inspect
 import sys
 from collections.abc import Coroutine, Iterable, Mapping, Sequence
 from enum import Enum
-from functools import cached_property
 from itertools import product
 from typing import Any, Callable, cast, overload
 
@@ -93,7 +92,7 @@ class Test:
         self.skip = skip
         self.stage = stage
 
-    @cached_property
+    @property
     def fullname(self) -> str:
         return f"{self.module}.{self.name}"
 

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -242,6 +242,41 @@ class cached_method(Generic[InstanceT, Params, ResultT]):
         return func(*args, **kwargs)
 
 
+class cached_no_args_method(Generic[InstanceT, ResultT]):
+    def __init__(self, method: Callable[[InstanceT], ResultT]) -> None:
+        self._method = method
+        update_wrapper(self, method)
+
+    @overload
+    def __get__(
+        self, instance: None, objtype: object = None
+    ) -> Callable[[InstanceT], ResultT]: ...
+
+    @overload
+    def __get__(
+        self, instance: InstanceT, objtype: object = None
+    ) -> Callable[[], ResultT]: ...
+
+    def __get__(
+        self, instance: None | InstanceT, objtype: object = None
+    ) -> Callable[[InstanceT], ResultT] | Callable[[], ResultT]:
+        if instance is None:
+            return self
+
+        res = self._method(instance)
+
+        @wraps(self._method)
+        def lookup() -> ResultT:
+            return res
+
+        setattr(instance, self._method.__name__, lookup)
+        return lookup
+
+    def __call__(self, instance: InstanceT) -> ResultT:
+        func = getattr(instance, self._method.__name__)
+        return func()
+
+
 T = TypeVar("T")
 
 

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -18,6 +18,7 @@ from logging import Logger
 from typing import ClassVar, Literal
 
 import cocotb
+from cocotb._utils import cached_no_args_method
 from cocotb.handle import (
     Deposit,
     Force,
@@ -404,11 +405,8 @@ class Clock:
         for _ in range(num_cycles):
             await edge_type(self._signal)
 
+    @cached_no_args_method
     def __repr__(self) -> str:
-        return self._repr
-
-    @cached_property
-    def _repr(self) -> str:
         freq_mhz = 1 / get_time_from_sim_steps(
             get_sim_steps(self._period, self._unit), "us"
         )

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -34,7 +34,7 @@ from cocotb._gpi_triggers import (
     ValueChange,
     current_gpi_trigger,
 )
-from cocotb._utils import DocIntEnum
+from cocotb._utils import DocIntEnum, cached_no_args_method
 from cocotb.types import Array, Logic, LogicArray, Range
 from cocotb.types._indexing import do_indexing_changed_warning, indexing_changed
 from cocotb_tools import _env
@@ -1354,13 +1354,10 @@ class LogicArrayObject(
     def __str__(self) -> str:
         return str(self.value)
 
+    @cached_no_args_method
     def __len__(self) -> int:
         # can't use `range` to get length because `range` is for outer-most dimension only
         # and this object needs to support multi-dimensional packed arrays.
-        return self._len
-
-    @cached_property
-    def _len(self) -> int:
         return self._handle.get_num_elems()
 
     def __getitem__(self, _: object) -> NoReturn:
@@ -1517,12 +1514,9 @@ class EnumObject(_NonIndexableValueObjectBase[int, Union[LogicArray, int, str]])
     def __int__(self) -> int:
         return int(self.value)
 
-    @cached_property
-    def _len(self) -> int:
-        return self._handle.get_num_elems()
-
+    @cached_no_args_method
     def __len__(self) -> int:
-        return self._len
+        return self._handle.get_num_elems()
 
     @cached_property
     def is_signed(self) -> bool:
@@ -1606,12 +1600,9 @@ class IntegerObject(_NonIndexableValueObjectBase[int, int]):
     def __int__(self) -> int:
         return self.value
 
-    @cached_property
-    def _len(self) -> int:
-        return self._handle.get_num_elems()
-
+    @cached_no_args_method
     def __len__(self) -> int:
-        return self._len
+        return self._handle.get_num_elems()
 
     @cached_property
     def is_signed(self) -> bool:


### PR DESCRIPTION
More efficient than `cached_method` for functions that take no argument.