### PR TITLE
Update dependabot config to update the lockfile only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
This will prevent dependabot from updating `pypyroject.toml` only bumping the uv lockfile.