### PR TITLE
Add ability to randomize test order

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -960,6 +960,19 @@ Other Runtime Information
 
 .. autodata:: cocotb.is_simulation
 
+.. envvar:: COCOTB_RANDOM_TEST_ORDER
+
+    Type :ref:`env-boolean`
+
+    Default: :data:`False`
+
+    Enable randomizing the order of tests within each stage. To recreate the
+    same test order, the random seed must be set.
+
+    If not set, all tests are ran in the order in which they were discovered.
+
+    .. versionadded:: 2.1
+
 Debugging
 ---------
 

--- a/docs/source/newsfragments/5106.feature.rst
+++ b/docs/source/newsfragments/5106.feature.rst
@@ -1,0 +1,1 @@
+Added :envvar:`COCOTB_RANDOM_TEST_ORDER` environment variables to enable randomized ordering of cocotb tests within each stage.

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -225,6 +225,9 @@ class RegressionManager:
         self._included: list[bool]
         self._regression_terminated: BaseException | None = None
         self._regression_seed = cocotb.RANDOM_SEED
+        self._random_test_order = _env.as_bool(
+            "COCOTB_RANDOM_TEST_ORDER", default=False
+        )
         self._random_state: Any
         self._max_failures = _env.as_int("COCOTB_MAX_FAILURES", default=0)
         self._random_x_resolver_state: Any
@@ -342,6 +345,10 @@ class RegressionManager:
         """Start the regression."""
 
         self.log.info("Running tests")
+
+        # if needed, randomize tests before sorting into stages
+        if self._random_test_order:
+            random.shuffle(self._test_queue)
 
         # sort tests into stages
         self._test_queue.sort(key=lambda test: test.stage)

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -83,6 +83,7 @@ def _help_vars_text() -> str:
                                  Files to apply pytest assertion rewrites to (default *.py)
         COCOTB_MAX_FAILURES      Maximum number of test failures before aborting the regression
         COCOTB_LIST_TESTS        Prints all tests in the order they would be executed and exits
+        COCOTB_RANDOM_TEST_ORDER Enables randomizing the order of tests within each stage
 
         Scheduler
         ---------

--- a/tests/test_cases/test_random_test_order/Makefile
+++ b/tests/test_cases/test_random_test_order/Makefile
@@ -1,0 +1,18 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+COCOTB_TEST_MODULES = test_random_test_order
+
+# This particular seed value provides a nice spread of how random the test order can be.
+#
+# Specifically, it demonstrates that:
+#	- Tests within a stage are shuffled.
+#	- The ordering of stages is upheld.
+# 	- Parametrized tests are shuffled among the stage.
+export COCOTB_RANDOM_SEED := 1233
+
+# Set COCOTB_RANDOM_TEST_ORDER to randomize tests within stages.
+export COCOTB_RANDOM_TEST_ORDER := 1
+
+include ../../designs/sample_module/Makefile

--- a/tests/test_cases/test_random_test_order/test_random_test_order.py
+++ b/tests/test_cases/test_random_test_order/test_random_test_order.py
@@ -1,0 +1,50 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import cocotb
+
+# Track which test gets ran during the simulation.
+count = 0
+
+
+# Try this a parametrized version of a test.
+@cocotb.test(stage=0)
+@cocotb.parametrize(index=[0, 1, 2])
+async def test_a0(dut: object, index: int) -> None:
+    """Run a test."""
+    global count
+    count += 1
+    if index == 0:
+        assert count == 3
+    elif index == 1:
+        assert count == 2
+    elif index == 2:
+        assert count == 5
+
+
+@cocotb.test(stage=0)
+async def test_b0(dut: object) -> None:
+    """Run a test."""
+    global count
+    count += 1
+    assert count == 1
+
+
+@cocotb.test(stage=0)
+async def test_c0(dut: object) -> None:
+    """Run a test."""
+    global count
+    count += 1
+    assert count == 4
+
+
+# Try with a test in a different stage.
+@cocotb.test(stage=1)
+async def test_a1(dut: object) -> None:
+    """Run a test."""
+    global count
+    count += 1
+    # Verify this test is always last.
+    assert count == 6


### PR DESCRIPTION
Creates a new environment variable (COCOTB_RANDOM_TEST_ORDER) to enable shuffling of tests within the regression manager (closes #5106).

This change provides a new capability without breaking existing functionality by preserving the original test ordering by default. Users can set a new environment variable, `COCOTB_RANDOM_TEST_ORDER`, to enable this new capability. The randomized ordering of stages is beneficial to cocotb users because without this capability, users did not have a way to try to verify that state was not being preserved between tests, or that some state in the previous test was affecting a future test. By randomizing test order, a cocotb user can run regression tests and have a higher chance of identifying if any tests are relying on past state during a simulation.

This capability also relies on the `cocotb.RANDOM_SEED`, in which it will reproduce the same ordering if a random seed is set. This is useful to ensure reproducibility if a certain ordering yielded failed tests.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
