### PR TITLE
Make Makefile `sim` target not recursive

### DIFF
--- a/docs/source/newsfragments/5382.change.rst
+++ b/docs/source/newsfragments/5382.change.rst
@@ -1,0 +1,1 @@
+The :ref:`Makefile <building>` target ``sim`` no longer recursively calls ``make``. This makes it possible to use ``+=`` with Make variables without the right hand side being added twice.

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -11,7 +11,7 @@ COCOTB_MAKEFILE_INC_INCLUDED = 1
 
 # Default sim rule will force a re-run of the simulation (though the cocotb library
 # and RTL compilation phases are still evaluated by makefile dependencies)
-.PHONY: sim, _rm_regresion
+.PHONY: sim, _rm_results
 _rm_results:
 	$(RM) $(COCOTB_RESULTS_FILE)
 sim: _rm_results regression

--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -11,10 +11,10 @@ COCOTB_MAKEFILE_INC_INCLUDED = 1
 
 # Default sim rule will force a re-run of the simulation (though the cocotb library
 # and RTL compilation phases are still evaluated by makefile dependencies)
-.PHONY: sim
-sim:
+.PHONY: sim, _rm_regresion
+_rm_results:
 	$(RM) $(COCOTB_RESULTS_FILE)
-	"$(MAKE)" -f $(firstword $(MAKEFILE_LIST)) $(COCOTB_RESULTS_FILE)
+sim: _rm_results regression
 
 # Make sure to use bash for the pipefail option used in many simulator Makefiles
 SHELL := bash


### PR DESCRIPTION
Closes #4284. Recursive Makefiles cause user makefiles to be evaluated twice, so using += on variables causes the right hand side to be added twice.

