### PR TITLE
Direct run verilator rather than call perl

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1625,7 +1625,6 @@ class Verilator(Runner):
         cmds = []
         cmds.append(
             [
-                "perl",
                 self.executable,
                 "-cc",
                 "--exe",


### PR DESCRIPTION

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->

Closes issue #5474 
