### PR TITLE
feat(pytest-plugin): optional @pytest.mark.cocotb_runner marker

### DIFF
--- a/docs/source/pytest.rst
+++ b/docs/source/pytest.rst
@@ -229,6 +229,29 @@ name of HDL top level design will be ``design``.
         sample_module.test()
 
 
+Using the :deco:`!pytest.mark.cocotb_runner` marker is optional for test functions if they meet the following criteria:
+
+* start with ``test_``
+* is a normal function (``def`` without the ``async`` keyword)
+* has a positional argument annotated with the :class:`~cocotb_tools.pytest.hdl.HDL` class type
+
+.. code:: python
+
+    # test_*.py
+
+    from cocotb_tools.pytest.hdl import HDL
+
+
+    def test_sample_module(sample_module: HDL) -> None:
+        """Test DUT without explicitly marking this test function with the :deco:`!pytest.mark.cocotb_runner`."""
+        sample_module.test()
+
+
+    async def test_dut_feature_1(dut) -> None:
+        """Test DUT feature 1."""
+        ...
+
+
 :py:deco:`!pytest.mark.cocotb_test`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -122,6 +122,9 @@ class TestGenerator:
             | tuple[Sequence[str], Sequence[Sequence[object]]]
         ] = []
 
+        # Expected by pytest. Used to extract wrapped test function from object (decorator)
+        self.__func__ = func
+
     def generate_tests(self) -> Iterable[Test]:
         option_reprs: dict[str, list[str]] = {}
 
@@ -179,6 +182,10 @@ class TestGenerator:
                 skip=self.skip,
                 stage=self.stage,
             )
+
+    async def __call__(self, *args: object, **kwargs: object) -> None:
+        # Needed by pytest. It calls callable(obj) before extracting a test function from the self.__func__ attribute
+        await self.func(*args, **kwargs)
 
 
 def _reprs(values: Sequence[object]) -> list[str]:

--- a/src/cocotb_tools/pytest/_compat.py
+++ b/src/cocotb_tools/pytest/_compat.py
@@ -6,118 +6,160 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
+from inspect import iscoroutinefunction, signature
+from typing import get_type_hints
 
-from pytest import Class, Mark, Module, mark
+from pytest import Function, Mark, mark
 
-from cocotb._decorators import Test, TestGenerator
-from cocotb.simtime import TimeUnit
+from cocotb._decorators import TestGenerator
+from cocotb_tools.pytest.hdl import HDL
 
-
-def is_cocotb_decorator(obj: object) -> bool:
-    """Check if provided object was decorated with cocotb decorator."""
-    return isinstance(obj, (Test, TestGenerator))
+_MARKED: tuple[str, ...] = ("cocotb_runner", "cocotb_test")
+"""List of pytest markers to mark cocotb test functions."""
 
 
-def cocotb_decorator_as_pytest_marks(
-    collector: Module | Class, name: str, obj: object
-) -> object:
+def cocotb_decorator_as_pytest_marks(obj: TestGenerator) -> None:
     """Convert object decorated with cocotb decorator to ``@pytest.mark.*``.
 
     Args:
-        collector: Pytest collector like Python Class or Module.
-        name: Name of object.
         obj: Object decorated with cocotb decorator like ``@cocotb.test``.
-
-    Returns:
-        Unwrapped decorated object with added pytest marks.
     """
-    if isinstance(obj, Test):
-        return _as_pytest_marks(
-            collector,
-            name,
-            obj.func,
-            timeout=obj.timeout,
-            expect_fail=obj.expect_fail,
-            expect_error=obj.expect_error,
-            skip=obj.skip,
-            stage=obj.stage,
-        )
+    # Skip already converted object
+    # This can happen when multiple cocotb runners are loading the same test module
+    if getattr(obj.__func__, "__test__", False):
+        return
 
