### PR TITLE
Revert "Introduce and use cached_no_args_method"

### DIFF
--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -242,41 +242,6 @@ class cached_method(Generic[InstanceT, Params, ResultT]):
         return func(*args, **kwargs)
 
 
-class cached_no_args_method(Generic[InstanceT, ResultT]):
-    def __init__(self, method: Callable[[InstanceT], ResultT]) -> None:
-        self._method = method
-        update_wrapper(self, method)
-
-    @overload
-    def __get__(
-        self, instance: None, objtype: object = None
-    ) -> Callable[[InstanceT], ResultT]: ...
-
-    @overload
-    def __get__(
-        self, instance: InstanceT, objtype: object = None
-    ) -> Callable[[], ResultT]: ...
-
-    def __get__(
-        self, instance: None | InstanceT, objtype: object = None
-    ) -> Callable[[InstanceT], ResultT] | Callable[[], ResultT]:
-        if instance is None:
-            return self
-
-        res = self._method(instance)
-
-        @wraps(self._method)
-        def lookup() -> ResultT:
-            return res
-
-        setattr(instance, self._method.__name__, lookup)
-        return lookup
-
-    def __call__(self, instance: InstanceT) -> ResultT:
-        func = getattr(instance, self._method.__name__)
-        return func()
-
-
 T = TypeVar("T")
 
 

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -18,7 +18,6 @@ from logging import Logger
 from typing import ClassVar, Literal
 
 import cocotb
-from cocotb._utils import cached_no_args_method
 from cocotb.handle import (
     Deposit,
     Force,
@@ -405,7 +404,6 @@ class Clock:
         for _ in range(num_cycles):
             await edge_type(self._signal)
 
-    @cached_no_args_method
     def __repr__(self) -> str:
         freq_mhz = 1 / get_time_from_sim_steps(
             get_sim_steps(self._period, self._unit), "us"

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -34,7 +34,7 @@ from cocotb._gpi_triggers import (
     ValueChange,
     current_gpi_trigger,
 )
-from cocotb._utils import DocIntEnum, cached_no_args_method
+from cocotb._utils import DocIntEnum
 from cocotb.types import Array, Logic, LogicArray, Range
 from cocotb.types._indexing import do_indexing_changed_warning, indexing_changed
 from cocotb_tools import _env
@@ -1379,7 +1379,6 @@ class LogicArrayObject(
     def __str__(self) -> str:
         return str(self.value)
 
-    @cached_no_args_method
     def __len__(self) -> int:
         # can't use `range` to get length because `range` is for outer-most dimension only
         # and this object needs to support multi-dimensional packed arrays.
@@ -1537,7 +1536,6 @@ class EnumObject(
     def __int__(self) -> int:
         return int(self.value)
 
-    @cached_no_args_method
     def __len__(self) -> int:
         return self._handle.get_num_elems()
 
@@ -1628,7 +1626,6 @@ class IntegerObject(_NonIndexableValueObjectBase[int, int], _SignednessObjectMix
     def __int__(self) -> int:
         return self.value
 
-    @cached_no_args_method
     def __len__(self) -> int:
         return self._handle.get_num_elems()
 


### PR DESCRIPTION
This reverts commit 4c2f0b7f8da512c9b6df404f20524d178e280dd3.

The way Python looks up special methods like `__len__` when calling `len(...)` is not like normal lookup. This causes the `__get__` on `cached_no_args_method` to be called with an instance object, which adds the wrapped function. But it does this on every call, it *never* looks up the method from the object's `__dict__`.

Turns out caching the length isn't needed, just running the function is fast.
