### PR TITLE
Support `pytest.xfail` and `pytest.skip`

### DIFF
--- a/docs/source/newsfragments/5380.feature.rst
+++ b/docs/source/newsfragments/5380.feature.rst
@@ -1,0 +1,1 @@
+Added support for :func:`pytest.skip` and :func:`pytest.xfail` for ending the test early.

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -324,6 +324,33 @@ It may appear as one or more attributes here depending on the number of compilat
     cocotb.log.info(cocotb.packages.my_package.foo.value)
 
 
+Forcing a test to end with a given result
+=========================================
+
+In addition to the normal ways a test can pass or fail (see :ref:`passing_and_failing_tests`),
+a test can be forced to end with a given result using the following functions:
+
+* :func:`pytest.xfail` to end the test with an expected fail (considered a pass)
+* :func:`pytest.skip` to end the test with a skip
+
+These functions can be called from any Task and will end the test immediately with the given result.
+They are typically used when you cannot use the :deco:`cocotb.skipif` or :deco:`cocotb.xfail` decorators
+to describe the exact conditions under which a test should be skipped or have reached an expected fail state.
+
+.. code-block:: python
+
+    @cocotb.test()
+    async def test(dut):
+        if load_stimulus_from_a_file(dut.paramA, dut.paramB) is None:
+            pytest.skip("The test stimulus is not available, assuming this combination of parameters is not supported")
+
+    @cocotb.test()
+    async def test(dut):
+        ...
+        if dut.read_empty.value == 0:
+            pytest.xfail("The read interface is not empty, but this test is expected to fail in this case")
+
+
 .. _passing_and_failing_tests:
 
 Passing and failing tests
@@ -331,10 +358,10 @@ Passing and failing tests
 
 When cocotb tests complete execution, they have either `passed` or `failed`.
 
-In general, if a test coroutine completes without raising an :exc:`!Exception`,
+In general, if the main test coroutine completes without raising an :exc:`!Exception`,
 or if the test coroutine or any running :class:`~cocotb.task.Task` calls :func:`cocotb.pass_test`,
 the test is considered to have `passed`.
-Also, if a test raises a :exc:`~asyncio.CancelledError`,
+Also, if the main test coroutine raises a :exc:`~asyncio.CancelledError`,
 or is :keyword:`await`\ ing a :class:`!Task` that is cancelled and does not handle it (or re-raises it),
 the test will end immediately but it will have `passed`.
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -17,7 +17,7 @@ import re
 import sys
 import time
 import warnings
-from enum import auto
+from enum import Enum, auto
 from importlib import import_module
 from typing import Any, cast
 
@@ -151,16 +151,23 @@ class RegressionMode(DocEnum):
     )
 
 
+class _TestOutcome(Enum):
+    PASS = auto()
+    FAIL = auto()
+    SKIP = auto()
+    XFAIL = auto()
+
+
 class _TestResults:
     def __init__(
         self,
         test_fullname: str,
-        passed: None | bool,
+        outcome: _TestOutcome,
         wall_time_s: float,
         sim_time_ns: float,
     ) -> None:
         self.test_fullname = test_fullname
-        self.passed = passed
+        self.outcome = outcome
         self.wall_time_s = wall_time_s
         self.sim_time_ns = sim_time_ns
 
@@ -191,6 +198,7 @@ class RegressionManager:
     COLOR_PASSED = ANSI.GREEN_FG
     COLOR_SKIPPED = ANSI.YELLOW_FG
     COLOR_FAILED = ANSI.RED_FG
+    COLOR_XFAILED = ANSI.YELLOW_FG
 
     _timer1 = Timer(1)
 
@@ -379,7 +387,7 @@ class RegressionManager:
 
             # if the test is skipped, record and continue
             if self._test.skip and self._mode != RegressionMode.TESTCASE:
-                self._record_test_skipped()
+                self._record_test_skipped(wall_time_s=0, sim_time_ns=0, msg=None)
                 continue
 
             # if the test should be run, but the simulator has failed, record and continue
@@ -496,6 +504,22 @@ class RegressionManager:
         test = self._test
 
         if exc is not None:
+            # These special exceptions take precedence over expect_error and expect_fail.
+            if isinstance(exc, pytest.skip.Exception):
+                # We got a skip exception, so we consider the test skipped.
+                return self._record_test_skipped(
+                    wall_time_s=wall_time_s,
+                    sim_time_ns=sim_time_ns,
+                    msg=exc.msg,
+                )
+            elif isinstance(exc, pytest.xfail.Exception):
+                # We got an xfail exception, so we consider the test xfailed.
+                return self._record_test_xfail(
+                    wall_time_s=wall_time_s,
+                    sim_time_ns=sim_time_ns,
+                    result=None,
+                    msg=exc.msg,
+                )
             if test.expect_error:
                 expected_error_set = set(test.expect_error)
 
