### PR TITLE
fix(test_integers): invalid boundary ranges

### DIFF
--- a/tests/test_cases/test_integers/test_integers.py
+++ b/tests/test_cases/test_integers/test_integers.py
@@ -83,14 +83,18 @@ async def test_int_verilog(
     await Timer(1)
 
     for value in (
+        # Above maximum value
         max_value + 1,
-        random.randint(max_value, 2 * max_value),
+        random.randint(max_value + 1, 2 * max_value),
         2 * max_value,
         random.randint(2 * max_value, 10 * max_value),
+        10 * max_value,
+        # Below minimum value
         min_value - 1,
-        random.randint(2 * min_value, min_value),
+        random.randint(2 * min_value, min_value - 1),
         2 * min_value,
         random.randint(10 * min_value, 2 * min_value),
+        10 * min_value,
     ):
         cocotb.log.info(f"Testing value={value}")
 
@@ -171,14 +175,18 @@ async def test_integer_access_vhdl(
     await Timer(1)
 
     for value in (
+        # Above maximum value
         max_value + 1,
-        random.randint(max_value, 2 * max_value),
+        random.randint(max_value + 1, 2 * max_value),
         2 * max_value,
         random.randint(2 * max_value, 10 * max_value),
+        10 * max_value,
+        # Below minimum value
         min_value - 1,
-        random.randint(2 * min_value, min_value),
+        random.randint(2 * min_value, min_value - 1),
         2 * min_value,
         random.randint(10 * min_value, 2 * min_value),
+        10 * min_value,
     ):
         cocotb.log.info(f"Testing value={value}")
 


### PR DESCRIPTION
Fixes #5298. Cause: Invalid boundary ranges for random values below minimum and above maximum. Added also edge cases.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
