### PR TITLE
PYGPI: Fix logging finalize

### DIFF
--- a/src/cocotb/share/lib/pygpi/logging.cpp
+++ b/src/cocotb/share/lib/pygpi/logging.cpp
@@ -215,6 +215,8 @@ void pygpi_logging_finalize() {
     gpi_set_log_handler(fallback_log_handler, fallback_log_userdata);
     Py_XDECREF(m_log_func);
     Py_XDECREF(m_get_logger);
+    m_log_func = nullptr;
+    m_get_logger = nullptr;
     for (auto &elem : m_logger_map) {
         Py_DECREF(elem.second);
     }


### PR DESCRIPTION
If these are left non-null,
then the log at the end of `finalize()` in `embed.cpp` tries to use the Python logger after `Py_Finalize()` has been called.
This fix allows `pygpi_log_handler()` to use the native fallback handler from GPI.

The bug is only hit when running with `PYGPI_DEBUG=1`.