### PR TITLE
Group uv lockfile updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,9 @@ updates:
     cooldown:
       default-days: 7
     versioning-strategy: lockfile-only
+    groups:
+      updates:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
     groups:
       updates:
         applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
Groups all minor and patch version bumps in uv lockfile into a single PR.
