### PR TITLE
Deprecate `cocotb.pass_test`

### DIFF
--- a/docs/source/newsfragments/5395.removal.rst
+++ b/docs/source/newsfragments/5395.removal.rst
@@ -1,0 +1,1 @@
+Deprecated :func:`cocotb.pass_test`. Instead, use :func:`cocotb.skip` to skip a test or use :func:`cocotb.end_test` to end a test while respecting expected failures.

--- a/docs/source/upgrade-2.0.rst
+++ b/docs/source/upgrade-2.0.rst
@@ -1276,19 +1276,20 @@ This is unexpected and generally not useful.
     assert cocotb.top.data.value == 0
 
 
-********************************************************************
-Use :func:`!cocotb.pass_test` instead of raising :exc:`!TestSuccess`
-********************************************************************
+*******************************************************************************************
+Use :func:`!cocotb.end_test` or :func:`!pytest.skip` instead of raising :exc:`!TestSuccess`
+*******************************************************************************************
 
 Change
 ======
 
-:external+cocotb19:py:exc:`~cocotb.result.TestSuccess` was deprecated and replaced with :func:`cocotb.pass_test`.
+:external+cocotb19:py:exc:`~cocotb.result.TestSuccess` was deprecated and replaced with :func:`cocotb.end_test` and :func:`pytest.skip`.
 
 How To Upgrade
 ==============
 
-Replace ``raise TestSuccess(msg)`` with a call to :func:`!cocotb.pass_test`.
+Replace ``raise TestSuccess(msg)`` with a call to :func:`!cocotb.end_test` when you need to end the test immediately.
+Replace ``raise TestSuccess(msg)`` with a call to :func:`!pytest.skip` when you need to end the test immediately and force the outcome to 'skipped'.
 
 .. code-block:: python
     :caption: Old way with :exc:`!TestSuccess`
@@ -1298,16 +1299,23 @@ Replace ``raise TestSuccess(msg)`` with a call to :func:`!cocotb.pass_test`.
         raise TestSuccess("Test finished without DUT erroring")
 
 .. code-block:: python
-    :caption: New way with :func:`!cocotb.pass_test`
+    :caption: New way with :func:`!cocotb.end_test`
     :class: new
 
     if cocotb.top.error.value == 0:
-        cocotb.pass_test("Test finished without DUT erroring")
+        cocotb.end_test("Test finished without DUT erroring")
+
+.. code-block:: python
+    :caption: New way with :func:`!pytest.skip`
+    :class: new
+
+    if cocotb.top.param.value == 0:
+        pytest.skip("Test skipped because param is 0")
 
 Rationale
 =========
 
-cocotb needs a way to end a test with a pass from any Task, not just the main test Task.
+cocotb needs a way to end a test from any Task, not just the main test Task.
 :exc:`!TestSuccess` was created for that purpose.
 But being an exception, it has an additional implied interface:
 
@@ -1316,8 +1324,8 @@ But being an exception, it has an additional implied interface:
 
 However, neither of these implied behaviors is actually supported.
 
-:func:`!cocotb.pass_test` being a function call avoids these implicit interfaces.
-It also parallels the design of :func:`sys.exit`.
+:func:`!cocotb.end_test` and :func:`!pytest.skip` being function calls avoids these implicit interfaces.
+They also parallel the design of :func:`sys.exit`.
 
 
 *******************************************************************

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -320,6 +320,9 @@ class TestSuccess(BaseException):
         self.msg = msg
 
 
+@deprecated(
+    "Use `cocotb.skip` to skip a test, or use `cocotb.end_test` to end a test while respecting expected failures."
+)
 def pass_test(msg: str | None = None) -> NoReturn:
     """Force a test to pass.
 
@@ -332,6 +335,11 @@ def pass_test(msg: str | None = None) -> NoReturn:
         msg: The message to display when the test passes.
 
     .. versionadded:: 2.0
+
+    .. deprecated:: 2.1
+        Forcing a test to pass is considered bad practice.
+        Use :func:`cocotb.skip` if you want to end the test immediately and force the outcome to 'skipped'.
+        Or use :func:`cocotb.end_test` if you want to end the test immediately while respecting expected failures.
     """
     raise TestSuccess(msg)
 

