### PR TITLE
Remove `cached_method`

### DIFF
--- a/src/cocotb/types/_range.py
+++ b/src/cocotb/types/_range.py
@@ -8,8 +8,6 @@ from collections.abc import Iterator, Sequence
 from functools import cache
 from typing import Any, overload
 
-from cocotb._utils import cached_method
-
 
 class Range(Sequence[int]):
     r"""
@@ -167,7 +165,16 @@ class Range(Sequence[int]):
     def __repr__(self) -> str:
         return f"{type(self).__qualname__}({self.left!r}, {self.direction!r}, {self.right!r})"
 
-    index = cached_method(Sequence[int].index)
+    def index(
+        self, value: Any, start: int | None = None, stop: int | None = None, /
+    ) -> int:
+        if start is not None or stop is not None:
+            if start is None:
+                start = self._range.start
+            if stop is None:
+                stop = self._range.stop
+            return super().index(value, start, stop)
+        return self._range.index(value)
 
     def __copy__(self) -> Range:
         return Range.from_range(self._range)

--- a/tests/pytest/test_range.py
+++ b/tests/pytest/test_range.py
@@ -148,3 +148,35 @@ def test_copy() -> None:
     l = Range(-2, "to", 1)
     assert l == copy.copy(l)
     assert l == copy.deepcopy(l)
+
+
+def test_index() -> None:
+    r = Range(1, "to", 5)
+    # value no longer in range
+    with pytest.raises(ValueError):
+        r.index(1, 2, 5)
+    with pytest.raises(ValueError):
+        r.index(1, 2)
+    with pytest.raises(ValueError):
+        r.index(5, 0, 4)
+    # value not in range at all
+    with pytest.raises(ValueError):
+        r.index(10, 1, 5)
+    with pytest.raises(ValueError):
+        r.index(10, 1)
+    with pytest.raises(ValueError):
+        r.index(0, 1, 5)
+    with pytest.raises(ValueError):
+        r.index(0, 1)
+    # start is past stop, will never find
+    with pytest.raises(ValueError):
+        r.index(3, 10, 5)
+    with pytest.raises(ValueError):
+        r.index(3, 10)
+    # start is before start of range, will always find
+    assert r.index(3, 0, 10) == 2
+    # stop is past end of range, will always find
+    assert r.index(3, 0, 10) == 2
+    # stop is before start of range, will never find
+    with pytest.raises(ValueError):
+        r.index(3, 0, -10)


### PR DESCRIPTION
It was only used in one place and actually did something weird where it modified `Sequence.index` rather than modifying `Range.index`.

No docs were added because there were no docs originally.