-    if isinstance(obj, TestGenerator):
-        return _as_pytest_marks(
-            collector,
-            name,
-            obj.func,
-            timeout=obj.timeout,
-            expect_fail=obj.expect_fail,
-            expect_error=obj.expect_error,
-            skip=obj.skip,
-            stage=obj.stage,
-            options=obj.options,
-        )
-
-    return obj
-
-
-def _as_pytest_marks(
-    collector: Module | Class,
-    name: str,
-    obj: object,
-    timeout: tuple[float, TimeUnit] | None,
-    expect_fail: bool,
-    expect_error: Iterable[type[BaseException]],
-    skip: bool,
-    stage: int,
-    options: list[
-        tuple[str, Sequence[object]] | tuple[Sequence[str], Sequence[Sequence[object]]]
-    ]
-    | None = None,
-) -> object:
-    if getattr(obj, "__test__", False):
-        return obj  # object already unwrapped for pytest, skip it
-
-    markers: list[Mark] = []
+    # Get pytest markers added at cocotb decorator level
+    markers: list[Mark] = list(getattr(obj, "pytestmark", ()))
 
     # Replace @cocotb.parametrize(...) decorator with equivalent @pytest.mark.parametrize(...) markers
     # @cocotb.parametrize(x=[1, 2], y=[3, 4])
     # vvv
     # @pytest.parametrize("x", [1, 2])
     # @pytest.parametrize("y", [3, 4])
-    for names, values in options or ():
+    for names, values in obj.options or ():
         if isinstance(names, str):
             markers.append(mark.parametrize(names, values).mark)
         else:
             markers.append(mark.parametrize(",".join(names), values).mark)
 
-    if stage:
+    # @cocotb.test(stage=...)
+    if obj.stage:
         # Supported by external plugin: pytest-order
-        markers.append(mark.order(stage).mark)
+        markers.append(mark.order(obj.stage).mark)
 
-    if skip:
+    # @cocotb.test(skip=...)
+    if obj.skip:
         markers.append(mark.skip().mark)
 
-    if expect_fail or expect_error:
+    # @cocotb.test(expect_fail=..., expect_error=...)
+    if obj.expect_fail or obj.expect_error:
         markers.append(
             mark.xfail(
-                raises=tuple(expect_error) if expect_error else None,
+                raises=tuple(obj.expect_error) if obj.expect_error else None,
                 strict=True,
             ).mark
         )
 
-    if timeout:
-        markers.append(mark.cocotb_timeout(duration=timeout[0], unit=timeout[1]).mark)
+    # @cocotb.test(timeout=...)
+    if obj.timeout:
+        markers.append(
+            mark.cocotb_timeout(duration=obj.timeout[0], unit=obj.timeout[1]).mark
+        )
 
-    markers.append(mark.cocotb_test().mark)
-    markers.extend(getattr(obj, "pytestmark", ()))
+    # Get pytest markers added at test function level
+    markers.extend(getattr(obj.__func__, "pytestmark", ()))
 
-    # Add pytest marks to object
+    # Add missing @pytest.mark.cocotb_test marker to test function
+    if not any(marker.name == "cocotb_test" for marker in markers):
+        markers.append(mark.cocotb_test().mark)
+
+    # Add pytest markers to test function and decorator
+    setattr(obj.__func__, "pytestmark", markers)
     setattr(obj, "pytestmark", markers)
 
-    # __test__ will tell pytest to treat this object as test item
+    # Mark test function with @cocotb.test decorator as test for pytest
+    mark_as_test(obj)
+
+
+def is_marked_as_cocotb(obj: object) -> bool:
+    """Check if object is marked with :deco:`!pytest.mark.cocotb_runner` or :deco:`!pytest.mark.cocotb_test`.
+
+    Args:
+        obj: Collected item by the pytest Python collector (:class:`pytest.Module` or :class:`pytest.Class`).
+
+    Returns:
+        :data:`True` if collected item is already marked with :deco:`!pytest.mark.cocotb_runner` or
+        :deco:`!pytest.mark.cocotb_test` decorator. Otherwise :data:`False`.
+    """
+    # Get list of pytest markers added to test function
+    markers: Iterable[Mark] | None = getattr(obj, "pytestmark", None)
+
+    # Check if object was marked with @pytest.mark.cocotb_runner or @pytest.mark.cocotb_test
+    return any(marker.name in _MARKED for marker in markers or ())
+
+
+def mark_as_test(obj: object) -> None:
+    """Mark object as test for pytest.
+
+    Args:
+        obj: Collected item by the pytest Python collector (:class:`pytest.Module` or :class:`pytest.Class`).
+    """
+    # Needed to tell pytest that collected object is a test function
     setattr(obj, "__test__", True)
 
