### PR TITLE
Remove extra space in Makefile

### DIFF
--- a/src/cocotb_tools/makefiles/simulators/Makefile.icarus
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.icarus
@@ -38,7 +38,7 @@ endif
 
 # Compilation phase
 
-ifeq ($(WAVES), 1)
+ifeq ($(WAVES),1)
     VERILOG_SOURCES += $(SIM_BUILD)/cocotb_iverilog_dump.v
     COMPILE_ARGS += -s cocotb_iverilog_dump
     FST = -fst


### PR DESCRIPTION
This can sometimes cause comparison issues.
