### PR TITLE
Fixes to `PackedObject`

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -789,6 +789,12 @@ Simulator Objects
 .. autoclass:: LogicArrayObject
     :members:
     :member-order: bysource
+    :special-members: __len__, __getitem__, __iter__
+    :inherited-members: SimHandleBase, ValueObjectBase
+
+.. autoclass:: PackedObject
+    :members:
+    :member-order: bysource
     :special-members: __len__
     :inherited-members: SimHandleBase, ValueObjectBase
 

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -1241,31 +1241,11 @@ class _SignednessObjectMixin(SimHandleBase):
             return (2 ** len(self)) - 1
 
 
-class LogicArrayObject(
+class _LogicArrayObjectBase(
     _NonIndexableValueObjectBase[LogicArray, Union[LogicArray, Logic, int, str]],
     _RangeableObjectMixin,
     _SignednessObjectMixin,
 ):
-    """A logic array simulation object.
-
-    Inherits from :class:`SimHandleBase` and :class:`ValueObjectBase`.
-
-    Verilog packed vectors, structs, and unions do not map to this type, but :class:`PackedObject`.
-    Unpacked vectors of type ``logic`` and ``bit`` map to :class:`ArrayObject`.
-
-    VHDL types that map to this object:
-
-        * ``std_logic_vector`` and ``std_ulogic_vector``
-        * ``unsigned``
-        * ``signed``
-        * ``ufixed``
-        * ``sfixed``
-        * ``float``
-
-    .. versionchanged:: 2.1
-        Verilog packed objects no longer map to this type, but :class:`PackedObject`.
-    """
-
     def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
@@ -1377,13 +1357,6 @@ class LogicArrayObject(
         # and this object needs to support multi-dimensional packed arrays.
         return self._handle.get_num_elems()
 
-    def __getitem__(self, index: int) -> LogicObject:
-        handle = self._handle.get_handle_by_index(index)
-        if handle is None:
-            raise IndexError
-
-        return LogicObject(handle, self._path)
-
     @cached_property
     def _min_val(self) -> int:
         # Backwards compatibility. Always wrap negative values.
@@ -1395,7 +1368,40 @@ class LogicArrayObject(
         return (2 ** len(self)) - 1
 
 
-class PackedObject(LogicArrayObject):
+class LogicArrayObject(_LogicArrayObjectBase):
+    """A logic array simulation object.
+
+    Inherits from :class:`SimHandleBase` and :class:`ValueObjectBase`.
+
+    Verilog packed vectors, structs, and unions do not map to this type, but :class:`PackedObject`.
+    Unpacked vectors of type ``logic`` and ``bit`` map to :class:`ArrayObject`.
+
+    VHDL types that map to this object:
+
+        * ``std_logic_vector`` and ``std_ulogic_vector``
+        * ``unsigned``
+        * ``signed``
+        * ``ufixed``
+        * ``sfixed``
+        * ``float``
+
+    .. versionchanged:: 2.1
+        Verilog packed objects no longer map to this type, but :class:`PackedObject`.
+    """
+
+    def __getitem__(self, index: int) -> LogicObject:
+        handle = self._handle.get_handle_by_index(index)
+        if handle is None:
+            raise IndexError
+
+        return LogicObject(handle, self._path)
+
+    def __iter__(self) -> Iterable[LogicObject]:
+        for i in self.range:
+            yield self[i]
+
+
+class PackedObject(_LogicArrayObjectBase):
     """A packed Verilog struct, union, or vector simulation object.
 
     Verilog types that map to this object:
@@ -1406,13 +1412,19 @@ class PackedObject(LogicArrayObject):
     .. versionadded:: 2.1
     """
 
-    def __getitem__(self, _: object) -> NoReturn:
+    def _indexing_error(self) -> NoReturn:
         raise TypeError(
             "Indexing into Verilog packed objects (arrays, structs, or unions) is not currently supported.\n"
             "Try instead reading the whole value and slicing: `t = handle.value; t[0:3]`.\n"
             "If you need to use an element in an Edge Trigger, consider making the array or struct unpacked.\n"
             "Alternatively, use `ValueChange` on the whole object and check the bit(s) you care about for changes afterwards."
         )
+
+    def __getitem__(self, _: object) -> NoReturn:
+        self._indexing_error()
+
+    def __iter__(self) -> NoReturn:
+        self._indexing_error()
 
 
 class RealObject(_NonIndexableValueObjectBase[float, float]):
@@ -1757,7 +1769,6 @@ _handle2obj: dict[
 _type2cls: dict[int, type[_ConcreteHandleTypes]] = {
     simulator.MODULE: HierarchyObject,
     simulator.STRUCTURE: HierarchyObject,
-    simulator.PACKED_STRUCTURE: LogicArrayObject,
     simulator.LOGIC: LogicObject,
     simulator.LOGIC_ARRAY: LogicArrayObject,
     simulator.PACKED_OBJECT: PackedObject,

--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -208,10 +208,9 @@ typedef enum gpi_objtype_e {
     GPI_STRING = 11,
     GPI_GENARRAY = 12,
     GPI_PACKAGE = 13,
-    GPI_PACKED_STRUCTURE = 14,
+    GPI_PACKED_OBJECT = 14,
     GPI_LOGIC = 15,
     GPI_LOGIC_ARRAY = 16,
-    GPI_PACKED_OBJECT = 17,
 } gpi_objtype;
 
 /** Direction of range constraint of an object. */

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -158,7 +158,7 @@ static gpi_objtype const_type_to_gpi_objtype(int32_t const_type) {
             LOG_WARN(
                 "VPI: Xcelium reports undefined parameters as vpiUndefined, "
                 "guessing this is a logic vector");
-            return GPI_LOGIC_ARRAY;
+            return GPI_PACKED_OBJECT;
 #endif
         case vpiDecConst:
         case vpiBinaryConst:
@@ -280,8 +280,8 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
             auto is_vector = false;
             if (vpi_get(vpiPacked, new_hdl)) {
                 LOG_DEBUG("VPI: Found packed struct/union data type");
-                new_obj = new VpiSignalObjHdl(this, new_hdl,
-                                              GPI_PACKED_STRUCTURE, false);
+                new_obj = new VpiSignalObjHdl(this, new_hdl, GPI_PACKED_OBJECT,
+                                              false);
                 break;
             } else if (vpi_get(vpiVector, new_hdl)) {
                 is_vector = true;

--- a/src/cocotb/share/lib/pygpi/bind.cpp
+++ b/src/cocotb/share/lib/pygpi/bind.cpp
@@ -1029,8 +1029,6 @@ static int add_module_constants(PyObject *simulator) {
         PyModule_AddIntConstant(simulator, "NETARRAY", GPI_ARRAY) < 0 ||
         PyModule_AddIntConstant(simulator, "ENUM", GPI_ENUM) < 0 ||
         PyModule_AddIntConstant(simulator, "STRUCTURE", GPI_STRUCTURE) < 0 ||
-        PyModule_AddIntConstant(simulator, "PACKED_STRUCTURE",
-                                GPI_PACKED_STRUCTURE) < 0 ||
         PyModule_AddIntConstant(simulator, "REAL", GPI_REAL) < 0 ||
         PyModule_AddIntConstant(simulator, "INTEGER", GPI_INTEGER) < 0 ||
         PyModule_AddIntConstant(simulator, "STRING", GPI_STRING) < 0 ||

--- a/src/cocotb/simulator.pyi
+++ b/src/cocotb/simulator.pyi
@@ -25,7 +25,6 @@ PACKAGE: int
 REAL: int
 STRING: int
 STRUCTURE: int
-PACKED_STRUCTURE: int
 UNKNOWN: int
 RISING: int
 FALLING: int

--- a/tests/test_cases/test_array/test_array.py
+++ b/tests/test_cases/test_array/test_array.py
@@ -7,14 +7,18 @@ from __future__ import annotations
 import logging
 import os
 
+import pytest
+
 import cocotb
 from cocotb.clock import Clock
 from cocotb.handle import (
+    Any,
     ArrayObject,
     HierarchyArrayObject,
     HierarchyObject,
     LogicArrayObject,
     LogicObject,
+    PackedObject,
     _HierarchyObjectBase,
 )
 from cocotb.triggers import Timer
@@ -364,36 +368,38 @@ async def test_direct_constant_indexing(dut):
 async def test_direct_signal_indexing(dut):
     """Test directly accessing signal/net data in arrays, i.e. not iterating"""
 
-    assert isinstance(dut.sig_t1, LogicArrayObject)
+    packed_array_type = PackedObject if LANGUAGE == "verilog" else LogicArrayObject
+
+    assert isinstance(dut.sig_t1, packed_array_type)
     assert isinstance(dut.sig_t2, ArrayObject)
-    assert isinstance(dut.sig_t2[5], LogicArrayObject)
-    assert isinstance(dut.sig_t3b[3], LogicArrayObject)
+    assert isinstance(dut.sig_t2[5], packed_array_type)
+    assert isinstance(dut.sig_t3b[3], packed_array_type)
     assert isinstance(dut.sig_t3a, ArrayObject)
     assert isinstance(dut.sig_t4, ArrayObject)
     assert isinstance(dut.sig_t4[3], ArrayObject)
-    assert isinstance(dut.sig_t4[3][4], LogicArrayObject)
+    assert isinstance(dut.sig_t4[3][4], packed_array_type)
     assert isinstance(dut.sig_t5, ArrayObject)
     assert isinstance(dut.sig_t5[1], ArrayObject)
-    assert isinstance(dut.sig_t5[1][0], LogicArrayObject)
+    assert isinstance(dut.sig_t5[1][0], packed_array_type)
     assert isinstance(dut.sig_t6, ArrayObject)
     assert isinstance(dut.sig_t6[1], ArrayObject)
-    assert isinstance(dut.sig_t6[0][3], LogicArrayObject)
+    assert isinstance(dut.sig_t6[0][3], packed_array_type)
 
     if LANGUAGE in ["verilog"]:
         assert isinstance(dut.sig_t7[1], ArrayObject)
-        assert isinstance(dut.sig_t7[0][3], LogicArrayObject)
-        assert isinstance(dut.sig_t8, LogicArrayObject)
+        assert isinstance(dut.sig_t7[0][3], PackedObject)
+        assert isinstance(dut.sig_t8, PackedObject)
 
     assert isinstance(dut.sig_cmplx, ArrayObject)
     assert isinstance(dut.sig_cmplx[1], HierarchyObject)
     assert isinstance(dut.sig_cmplx[1].a, LogicObject)
     assert isinstance(dut.sig_cmplx[1].b, ArrayObject)
-    assert isinstance(dut.sig_cmplx[1].b[1], LogicArrayObject)
+    assert isinstance(dut.sig_cmplx[1].b[1], packed_array_type)
 
     assert isinstance(dut.sig_rec, HierarchyObject)
     assert isinstance(dut.sig_rec.a, LogicObject)
     assert isinstance(dut.sig_rec.b, ArrayObject)
-    assert isinstance(dut.sig_rec.b[1], LogicArrayObject)
+    assert isinstance(dut.sig_rec.b[1], packed_array_type)
 
 
 @cocotb.test(skip=(LANGUAGE in ["verilog"]))
@@ -402,3 +408,62 @@ async def test_extended_identifiers(dut):
 
     assert isinstance(dut["\\ext_id\\"], LogicObject)
     assert isinstance(dut["\\!\\"], LogicObject)
+
+
+@cocotb.test
+@cocotb.skipif(
+    LANGUAGE != "vhdl",
+    reason="Verilog doesn't support iterating over arrays of structures",
+)
+@cocotb.xfail(
+    SIM_NAME.startswith("ghdl"),
+    reason="GHDL uses VPI which doesn't support iterating/indexing of std_logic_vector",
+    raises=TypeError,
+)
+@cocotb.parametrize(array_name=["port_desc_in", "port_asc_in", "sig_desc", "sig_asc"])
+async def test_iterate_over_logic_arrays(dut: Any, array_name: str) -> None:
+    array = getattr(dut, array_name)
+    assert len(array) == 8
+
+    array.value = 0xFF
+    await Timer(1)
+
+    for bit in array:
+        assert isinstance(bit, LogicObject)
+        bit.value = 0
+    await Timer(1)
+
+    assert array.value == 0
+
+    for i in array.range:
+        bit = array[i]
+        assert isinstance(bit, LogicObject)
+        bit.value = 1
+    await Timer(1)
+
+    assert array.value == 0xFF
+
+
+@cocotb.test
+@cocotb.skipif(
+    LANGUAGE != "verilog",
+    reason="Verilog iteration and indexing of packed arrays is not allowed",
+)
+@cocotb.parametrize(array_name=["port_desc_in", "port_asc_in", "sig_desc", "sig_asc"])
+async def test_packed_indexing_fails(dut: Any, array_name: str) -> None:
+    array = getattr(dut, array_name)
+    with pytest.raises(TypeError):
+        array[0]
+
+
+@cocotb.test
+@cocotb.skipif(
+    LANGUAGE != "verilog",
+    reason="Verilog iteration and indexing of packed arrays is not allowed",
+)
+@cocotb.parametrize(array_name=["port_desc_in", "port_asc_in", "sig_desc", "sig_asc"])
+async def test_packed_iteration_fails(dut: Any, array_name: str) -> None:
+    array = getattr(dut, array_name)
+    with pytest.raises(TypeError):
+        for _ in array:
+            pass

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -17,7 +17,7 @@ from cocotb.handle import (
     HierarchyObject,
     Immediate,
     IntegerObject,
-    LogicArrayObject,
+    PackedObject,
     StringObject,
 )
 from cocotb.triggers import Timer
@@ -390,7 +390,7 @@ async def access_boolean(dut):
 @cocotb.test(skip=LANGUAGE in ["vhdl"])
 async def access_internal_register_array(dut):
     """Test access to an internal register array"""
-    assert isinstance(dut.register_array[1], LogicArrayObject)
+    assert isinstance(dut.register_array[1], PackedObject)
     dut.register_array[1].value = 4
     await Timer(1, "ns")
     assert dut.register_array[1].value == 4

--- a/tests/test_cases/test_integers/test_integers.py
+++ b/tests/test_cases/test_integers/test_integers.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 import cocotb
-from cocotb.handle import LogicArrayObject
+from cocotb.handle import LogicArrayObject, PackedObject
 from cocotb.triggers import Timer
 from cocotb.types import LogicArray
 from cocotb_tools.sim_versions import GhdlVersion, VerilatorVersion
@@ -56,7 +56,7 @@ async def test_int_verilog(
 
     # For backwards compatibility, LogicArrayObjects always use (INT_MIN, UINT_MAX) for bounds.
     # Some simulators discover integer handles as LogicArrayObjects.
-    if isinstance(handle, LogicArrayObject):
+    if isinstance(handle, PackedObject):
         min_value = -(2 ** (width - 1))
         max_value = (2**width) - 1
 

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -12,7 +12,7 @@ from cocotb.handle import (
     GPIDiscovery,
     HierarchyArrayObject,
     HierarchyObject,
-    LogicArrayObject,
+    PackedObject,
 )
 
 ########################################################################################
@@ -69,7 +69,7 @@ async def recursive_discovery(dut):
     assert expected == actual
     tlog.info("Found a total of %d things", actual)
 
-    assert isinstance(dut.i_verilog.uart1.baud_gen_1.baud_freq, LogicArrayObject)
+    assert isinstance(dut.i_verilog.uart1.baud_gen_1.baud_freq, PackedObject)
 
 
 @cocotb.test

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -4,7 +4,7 @@ import os
 from typing import Any
 
 import cocotb
-from cocotb.handle import ArrayObject, LogicArrayObject, LogicObject
+from cocotb.handle import ArrayObject, LogicObject, PackedObject
 from cocotb.triggers import Timer
 
 SIM_NAME = cocotb.SIM_NAME.lower()
@@ -19,7 +19,7 @@ questa_vpi_compat = (
 
 @cocotb.test()
 async def test_in_vect_packed(dut):
-    assert isinstance(dut.in_vect_packed, LogicArrayObject)
+    assert isinstance(dut.in_vect_packed, PackedObject)
     assert len(dut.in_vect_packed) == 3
 
     test_value = 0x5
@@ -44,7 +44,7 @@ async def test_in_vect_unpacked(dut):
 
 @cocotb.test()
 async def test_in_arr(dut):
-    assert isinstance(dut.in_arr, LogicArrayObject)
+    assert isinstance(dut.in_arr, PackedObject)
     assert len(dut.in_arr) == 3
 
     test_value = 0x5
@@ -55,7 +55,7 @@ async def test_in_arr(dut):
 
 @cocotb.test()
 async def test_in_2d_vect_packed_packed(dut):
-    assert isinstance(dut.in_2d_vect_packed_packed, LogicArrayObject)
+    assert isinstance(dut.in_2d_vect_packed_packed, PackedObject)
     assert len(dut.in_2d_vect_packed_packed) == 9
 
     test_value = (0x5 << 6) | (0x5 << 3) | 0x5
@@ -70,7 +70,7 @@ async def test_in_2d_vect_packed_unpacked(dut):
     assert len(dut.in_2d_vect_packed_unpacked) == 3
 
     dut.in_2d_vect_packed_unpacked[0]
-    assert isinstance(dut.in_2d_vect_packed_unpacked[0], LogicArrayObject)
+    assert isinstance(dut.in_2d_vect_packed_unpacked[0], PackedObject)
     assert len(dut.in_2d_vect_packed_unpacked[0]) == 3
 
     test_value = [0x5, 0x5, 0x5]
@@ -103,7 +103,7 @@ async def test_in_2d_vect_unpacked_unpacked(dut):
 
 @cocotb.test()
 async def test_in_arr_packed(dut):
-    assert isinstance(dut.in_arr_packed, LogicArrayObject)
+    assert isinstance(dut.in_arr_packed, PackedObject)
     assert len(dut.in_arr_packed) == 9
 
     test_value = 365
@@ -118,7 +118,7 @@ async def test_in_arr_unpacked(dut):
     assert len(dut.in_arr_unpacked) == 3
 
     dut.in_arr_unpacked[0]
-    assert isinstance(dut.in_arr_unpacked[0], LogicArrayObject)
+    assert isinstance(dut.in_arr_unpacked[0], PackedObject)
     assert len(dut.in_arr_unpacked[0]) == 3
 
     test_value = [0x5, 0x5, 0x5]
@@ -129,7 +129,7 @@ async def test_in_arr_unpacked(dut):
 
 @cocotb.test()
 async def test_in_2d_arr(dut):
-    assert isinstance(dut.in_2d_arr, LogicArrayObject)
+    assert isinstance(dut.in_2d_arr, PackedObject)
     assert len(dut.in_2d_arr) == 9
 
     test_value = 365
@@ -140,7 +140,7 @@ async def test_in_2d_arr(dut):
 
 @cocotb.test()
 async def test_in_vect_packed_packed_packed(dut):
-    assert isinstance(dut.in_vect_packed_packed_packed, LogicArrayObject)
+    assert isinstance(dut.in_vect_packed_packed_packed, PackedObject)
     assert len(dut.in_vect_packed_packed_packed) == 27
 
     test_value = 95869805
@@ -157,7 +157,7 @@ async def test_in_vect_packed_packed_unpacked(dut):
     assert len(dut.in_vect_packed_packed_unpacked) == 3
 
     dut.in_vect_packed_packed_unpacked[0]
-    assert isinstance(dut.in_vect_packed_packed_unpacked[0], LogicArrayObject)
+    assert isinstance(dut.in_vect_packed_packed_unpacked[0], PackedObject)
     assert len(dut.in_vect_packed_packed_unpacked[0]) == 9
 
     test_value = [365, 365, 365]
@@ -179,7 +179,7 @@ async def test_in_vect_packed_unpacked_unpacked(dut):
     assert len(dut.in_vect_packed_unpacked_unpacked[0]) == 3
 
     dut.in_vect_packed_unpacked_unpacked[0][0]
-    assert isinstance(dut.in_vect_packed_unpacked_unpacked[0][0], LogicArrayObject)
+    assert isinstance(dut.in_vect_packed_unpacked_unpacked[0][0], PackedObject)
     assert len(dut.in_vect_packed_unpacked_unpacked[0][0]) == 3
 
     test_value = 3 * [3 * [5]]
@@ -215,7 +215,7 @@ async def test_in_vect_unpacked_unpacked_unpacked(dut):
 
 @cocotb.test()
 async def test_in_arr_packed_packed(dut):
-    assert isinstance(dut.in_arr_packed_packed, LogicArrayObject)
+    assert isinstance(dut.in_arr_packed_packed, PackedObject)
     assert len(dut.in_arr_packed_packed) == 27
 
     test_value = (365 << 18) | (365 << 9) | (365)
@@ -231,7 +231,7 @@ async def test_in_arr_packed_unpacked(dut):
     assert len(dut.in_arr_packed_unpacked) == 3
 
     dut.in_arr_packed_unpacked[0]
-    assert isinstance(dut.in_arr_packed_unpacked[0], LogicArrayObject)
+    assert isinstance(dut.in_arr_packed_unpacked[0], PackedObject)
     assert len(dut.in_arr_packed_unpacked[0]) == 9
 
     test_value = [365, 365, 365]
@@ -253,7 +253,7 @@ async def test_in_arr_unpacked_unpacked(dut):
     assert len(dut.in_arr_unpacked_unpacked[0]) == 3
 
     dut.in_arr_unpacked_unpacked[0][0]
-    assert isinstance(dut.in_arr_unpacked_unpacked[0][0], LogicArrayObject)
+    assert isinstance(dut.in_arr_unpacked_unpacked[0][0], PackedObject)
     assert len(dut.in_arr_unpacked_unpacked[0][0]) == 3
 
     test_value = 3 * [3 * [5]]
@@ -264,7 +264,7 @@ async def test_in_arr_unpacked_unpacked(dut):
 
 @cocotb.test()
 async def test_in_2d_arr_packed(dut):
-    assert isinstance(dut.in_2d_arr_packed, LogicArrayObject)
+    assert isinstance(dut.in_2d_arr_packed, PackedObject)
     assert len(dut.in_2d_arr_packed) == 27
 
     test_value = (365 << 18) | (365 << 9) | (365)
@@ -280,7 +280,7 @@ async def test_in_2d_arr_unpacked(dut):
     assert len(dut.in_2d_arr_unpacked) == 3
 
     dut.in_2d_arr_unpacked[0]
-    assert isinstance(dut.in_2d_arr_unpacked[0], LogicArrayObject)
+    assert isinstance(dut.in_2d_arr_unpacked[0], PackedObject)
     assert len(dut.in_2d_arr_unpacked[0]) == 9
 
     test_value = [365, 365, 365]
@@ -291,7 +291,7 @@ async def test_in_2d_arr_unpacked(dut):
 
 @cocotb.test()
 async def test_in_3d_arr(dut):
-    assert isinstance(dut.in_3d_arr, LogicArrayObject)
+    assert isinstance(dut.in_3d_arr, PackedObject)
     assert len(dut.in_3d_arr) == 27
 
     test_value = (365 << 18) | (365 << 9) | (365)
@@ -303,7 +303,7 @@ async def test_in_3d_arr(dut):
 # Riviera fails when trying to access packed structs (gh-4753)
 @cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("riviera"))
 async def test_struct(dut: Any) -> None:
-    assert isinstance(dut.in_struct_packed, LogicArrayObject)
+    assert isinstance(dut.in_struct_packed, PackedObject)
     assert len(dut.in_struct_packed) == 24
 
     dut.in_struct_packed.value = 123
@@ -314,7 +314,7 @@ async def test_struct(dut: Any) -> None:
 # Riviera crashes when trying to access packed structs (gh-4753)
 @cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("riviera"))
 async def test_struct_1d_arr_packed(dut: Any) -> None:
-    assert isinstance(dut.in_struct_packed_array_packed, LogicArrayObject)
+    assert isinstance(dut.in_struct_packed_array_packed, PackedObject)
     assert len(dut.in_struct_packed_array_packed) == 72
 
     dut.in_struct_packed_array_packed.value = 123456
@@ -328,7 +328,7 @@ async def test_struct_1d_arr_unpacked(dut: Any) -> None:
     assert isinstance(dut.in_struct_packed_array_unpacked, ArrayObject)
     assert len(dut.in_struct_packed_array_unpacked) == 3
 
-    assert isinstance(dut.in_struct_packed_array_unpacked[0], LogicArrayObject)
+    assert isinstance(dut.in_struct_packed_array_unpacked[0], PackedObject)
     assert len(dut.in_struct_packed_array_unpacked[0]) == 24
 
     dut.in_struct_packed_array_unpacked.value = [6798, 2000, 3000]
@@ -340,7 +340,7 @@ async def test_struct_1d_arr_unpacked(dut: Any) -> None:
 # Riviera crashes when trying to access packed structs (gh-4753)
 @cocotb.test(skip=cocotb.SIM_NAME.lower().startswith("riviera"))
 async def test_struct_2d_arr_packed_packed(dut: Any) -> None:
-    assert isinstance(dut.in_struct_packed_arr_packed_packed, LogicArrayObject)
+    assert isinstance(dut.in_struct_packed_arr_packed_packed, PackedObject)
     assert len(dut.in_struct_packed_arr_packed_packed) == 216
 
     dut.in_struct_packed_arr_packed_packed.value = 123458123456123
@@ -353,7 +353,7 @@ async def test_struct_2d_arr_packed_packed(dut: Any) -> None:
 async def test_struct_2d_arr_packed_unpacked(dut: Any) -> None:
     assert isinstance(dut.in_struct_packed_arr_packed_unpacked, ArrayObject)
     assert len(dut.in_struct_packed_arr_packed_unpacked) == 3
-    assert isinstance(dut.in_struct_packed_arr_packed_unpacked[0], LogicArrayObject)
+    assert isinstance(dut.in_struct_packed_arr_packed_unpacked[0], PackedObject)
     assert len(dut.in_struct_packed_arr_packed_unpacked[0]) == 72
 
 
@@ -368,7 +368,5 @@ async def test_struct_2d_arr_unpacked_unpacked(dut: Any) -> None:
     assert len(dut.in_struct_packed_arr_unpacked_unpacked) == 3
     assert isinstance(dut.in_struct_packed_arr_unpacked_unpacked[0], ArrayObject)
     assert len(dut.in_struct_packed_arr_unpacked_unpacked[0]) == 3
-    assert isinstance(
-        dut.in_struct_packed_arr_unpacked_unpacked[0][2], LogicArrayObject
-    )
+    assert isinstance(dut.in_struct_packed_arr_unpacked_unpacked[0][2], PackedObject)
     assert len(dut.in_struct_packed_arr_unpacked_unpacked[0][2]) == 24

--- a/tests/test_cases/test_package/test_package.py
+++ b/tests/test_cases/test_package/test_package.py
@@ -9,7 +9,7 @@ A set of tests that demonstrate package access
 from __future__ import annotations
 
 import cocotb
-from cocotb.handle import HierarchyObject, LogicArrayObject
+from cocotb.handle import HierarchyObject, PackedObject
 
 
 # Riviera-PRO 2019.10 does not detect packages over GPI:
@@ -32,55 +32,55 @@ async def test_package_access(_) -> None:
     assert isinstance(pkg1, HierarchyObject)
     assert pkg1._path.startswith("cocotb_package_pkg_1")
 
-    assert isinstance(pkg1.five_int, LogicArrayObject)
+    assert isinstance(pkg1.five_int, PackedObject)
     assert pkg1.five_int._path == "cocotb_package_pkg_1::five_int"
     assert pkg1.five_int.value == 5
 
-    assert isinstance(pkg1.eight_logic, LogicArrayObject)
+    assert isinstance(pkg1.eight_logic, PackedObject)
     assert pkg1.eight_logic._path == "cocotb_package_pkg_1::eight_logic"
     assert pkg1.eight_logic.value == 8
 
-    assert isinstance(pkg1.bit_1_param, LogicArrayObject)
+    assert isinstance(pkg1.bit_1_param, PackedObject)
     assert pkg1.bit_1_param._path == "cocotb_package_pkg_1::bit_1_param"
     assert pkg1.bit_1_param.value == 1
 
-    assert isinstance(pkg1.bit_2_param, LogicArrayObject)
+    assert isinstance(pkg1.bit_2_param, PackedObject)
     assert pkg1.bit_2_param._path == "cocotb_package_pkg_1::bit_2_param"
     assert pkg1.bit_2_param.value == 3
 
-    assert isinstance(pkg1.bit_600_param, LogicArrayObject)
+    assert isinstance(pkg1.bit_600_param, PackedObject)
     assert pkg1.bit_600_param._path == "cocotb_package_pkg_1::bit_600_param"
     assert pkg1.bit_600_param.value == 12345678912345678912345689
 
-    assert isinstance(pkg1.byte_param, LogicArrayObject)
+    assert isinstance(pkg1.byte_param, PackedObject)
     assert pkg1.byte_param._path == "cocotb_package_pkg_1::byte_param"
     assert pkg1.byte_param.value == 100
 
-    assert isinstance(pkg1.shortint_param, LogicArrayObject)
+    assert isinstance(pkg1.shortint_param, PackedObject)
     assert pkg1.shortint_param._path == "cocotb_package_pkg_1::shortint_param"
     assert pkg1.shortint_param.value == 63000
 
-    assert isinstance(pkg1.int_param, LogicArrayObject)
+    assert isinstance(pkg1.int_param, PackedObject)
     assert pkg1.int_param._path == "cocotb_package_pkg_1::int_param"
     assert pkg1.int_param.value == 50
 
-    assert isinstance(pkg1.longint_param, LogicArrayObject)
+    assert isinstance(pkg1.longint_param, PackedObject)
     assert pkg1.longint_param._path == "cocotb_package_pkg_1::longint_param"
     assert pkg1.longint_param.value == 0x11C98C031CB
 
-    assert isinstance(pkg1.integer_param, LogicArrayObject)
+    assert isinstance(pkg1.integer_param, PackedObject)
     assert pkg1.integer_param._path == "cocotb_package_pkg_1::integer_param"
     assert pkg1.integer_param.value == 125000
 
-    assert isinstance(pkg1.logic_130_param, LogicArrayObject)
+    assert isinstance(pkg1.logic_130_param, PackedObject)
     assert pkg1.logic_130_param._path == "cocotb_package_pkg_1::logic_130_param"
     assert pkg1.logic_130_param.value == 0x8C523EC7DC553A2B
 
-    assert isinstance(pkg1.reg_8_param, LogicArrayObject)
+    assert isinstance(pkg1.reg_8_param, PackedObject)
     assert pkg1.reg_8_param._path == "cocotb_package_pkg_1::reg_8_param"
     assert pkg1.reg_8_param.value == 200
 
-    assert isinstance(pkg1.time_param, LogicArrayObject)
+    assert isinstance(pkg1.time_param, PackedObject)
     assert pkg1.time_param._path == "cocotb_package_pkg_1::time_param"
     assert pkg1.time_param.value == 0x2540BE400
 
@@ -88,7 +88,7 @@ async def test_package_access(_) -> None:
     assert isinstance(pkg2, HierarchyObject)
     assert pkg2._path.startswith("cocotb_package_pkg_2")
 
-    assert isinstance(pkg2.eleven_int, LogicArrayObject)
+    assert isinstance(pkg2.eleven_int, PackedObject)
     assert pkg2.eleven_int._path == "cocotb_package_pkg_2::eleven_int"
     assert pkg2.eleven_int.value == 11
 

--- a/tests/test_cases/test_verilog_access/test_verilog_access.py
+++ b/tests/test_cases/test_verilog_access/test_verilog_access.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import cocotb
-from cocotb.handle import HierarchyObject, LogicArrayObject, LogicObject
+from cocotb.handle import HierarchyObject, LogicObject, PackedObject
 
 
 @cocotb.test()
@@ -18,7 +18,7 @@ async def port_not_hierarchy(dut):
     assert isinstance(dut.clk, LogicObject)
     assert isinstance(dut.i_verilog, HierarchyObject)
     assert isinstance(dut.i_verilog.clock, LogicObject)
-    assert isinstance(dut.i_verilog.tx_data, LogicArrayObject)
+    assert isinstance(dut.i_verilog.tx_data, PackedObject)
 
     for _ in dut:
         pass
@@ -29,4 +29,4 @@ async def port_not_hierarchy(dut):
     assert isinstance(dut.clk, LogicObject)
     assert isinstance(dut.i_verilog, HierarchyObject)
     assert isinstance(dut.i_verilog.clock, LogicObject)
-    assert isinstance(dut.i_verilog.tx_data, LogicArrayObject)
+    assert isinstance(dut.i_verilog.tx_data, PackedObject)


### PR DESCRIPTION
Missed adding the new type to documentation in the code review for #5354.

Additionally, `PackedObject` being a subtype of `LogicArrayObject` is not type safe as `PackedObject` supports less functionality (no indexing or iteration). Separating the two into unrelated types required updating a bunch of tests.

### TODO
- [x] Add test for iteration
- [ ] Add test for bad index