-    # This is needed by pytest code inspection mechanism
-    setattr(collector.obj, name, obj)
+    if hasattr(obj, "__func__"):
+        # Needed to tell pytest that wrapped function in collected object is a test function
+        setattr(obj.__func__, "__test__", True)
 
-    return obj
+
+def is_cocotb_runner(item: Function) -> bool:
+    """Check if test function is a cocotb runner.
+
+    Args:
+        item: Collected item as pytest test function.
+
+    Returns:
+        :data:`True` if collected item is a cocotb runner. Otherwise :data:`False`.
+    """
+    if not iscoroutinefunction(item.function):
+        if item.get_closest_marker("cocotb_runner"):
+            return True
+
+        # Determine based on used HDL fixture in arguments, fixture name is irrelevant, detect based on argument type
+        for name, type_hint in get_type_hints(item.function).items():
+            if name in item.fixturenames and type_hint and issubclass(type_hint, HDL):
+                return True
+
+    return False
+
+
+def is_cocotb_test(item: Function) -> bool:
+    """Check if test function is a cocotb test.
+
+    Args:
+        item: Collected item as pytest test function.
+
+    Returns:
+        :data:`True` if collected item is a cocotb test. Otherwise :data:`False`.
+    """
+    return iscoroutinefunction(item.function) and (
+        item.get_closest_marker("cocotb_test") is not None
+        or "dut" in signature(item.function).parameters
+    )
+
+
+def pre_process_collected_item(obj: object) -> None:
+    """Pre-process collected item.
+
+    Args:
+        obj: Collected item by the pytest Python collector (:class:`pytest.Module` or :class:`pytest.Class`).
+    """
+    if isinstance(obj, TestGenerator):
+        # Convert @cocotb.* decorators to @pytest.mark.* markers
+        cocotb_decorator_as_pytest_marks(obj)
+
+    elif is_marked_as_cocotb(obj):
+        # Mark object with @pytest.mark.cocotb_runner or @pytest.mark.cocotb_test as test
+        mark_as_test(obj)

