### PR TITLE
Resolved verilator hanging on $error when waves are enabled

### DIFF
--- a/docs/source/newsfragments/5423.bugfix.rst
+++ b/docs/source/newsfragments/5423.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Verilator hanging when ``$fatal`` is triggered in simulations with waves/tracing enabled.

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -62,8 +62,8 @@ void wrap_up() {
 
 #if VM_TRACE
     if (tfp) {
-        delete tfp;
-        tfp = nullptr;
+        // We don't delete the trace object to avoid deadlock in verilator sims.
+        tfp->close();
     }
 #endif
 
@@ -210,6 +210,13 @@ int main(int argc, char **argv) {
     top->final();
 
     wrap_up();
+
+#if VM_TRACE
+    if (tfp) {
+        delete tfp;
+        tfp = nullptr;
+    }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
There was an issue in the `wrap_up` function defined in `src/cocotb/share/lib/verilator/verilator.cpp` which would result in cocotb hanging if verilator was built with waves enabled. The `runExitCallbacks()` function defined in verilator acquires the `VlCbStatic.s_exitCbs` lock when it is called. It then calls the `wrap_up` function which was added as an exit callback. The `wrap_up` function calls the destructor for the trace file pointer which attempts to reacquire the `VlCbStatic.s_exitCbs` lock resulting in the process hanging. This change moves the destruction handling for the trace file pointer outside of the exit callback function, which prevents this hanging.