### PR TITLE
Make pytest dependency required

### DIFF
--- a/docs/source/newsfragments/5363.change.rst
+++ b/docs/source/newsfragments/5363.change.rst
@@ -1,0 +1,1 @@
+:mod:`pytest` is no longer an optional dependency, but is required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,17 @@ maintainers = [
     {name = "Philipp Wagner"},
 ]
 dependencies = [
+    # For finding the libpython on the system so the GPI can preload it before
+    # embedding the Python interpreter.
     "find_libpython",
+    # Backport of Python 3.11's ExceptionGroups that are thrown by TaskManager.
     "exceptiongroup; python_version < '3.11'",
+    # For assertion rewriting, `raises` and `warns` context managers,
+    # `RaisesExc` and `RaisesGroup` test expected errors,
+    # `skip` and `xfail` functions for ending tests early,
+    # and for pytest plugin and test running functionality.
+    # Assertion rewriting interface changed in version 6.
+    "pytest >= 6",
 ]
 requires-python = ">= 3.9"
 classifiers = [

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -21,10 +21,11 @@ from enum import auto
 from importlib import import_module
 from typing import Any
 
+import pytest
+
 import cocotb
 import cocotb._event_loop
 import cocotb._shutdown as shutdown
-import cocotb._test_manager
 import cocotb.types._resolve
 from cocotb import logging as cocotb_logging
 from cocotb import simulator
@@ -52,19 +53,11 @@ TestGenerator.__module__ = __name__
 Test.__module__ = __name__
 TestFactory.__module__ = __name__
 
-Failed: type[BaseException]
-try:
-    import pytest
-except ModuleNotFoundError:
-    Failed = AssertionError
-else:
-    try:
-        with pytest.raises(Exception):
-            pass
-    except BaseException as _raises_e:
-        Failed = type(_raises_e)
-    else:
-        assert False, "pytest.raises doesn't raise an exception when it fails"
+
+_TestFailures: tuple[type[BaseException], ...] = (
+    AssertionError,
+    pytest.raises.Exception,  # type: ignore[attr-defined]
+)
 
 
 class SimFailure(BaseException):
@@ -276,35 +269,21 @@ class RegressionManager:
 
         Must be called before all modules containing tests are imported.
         """
-        try:
-            import pytest  # noqa: PLC0415
-        except ImportError:
-            _logger.info(
-                "pytest not found, install it to enable better AssertionError messages"
-            )
+        # Install the assertion rewriting hook, which must be done before we
+        # import the test modules.
+        from _pytest.assertion import install_importhook  # noqa: PLC0415
+        from _pytest.config import Config  # noqa: PLC0415
+
+        python_files = os.getenv("COCOTB_REWRITE_ASSERTION_FILES", "*.py").strip()
+        if not python_files:
+            # Even running the hook causes exceptions in some cases, so if the user
+            # selects nothing, don't install the hook at all.
             return
-        try:
-            # Install the assertion rewriting hook, which must be done before we
-            # import the test modules.
-            from _pytest.assertion import install_importhook  # noqa: PLC0415
-            from _pytest.config import Config  # noqa: PLC0415
 
-            python_files = os.getenv("COCOTB_REWRITE_ASSERTION_FILES", "*.py").strip()
-            if not python_files:
-                # Even running the hook causes exceptions in some cases, so if the user
-                # selects nothing, don't install the hook at all.
-                return
-
-            pytest_conf = Config.fromdictargs(
-                {}, ["--capture=no", "-o", f"python_files={python_files}"]
-            )
-            install_importhook(pytest_conf)
-        except Exception:
-            _logger.exception(
-                "Configuring the assertion rewrite hook using pytest %s failed. "
-                "Please file a bug report!",
-                pytest.__version__,
-            )
+        pytest_conf = Config.fromdictargs(
+            {}, ["--capture=no", "-o", f"python_files={python_files}"]
+        )
+        install_importhook(pytest_conf)
 
     def start_regression(self) -> None:
         """Start the regression."""
@@ -507,7 +486,7 @@ class RegressionManager:
                 )
 
         elif test.expect_fail:
-            if isinstance(exc, (AssertionError, Failed)):
+            if isinstance(exc, _TestFailures):
                 self._record_test_passed(
                     wall_time_s=wall_time_s,
                     sim_time_ns=sim_time_ns,

--- a/uv.lock
+++ b/uv.lock
@@ -561,6 +561,8 @@ source = { editable = "." }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "find-libpython" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.dev-dependencies]
@@ -654,6 +656,7 @@ test-common = [
 requires-dist = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "find-libpython" },
+    { name = "pytest", specifier = ">=6" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Since we are using it for so many features we should maybe make it a required dependency. 

Features we support/use or will support/use in the near future:
* Assertion rewriting
* `pytest.raises` and `pytest.warns`
* `pytest.RaisesExc` and `pytest.RaisesGroup`
* `pytest.skip` and `pytest.xfail`
* For running Runner tests without plugin
* Pytest plugin

### TODO
- [x] newsfrag