### PR TITLE
Add missing `@cocotb.test`

### DIFF
--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -110,12 +110,12 @@ async def test_delayed_assignment_still_errors(dut):
     with pytest.raises(ValueError):
         dut.stream_in_data.value = Immediate("1010 not a real binary string")
     with pytest.raises(TypeError):
-        dut.stream_in_int.value = Immediate([])
+        dut.stream_in_data.value = Immediate([])
 
     with pytest.raises(ValueError):
         dut.stream_in_data.value = "1010 not a real binary string"
     with pytest.raises(TypeError):
-        dut.stream_in_int.value = []
+        dut.stream_in_data.value = []
 
 
 @cocotb.xfail(

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -103,6 +103,7 @@ async def test_string_ansi_color(dut):
         assert dut.stream_in_string_asciival_sum.value == asciival_sum
 
 
+@cocotb.test
 async def test_delayed_assignment_still_errors(dut):
     """Writing a bad value should fail even if the write is scheduled to happen later"""
 

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -107,13 +107,13 @@ async def test_string_ansi_color(dut):
 async def test_delayed_assignment_still_errors(dut):
     """Writing a bad value should fail even if the write is scheduled to happen later"""
 
-    with pytest.raises(TypeError):
-        dut.stream_in_int.value = Immediate("1010 not a real binary string")
+    with pytest.raises(ValueError):
+dut.stream_in_data.value = Immediate("1010 not a real binary string")
     with pytest.raises(TypeError):
         dut.stream_in_int.value = Immediate([])
 
     with pytest.raises(ValueError):
-        dut.stream_in_int.value = "1010 not a real binary string"
+        dut.stream_in_data.value = "1010 not a real binary string"
     with pytest.raises(TypeError):
         dut.stream_in_int.value = []
 

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -108,7 +108,7 @@ async def test_delayed_assignment_still_errors(dut):
     """Writing a bad value should fail even if the write is scheduled to happen later"""
 
     with pytest.raises(ValueError):
-dut.stream_in_data.value = Immediate("1010 not a real binary string")
+        dut.stream_in_data.value = Immediate("1010 not a real binary string")
     with pytest.raises(TypeError):
         dut.stream_in_int.value = Immediate([])
 

--- a/tests/test_cases/test_cocotb/test_handle.py
+++ b/tests/test_cases/test_cocotb/test_handle.py
@@ -107,7 +107,7 @@ async def test_string_ansi_color(dut):
 async def test_delayed_assignment_still_errors(dut):
     """Writing a bad value should fail even if the write is scheduled to happen later"""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         dut.stream_in_int.value = Immediate("1010 not a real binary string")
     with pytest.raises(TypeError):
         dut.stream_in_int.value = Immediate([])


### PR DESCRIPTION
Add test for delayed assignment error handling

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
