### PR TITLE
X randomization fixes

### DIFF
--- a/docs/source/newsfragments/5306.bugfix.rst
+++ b/docs/source/newsfragments/5306.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where :envvar:`COCOTB_RESOLVE_X` when set ``"random"`` would resolve all non-``0``/``1`` values in a vector to the same value.

--- a/docs/source/newsfragments/5306.change.rst
+++ b/docs/source/newsfragments/5306.change.rst
@@ -1,0 +1,1 @@
+Split the random number generator (RNG) for the :envvar:`COCOTB_RESOLVE_X` ``"random"`` mode from the global Python RNG, so that switching from one :envvar:`!COCOTB_RESOLVE_X` mode to another would not affect the random number sequence of the rest of the testbench.

--- a/src/cocotb/types/_resolve.py
+++ b/src/cocotb/types/_resolve.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import sys
 from functools import cache
-from random import getrandbits
+from random import Random
 from typing import Callable, Final, Literal, cast
 
 from cocotb_tools import _env
@@ -15,6 +15,8 @@ if sys.version_info >= (3, 10):
 
 ResolverLiteral: TypeAlias = Literal["weak", "zeros", "ones", "random"]
 
+
+_randomResolveRng = Random()
 
 _01lookup = ("0", "1")
 
@@ -27,7 +29,7 @@ class _random_resolve_table(dict[str, str]):
         self["H"] = "1"
 
     def __missing__(self, _: str) -> str:
-        return _01lookup[getrandbits(1)]
+        return _01lookup[_randomResolveRng.getrandbits(1)]
 
 
 _rnd_table = _random_resolve_table()

--- a/src/cocotb/types/_resolve.py
+++ b/src/cocotb/types/_resolve.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import sys
 from functools import cache
 from random import getrandbits
-from typing import Callable, Final, Literal
+from typing import Callable, Final, Literal, cast
 
 from cocotb_tools import _env
 
@@ -16,18 +16,21 @@ if sys.version_info >= (3, 10):
 ResolverLiteral: TypeAlias = Literal["weak", "zeros", "ones", "random"]
 
 
-_ord_0 = ord("0")
+_01lookup = ("0", "1")
 
 
-class _random_resolve_table(dict[int, int]):
+class _random_resolve_table(dict[str, str]):
     def __init__(self) -> None:
-        self[ord("0")] = ord("0")
-        self[ord("1")] = ord("1")
-        self[ord("L")] = ord("0")
-        self[ord("H")] = ord("1")
+        self["0"] = "0"
+        self["1"] = "1"
+        self["L"] = "0"
+        self["H"] = "1"
 
-    def __missing__(self, _: str) -> int:
-        return getrandbits(1) + _ord_0
+    def __missing__(self, _: str) -> str:
+        return _01lookup[getrandbits(1)]
+
+
+_rnd_table = _random_resolve_table()
 
 
 _resolve_tables: dict[str, dict[int, int]] = {
@@ -35,7 +38,6 @@ _resolve_tables: dict[str, dict[int, int]] = {
     "weak": str.maketrans("LHW", "01X"),
     "zeros": str.maketrans("LHUXZW-", "0100000"),
     "ones": str.maketrans("LHUXZW-", "0111111"),
-    "random": _random_resolve_table(),
 }
 
 _VALID_RESOLVERS = ("error", "weak", "zeros", "ones", "random")
@@ -49,10 +51,17 @@ def get_str_resolver(resolver: ResolverLiteral) -> Callable[[str], str]:
     if resolver not in _VALID_RESOLVERS:
         raise ValueError(f"Invalid resolver: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}")
 
-    resolve_table = _resolve_tables[resolver]
+    if resolver == "random":
+        # Can't use str.translate for random resolving as it assumes that the mapping
+        # will not change over the course of the call.
+        def resolve_func(value: str) -> str:
+            return "".join(map(_rnd_table.__getitem__, value))
 
-    def resolve_func(value: str) -> str:
-        return value.translate(resolve_table)
+    else:
+        resolve_table = _resolve_tables[resolver]
+
+        def resolve_func(value: str) -> str:
+            return value.translate(resolve_table)
 
     return resolve_func
 
@@ -70,7 +79,7 @@ def _init() -> Callable[[str], str] | None:
 
     # get resolver
     try:
-        return get_str_resolver(resolver)
+        return get_str_resolver(cast("ResolverLiteral", resolver))
     except ValueError:
         raise ValueError(
             f"Invalid COCOTB_RESOLVE_X value: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}"


### PR DESCRIPTION
The first commit fixes X randomization by avoiding the use of `str.translate` due to python/cpython#144463. The second commit increases test reproducibility when switching between random and non-random X resolution modes.

### TODO

- [x] newsfragment