### PR TITLE
Improve Makefile error reporting if simulator CMD is not found

### DIFF
--- a/src/cocotb_tools/makefiles/Makefile.inc
+++ b/src/cocotb_tools/makefiles/Makefile.inc
@@ -55,6 +55,11 @@ define check_results
     @$(PYTHON_BIN) -m cocotb_tools.check_results $(COCOTB_RESULTS_FILE)
 endef
 
+# Find an executable or fail if it can't be found.
+define find_command
+    $(or $(shell :; command -v $(1) 2>/dev/null),$(error Unable to locate command '$(1)'))
+endef
+
 SIM_BUILD ?= sim_build
 export SIM_BUILD
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.activehdl
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.activehdl
@@ -7,10 +7,10 @@
 CMD_BIN := vsimsa
 
 ifdef ACTIVEHDL_BIN_DIR
-    CMD := $(shell :; command -v $(ACTIVEHDL_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(ACTIVEHDL_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
     ACTIVEHDL_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.cvc
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.cvc
@@ -14,10 +14,10 @@ else
 CMD_BIN := cvc64
 
 ifdef CVC_BIN_DIR
-    CMD := $(shell :; command -v $(CVC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CVC_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
     CVC_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.dsim
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.dsim
@@ -5,14 +5,10 @@
 CMD_BIN := dsim
 
 ifdef DSIM_BIN_DIR
-    CMD := $(shell :; command -v $(DSIM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(DSIM_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
-endif
-
-ifeq (, $(CMD))
-    $(error Unable to locate command >$(CMD_BIN)<)
+    CMD := $(call find_command,$(CMD_BIN))
 endif
 
 ifeq ($(WAVES), 1)

--- a/src/cocotb_tools/makefiles/simulators/Makefile.ghdl
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.ghdl
@@ -15,10 +15,10 @@ else
 CMD_BIN := ghdl
 
 ifdef GHDL_BIN_DIR
-    CMD := $(shell :; command -v $(GHDL_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(GHDL_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
     GHDL_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.icarus
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.icarus
@@ -17,10 +17,10 @@ else
 CMD_BIN := iverilog
 
 ifdef ICARUS_BIN_DIR
-    CMD := $(shell :; command -v $(ICARUS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(ICARUS_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
     ICARUS_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.ius
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.ius
@@ -9,10 +9,10 @@
 CMD_BIN := irun
 
 ifdef IUS_BIN_DIR
-    CMD := $(shell :; command -v $(IUS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(IUS_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
     IUS_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.nvc
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.nvc
@@ -12,10 +12,10 @@ else
 CMD_BIN := nvc
 
 ifdef NVC_BIN_DIR
-    CMD := $(shell :; command -v $(NVC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(NVC_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
 	NVC_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.questa
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.questa
@@ -7,10 +7,10 @@
 CMD_BIN := vsim
 
 ifdef MODELSIM_BIN_DIR
-    CMD := $(shell :; command -v $(MODELSIM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(MODELSIM_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
 endif
 
 # Determine the version of Questa being used.

--- a/src/cocotb_tools/makefiles/simulators/Makefile.questa-compat
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.questa-compat
@@ -9,10 +9,10 @@
 CMD_BIN := vsim
 
 ifdef MODELSIM_BIN_DIR
-    CMD := $(shell :; command -v $(MODELSIM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(MODELSIM_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
 	MODELSIM_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.questa-qisqrun
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.questa-qisqrun
@@ -9,19 +9,12 @@ QRUN_BIN := qrun
 VIS_BIN := vis
 
 ifdef MODELSIM_BIN_DIR
-    QRUN_CMD := $(shell :; command -v $(MODELSIM_BIN_DIR)/$(QRUN_BIN) 2>/dev/null)
-    VIS_CMD := $(shell :; command -v $(MODELSIM_BIN_DIR)/$(VIS_BIN) 2>/dev/null)
+    QRUN_CMD := $(call find_command,$(MODELSIM_BIN_DIR)/$(QRUN_BIN))
+    VIS_CMD := $(call find_command,$(MODELSIM_BIN_DIR)/$(VIS_BIN))
 else
     # auto-detect bin dir from system path
-    QRUN_CMD := $(shell :; command -v $(QRUN_BIN) 2>/dev/null)
-    VIS_CMD := $(shell :; command -v $(VIS_BIN) 2>/dev/null)
-endif
-
-ifeq (,$(QRUN_CMD))
-    $(error Unable to locate command >$(QRUN_BIN)<)
-endif
-ifeq (,$(VIS_CMD))
-    $(error Unable to locate command >$(VIS_BIN)<)
+    QRUN_CMD := $(call find_command,$(QRUN_BIN))
+    VIS_CMD := $(call find_command,$(VIS_BIN))
 endif
 
 DESIGNFILE ?= design.bin

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -13,10 +13,10 @@ else
 endif
 
 ifdef ALDEC_BIN_DIR
-    CMD := $(shell :; command -v $(ALDEC_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(ALDEC_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
 	ALDEC_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.vcs
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.vcs
@@ -14,10 +14,10 @@ else
 CMD_BIN := vcs
 
 ifdef VCS_BIN_DIR
-    CMD := $(shell :; command -v $(VCS_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(VCS_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
     VCS_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.verilator
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.verilator
@@ -15,10 +15,10 @@ else
 CMD_BIN := verilator
 
 ifdef VERILATOR_BIN_DIR
-  CMD := $(shell :; command -v $(VERILATOR_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+  CMD := $(call find_command,$(VERILATOR_BIN_DIR)/$(CMD_BIN))
 else
   # auto-detect bin dir from system path
-  CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+  CMD := $(call find_command,$(CMD_BIN))
   VERILATOR_BIN_DIR := $(shell dirname $(CMD))
 endif
 

--- a/src/cocotb_tools/makefiles/simulators/Makefile.xcelium
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.xcelium
@@ -9,10 +9,10 @@
 CMD_BIN := xrun
 
 ifdef XCELIUM_BIN_DIR
-    CMD := $(shell :; command -v $(XCELIUM_BIN_DIR)/$(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(XCELIUM_BIN_DIR)/$(CMD_BIN))
 else
     # auto-detect bin dir from system path
-    CMD := $(shell :; command -v $(CMD_BIN) 2>/dev/null)
+    CMD := $(call find_command,$(CMD_BIN))
     XCELIUM_BIN_DIR := $(shell dirname $(CMD))
 endif
 


### PR DESCRIPTION
If `command -v` failed to find the given `CMD` it would return an empty string, which Make is perfectly happy to roll with, leading to weird errors in subsequent commands.

A couple of Makefiles had checking for this (dsim and questa-qisqrun), but most didn't. This commit adds a dedicated `find_command` macro which finds the given command and exits with a reasonable error if it isn't found.

Fixes #5396

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
