### PR TITLE
Use `nox-uv`

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -41,8 +41,10 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install nox
-        run: python3 -m pip install nox
+        run: python3 -m pip install nox nox-uv
 
       # Use the cibuildwheel configuration inside nox, instead of the
       # cibuildwheel GitHub Action, to make the process easy to reproduce
@@ -71,8 +73,10 @@ jobs:
         path: dist
         pattern: cocotb-dist-*
         merge-multiple: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
     - name: Install nox
-      run: python3 -m pip install nox
+      run: python3 -m pip install nox nox-uv
     - name: Smoke-test the sdist
       run: nox -s release_test_sdist
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -123,9 +123,11 @@ jobs:
       if: startsWith(matrix.python-version, '3.14') && startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get install -y --no-install-recommends libxml2-dev libxslt-dev
       # Run tests that don't need a simulator.
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
     - name: Install Python testing dependencies
       run: |
-        pip install nox
+        pip install nox nox-uv
 
       # Install Icarus
     - name: Set up Icarus (Ubuntu - apt)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,7 @@ repos:
     - pytest
     - coverage
     - nox
+    - nox-uv
     files: ^(src/cocotb/|src/pygpi/|noxfile.py)
 
 ci:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,8 +252,8 @@ pretty = true
 [dependency-groups]
 dev = [
     # required for development
-    "pip>=25.1",  # 25.1 needed for '--groups'
     "nox",
+    "nox-uv",
     "pre-commit",
     # allows linting the project manually
     "clang-format",

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,7 @@ dev = [
     { name = "gcovr" },
     { name = "mypy" },
     { name = "nox" },
-    { name = "pip" },
+    { name = "nox-uv" },
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -667,7 +667,7 @@ dev = [
     { name = "gcovr", specifier = "==8.4" },
     { name = "mypy", specifier = ">=1.18" },
     { name = "nox" },
-    { name = "pip", specifier = ">=25.1" },
+    { name = "nox-uv" },
     { name = "pre-commit" },
     { name = "pytest", specifier = ">=6" },
     { name = "pytest-cov" },
@@ -1894,6 +1894,18 @@ wheels = [
 ]
 
 [[package]]
+name = "nox-uv"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nox" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/e8/670919c513c22f4bf1656d84dd99a9ad1a5eaaeadf2457bab3efeeac14e0/nox_uv-0.7.1.tar.gz", hash = "sha256:f075d610b4648732fd17cbc9fa48be7d2c23df7b188fed3e4e6dde7bd1f14f20", size = 5124, upload-time = "2026-02-05T03:55:34.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/0a/a6798a215366c9b034e92a9992d9013da5f544a488216fc54204ccf3c134/nox_uv-0.7.1-py3-none-any.whl", hash = "sha256:91361cc282a0a764de1b94ad002b67d5b43de4adc3f56e16d1b79928c8ec0433", size = 5457, upload-time = "2026-02-05T03:55:35.994Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2039,15 +2051,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/98/fc53ab36da80b88df0967896b6c4b4cd948a0dc5aa40a754266aa3ae48b3/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3", size = 5313850, upload-time = "2026-02-11T04:23:00.554Z" },
     { url = "https://files.pythonhosted.org/packages/30/02/00fa585abfd9fe9d73e5f6e554dc36cc2b842898cbfc46d70353dae227f8/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735", size = 5963343, upload-time = "2026-02-11T04:23:02.934Z" },
     { url = "https://files.pythonhosted.org/packages/f2/26/c56ce33ca856e358d27fda9676c055395abddb82c35ac0f593877ed4562e/pillow-12.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e", size = 7029880, upload-time = "2026-02-11T04:23:04.783Z" },
-]
-
-[[package]]
-name = "pip"
-version = "26.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
~~Depends on #5327.~~ ~~Depends on #5336.~~

Adds `nox-uv` as a development dependency and convert the noxfile to use it. This allows us to use `uv sync` to install dependency groups.

As opposed to #5314 this keeps nox which means...
* Will use `nox -s docs` and `nox -k "dev_test and icarus and verilog"` etc instead of `uv run invoke docs`
* Each session still maintains it's own venv for reasons...
* But builds are cached so no more rebuilding cocotb unless the sources change
* No major rewrite