### PR TITLE
ci: skip licensed simulator tests for fork PRs

### DIFF
--- a/.github/workflows/build-test-dev.yml
+++ b/.github/workflows/build-test-dev.yml
@@ -55,7 +55,12 @@ jobs:
       group: ci-free
 
   test_dev_licensed:
-    if: github.repository == 'cocotb/cocotb'
+    # Only run licensed simulator tests for pushes to master/stable or PRs
+    # originating from the same repo (not forks, which lack simulator secrets).
+    if: >-
+      github.repository == 'cocotb/cocotb'
+      && (github.event_name == 'push'
+          || github.event.pull_request.head.repo.full_name == 'cocotb/cocotb')
     name: Regression Tests
     uses: ./.github/workflows/regression-tests.yml
     with:


### PR DESCRIPTION
## Summary
- The `test_dev_licensed` job condition only checked `github.repository == 'cocotb/cocotb'`, which is true even for PRs from forks (the workflow runs in the target repo)
- Fork PRs lack the secrets needed for licensed simulators, causing all proprietary simulator jobs (questa, riviera, vcs, xcelium) to fail with "Unable to locate a modulefile" errors
- Add check that `github.event.pull_request.head.repo.full_name == 'cocotb/cocotb'` so licensed tests only run on pushes or same-repo PRs

## Test plan
- [ ] Verify licensed simulator jobs no longer appear on fork PRs
- [ ] Verify licensed simulator jobs still run on pushes to master and same-repo PRs