### PR TITLE
Fix some ResourceWarnings caused by TaskManager

### DIFF
--- a/tests/test_cases/test_cocotb/test_task_manager.py
+++ b/tests/test_cases/test_cocotb/test_task_manager.py
@@ -1119,8 +1119,10 @@ async def test_bad_args(_: object) -> None:
         async def oops_async_generator() -> AsyncGenerator[None, None, None]:
             yield None
 
+        c = oops_async_generator()
         with pytest.raises(TypeError):
-            tm.start_soon(oops_async_generator())  # type: ignore
+            tm.start_soon(c)  # type: ignore
+        await c.aclose()  # avoid ResourceWarning since we didn't await it.
 
         with pytest.raises(TypeError):
             tm.fork(oops_async_generator)  # type: ignore


### PR DESCRIPTION
Previously when calling `start_soon` with a coroutine it wrapped the coroutine in a `_waiter` coroutine. Not only is this unnecessary, it was causing issues. If this was done and then the TaskManager cancelled the Task for that coroutine before it was ever run, a CancelledError was thrown into the `_waiter` task. But because it was never started, no code is actually run. So the CancelledError isn't propagated up into the user's coro and it's never closed, leading to the ResourceWarning.

TaskManager was added this version, so no need for newsfragments.