### PR TITLE
fix(test_task_manager): RuntimeError: ignored GeneratorExit exception

### DIFF
--- a/tests/test_cases/test_cocotb/test_task_manager.py
+++ b/tests/test_cases/test_cocotb/test_task_manager.py
@@ -855,8 +855,10 @@ async def test_start_soon_after_cancel_no_continue(_: object) -> None:
             finally:
                 c = coro(2)
                 with pytest.raises(RuntimeError):
-                    tm.start_soon(c)
-                c.close()  # avoid ResourceWarning since we didn't await it.
+                    try:
+                        tm.start_soon(c)
+                    finally:
+                        c.close()
 
     except BaseExceptionGroup as e:
         my_exc, rest = e.split(MyException)
@@ -903,8 +905,10 @@ async def test_start_soon_outside_context(_: object, continue_on_error: bool) ->
 
     c = coro(1)
     with pytest.raises(RuntimeError):
-        tm.start_soon(c)
-    c.close()  # avoid ResourceWarning since we didn't await it.
+        try:
+            tm.start_soon(c)
+        finally:
+            c.close()
 
 
 @cocotb.test
@@ -934,8 +938,10 @@ async def test_add_tasks_from_another_task(_: object, continue_on_error: bool) -
 
     c = coro(1)
     with pytest.raises(RuntimeError):
-        tm.start_soon(c)
-    c.close()  # avoid ResourceWarning since we didn't await it.
+        try:
+            tm.start_soon(c)
+        finally:
+            c.close()
 
     ev.set()
 
@@ -951,8 +957,10 @@ async def test_start_soon_after_finished(_: object, continue_on_error: bool) -> 
 
     c = coro(1)
     with pytest.raises(RuntimeError):
-        tm.start_soon(c)
-    c.close()  # avoid ResourceWarning since we didn't await it.
+        try:
+            tm.start_soon(c)
+        finally:
+            c.close()
 
 
 @cocotb.test


### PR DESCRIPTION
Fixes #5297 (probably). More technical details about potential fix in my comment: https://github.com/cocotb/cocotb/issues/5297#issuecomment-3833890963

Tested aggressively locally:

```plaintext
for i in $(seq 1 20); do SIM=ghdl TOPLEVEL_LANG=vhdl make -C ./tests/test_cases/test_cocotb; done
```

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
