### PR TITLE
Restore old (pre #5232) root handle name resolution logic

### DIFF
--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import random
 import tempfile
 import time
@@ -219,15 +220,18 @@ def _setup_random_seed() -> None:
 
 
 def _setup_root_handle() -> None:
-    root_name: str = _env.as_str("COCOTB_TOPLEVEL")
-
-    if "." in root_name:
-        # Skip any library component of the toplevel
-        root_name = root_name.split(".", 1)[1]
+    root_name = os.getenv("COCOTB_TOPLEVEL")
+    if root_name is not None:
+        root_name = root_name.strip()
+        if root_name == "":
+            root_name = None
+        elif "." in root_name:
+            # Skip any library component of the toplevel
+            root_name = root_name.split(".", 1)[1]
 
     from cocotb import simulator  # noqa: PLC0415
 
-    handle = simulator.get_root_handle(root_name or None)
+    handle = simulator.get_root_handle(root_name)
     if not handle:
         raise RuntimeError(f"Can not find root handle {root_name!r}")
 

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -227,7 +227,7 @@ def _setup_root_handle() -> None:
 
     from cocotb import simulator  # noqa: PLC0415
 
-    handle = simulator.get_root_handle(root_name)
+    handle = simulator.get_root_handle(root_name or None)
     if not handle:
         raise RuntimeError(f"Can not find root handle {root_name!r}")
 


### PR DESCRIPTION
The C++ code checks against `!name`, but after changing `_setup_root_handle()` to use `_env.as_str()` we get an empty string instead of None, which gets translated to a valid pointer.