### PR TITLE
Add support for visual separators in LogicArray string literals

### DIFF
--- a/docs/source/newsfragments/5220.feature.1.rst
+++ b/docs/source/newsfragments/5220.feature.1.rst
@@ -1,0 +1,1 @@
+Added support for using underscores (``_``) as visual separators in :class:`str` values used to set the value of :class:`~cocotb.handle.LogicArrayObject` to enhance readability of long bitstrings, e.g. ``dut.signal.value = "1010_1101"``.

--- a/docs/source/newsfragments/5220.feature.rst
+++ b/docs/source/newsfragments/5220.feature.rst
@@ -1,0 +1,1 @@
+Added visual separator support to :class:`.LogicArray` string construction. This allows underscores (``_``) to be used to improve readability of long bitstrings, e.g. ``"1010_1101"``.

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -22,6 +22,11 @@ def test_logic_array_str_construction():
     with pytest.raises(ValueError):
         LogicArray("5h7_@")
 
+    assert LogicArray("1010_1101") == LogicArray("10101101")
+    assert LogicArray("10_____10") == LogicArray("1010")
+    assert LogicArray("_0_") == LogicArray("0")
+    assert LogicArray("___") == LogicArray("")
+
 
 def test_logic_array_iterable_construction():
     assert LogicArray([False, 1, "X", Logic("Z")]) == LogicArray("01XZ")

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -447,3 +447,19 @@ async def test_setattr_error_msg(dut: Any) -> None:
 async def test_pickling_prohibited(dut: object) -> None:
     with pytest.raises(NotImplementedError):
         pickle.dumps(dut)
+
+
+@cocotb.test
+async def test_handle_str_with_separators(dut: Any) -> None:
+    """Test that LogicArray handles string inputs with visual separators correctly."""
+    dut.stream_in_data.value = "1010_1101"
+    await Timer(1, "ns")
+    assert dut.stream_in_data.value == LogicArray("10101101")
+
+    dut.stream_in_data.value = "11__00__11__00"
+    await Timer(1, "ns")
+    assert dut.stream_in_data.value == LogicArray("11001100")
+
+    dut.stream_in_data.value = "__01010011__"
+    await Timer(1, "ns")
+    assert dut.stream_in_data.value == LogicArray("01010011")


### PR DESCRIPTION
Closes #5220. This is expected to reduce performance of `LogicArray` construction with strings. The benchmark may go down.