### PR TITLE
Include skipif in `__all__`

### DIFF
--- a/src/cocotb/__init__.py
+++ b/src/cocotb/__init__.py
@@ -27,6 +27,7 @@ __all__ = (
     "parametrize",
     "pass_test",
     "plusargs",
+    "skipif",
     "start",
     "start_soon",
     "test",


### PR DESCRIPTION
Missed originally. Local mypy is showing this as an issue in downstream files.