### PR TITLE
Allow external libraries to register Python runners

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -119,6 +119,9 @@ Python Test Runner
 
 .. autofunction:: get_runner
 
+.. autodata:: SUPPORTED_RUNNERS
+   :no-value:
+                  
 .. autoclass:: Runner
     :members:
 

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -121,7 +121,7 @@ Python Test Runner
 
 .. autodata:: SUPPORTED_RUNNERS
    :no-value:
-                  
+
 .. autoclass:: Runner
     :members:
 

--- a/docs/source/newsfragments/5415.feature.rst
+++ b/docs/source/newsfragments/5415.feature.rst
@@ -1,0 +1,1 @@
+Added public variable :data:`cocotb_tools.runner.SUPPORTED_RUNNERS`, allowing external libraries to register additional simulators for the ``get_runner()`` function.

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -2079,8 +2079,8 @@ SUPPORTED_RUNNERS: dict[str, type[Runner]] = {
     "dsim": Dsim,
 }
 """
-Dictionary mapping of simulator names to corresponding python runners; the keys
-of this dictionary make up valid `simulator_name` strings to pass to :meth:`get_runner()`.
+Dictionary mapping of simulator names to corresponding python runners.
+The keys of this dictionary make up valid `simulator_name` strings to pass to :func:`get_runner()`.
 
 External libraries may register additional implementations of python runners
 by adding keys to this dictionary.

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -2066,6 +2066,27 @@ class Dsim(Runner):
         return cmds
 
 
+SUPPORTED_RUNNERS: dict[str, type[Runner]] = {
+    "icarus": Icarus,
+    "questa": Questa,
+    "ghdl": Ghdl,
+    "riviera": Riviera,
+    "activehdl": ActiveHDL,
+    "verilator": Verilator,
+    "xcelium": Xcelium,
+    "nvc": Nvc,
+    "vcs": Vcs,
+    "dsim": Dsim,
+}
+"""
+Dictionary mapping of simulator names to corresponding python runners; the keys
+of this dictionary make up valid `simulator_name` strings to pass to :meth:`get_runner()`.
+
+External libraries may register additional implementations of python runners
+by adding keys to this dictionary.
+"""
+
+    
 def get_runner(simulator_name: str) -> Runner:
     """Return an instance of a runner for *simulator_name*.
 
@@ -2076,21 +2097,8 @@ def get_runner(simulator_name: str) -> Runner:
         ValueError: If *simulator_name* is not one of the supported simulators or an alias of one.
     """
 
-    supported_sims: dict[str, type[Runner]] = {
-        "icarus": Icarus,
-        "questa": Questa,
-        "ghdl": Ghdl,
-        "riviera": Riviera,
-        "activehdl": ActiveHDL,
-        "verilator": Verilator,
-        "xcelium": Xcelium,
-        "nvc": Nvc,
-        "vcs": Vcs,
-        "dsim": Dsim,
-        # TODO: "activehdl": ActiveHdl,
-    }
     try:
-        return supported_sims[simulator_name]()
+        return SUPPORTED_RUNNERS[simulator_name]()
     except KeyError:
         raise ValueError(
             f"Simulator {simulator_name!r} is not in supported list: {', '.join(supported_sims)}"

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -2101,5 +2101,5 @@ def get_runner(simulator_name: str) -> Runner:
         return SUPPORTED_RUNNERS[simulator_name]()
     except KeyError:
         raise ValueError(
-            f"Simulator {simulator_name!r} is not in supported list: {', '.join(supported_sims)}"
+            f"Simulator {simulator_name!r} is not in supported list: {', '.join(SUPPORTED_RUNNERS)}"
         ) from None

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -2086,7 +2086,7 @@ External libraries may register additional implementations of python runners
 by adding keys to this dictionary.
 """
 
-    
+
 def get_runner(simulator_name: str) -> Runner:
     """Return an instance of a runner for *simulator_name*.
 

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -2079,10 +2079,10 @@ SUPPORTED_RUNNERS: dict[str, type[Runner]] = {
     "dsim": Dsim,
 }
 """
-Dictionary mapping of simulator names to corresponding python runners.
-The keys of this dictionary make up valid `simulator_name` strings to pass to :func:`get_runner()`.
+Dictionary mapping of simulator names to corresponding Python runners.
+The keys of this dictionary make up valid ``simulator_name`` strings to pass to :func:`get_runner()`.
 
-External libraries may register additional implementations of python runners
+External libraries may register additional implementations of Python runners
 by adding keys to this dictionary.
 """
 


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
Very slight change to the `get_runner()` function in the Python runner; by making the dictionary mapping simulator names to python runner types a global variable external packages can register alternative/additonal python runner types (either for expanding simulator support beyond those that can be officially supported by cocotb, or for alternate versions of python runners for existing simulator). Specifically in my [vicoco](https://github.com/kiran-vuksanaj/vicoco) project (and soon also themperek's [cocotb-vivado](https://github.com/themperek/cocotb-vivado), I've implemented a Python runner to be able to build for + test with the Vivado simulator; I currently patch in a replacement get_runner() function but this doesn't feel like a particularly elegant solution.

With this change, a cocotb extension package could add an extra python runner by registering it with
`cocotb_tools.runner.SUPPORTED_SIMULATORS["simulator_name"] = NewRunnerImplementation`. Nothing would change for the existing python runners in cocotb.