--- a/src/cocotb/result.py
+++ b/src/cocotb/result.py
@@ -9,7 +9,7 @@ import warnings
 def __getattr__(name: str) -> object:
     if name == "TestSuccess":
         warnings.warn(
-            "`raise TestSuccess` is deprecated. Use `cocotb.pass_test()` instead.",
+            "`raise TestSuccess` is deprecated. Use `cocotb.end_test` or `pytest.skip` instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -324,3 +324,46 @@ async def test_Task_kill_running(_: object) -> None:
     task = cocotb.start_soon(example())
     await task
     assert task.done()
+
+
+@cocotb.test
+async def test_pass_test_in_task(_) -> None:
+    async def raise_test_success():
+        await Timer(1, unit="ns")
+        with pytest.warns(DeprecationWarning):
+            cocotb.pass_test("Finished test early")
+
+    cocotb.start_soon(raise_test_success())
+    await Timer(10, unit="ns")
+
+
+@cocotb.test
+async def test_pass_test_in_test(_) -> None:
+    with pytest.warns(DeprecationWarning):
+        cocotb.pass_test("Finished test early")
+
+
+@cocotb.test
+@cocotb.xfail(raises=TypeError)
+async def test_pass_test_in_xfail_exception(dut: object) -> None:
+    with pytest.warns(DeprecationWarning):
+        cocotb.pass_test("Finished test early")
+
+
+@cocotb.test
+@cocotb.xfail()
+async def test_pass_test_in_xfail_assert(dut: object) -> None:
+    with pytest.warns(DeprecationWarning):
+        cocotb.pass_test("Finished test early")
+
+
+@cocotb.test(expect_error=TypeError)
+async def test_pass_test_in_expect_error(dut: object) -> None:
+    with pytest.warns(DeprecationWarning):
+        cocotb.pass_test("Finished test early")
+
+
+@cocotb.test(expect_fail=True)
+async def test_pass_test_in_expect_fail(dut: object) -> None:
+    with pytest.warns(DeprecationWarning):
+        cocotb.pass_test("Finished test early")

--- a/tests/test_cases/test_cocotb/test_tests.py
+++ b/tests/test_cases/test_cocotb/test_tests.py
@@ -201,21 +201,6 @@ async def test_test_without_parenthesis_ran(dut):
 
 
 @cocotb.test
-async def test_pass_test_in_task(_) -> None:
-    async def raise_test_success():
-        await Timer(1, unit="ns")
-        cocotb.pass_test("Finished test early")
-
-    cocotb.start_soon(raise_test_success())
-    await Timer(10, unit="ns")
-
-
-@cocotb.test
-async def test_pass_test_in_test(_) -> None:
-    cocotb.pass_test("Finished test early")
-
-
-@cocotb.test
 async def test_bad_xfail(dut: object) -> None:
     with pytest.raises(TypeError):
 
@@ -240,18 +225,6 @@ async def test_bad_xfail(dut: object) -> None:
         )
         async def dummy(_: object) -> None:
             pass
-
-
-@cocotb.test
-@cocotb.xfail(raises=TypeError)
-async def test_pass_test_in_xfail_exception(dut: object) -> None:
-    cocotb.pass_test("Finished test early")
-
-
-@cocotb.test
-@cocotb.xfail()
-async def test_pass_test_in_xfail_assert(dut: object) -> None:
-    cocotb.pass_test("Finished test early")
 
 
 @cocotb.test


### PR DESCRIPTION
Closes #5379. Depends on #5392.

Documentation will come in separate PR: #5394.

### TODO
- [x] newsfrag