### PR TITLE
Reduce overhead of large regressions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         pip install pytest pytest-benchmark
         pip install .
-        pytest -c /dev/null tests/benchmark.py --benchmark-json output.json
+        pytest -c /dev/null tests/benchmarks --benchmark-json output.json
 
     # Pushing the benchmark requires elevated permissions to the
     # cocotb/cocotb-benchmark-results repository, which we only grant for

--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -96,6 +96,7 @@ class Test:
         self.expect_error = expect_error
         self.skip = skip
         self.stage = stage
+        self.included = not skip
 
     @property
     def fullname(self) -> str:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -627,9 +627,12 @@ class RegressionManager:
 
     def _get_lineno(self, test: Test) -> int:
         try:
-            return inspect.getsourcelines(test.func)[1]
-        except OSError:
-            return 1
+            return test.func.__code__.co_firstlineno
+        except AttributeError:
+            try:
+                return inspect.getsourcelines(test.func)[1]
+            except OSError:
+                return 1
 
     def _log_test_start(self) -> None:
         """Called by :meth:`_execute` to log that a test is starting."""

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -353,19 +353,20 @@ class RegressionManager:
         # sort tests into stages
         self._test_queue.sort(key=lambda test: test.stage)
 
-        # mark tests for running
+        # mark tests for running and count included tests
         if self._filters:
-            self._included = [False] * len(self._test_queue)
-            for i, test in enumerate(self._test_queue):
+            self.total_tests = 0
+            for test in self._test_queue:
+                test.included = False
                 for filter in self._filters:
                     if filter.search(test.fullname):
-                        self._included[i] = True
+                        test.included = True
+                        self.total_tests += 1
         else:
-            self._included = [True] * len(self._test_queue)
+            self.total_tests = sum(1 for test in self._test_queue if test.included)
 
         # compute counts
         self.count = 1
-        self.total_tests = sum(self._included)
         if self.total_tests == 0:
             self.log.warning(
                 "No tests left after filtering with: %s",
@@ -385,10 +386,9 @@ class RegressionManager:
         """
         while self._test_queue:
             self._test = self._test_queue.pop(0)
-            included = self._included.pop(0)
 
             # if the test is not included, record and continue
-            if not included:
+            if not self._test.included:
                 self._record_test_excluded()
                 continue
 

--- a/tests/benchmarks/test_matrix_multiplier.py
+++ b/tests/benchmarks/test_matrix_multiplier.py
@@ -8,6 +8,10 @@ from pathlib import Path
 
 from cocotb_tools.runner import get_runner
 
+proj_path = (
+    Path(__file__).resolve().parent.parent.parent / "examples" / "matrix_multiplier"
+)
+
 
 def build_and_run_matrix_multiplier(benchmark, sim):
     hdl_toplevel_lang = "verilog"
@@ -17,10 +21,6 @@ def build_and_run_matrix_multiplier(benchmark, sim):
     if sim == "nvc":
         build_args = ["--std=08"]
         hdl_toplevel_lang = "vhdl"
-
-    proj_path = (
-        Path(__file__).resolve().parent.parent / "examples" / "matrix_multiplier"
-    )
 
     sys.path.append(str(proj_path / "tests"))
 
@@ -38,6 +38,7 @@ def build_and_run_matrix_multiplier(benchmark, sim):
         hdl_toplevel="matrix_multiplier",
         sources=sources,
         build_args=build_args,
+        build_dir="sim_build/matrix_multiplier",
     )
 
     @benchmark

--- a/tests/benchmarks/test_parameterize_perf/parametrize_perf_top.sv
+++ b/tests/benchmarks/test_parameterize_perf/parametrize_perf_top.sv
@@ -1,0 +1,6 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+module parametrize_perf_top;
+endmodule

--- a/tests/benchmarks/test_parameterize_perf/parametrize_performance_tests.py
+++ b/tests/benchmarks/test_parameterize_perf/parametrize_performance_tests.py
@@ -1,0 +1,12 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import cocotb
+
+
+@cocotb.test()
+@cocotb.parametrize(a=range(50), b=range(50), c=range(50))
+async def parametrize(dut, a, b, c):
+    pass

--- a/tests/benchmarks/test_parameterize_perf/test_parameterize_perf.py
+++ b/tests/benchmarks/test_parameterize_perf/test_parameterize_perf.py
@@ -1,0 +1,32 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from cocotb_tools.runner import get_runner
+
+THIS_DIR = Path(__file__).resolve().parent
+
+
+def test_parameterize_perf_icarus(benchmark) -> None:
+    if str(THIS_DIR) not in sys.path:
+        sys.path.append(str(THIS_DIR))
+
+    runner = get_runner("icarus")
+
+    runner.build(
+        hdl_toplevel="parametrize_perf_top",
+        sources=[THIS_DIR / "parametrize_perf_top.sv"],
+        build_dir="sim_build",
+    )
+
+    @benchmark
+    def run_test() -> None:
+        runner.test(
+            hdl_toplevel="parametrize_perf_top",
+            test_module="parametrize_performance_tests",
+            test_filter="parametrize/a=49/b=49/c=49",
+        )


### PR DESCRIPTION
Closes #5137.

In the issue, generating a regression with a million tests and then selecting one regressed from taking a few seconds to practically infinite time between 1.9 and 2.0. This was because of the change to record all excluded functions in the results.xml.

We presumably want those unincluded tests recorded, so I used py-spy and speedscope to quickly identify the main culprits and address them.

Generating a million tests still takes forever, but large combinations like 125k tests are more manageable.