### PR TITLE
Refactor TestManager (part 2)

### DIFF
--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -892,14 +892,16 @@ class RegressionManager:
         if self._tearing_down:
             return
 
-        # We assume if we get here, the simulation ended unexpectedly due to an assertion failure,
-        # or due to an end of events from the simulator.
-        self._sim_failure = SimFailure(
+        msg = (
             "cocotb expected it would shut down the simulation, but the simulation ended prematurely. "
             "This could be due to an assertion failure or a call to an exit routine in the HDL, "
             "or due to the simulator running out of events to process (is your clock running?)."
         )
-        self._running_test.abort()
+
+        # We assume if we get here, the simulation ended unexpectedly due to an assertion failure,
+        # or due to an end of events from the simulator.
+        self._sim_failure = SimFailure(msg)
+        self._running_test.cancel(msg)
         cocotb._event_loop._inst.run()
 
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -364,7 +364,6 @@ class RegressionManager:
             except Exception:
                 self._record_test_init_failed()
                 continue
-            cocotb._test_manager.set_current_test(self._running_test)
 
             self._log_test_start()
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -440,9 +440,16 @@ class RegressionManager:
         cocotb.RANDOM_SEED = self._regression_seed
         random.setstate(self._random_state)
 
+        exc: BaseException | None
+        if self._sim_failure is not None:
+            # When the simulation is failing, we override the typical test results.
+            exc = self._sim_failure
+        else:
+            exc = self._running_test.exception()
+
         # Judge and record pass/fail.
         self._score_test(
-            self._running_test.exception(),
+            exc,
             wall_time,
             sim_time_ns,
         )
@@ -906,7 +913,7 @@ class RegressionManager:
             "This could be due to an assertion failure or a call to an exit routine in the HDL, "
             "or due to the simulator running out of events to process (is your clock running?)."
         )
-        self._running_test.abort(self._sim_failure)
+        self._running_test.abort()
         cocotb._event_loop._inst.run()
 
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -26,7 +26,6 @@ from typing import Any, Callable
 import cocotb
 import cocotb._event_loop
 import cocotb._shutdown as shutdown
-import cocotb._test_manager
 from cocotb import logging as cocotb_logging
 from cocotb import simulator
 from cocotb._base_triggers import Trigger
@@ -39,7 +38,6 @@ from cocotb._utils import DocEnum, safe_divide
 from cocotb._xunit_reporter import XUnitReporter, bin_xml_escape
 from cocotb.logging import ANSI
 from cocotb.simtime import get_sim_time
-from cocotb.task import Task
 from cocotb_tools import _env
 
 __all__ = (
@@ -390,8 +388,11 @@ class RegressionManager:
             func = self._test.func
 
         coro = func(cocotb.top, *self._test.args, **self._test.kwargs)
-        main_task = Task(coro, name=f"Test {self._test.name}")
-        return TestManager(self._test_complete, main_task)
+        return TestManager(
+            coro,
+            test_complete_cb=self._test_complete,
+            name=self._test.name,
+        )
 
     def _schedule_next_test(self) -> None:
         # seed random number generator based on test module, name, and COCOTB_RANDOM_SEED

--- a/src/cocotb_tools/pytest/_fixture.py
+++ b/src/cocotb_tools/pytest/_fixture.py
@@ -6,16 +6,17 @@
 
 from __future__ import annotations
 
-from typing import Any
+from types import TracebackType
+from typing import Any, Union
 
-from cocotb.task import Task
-
-
-class AsyncFixture(Task):
-    """Asynchronous fixture."""
+from cocotb._test_manager import TestManager
 
 
-class AsyncFixtureCachedResult(tuple):
+class AsyncFixtureCachedResult(
+    tuple[
+        TestManager, Any, Union[tuple[BaseException, Union[TracebackType, None]], None]
+    ]
+):
     """Cached result from asynchronous fixture.
 
     Class compatible with pytest fixture cached result.
@@ -35,7 +36,7 @@ class AsyncFixtureCachedResult(tuple):
 
     def __getitem__(self, index: Any) -> Any:
         """Dynamically get result from asynchronous task."""
-        task: Task = super().__getitem__(0)
+        task = super().__getitem__(0)._main_task
 
         if not task.done() or index == 1:
             return super().__getitem__(index)
@@ -53,4 +54,4 @@ class AsyncFixtureCachedResult(tuple):
 
 def resolve_fixture_arg(arg: Any) -> Any:
     """Resolve fixture argument."""
-    return arg.result() if isinstance(arg, AsyncFixture) else arg
+    return arg._main_task.result() if isinstance(arg, TestManager) else arg

--- a/src/cocotb_tools/pytest/_regression.py
+++ b/src/cocotb_tools/pytest/_regression.py
@@ -816,7 +816,6 @@ class RegressionManager:
             running_test: Test to run.
         """
         self._running_test = running_test
-        cocotb._test_manager.set_current_test(running_test)
 
         if self._scheduled:
             self._timer1._register(self._running_test.start)

--- a/src/cocotb_tools/pytest/_test.py
+++ b/src/cocotb_tools/pytest/_test.py
@@ -6,8 +6,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Coroutine
 from typing import Any, Callable
 
+from cocotb._base_triggers import Trigger
 from cocotb._test_manager import TestManager
 from cocotb.task import Task
 
@@ -16,10 +18,14 @@ class RunningTestSetup(TestManager):
     """Running test setup without cancelling added sub-tasks."""
 
     def __init__(
-        self, test_complete_cb: Callable[[], None], main_task: Task[None]
+        self,
+        coro: Coroutine[Trigger, None, None],
+        *,
+        name: str,
+        test_complete_cb: Callable[[], None],
     ) -> None:
         """Create new instance of running test setup."""
-        super().__init__(test_complete_cb=test_complete_cb, main_task=main_task)
+        super().__init__(coro, name=name, test_complete_cb=test_complete_cb)
 
         self.subtasks: list[Task[Any]] = []
         """Sub-tasks that must be keep alive during test setup, call and teardown."""


### PR DESCRIPTION
Numerous small improvements, but primarily this is intended to ensure that all tasks are finished before calling the `test_complete_cb`. Best reviewed commit-by-commit. Will squash when merging.

Depends on #5296. Depends on #5313.