### PR TITLE
tests(pytest-plugin): testing pytest fixtures

### DIFF
--- a/tests/pytest_plugin/test_fixture.py
+++ b/tests/pytest_plugin/test_fixture.py
@@ -1,0 +1,65 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test pytest fixtures with cocotb."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Generator
+
+from pytest import fixture
+
+
+@fixture(name="x")
+def x_fixture() -> int:
+    """Simple fixture that is returning a value."""
+    return 5
+
+
+@fixture(name="x_generator")
+def x_generator_fixture() -> Generator[int, None, None]:
+    """Simple generator fixture that is returning a value."""
+    yield 10
+
+
+@fixture(name="x_async")
+async def x_async_fixture() -> int:
+    """Simple asynchronous fixture that is returning a value."""
+    return 15
+
+
+@fixture(name="x_async_generator")
+async def x_async_generator_fixture() -> AsyncGenerator[int, None]:
+    """Simple asynchronous generator fixture that is returning a value."""
+    yield 20
+
+
+async def test_fixture_value(dut, x: int) -> None:
+    """Test fixture."""
+    assert x == 5
+
+
+async def test_fixture_generator(dut, x_generator: int) -> None:
+    """Test generator fixture."""
+    assert x_generator == 10
+
+
+async def test_fixture_asynchronous_value(dut, x_async: int) -> None:
+    """Test asynchronous fixture."""
+    assert x_async == 15
+
+
+async def test_fixture_asynchronous_generator(dut, x_async_generator: int) -> None:
+    """Test asynchronous generator fixture."""
+    assert x_async_generator == 20
+
+
+async def test_fixture_mix(
+    dut, x: int, x_generator: int, x_async: int, x_async_generator
+) -> None:
+    """Test mix of non-asynchronous and asynchronous fixtures."""
+    assert x == 5
+    assert x_generator == 10
+    assert x_async == 15
+    assert x_async_generator == 20

--- a/tests/pytest_plugin/test_sample_module.py
+++ b/tests/pytest_plugin/test_sample_module.py
@@ -57,6 +57,7 @@ def test_sample_module(sample_module: HDL) -> None:
     "test_caplog",
     "test_pass",
     "test_timeout",
+    "test_fixture",
 )
 def test_sample_module_extra(sample_module: HDL) -> None:
     """Running HDL simulator using cocotb runner for sample module."""


### PR DESCRIPTION
Context: https://github.com/cocotb/cocotb/pull/5289/changes#r2750839059

Added missing tests for pytest plugin to test pytest fixtures (normal and asynchronous) with cocotb. To run them:

```plaintext
pytest -s ./tests/pytest_plugin/ -k test_fixture
```

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
