### PR TITLE
Coverage: don't override path of combined output file

### DIFF
--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -166,18 +166,14 @@ def _start_user_coverage() -> None:
                     ]
 
                     if files:
-                        final_data_file = ".coverage"
                         if config_filepath is None:
                             cocotb_package_dir = Path(__file__).parent.absolute()
                             combiner = coverage.coverage(
-                                data_file=final_data_file,
                                 branch=True,
                                 omit=[f"{cocotb_package_dir}/*"],
                             )
                         else:
-                            combiner = coverage.coverage(
-                                data_file=final_data_file, config_file=config_filepath
-                            )
+                            combiner = coverage.coverage(config_file=config_filepath)
                         combiner.combine(data_paths=files, strict=True, keep=True)
                 finally:
                     tmp_data_file_controller.close()


### PR DESCRIPTION
This fixes a bug where `data_file` will override any value from the configuration file, so the file name always gets named `.coverage` regardless. That is the default anyway, if left unspecified, so I think for the final combined file it makes sense to just leave out that argument entirely.