### PR TITLE
docs: Remove version badge style from GPI page

### DIFF
--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -513,8 +513,9 @@ hr.docutils {
     opacity: 1.0;
 }
 
-/* Add badges for links that point to docs of specific cocotb versions */
-a[href*="docs.cocotb.org"]::after {
+/* Add version badges for links that point to docs of specific cocotb versions */
+/* Do not show badges on certain pages (class set in cocotb.js) */
+body:not(.no-version-badges) a[href*="docs.cocotb.org"]::after {
     background-color: white;
     color: var(--color-cocotb-blue);
     border: 1px solid;
@@ -528,31 +529,31 @@ a[href*="docs.cocotb.org"]::after {
     text-decoration: none;
 }
 
-a[href*="docs.cocotb.org"][href*="v1.9"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.9"]::after {
     content: "v1.9";
 }
-a[href*="docs.cocotb.org"][href*="v1.8"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.8"]::after {
     content: "v1.8";
 }
-a[href*="docs.cocotb.org"][href*="v1.7"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.7"]::after {
     content: "v1.7";
 }
-a[href*="docs.cocotb.org"][href*="v1.6"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.6"]::after {
     content: "v1.6";
 }
-a[href*="docs.cocotb.org"][href*="v1.5"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.5"]::after {
     content: "v1.5";
 }
-a[href*="docs.cocotb.org"][href*="v1.4"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.4"]::after {
     content: "v1.4";
 }
-a[href*="docs.cocotb.org"][href*="v1.3"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.3"]::after {
     content: "v1.3";
 }
-a[href*="docs.cocotb.org"][href*="v1.2"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.2"]::after {
     content: "v1.2";
 }
-a[href*="docs.cocotb.org"][href*="v1.1"]::after {
+body:not(.no-version-badges) a[href*="docs.cocotb.org"][href*="v1.1"]::after {
     content: "v1.1";
 }
 

--- a/docs/source/_static/cocotb.js
+++ b/docs/source/_static/cocotb.js
@@ -2,4 +2,7 @@ document.addEventListener("DOMContentLoaded", function () {
     if (window.location.href.includes("release_notes")) {
         document.body.classList.add("release-notes");
     }
+    if (window.location.href.includes("library_reference_c.html")) {
+        document.body.classList.add("no-version-badges");
+    }
 });


### PR DESCRIPTION
Needs JS in addition to CSS unfortunately.

Rendered: https://cocotb--5334.org.readthedocs.build/en/5334/library_reference_c.html#gpi_8h_1autotoc_md1

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
