### PR TITLE
Force git tags in versions to be alphanumeric

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if "dev" in __version__:
         rev = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"], universal_newlines=True
         ).strip()
-        __version__ += f"+{rev}"
+        __version__ += f"+r{rev}"
     except Exception:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ if "dev" in __version__:
         rev = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"], universal_newlines=True
         ).strip()
+        # We add an 'r' to ensure this local version field is alphanumeric.
+        # Otherwise when a version is a number with leading 0s they will be stripped.
         __version__ += f"+r{rev}"
     except Exception:
         pass

--- a/tests/pytest/test_version.py
+++ b/tests/pytest/test_version.py
@@ -17,6 +17,6 @@ def test_version():
         rev = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"], universal_newlines=True
         ).strip()
-        assert parts[1] == rev, (
+        assert parts[1] == f"r{rev}", (
             "Installed cocotb version is not the same as your latest git version"
         )


### PR DESCRIPTION
Closes #5467.

If a git commit happens to be entirely numeric and the leading characters are 0s they will be stripped leading to odd and inconsistently sized version strings. Adding a non-hex letter forces this field to be alphanumeric and wont be treated as if it were a number.
