### PR TITLE
Fix ecosystem tests

### DIFF
--- a/.github/workflows/ecosystem-compat.yml
+++ b/.github/workflows/ecosystem-compat.yml
@@ -22,8 +22,12 @@ on:
 jobs:
   cocotb-coverage:
     if: github.repository == 'cocotb/cocotb'
-    name: Test cocotb-coverage 1.2
-    runs-on: ubuntu-22.04
+    name: Test cocotb-coverage
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        cocotb-coverage-version: [ "2.0" ]
+
     steps:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -32,90 +36,86 @@ jobs:
 
       - name: Install Icarus Verilog
         run: sudo apt-get install -y --no-install-recommends iverilog
-
-      - name: Checkout cocotb repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          path: cocotb
 
       - name: Checkout cocotb-coverage repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: mciepluc/cocotb-coverage
           path: cocotb-coverage
+          ref: v${{ matrix.cocotb-coverage-version }}
 
       - name: Install the release version of cocotb-coverage
-        run: pip3 install cocotb-coverage==1.2
+        run: pip install ./cocotb-coverage
 
       - name: Install the development version of cocotb
-        run: pip3 install ./cocotb
+        run: pip install git+https://github.com/cocotb/cocotb.git
 
       - name: Run tests
-        # Don't run tests through tox (as present in cocotb-coverage) to be able
-        # to override the cocotb dependency.
+        if: ${{ matrix.cocotb-coverage-version }} == '2.0'
+        env:
+          SIM: icarus
+          TOPLEVEL_LANG: verilog
         run: |
-          pip3 install pytest
+          pip install pytest cocotb-bus numpy
           cd cocotb-coverage
-          export SIM=icarus
           make -k -C tests
+          make -C examples/fifo/tests
+          make -C examples/pkt_switch/tests
 
   pyuvm:
     if: github.repository == 'cocotb/cocotb'
-    name: Test pyuvm 3+
-    runs-on: ubuntu-22.04
+    name: Test pyuvm
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        pyuvm-version: [ "4.0.1" ]
+
     steps:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.11"
 
-      - name: Install GHDL
-        run: sudo apt-get install -y --no-install-recommends ghdl
-
       - name: Install Icarus Verilog
         run: sudo apt-get install -y --no-install-recommends iverilog
 
-      - name: Checkout cocotb repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Install NVC
+        uses: nickg/setup-nvc@v1
         with:
-          path: cocotb
+          version: r1.19.3
 
       - name: Checkout pyuvm repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          path: pyuvm_clone
           repository: pyuvm/pyuvm
+          path: pyuvm
+          ref: ${{ matrix.pyuvm-version }}
 
-      - name: Install the release version of pyuvm
-        run: pip3 install pyuvm>=3.0.0
+      - name: Install pyuvm
+        run: pip install ./pyuvm
 
       - name: Install the development version of cocotb
-        run: pip3 install ./cocotb
+        run: pip install git+https://github.com/cocotb/cocotb.git
 
       - name: Run tests
-          # Don't run tests through tox (as present in pyuvm) to be able
-          # to override the cocotb dependency.
+        if: ${{ matrix.pyuvm-version }} == '4.0.1'
+        working-directory: pyuvm
+        env:
+          VERILOG_SIM: icarus
+          VHDL_SIM: nvc
         run: |
-          pip3 install pytest
-          export SIM=icarus
-          make -C pyuvm_clone/tests/cocotb_tests/run_phase sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/decorator sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/t05_base_classes sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/t08_factories sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/t09_phasing sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/t12_tlm sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/t13_components sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/config_db sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/t14_15_sequences sim checkclean
-          make -C pyuvm_clone/tests/cocotb_tests/ext_classes sim checkclean
-          make -C pyuvm_clone/examples/TinyALU sim checkclean
-          make -C pyuvm_clone/examples/TinyALU_reg sim checkclean
-          make SIM=ghdl TOPLEVEL_LANG=vhdl -C pyuvm_clone/examples/TinyALU sim checkclean
+          pip install pytest
+          pytest
+          make cocotb_tests
 
   forastero:
     if: github.repository == 'cocotb/cocotb'
     name: Test Forastero
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        forastero-version: [ "1.2.1" ]
+
     steps:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -125,22 +125,24 @@ jobs:
       - name: Install Icarus Verilog
         run: sudo apt-get install -y --no-install-recommends iverilog
 
-      - name: Checkout cocotb repository
+      - name: Checkout Forastero repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          path: cocotb
+          repository: intuity/forastero
+          path: forastero
+          ref: ${{ matrix.forastero-version }}
 
       - name: Install the release version of Forastero
-        run: pip3 install forastero
+        run: pip install ./forastero
 
       - name: Install the development version of cocotb
-        run: pip3 install ./cocotb
+        run: pip install git+https://github.com/cocotb/cocotb.git
 
       - name: Run tests
+        working-directory: forastero
+        env:
+          SIM: icarus
+          TOPLEVEL_LANG: verilog
         run: |
-          # Clone matching tag of Forastero git repository
-          git clone --branch $(pip3 freeze | grep forastero | cut -d= -f3) https://github.com/intuity/forastero.git forastero_clone
-          # Run Forastero examples
-          export SIM=icarus
-          make -C forastero_clone/examples/arbiter_strict
-          make -C forastero_clone/examples/arbiter_window
+          make -C examples/arbiter_strict
+          make -C examples/arbiter_window


### PR DESCRIPTION
Depends on #5509. These have been broken for a while. We had to update cocotb-coverage since they just added support for cocotb 2.0+ and the pyuvm one was kinda stale, I think most people have updated to 4.0 since it's deliberately 2.0 compatible.

The new flow for all tests is:
1. install tools and other testing requirements
2. clone a release version of the library under test (LUT)
3. pip install the local clone of the release version of the LUT
4. install cocotb master from Github
5. run the LUT's tests manually to allow for cocotb version override