@@ -505,7 +529,7 @@ class RegressionManager:
                 )
                 if matched:
                     # We got an RaisesExc or RaisesGroup that matches the expected exception.
-                    return self._record_test_passed(
+                    return self._record_test_xfail(
                         wall_time_s=wall_time_s,
                         sim_time_ns=sim_time_ns,
                         result=exc,
@@ -520,7 +544,7 @@ class RegressionManager:
 
                 if isinstance(exc, tuple(expected_excs_set)):
                     # Non-exception group error with expected type.
-                    return self._record_test_passed(
+                    return self._record_test_xfail(
                         wall_time_s=wall_time_s,
                         sim_time_ns=sim_time_ns,
                         result=exc,
@@ -545,7 +569,7 @@ class RegressionManager:
             elif test.expect_fail:
                 if isinstance(exc, _TestFailures):
                     # We expected a failure and got one.
-                    return self._record_test_passed(
+                    return self._record_test_xfail(
                         wall_time_s=wall_time_s,
                         sim_time_ns=sim_time_ns,
                         result=exc,
@@ -586,10 +610,7 @@ class RegressionManager:
         else:
             # We expected a pass and got one.
             return self._record_test_passed(
-                wall_time_s=wall_time_s,
-                sim_time_ns=sim_time_ns,
-                result=None,
-                msg=None,
+                wall_time_s=wall_time_s, sim_time_ns=sim_time_ns
             )
 
     def _get_lineno(self, test: Test) -> int:
@@ -630,20 +651,27 @@ class RegressionManager:
 
         # do not log anything, nor save details for the summary
 
-    def _record_test_skipped(self) -> None:
+    def _record_test_skipped(
+        self,
+        wall_time_s: float,
+        sim_time_ns: float,
+        msg: str | None,
+    ) -> None:
         """Called by :meth:`_execute` when a test is skipped."""
 
         # log test results
         hilight_start = "" if cocotb_logging.strip_ansi else self.COLOR_SKIPPED
         hilight_end = "" if cocotb_logging.strip_ansi else ANSI.DEFAULT
+        if msg is not None:
+            msg = f": {msg}"
+        else:
+            msg = f" ({self.count}/{self.total_tests}){_format_doc(self._test.doc)}"
         self.log.info(
-            "%sskipping%s %s (%d/%d)%s",
+            "%sskipping%s %s%s",
             hilight_start,
             hilight_end,
             self._test.fullname,
-            self.count,
-            self.total_tests,
-            _format_doc(self._test.doc),
+            msg,
         )
 
         # write out xunit results
@@ -663,9 +691,9 @@ class RegressionManager:
         self._test_results.append(
             _TestResults(
                 test_fullname=self._test.fullname,
-                passed=None,
-                sim_time_ns=0,
-                wall_time_s=0,
+                outcome=_TestOutcome.SKIP,
+                sim_time_ns=sim_time_ns,
+                wall_time_s=wall_time_s,
             )
         )
 
@@ -706,7 +734,7 @@ class RegressionManager:
         self._test_results.append(
             _TestResults(
                 test_fullname=self._test.fullname,
-                passed=False,
+                outcome=_TestOutcome.FAIL,
                 sim_time_ns=0,
                 wall_time_s=0,
             )
@@ -716,7 +744,7 @@ class RegressionManager:
         self.failures += 1
         self.count += 1
 
-    def _record_test_passed(
+    def _record_test_xfail(
         self,
         wall_time_s: float,
         sim_time_ns: float,
@@ -764,7 +792,48 @@ class RegressionManager:
         self._test_results.append(
             _TestResults(
                 test_fullname=self._test.fullname,
-                passed=True,
+                outcome=_TestOutcome.PASS,
+                sim_time_ns=sim_time_ns,
+                wall_time_s=wall_time_s,
+            )
+        )
+
+    def _record_test_passed(
+        self,
+        wall_time_s: float,
+        sim_time_ns: float,
+    ) -> None:
+        start_hilight = "" if cocotb_logging.strip_ansi else self.COLOR_PASSED
+        stop_hilight = "" if cocotb_logging.strip_ansi else ANSI.DEFAULT
+        self.log.info(
+            "%s %spassed%s",
+            self._test.fullname,
+            start_hilight,
+            stop_hilight,
+        )
+
+        # write out xunit results
+        ratio_time = safe_divide(sim_time_ns, wall_time_s)
+        lineno = self._get_lineno(self._test)
+        self.xunit.add_testcase(
+            name=self._test.name,
+            classname=self._test.module,
+            file=inspect.getfile(self._test.func),
+            lineno=repr(lineno),
+            time=repr(wall_time_s),
+            sim_time_ns=repr(sim_time_ns),
+            ratio_time=repr(ratio_time),
+        )
+
+        # update running passed/failed/skipped counts
+        self.passed += 1
+        self.count += 1
+
+        # save details for summary
+        self._test_results.append(
+            _TestResults(
+                test_fullname=self._test.fullname,
+                outcome=_TestOutcome.PASS,
                 sim_time_ns=sim_time_ns,
                 wall_time_s=wall_time_s,
             )
@@ -817,7 +886,7 @@ class RegressionManager:
         self._test_results.append(
             _TestResults(
                 test_fullname=self._test.fullname,
-                passed=False,
+                outcome=_TestOutcome.FAIL,
                 sim_time_ns=sim_time_ns,
                 wall_time_s=wall_time_s,
             )
@@ -899,20 +968,25 @@ class RegressionManager:
         hilite: str
         lolite: str
         for result in self._test_results:
-            if result.passed is None:
+            if result.outcome == _TestOutcome.SKIP:
                 ratio = "-.--"
                 pass_fail_str = "SKIP"
                 hilite = self.COLOR_SKIPPED
                 lolite = ANSI.DEFAULT
-            elif result.passed:
+            elif result.outcome == _TestOutcome.PASS:
                 ratio = format(result.ratio, "0.2f")
                 pass_fail_str = "PASS"
                 hilite = self.COLOR_PASSED
                 lolite = ANSI.DEFAULT
-            else:
+            elif result.outcome == _TestOutcome.FAIL:
                 ratio = format(result.ratio, "0.2f")
                 pass_fail_str = "FAIL"
                 hilite = self.COLOR_FAILED
+                lolite = ANSI.DEFAULT
+            elif result.outcome == _TestOutcome.XFAIL:
+                ratio = format(result.ratio, "0.2f")
+                pass_fail_str = "XFAIL"
+                hilite = self.COLOR_XFAILED
                 lolite = ANSI.DEFAULT
 
             if cocotb_logging.strip_ansi:

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -11,7 +11,6 @@ Tests of cocotb.test functionality
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Coroutine
 
 import pytest
@@ -19,9 +18,6 @@ from common import MyBaseException, MyException
 
 import cocotb
 from cocotb.triggers import NullTrigger, SimTimeoutError, Timer
-
-if sys.version_info < (3, 11):
-    from exceptiongroup import ExceptionGroup
 
 
 @cocotb.test(expect_error=NameError)
@@ -217,32 +213,6 @@ async def test_pass_test_in_task(_) -> None:
 @cocotb.test
 async def test_pass_test_in_test(_) -> None:
     cocotb.pass_test("Finished test early")
-
-
-@cocotb.test
-@cocotb.xfail(
-    raises=pytest.RaisesGroup(
-        ValueError,
-        ValueError,
-        pytest.RaisesExc(TypeError, match="^expected int$"),
-        match="^my group$",
-    )
-)
-async def test_xfail_with_raises_group(dut: object) -> None:
-    raise ExceptionGroup(
-        "my group",
-        [
-            ValueError(),
-            TypeError("expected int"),
-            ValueError(),
-        ],
-    )
-
-
-@cocotb.test
-@cocotb.xfail(raises=pytest.RaisesGroup(pytest.RaisesGroup(ValueError)))
-async def test_xfail_with_raises_group_nested(dut: object) -> None:
-    raise ExceptionGroup("", (ExceptionGroup("", (ValueError(),)),))
 
 
 @cocotb.test

--- a/tests/test_cases/test_skip/Makefile
+++ b/tests/test_cases/test_skip/Makefile
@@ -1,0 +1,13 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+COCOTB_TEST_MODULES := test_skip
+
+# Ensure we had the correct number of skips
+.PHONY: override_for_this_test
+override_for_this_test:
+	$(MAKE) all
+	test $$(grep '<skipped />' $(COCOTB_RESULTS_FILE) | wc -l) -eq 4
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_skip/test_skip.py
+++ b/tests/test_cases/test_skip/test_skip.py
@@ -1,0 +1,38 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import pytest
+
+import cocotb
+from cocotb.triggers import Timer
+
+
+@cocotb.test
+async def test_skip(_: object) -> None:
+    pytest.skip("This test is skipped")
+    assert False  # This should not be reached
+
+
+@cocotb.test
+async def test_skip_in_task(_: object) -> None:
+    async def skipit() -> None:
+        pytest.skip("This test is skipped")
+        assert False  # This should not be reached
+
+    task = cocotb.start_soon(skipit())
+    await Timer(1)
+    await task
+    assert False  # This should not be reached
+
+
+@cocotb.test
+@cocotb.skipif(True, reason="This test is skipped")
+async def test_skipif_deco(_: object) -> None:
+    assert False  # This test should not be run
+
+
+@cocotb.test(skip=True)
+async def test_skip_arg(_: object) -> None:
+    assert False  # This test should not be run

--- a/tests/test_cases/test_skipped_explicitly_run/Makefile
+++ b/tests/test_cases/test_skipped_explicitly_run/Makefile
@@ -19,4 +19,4 @@ override: clean all
 # Set COCOTB_TEST_FILTER; run test_skipped even though skip=True is set.
 COCOTB_TEST_FILTER = test_skipped
 
-COCOTB_TEST_MODULES = test_skipped
+COCOTB_TEST_MODULES = test_skipped_explicitly_run

--- a/tests/test_cases/test_skipped_explicitly_run/Makefile
+++ b/tests/test_cases/test_skipped_explicitly_run/Makefile
@@ -14,7 +14,7 @@ clean::
 .DEFAULT_GOAL := override
 .PHONY: override
 override: clean all
-	 @test -f $(SKIPPED_TEST_FILE) || (echo "ERROR: skip=True test was not ran!" >&2 && exit 1)
+	@test -f $(SKIPPED_TEST_FILE) || (echo "ERROR: skip=True test was not ran!" >&2 && exit 1)
 
 # Set COCOTB_TEST_FILTER; run test_skipped even though skip=True is set.
 COCOTB_TEST_FILTER = test_skipped

--- a/tests/test_cases/test_skipped_explicitly_run/test_skipped_explicitly_run.py
+++ b/tests/test_cases/test_skipped_explicitly_run/test_skipped_explicitly_run.py
@@ -11,6 +11,6 @@ skipped_file_name = "ran_skipped_test~"
 
 
 @cocotb.test(skip=True)
-async def test_skipped(dut):
+async def test_skipped(dut: object) -> None:
     """Touch a file so we can check that this test has run."""
     pathlib.Path(skipped_file_name).touch()

--- a/tests/test_cases/test_xfail/Makefile
+++ b/tests/test_cases/test_xfail/Makefile
@@ -1,0 +1,14 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+COCOTB_TEST_MODULES := test_xfail
+
+# Ensure the correct number of tests ran.
+# Maybe one day we can explicitly check for XFAIL.
+.PHONY: override_for_this_test
+override_for_this_test:
+	$(MAKE) all
+	python -m cocotb_tools.combine_results | grep -q "Ran a total .* 11 TestCases"
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_xfail/test_xfail.py
+++ b/tests/test_cases/test_xfail/test_xfail.py
@@ -1,0 +1,96 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import cocotb
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
+
+
+@cocotb.test
+async def test_xfail(_: object) -> None:
+    pytest.xfail("This test is expected to fail")
+
+
+class MyException(Exception):
+    pass
+
+
+@cocotb.test(expect_fail=True)
+async def test_expect_arg_assert(_: object) -> None:
+    assert False
+
+
+@cocotb.test(expect_fail=True)
+async def test_expect_arg_raises(_: object) -> None:
+    with pytest.raises(ValueError):
+        pass
+
+
+@cocotb.test(expect_fail=True)
+async def test_expect_arg_warns(_: object) -> None:
+    with pytest.warns(DeprecationWarning):
+        pass
+
+
+@cocotb.test(expect_error=MyException)
+async def test_expect_arg_exception(_: object) -> None:
+    raise MyException()
+
+
+@cocotb.test
+@cocotb.xfail(reason="This test is expected to fail")
+async def test_xfail_assert(_: object) -> None:
+    assert False
+
+
+@cocotb.test
+@cocotb.xfail(reason="This test is expected to fail")
+async def test_xfail_raises(_: object) -> None:
+    with pytest.raises(ValueError):
+        pass
+
+
+@cocotb.test
+@cocotb.xfail(reason="This test is expected to fail")
+async def test_xfail_warns(_: object) -> None:
+    with pytest.warns(DeprecationWarning):
+        pass
+
+
+@cocotb.test
+@cocotb.xfail(raises=MyException, reason="This test is expected to fail")
+async def test_xfail_exception(_: object) -> None:
+    raise MyException()
+
+
+@cocotb.test
+@cocotb.xfail(
+    raises=pytest.RaisesGroup(
+        ValueError,
+        ValueError,
+        pytest.RaisesExc(TypeError, match="^expected int$"),
+        match="^my group$",
+    )
+)
+async def test_xfail_with_raises_group(dut: object) -> None:
+    raise ExceptionGroup(
+        "my group",
+        [
+            ValueError(),
+            TypeError("expected int"),
+            ValueError(),
+        ],
+    )
+
+
+@cocotb.test
+@cocotb.xfail(raises=pytest.RaisesGroup(pytest.RaisesGroup(ValueError)))
+async def test_xfail_with_raises_group_nested(dut: object) -> None:
+    raise ExceptionGroup("", (ExceptionGroup("", (ValueError(),)),))


### PR DESCRIPTION
Closes #4476. Depends on #5357.

### TODO
- [x] tests
- [x] newsfrag
- [x] docs

