### PR TITLE
Fix release flow

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -50,7 +50,9 @@ jobs:
       # cibuildwheel GitHub Action, to make the process easy to reproduce
       # locally.
       - name: Build cocotb release
-        run: nox -s release_build
+        run: |
+          nox -s release_build_wheel
+          nox -s release_build_sdist
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:


### PR DESCRIPTION
Adding a `release_build` target whose only purpose is to call `release_build_sdist` and `release_build_wheel` is not valuable as `nox` creates a new venv for each session and this session would be created just to call the two others. 

Merging them into one session is also not recommended in case dependency conflicts cause issues, and also makes it difficult to do `session.notify([build])` in the `release_test_wheel` and `release_test_sdist` sessions, which also can't be merged since we install cocotb two different ways there.