### PR TITLE
Use qualified imports for cocotb.simulator

### DIFF
--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -76,9 +76,9 @@ def _process_plusargs() -> None:
 def _process_packages() -> None:
     pkg_dict = {}
 
-    from cocotb import simulator  # noqa: PLC0415
+    import cocotb.simulator  # noqa: PLC0415
 
-    pkgs = simulator.package_iterate()
+    pkgs = cocotb.simulator.package_iterate()
     if pkgs is None:
         cocotb.packages = SimpleNamespace()
         return
@@ -193,9 +193,9 @@ def _setup_root_handle() -> None:
             # Skip any library component of the toplevel
             root_name = root_name.split(".", 1)[1]
 
-    from cocotb import simulator  # noqa: PLC0415
+    import cocotb.simulator  # noqa: PLC0415
 
-    handle = simulator.get_root_handle(root_name)
+    handle = cocotb.simulator.get_root_handle(root_name)
     if not handle:
         raise RuntimeError(f"Can not find root handle {root_name!r}")
 

--- a/src/cocotb/_shutdown.py
+++ b/src/cocotb/_shutdown.py
@@ -22,6 +22,6 @@ def _shutdown() -> None:
 
 
 def _init() -> None:
-    from cocotb import simulator  # noqa: PLC0415
+    import cocotb.simulator  # noqa: PLC0415
 
-    simulator.set_sim_event_callback(_shutdown)
+    cocotb.simulator.set_sim_event_callback(_shutdown)

--- a/src/cocotb/clock.py
+++ b/src/cocotb/clock.py
@@ -18,6 +18,7 @@ from logging import Logger
 from typing import ClassVar, Literal
 
 import cocotb