--- a/src/cocotb_tools/pytest/_controller.py
+++ b/src/cocotb_tools/pytest/_controller.py
@@ -44,6 +44,11 @@ from pytest import (
 
 import cocotb
 from cocotb_tools import _env
+from cocotb_tools.pytest._compat import (
+    is_cocotb_runner,
+    is_cocotb_test,
+    pre_process_collected_item,
+)
 from cocotb_tools.pytest._handle import MockSimHandle
 from cocotb_tools.pytest._junitxml import JUnitXML
 from cocotb_tools.pytest._runner import Runner
@@ -158,6 +163,9 @@ class Controller:
         Yields:
             Collected test function, cocotb runner or cocotb test.
         """
+        # Convert @cocotb.* decorators to @pytest.mark.* markers
+        pre_process_collected_item(obj)
+
         result: Item | Collector | list[Item | Collector] | None = yield
 
         if result is None:
@@ -279,7 +287,7 @@ class Controller:
             if not isinstance(item, Function):
                 yield item
 
-            elif inspect.iscoroutinefunction(item.function):
+            elif is_cocotb_test(item):
                 if item.get_closest_marker("cocotb_runner"):
                     item.warn(
                         UserWarning(
@@ -287,29 +295,28 @@ class Controller:
                             f"This is an usage mistake. Please remove it from {item.nodeid!r}"
                         )
                     )
-                elif item.get_closest_marker("cocotb_test"):
-                    if runner:
-                        # Collected cocotb test must be always under cocotb runner
-                        if collectonly:
-                            # Show collected cocotb test under cocotb runner when invoking pytest --collect-only
-                            # It will help user to visualize hierarchy tree of cocotb tests and cocotb runners
-                            yield item
-                        else:
-                            # Add cocotb test keywords to cocotb runner
-                            # This will allow to run cocotb runner by using keywords associated with cocotb test
-                            runner.item.extra_keyword_matches.update(item.keywords)
-                            # Skip cocotb test here, it will be collected by pytest that is running from HDL simulator
-                else:
-                    yield item  # some coroutine test function that is not part of cocotb
 
-            elif item.get_closest_marker("cocotb_test"):
-                item.warn(
-                    UserWarning(
-                        "You have applied @pytest.mark.cocotb_test marker on non-async test function. "
-                        f"This is an usage mistake. Please remove it from {item.nodeid!r}"
+                if runner:
+                    # Collected cocotb test must be always under cocotb runner
+                    if collectonly:
+                        # Show collected cocotb test under cocotb runner when invoking pytest --collect-only
+                        # It will help user to visualize hierarchy tree of cocotb tests and cocotb runners
+                        yield item
+                    else:
+                        # Add cocotb test keywords to cocotb runner
+                        # This will allow to run cocotb runner by using keywords associated with cocotb test
+                        runner.item.extra_keyword_matches.update(item.keywords)
+                        # Skip cocotb test here, it will be collected by pytest that is running from HDL simulator
+
+            elif is_cocotb_runner(item):
+                if item.get_closest_marker("cocotb_test"):
+                    item.warn(
+                        UserWarning(
+                            "You have applied @pytest.mark.cocotb_test marker on non-async test function. "
+                            f"This is an usage mistake. Please remove it from {item.nodeid!r}"
+                        )
                     )
-                )
-            elif item.get_closest_marker("cocotb_runner"):
+
                 # Avoid recursion of cocotb runners
                 if not runner:
                     if not collectonly:

--- a/src/cocotb_tools/pytest/_regression.py
+++ b/src/cocotb_tools/pytest/_regression.py
@@ -45,11 +45,16 @@ import cocotb
 import cocotb._shutdown
 import cocotb._test
 from cocotb import simulator
+from cocotb._decorators import TestGenerator
 from cocotb._extended_awaitables import with_timeout
 from cocotb._gpi_triggers import Timer
 from cocotb._test import RunningTest
 from cocotb.simtime import TimeUnit, get_sim_time
 from cocotb.task import Task
+from cocotb_tools.pytest._compat import (
+    is_cocotb_test,
+    pre_process_collected_item,
+)
 from cocotb_tools.pytest._fixture import (
     AsyncFixture,
     AsyncFixtureCachedResult,
@@ -242,6 +247,9 @@ class RegressionManager:
         Item | Collector | list[Item | Collector] | None,
         list[Item | Collector] | None,
     ]:
+        # Convert @cocotb.* decorators to @pytest.mark.* markers
+        pre_process_collected_item(obj)
+
         result: Item | Collector | list[Item | Collector] | None = yield
 
         if result is None:
@@ -303,11 +311,8 @@ class RegressionManager:
             if not isinstance(item, Function):
                 yield item
 
-            elif "cocotb_test" in item.keywords and inspect.iscoroutinefunction(
-                item.function
-            ):
+            elif is_cocotb_test(item):
                 item.extra_keyword_matches.update(self._keywords)
-
                 yield item
 
     def _call_and_report(
@@ -618,6 +623,17 @@ class RegressionManager:
     @hookimpl(tryfirst=True)
     def pytest_pyfunc_call(self, pyfuncitem: Function) -> object | None:
         testfunction = pyfuncitem.obj
+        args: Iterable[object] = ()
+
+        if isinstance(testfunction, TestGenerator):
+            # Get test function from cocotb decorator object
+            testfunction = testfunction.func
+
+            if pyfuncitem.getparent(Class):
+                # Pytest will create an instance for class but instance method is not correctly retrieved
+                # by the pytest with getattr(instance, method_name) because it will get cocotb decorator object.
+                # We must inject created instance (self) to method manually
+                args = (pyfuncitem.instance,)  # self
 
         if not inspect.iscoroutinefunction(testfunction):
             return None
@@ -636,7 +652,7 @@ class RegressionManager:
                 for argname in pyfuncitem._fixtureinfo.argnames
             }
 
-            await testfunction(**kwargs)
+            await testfunction(*args, **kwargs)
 
         task: Task = Task(func(), name=f"Test {pyfuncitem.name}")
         self._call = RunningTest(self._call_completed, task)

--- a/tests/pytest_plugin/test_cocotb.py
+++ b/tests/pytest_plugin/test_cocotb.py
@@ -155,11 +155,11 @@ async def test_parametrize_series_2(dut, x: int, y: int, z: int) -> None:
 
 class TestClass:
     @cocotb.test
-    async def test_simple(dut) -> None:
+    async def test_simple(self, dut) -> None:
         """Test @cocotb.test under class."""
 
     @cocotb.parametrize(x=(1, 2), y=(3, 4))
-    async def test_parametrize_matrix(dut, x: int, y: int) -> None:
+    async def test_parametrize_matrix(self, dut, x: int, y: int) -> None:
         """Test @cocotb.parametrize under class."""
         assert x in (1, 2)
         assert y in (3, 4)

--- a/tests/pytest_plugin/test_parametrize.py
+++ b/tests/pytest_plugin/test_parametrize.py
@@ -28,20 +28,20 @@ async def test_series(dut, x: int, y: int, z: int) -> None:
 
 @pytest.mark.parametrize("z", (1, 2))
 class TestParametrize:
-    async def test_from_class(dut, z: int) -> None:
+    async def test_from_class(self, dut, z: int) -> None:
         """Test @pytest.mark.parametrize."""
         assert z in (1, 2)
 
     @pytest.mark.parametrize("x", [4, 5])
     @pytest.mark.parametrize("y", [6, 7, 8])
-    async def test_matrix(dut, x: int, y: int, z: int) -> None:
+    async def test_matrix(self, dut, x: int, y: int, z: int) -> None:
         """Test @pytest.mark.parametrize."""
         assert x in (4, 5)
         assert y in (6, 7, 8)
         assert z in (1, 2)
 
     @pytest.mark.parametrize("x,y", ((7, 8), (9, 4)))
-    async def test_series(dut, x: int, y: int, z: int) -> None:
+    async def test_series(self, dut, x: int, y: int, z: int) -> None:
         """Test @pytest.mark.parametrize."""
         assert x in (7, 9)
         assert y in (8, 4)

--- a/tests/pytest_plugin/test_sample_module.py
+++ b/tests/pytest_plugin/test_sample_module.py
@@ -83,6 +83,11 @@ def test_sample_module_parametrize(sample_module: HDL, int_param: int) -> None:
     sample_module.test()
 
 
+def test_sample_module_without_marker(sample_module: HDL) -> None:
+    """Test runner without using the :deco:`!pytest.mark.cocotb_runner` marker."""
+    sample_module.test()
+
+
 async def test_pass(dut) -> None:
     pass
 

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -213,3 +213,17 @@ async def test_pass_test_in_task(_) -> None:
 @cocotb.test
 async def test_pass_test_in_test(_) -> None:
     cocotb.pass_test("Finished test early")
+
+
+@cocotb.test
+async def test_decorator_call(_) -> None:
+    """Test if decorator is callable. Needed by the pytest unit testing framework."""
+    called: bool = False
+
+    @cocotb.test
+    async def mock() -> None:
+        nonlocal called
+        called = True
+
+    await mock()
+    assert called


### PR DESCRIPTION
- `@pytest.mark.cocotb_runner` marker is now optional
- Added an entry about optional marker in the documentation
- Added unit tests
- Added more comments/docstring
- Refactored `pytest_pycollect_makeitem` hook that is collecting and creating test items
- Refactored how cocotb decorators `@cocotb.test` and `@cocotb.parametrize` are handled

List all tests from the `without_marker` cocotb runner:

```plaintext
pytest -s -v ./tests/pytest_plugin/ -k without_marker --co
```

Output:

```plaintext
<Dir cocotb>
  <Dir tests>
    <Dir pytest_plugin>
      <Module test_sample_module.py>
        <Runner test_sample_module_without_marker>
          <Testbench test_sample_module>
            <Function test_pass>
            <Function test_simple>
            ...
```

Run all tests from the `without_marker` cocotb runner:

```plaintext
pytest -s -v ./tests/pytest_plugin/ -k without_marker
```

Original implementation of the pytest plugin was overriding cocotb decorator objects in test modules because object must be callable for pytest.

After refactoring, these objects are not overridden anymore. Pytest plugin will only add pytest markers to cocotb decorator objects in the expected `pytestmark` attribute. But this require to add the `__call__()` method and the `__func__` attribute to cocotb decorators that pytest is using to retrieve test function.

Closes #5253
Closes #5244

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
