### PR TITLE
Separate cocotb runners in pytest summary

### DIFF
--- a/src/cocotb_tools/pytest/plugin.py
+++ b/src/cocotb_tools/pytest/plugin.py
@@ -13,7 +13,7 @@ from argparse import ArgumentParser
 from collections.abc import Generator, Iterable, Mapping
 from pathlib import Path
 from time import time
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pluggy import Result
 from pytest import (
@@ -66,7 +66,9 @@ _ENTRY_POINT: str = ",".join(
 if TYPE_CHECKING:
     from typing import TypeAlias
 
-    TestStatus: TypeAlias = TestShortLogReport | tuple[str, str, str | tuple[str, Mapping[str, bool]]]
+    TestStatus: TypeAlias = (
+        TestShortLogReport | tuple[str, str, str | tuple[str, Mapping[str, bool]]]
+    )
 
 
 def _to_timescale(value: str) -> tuple[str, str]:

--- a/src/cocotb_tools/pytest/plugin.py
+++ b/src/cocotb_tools/pytest/plugin.py
@@ -13,7 +13,7 @@ from argparse import ArgumentParser
 from collections.abc import Generator, Iterable, Mapping
 from pathlib import Path
 from time import time
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from pluggy import Result
 from pytest import (
@@ -63,7 +63,10 @@ _ENTRY_POINT: str = ",".join(
         "cocotb_tools.pytest._init:run_regression",
     )
 )
-_TestStatus = TestShortLogReport | tuple[str, str, str | tuple[str, Mapping[str, bool]]]
+if TYPE_CHECKING:
+    from typing import TypeAlias
+
+    TestStatus: TypeAlias = TestShortLogReport | tuple[str, str, str | tuple[str, Mapping[str, bool]]]
 
 
 def _to_timescale(value: str) -> tuple[str, str]:
@@ -710,9 +713,9 @@ def _is_cocotb_test_report(item: Any) -> bool:
 @hookimpl(hookwrapper=True, trylast=True)
 def pytest_report_teststatus(
     report: CollectReport | TestReport, config: Config
-) -> Generator[None, Result[_TestStatus], None]:
-    result: Result[_TestStatus] = yield
-    status: _TestStatus = result.get_result()
+) -> Generator[None, Result[TestStatus], None]:
+    result: Result[TestStatus] = yield
+    status: TestStatus = result.get_result()
 
     if (
         isinstance(report, TestReport)


### PR DESCRIPTION
In this PR, I separate cocotb runners from the rest of the tests in `pytest`'s summary that is reported at the end of the session. I had to look in `pytest`'s source code to see how it handles different `--tb` and `--show-capture` options when reporting failures, and I found out that there's already a `TerminalReporter` class method that handles this for us:

https://github.com/pytest-dev/pytest/blob/3d10b5148e03eb82b3ee29181dbdc73cf82699e2/src/_pytest/terminal.py#L1166-L1168
https://github.com/pytest-dev/pytest/blob/3d10b5148e03eb82b3ee29181dbdc73cf82699e2/src/_pytest/terminal.py#L1175-L1199

I ended up reusing `summary_failures_combined()`, which made the PR fairly simple.

Closes: https://github.com/cocotb/cocotb/issues/5286