+import cocotb.simulator
 from cocotb.handle import (
     Deposit,
     Force,
@@ -27,7 +28,6 @@ from cocotb.handle import (
     _trust_inertial,
 )
 from cocotb.simtime import TimeUnit
-from cocotb.simulator import clock_create
 from cocotb.task import Task
 from cocotb.triggers import (
     Event,
@@ -304,7 +304,7 @@ class Clock:
             raise RuntimeError("Starting clock that has already been started.")
 
         if self._impl == "gpi":
-            clkobj = clock_create(self._signal._handle)
+            clkobj = cocotb.simulator.clock_create(self._signal._handle)
             set_action = {
                 Deposit: _GPISetAction.DEPOSIT,
                 Immediate: _GPISetAction.NO_DELAY,

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -22,7 +22,7 @@ from typing import (
     cast,
 )
 
-from cocotb import simulator
+import cocotb.simulator
 from cocotb._base_triggers import TriggerCallback
 from cocotb._deprecation import deprecated
 from cocotb._gpi_triggers import (
@@ -77,7 +77,7 @@ class SimHandleBase(ABC):
     """
 
     @abstractmethod
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         self._handle = handle
         self._path: str = self._name if path is None else path
         """The path to this handle, or its name if this is the root handle.
@@ -163,9 +163,11 @@ class _RangeableObjectMixin(SimHandleBase):
     def range(self) -> Range:
         """Return a :class:`~cocotb.types.Range` over the indexes of the array/vector."""
         left, right, direction = self._handle.get_range()
-        if direction == simulator.RANGE_NO_DIR:
+        if direction == cocotb.simulator.RANGE_NO_DIR:
             raise RuntimeError("Expected range to have a direction but got none!")
-        return Range(left, "to" if direction == simulator.RANGE_UP else "downto", right)
+        return Range(
+            left, "to" if direction == cocotb.simulator.RANGE_UP else "downto", right
+        )
 
     @property
     def left(self) -> int:
@@ -218,7 +220,7 @@ class _HierarchyObjectBase(SimHandleBase, Generic[KeyType]):
     """
 
     @abstractmethod
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
         self._sub_handles: dict[KeyType, SimHandleBase] = {}
         self._discovered = False
@@ -256,7 +258,7 @@ class _HierarchyObjectBase(SimHandleBase, Generic[KeyType]):
         if self._discovered:
             return
 
-        for thing in self._handle.iterate(simulator.OBJECTS):
+        for thing in self._handle.iterate(cocotb.simulator.OBJECTS):
             name = thing.get_name_string()
 
             # translate HDL name into a consistent key name
@@ -326,7 +328,7 @@ class _HierarchyObjectBase(SimHandleBase, Generic[KeyType]):
     @abstractmethod
     def _get_handle_by_key(
         self, key: KeyType, discovery_method: GPIDiscovery
-    ) -> simulator.sim_obj | None:
+    ) -> cocotb.simulator.sim_obj | None:
         """Get child object by key from the simulator.
 
         Args:
@@ -430,7 +432,7 @@ class HierarchyObject(_HierarchyObjectBase[str]):
         assert len(dut.some_module) == total
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
     def __setattr__(self, name: str, value: object) -> None:
@@ -507,7 +509,7 @@ class HierarchyObject(_HierarchyObjectBase[str]):
 
     def _get_handle_by_key(
         self, key: str, discovery_method: GPIDiscovery
-    ) -> simulator.sim_obj | None:
+    ) -> cocotb.simulator.sim_obj | None:
         return self._handle.get_handle_by_name(key, discovery_method)
 
 
@@ -551,7 +553,7 @@ class HierarchyArrayObject(
         assert len(dut.gen_pipe_stage) == len(dut.gen_pipe_stages.range)
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
     def _sub_handle_key(self, name: str) -> int:
@@ -579,7 +581,7 @@ class HierarchyArrayObject(
 
     def _get_handle_by_key(
         self, key: int, discovery_method: GPIDiscovery
-    ) -> simulator.sim_obj | None:
+    ) -> cocotb.simulator.sim_obj | None:
         if discovery_method is not GPIDiscovery.AUTO:
             raise NotImplementedError(
                 f"Only GPIDiscovery.AUTO is supported for {type(self).__qualname__} right now"
@@ -999,7 +1001,7 @@ class ArrayObject(
             dut.array_object[child_idx]
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
         self._sub_handles: dict[int, ChildObjectT] = {}
 
@@ -1126,7 +1128,7 @@ class LogicObject(
         * ``bit``
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
     def _set_value(
@@ -1266,7 +1268,7 @@ class LogicArrayObject(
         Verilog packed objects no longer map to this type, but :class:`PackedObject`.
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
     def _set_value(
@@ -1423,7 +1425,7 @@ class RealObject(_NonIndexableValueObjectBase[float, float]):
     This type is used when a ``real`` object in VHDL or ``float`` object in Verilog is seen.
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
     def _set_value(
@@ -1486,7 +1488,7 @@ class EnumObject(
     There may be many enumeration values that a given :class:`int` value represents.
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
     def _set_value(
@@ -1583,7 +1585,7 @@ class IntegerObject(_NonIndexableValueObjectBase[int, int], _SignednessObjectMix
     Objects that use this type are assumed to be two's complement 32-bit integers with 2-state (``0`` and ``1``) bits.
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
     def _set_value(
@@ -1667,7 +1669,7 @@ class StringObject(
     This type is used when a ``string`` (VHDL or Verilog) simulation object is seen.
     """
 
-    def __init__(self, handle: simulator.sim_obj, path: str | None) -> None:
+    def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
 
     def _set_value(
@@ -1750,29 +1752,29 @@ _ConcreteHandleTypes = Union[
 
 
 _handle2obj: dict[
-    simulator.sim_obj,
+    cocotb.simulator.sim_obj,
     _ConcreteHandleTypes,
 ] = {}
 
 _type2cls: dict[int, type[_ConcreteHandleTypes]] = {
-    simulator.MODULE: HierarchyObject,
-    simulator.STRUCTURE: HierarchyObject,
-    simulator.PACKED_STRUCTURE: LogicArrayObject,
-    simulator.LOGIC: LogicObject,
-    simulator.LOGIC_ARRAY: LogicArrayObject,
-    simulator.PACKED_OBJECT: PackedObject,
-    simulator.NETARRAY: ArrayObject[Any, ValueObjectBase[Any, Any]],
-    simulator.REAL: RealObject,
-    simulator.INTEGER: IntegerObject,
-    simulator.ENUM: EnumObject,
-    simulator.STRING: StringObject,
-    simulator.GENARRAY: HierarchyArrayObject[SimHandleBase],
-    simulator.PACKAGE: HierarchyObject,
+    cocotb.simulator.MODULE: HierarchyObject,
+    cocotb.simulator.STRUCTURE: HierarchyObject,
+    cocotb.simulator.PACKED_STRUCTURE: LogicArrayObject,
+    cocotb.simulator.LOGIC: LogicObject,
+    cocotb.simulator.LOGIC_ARRAY: LogicArrayObject,
+    cocotb.simulator.PACKED_OBJECT: PackedObject,
+    cocotb.simulator.NETARRAY: ArrayObject[Any, ValueObjectBase[Any, Any]],
+    cocotb.simulator.REAL: RealObject,
+    cocotb.simulator.INTEGER: IntegerObject,
+    cocotb.simulator.ENUM: EnumObject,
+    cocotb.simulator.STRING: StringObject,
+    cocotb.simulator.GENARRAY: HierarchyArrayObject[SimHandleBase],
+    cocotb.simulator.PACKAGE: HierarchyObject,
 }
 
 
 def _make_sim_object(
-    handle: simulator.sim_obj, path: str | None = None
+    handle: cocotb.simulator.sim_obj, path: str | None = None
 ) -> SimHandleBase:
     """Factory function to create the correct type of `SimHandle` object.
 

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -20,7 +20,7 @@ from functools import wraps
 from typing import Callable
 
 import cocotb.simtime
-from cocotb import simulator
+import cocotb.simulator
 from cocotb._ANSI import ANSI
 from cocotb._deprecation import deprecated
 from cocotb.simtime import TimeUnit, get_sim_time
@@ -185,12 +185,12 @@ def _setup_gpi_logger() -> None:
     @wraps(old_setLevel)
     def setLevel(level: int | str) -> None:
         old_setLevel(level)
-        simulator.set_gpi_log_level(gpi_logger.getEffectiveLevel())
+        cocotb.simulator.set_gpi_log_level(gpi_logger.getEffectiveLevel())
 
     gpi_logger.setLevel = setLevel  # type: ignore[method-assign]
 
     # Initialize PyGPI logging
-    simulator.initialize_logger(_log_from_c, logging.getLogger)
+    cocotb.simulator.initialize_logger(_log_from_c, logging.getLogger)
 
 
 def _configure() -> None:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -26,9 +26,9 @@ import pytest
 import cocotb
 import cocotb._event_loop
 import cocotb._shutdown as shutdown
+import cocotb.simulator
 import cocotb.types._resolve
 from cocotb import logging as cocotb_logging
-from cocotb import simulator
 from cocotb._decorators import Test, TestGenerator
 from cocotb._gpi_triggers import Timer
 from cocotb._test_factory import TestFactory
@@ -471,7 +471,7 @@ class RegressionManager:
         shutdown._shutdown()
 
         # Setup simulator finalization
-        simulator.stop_simulator()
+        cocotb.simulator.stop_simulator()
 
     def _test_complete(self) -> None:
         """Callback given to the test to be called when the test finished."""

--- a/src/cocotb/simtime.py
+++ b/src/cocotb/simtime.py
@@ -16,7 +16,7 @@ from functools import cache
 from math import ceil, floor
 from typing import Literal, cast, overload
 
-from cocotb import simulator
+import cocotb.simulator
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -156,7 +156,7 @@ def get_sim_time(unit: TimeUnit = "step", *, units: None = None) -> float:
             stacklevel=2,
         )
         unit = units
-    timeh, timel = simulator.get_sim_time()
+    timeh, timel = cocotb.simulator.get_sim_time()
     steps = timeh << 32 | timel
     return _get_time_from_sim_steps(steps, unit) if unit != "step" else steps
 
@@ -260,4 +260,4 @@ i.e. ``-15`` is ``10**-15`` seconds or 1 femtosecond.
 
 def _init() -> None:
     global time_precision
-    time_precision = simulator.get_precision()
+    time_precision = cocotb.simulator.get_precision()

--- a/src/cocotb_tools/pytest/_regression.py
+++ b/src/cocotb_tools/pytest/_regression.py
@@ -44,8 +44,8 @@ from pytest import (
 import cocotb
 import cocotb._shutdown
 import cocotb._test_manager
+import cocotb.simulator
 import cocotb.types._resolve
-from cocotb import simulator
 from cocotb._extended_awaitables import with_timeout
 from cocotb._gpi_triggers import Timer
 from cocotb._test_manager import TestManager
@@ -849,7 +849,7 @@ class RegressionManager:
         cocotb._shutdown._shutdown()
 
         # Setup simulator finalization
-        simulator.stop_simulator()
+        cocotb.simulator.stop_simulator()
 
 
 def _check_interactive_exception(call: CallInfo, report: TestReport) -> bool:


### PR DESCRIPTION
Fixing some cyclic import issues. We really need to move this module out of the cocotb namespace.
