### PR TITLE
examples/simple_dff: fix test_module typo

### DIFF
--- a/examples/simple_dff/test_dff.py
+++ b/examples/simple_dff/test_dff.py
@@ -59,7 +59,7 @@ def test_simple_dff_runner():
         always=True,
     )
 
-    runner.test(hdl_toplevel="dff", test_module="test_dff,")
+    runner.test(hdl_toplevel="dff", test_module="test_dff")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Fix a typo in the `simple_dff` example where the `test_module`
argument contains a trailing comma.

### Problem

The current code uses:

```python
test_module="test_dff,"

#Changed to:

'''python
test_module="test_dff"

