### PR TITLE
Small updates to modeling types

### DIFF
--- a/src/cocotb/types/_abstract_array.py
+++ b/src/cocotb/types/_abstract_array.py
@@ -112,7 +112,7 @@ class AbstractArray(Generic[T_co]):
         for i in Range(start, self.direction, stop):
             if self[i] == value:
                 return i
-        raise IndexError(f"{value!r} not in array")
+        raise ValueError(f"{value!r} not in array")
 
     def count(self, value: object) -> int:
         """Return number of occurrences of value.

--- a/tests/pytest/test_array.py
+++ b/tests/pytest/test_array.py
@@ -93,7 +93,7 @@ def test_index():
     r = Array(i for j in range(10) for i in range(10))  # 0-9 repeated 10 times
     assert r.index(5) == 5
     assert r.index(5, 10, 20) == 15
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         r.index(object())
 
 

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -161,13 +161,6 @@ def test_logic_invert():
     assert ~Logic("Z") == Logic("X")
 
 
-def test_logic_identity():
-    assert Logic(0) is Logic(False)
-    assert Logic("1") is Logic(1)
-    assert Logic("X") is Logic("x")
-    assert Logic("z") is Logic("Z")
-
-
 def test_resolve():
     for inp, exp in zip("UX01ZWLH-", "UX01ZX01-"):
         assert Logic(inp).resolve("weak") == Logic(exp)
@@ -226,18 +219,18 @@ def test_bit_constructor() -> None:
 
 
 def test_bit_ops() -> None:
-    assert Bit(1) | Bit(0) is Bit(1)
-    assert Bit(1) & Bit(0) is Bit(0)
-    assert Bit(1) ^ Bit(0) is Bit(1)
-    assert ~Bit(1) is Bit(0)
+    assert Bit(1) | Bit(0) == Bit(1)
+    assert Bit(1) & Bit(0) == Bit(0)
+    assert Bit(1) ^ Bit(0) == Bit(1)
+    assert ~Bit(1) == Bit(0)
 
 
 def test_bit_with_logic_ops() -> None:
     assert Logic(0) == Bit(0)
     assert Bit(0) == Logic(0)
-    assert Logic(1) & Bit(1) is Logic(1)
-    assert Bit(1) & Logic(1) is Logic(1)
-    assert Logic(0) | Bit(1) is Logic(1)
-    assert Bit(0) | Logic(1) is Logic(1)
-    assert Logic(1) ^ Bit(1) is Logic(0)
-    assert Bit(1) ^ Logic(1) is Logic(0)
+    assert Logic(1) & Bit(1) == Logic(1)
+    assert Bit(1) & Logic(1) == Logic(1)
+    assert Logic(0) | Bit(1) == Logic(1)
+    assert Bit(0) | Logic(1) == Logic(1)
+    assert Logic(1) ^ Bit(1) == Logic(0)
+    assert Bit(1) ^ Logic(1) == Logic(0)

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -338,7 +338,7 @@ def test_index():
     r = LogicArray("0001101", Range(7, "downto", 1))
     assert r.index(Logic("1")) == 4
     assert r.index(Logic("1"), 2, 0) == 1
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         r.index(object())
 
 


### PR DESCRIPTION
Removes guarantee that Logic and Bit are singletons comparable with `is`. Fixes incorrect type in `Array.index`.