### PR TITLE
Fix release build process

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -51,8 +51,8 @@ jobs:
       # locally.
       - name: Build cocotb release
         run: |
-          nox -s release_build_wheel
-          nox -s release_build_sdist
+          nox -s release_clean
+          nox -s release_build
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
@@ -61,33 +61,13 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
 
-  test_sdist:
-    name: Test the source distribution (sdist)
-    needs: build_release
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-      with:
-        python-version: "3.12"
-    - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
-      with:
-        path: dist
-        pattern: cocotb-dist-*
-        merge-multiple: true
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-    - name: Install nox
-      run: python3 -m pip install nox nox-uv
-    - name: Smoke-test the sdist
-      run: nox -s release_test_sdist
-
+  # This tests both the sdist and wheel builds in separate venvs back to back with just the pytest tests.
   test_release:
     name: Regression Tests
     needs: build_release
     uses: ./.github/workflows/regression-tests.yml
     with:
-      test_task: release_test_wheel
+      test_task: release_test
       download_artifacts: true
       group: ci-free
 
@@ -96,7 +76,7 @@ jobs:
     needs: build_release
     uses: ./.github/workflows/regression-tests.yml
     with:
-      test_task: release_test_wheel
+      test_task: release_test
       download_artifacts: true
       group: ci-licensed
 
@@ -105,7 +85,6 @@ jobs:
     needs:
     - test_release
     - test_release_licensed
-    - test_sdist
     permissions:
       id-token: write
     runs-on: ubuntu-22.04

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -93,11 +93,11 @@ jobs:
 
      # Download distribution artifacts (if any).
     - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
+      if: ${{ inputs.download_artifacts }}
       with:
         path: dist
         pattern: cocotb-dist-*
         merge-multiple: true
-      if: ${{ inputs.download_artifacts }}
 
       # Install Python
     - name: Set up Python ${{matrix.python-version}} (setup-python)

--- a/noxfile.py
+++ b/noxfile.py
@@ -420,15 +420,27 @@ def release_build_sdist(session: nox.Session) -> None:
     session.log(f"Source distribution in release mode built into {dist_dir!r}")
 
 
+@nox_uv.session(
+    uv_no_install_project=True,
+    uv_groups=[],
+    uv_sync_locked=False,
+)
+def release_build(session: nox.Session) -> None:
+    """Build all distributions for release."""
+    session.notify("release_build_wheel")
+    session.notify("release_build_sdist")
+
+
 def release_install_from_sdist(session: nox.Session) -> None:
     """Install cocotb from sdist."""
 
     # Find the sdist to install.
     sdists = list(Path(dist_dir).glob("cocotb-*.tar.gz"))
     if not sdists:
-        session.notify("release_build_sdist")
-        sdists = list(Path(dist_dir).glob("cocotb-*.tar.gz"))
-    if len(sdists) > 1:
+        session.error(
+            f"No potential sdist found in the {dist_dir!r} directory. Run the 'release_build_sdist' session first!"
+        )
+    elif len(sdists) > 1:
         session.error(
             f"More than one potential sdist found in the {dist_dir!r} "
             f"directory. Run the 'release_clean' session first!"
@@ -468,16 +480,16 @@ def release_install_from_wheel(session: nox.Session) -> None:
 
     wheels = list(Path(dist_dir).glob("cocotb-*.whl"))
     if not wheels:
-        session.notify("release_build_wheel")
-        wheels = list(Path(dist_dir).glob("cocotb-*.whl"))
-
+        session.error(
+            f"No potential wheel found in the {dist_dir!r} directory. Run the 'release_build_wheel' session first!"
+        )
     session.log(f"Installing cocotb from wheels in {dist_dir!r}")
     session.install(
         "--force-reinstall",
         "--only-binary",
         "cocotb",
         "--no-index",
-        "--no-dependencies",
+        "--no-deps",
         "--find-links",
         dist_dir,
         "cocotb",


### PR DESCRIPTION
I removed the special `test_sdist` step from the release flow. When the nox env `"release_test and {sim} and {lang}"` is selected, both the sdist and wheel tests will be run, each in their own venv.

I merged the `release_build_sdist` and `release_build_wheel` into a single `release_build` since building that empty venv with uv is actually pretty quick now.

And I removed support for running `release_build` in the `release_test` if builds weren't found, as I don't want the case where the download of the artifact fails/is malformed, it does a new build and tests that, but then what's deployed is the uploaded artifacts, not what was tested. This should never happen, but better safe than sorry.