### PR TITLE
Merge sessions in noxfile

### DIFF
--- a/.github/workflows/build-test-dev.yml
+++ b/.github/workflows/build-test-dev.yml
@@ -50,8 +50,7 @@ jobs:
     name: Regression Tests
     uses: ./.github/workflows/regression-tests.yml
     with:
-      nox_session_test_sim: dev_test_sim
-      nox_session_test_nosim: dev_test_nosim
+      test_task: dev_test
       collect_coverage: true
       group: ci-free
 
@@ -60,7 +59,6 @@ jobs:
     name: Regression Tests
     uses: ./.github/workflows/regression-tests.yml
     with:
-      nox_session_test_sim: dev_test_sim
-      nox_session_test_nosim: dev_test_nosim
+      test_task: dev_test
       collect_coverage: true
       group: ci-licensed

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -81,8 +81,7 @@ jobs:
     needs: build_release
     uses: ./.github/workflows/regression-tests.yml
     with:
-      nox_session_test_sim: release_test_sim
-      nox_session_test_nosim: release_test_nosim
+      test_task: release_test_wheel
       download_artifacts: true
       group: ci-free
 
@@ -91,8 +90,7 @@ jobs:
     needs: build_release
     uses: ./.github/workflows/regression-tests.yml
     with:
-      nox_session_test_sim: release_test_sim
-      nox_session_test_nosim: release_test_nosim
+      test_task: release_test_wheel
       download_artifacts: true
       group: ci-licensed
 

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -21,6 +21,5 @@ jobs:
     name: Regression Tests
     uses: ./.github/workflows/regression-tests.yml
     with:
-      nox_session_test_sim: dev_test_sim
-      nox_session_test_nosim: dev_test_nosim
+      test_task: dev_test
       group: experimental

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -19,7 +19,6 @@ jobs:
     name: Regression Tests
     uses: ./.github/workflows/regression-tests.yml
     with:
-      nox_session_test_sim: dev_test_sim
-      nox_session_test_nosim: dev_test_nosim
+      test_task: dev_test
       group: extended
       max_parallel: 5

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -6,14 +6,10 @@ name: Regression Tests
 on:
   workflow_call:
     inputs:
-      nox_session_test_sim:
+      test_task:
         required: true
         type: string
-        default: dev_test_sim
-      nox_session_test_nosim:
-        required: true
-        type: string
-        default: dev_test_nosim
+        default: dev_test
       collect_coverage:
         required: false
         type: boolean
@@ -130,11 +126,6 @@ jobs:
     - name: Install Python testing dependencies
       run: |
         pip install nox
-
-    - name: Run tests without simulators
-      if: ${{ matrix.test_nosim }}
-      run: nox -s "${{ inputs.nox_session_test_nosim }}"
-      continue-on-error: ${{matrix.may-fail || false}}
 
       # Install Icarus
     - name: Set up Icarus (Ubuntu - apt)
@@ -260,7 +251,7 @@ jobs:
       id: windowstesting
       continue-on-error: ${{matrix.may-fail || false}}
       run: |
-        nox -k "${{ inputs.nox_session_test_sim }} and ${{ matrix.sim }} and ${{ matrix.lang }}"
+        nox -k "${{ inputs.test_task }} and ${{ matrix.sim }} and ${{ matrix.lang }}"
       env:
         COCOTB_ANSI_OUTPUT: 1
         COCOTB_CI_SKIP_MAKE: 1
@@ -287,17 +278,17 @@ jobs:
         if [ "${{matrix.self-hosted}}" == "true" ]; then
           module load "${{ matrix.sim-version }}"
         fi
-        nox -k "${{ inputs.nox_session_test_sim }} and ${{ matrix.sim }} and ${{ matrix.lang }}"
+        nox -k "${{ inputs.test_task }} and ${{ matrix.sim }} and ${{ matrix.lang }}"
       env:
         COCOTB_ANSI_OUTPUT: 1
 
     # codecov
     - name: Combine and report coverage
       if: inputs.collect_coverage && matrix.cxx != 'clang++'
-      run: nox -s dev_coverage_combine
+      run: nox -s dev_coverage_report
     - name: Combine and report coverage (clang)
       if: inputs.collect_coverage && matrix.cxx == 'clang++'
-      run: nox -s dev_coverage_combine -- 'llvm-cov gcov'
+      run: nox -s dev_coverage_report -- 'llvm-cov gcov'
 
     - name: Upload to codecov
       if: inputs.collect_coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,9 +259,8 @@ dev = [
     "clang-format",
     "mypy>=1.18",  # 1.18 needed for descriptor typing
     "ruff",
-    # allows running tests manually if desired
-    {include-group = "test"},
-    {include-group = "test_coverage"},
+    # allows running tests and doing coverage reporting manually if desired
+    {include-group = "dev_test"},
     {include-group = "coverage_report"},
 ]
 docs = [
@@ -288,20 +287,17 @@ docs_preview = [
     {include-group = "docs"},
     "sphinx-autobuild",
 ]
+release_build_wheel = [
+    "cibuildwheel==3.2.1",
+]
 release_build_sdist = [
     "build",
 ]
-release_build_bdist = [
-    "cibuildwheel==3.2.1",
-]
-package_deps = [
-    "exceptiongroup; python_version<'3.11'",
-    "find_libpython",
-]
-test = [
+test_common = [
     "pytest>=6"
 ]
-test_coverage = [
+dev_test = [
+    {include-group = "test_common"},
     "coverage[toml]>=7.2",
     "pytest-cov",
 ]
@@ -309,8 +305,19 @@ coverage_report = [
     "coverage[toml]>=7.2",
     "gcovr==8.4",
 ]
+release_test = [
+    {include-group = "test_common"},
+
+    # We have to disable the use of the PyPi index when installing cocotb to
+    # guarantee that the wheels in dist are being used. But without an index
+    # pip cannot find the dependencies, which need to be installed from PyPi.
+    # Work around that by explicitly installing the dependencies first from
+    # PyPi, and then installing cocotb itself from the local dist directory.
+    "exceptiongroup; python_version<'3.11'",
+    "find_libpython",
+]
 
 [tool.uv.dependency-groups]
 # We need Python 3.11 to run Sphinx 8.2 and cibuildwheel 3.2
 docs = {requires-python = ">=3.11"}
-release_build_bdist = {requires-python = ">=3.11"}
+release_build_wheel = {requires-python = ">=3.11"}


### PR DESCRIPTION
This simplifies the noxfile and CI by merging sessions together. The idea being that reducing the number of sessions will reduce the number of different venvs and different dependency-groups we need to create which are doing the same thing. Closes #5017.

* the `dev_test_nosim` and `dev_test_sim` are merged into the single `dev_test`
* the `release_test_nosim` and `release_test_sim` are merged into the new `release_test`
* the CI name for this remove the use of the word "nox" because it may not always be nox.