### PR TITLE
Document coverage

### DIFF
--- a/docs/source/coverage.rst
+++ b/docs/source/coverage.rst
@@ -1,0 +1,130 @@
+********************
+Python Code Coverage
+********************
+
+cocotb provides support for collecting Python code coverage via the `coverage <https://coverage.readthedocs.io/>`_ package.
+
+There are two main approaches to enabling coverage collection in cocotb regressions:
+using the :envvar:`!COCOTB_USER_COVERAGE` environment variable, which is a temporary enablement,
+or by instrumenting your environment with :mod:`!coverage`'s :mod:`!sitecustomize` hook, which is a more permanent solution.
+
+The first step in either approach is to install the :mod:`!coverage` package if you haven't already.
+
+.. code-block:: bash
+
+   pip install coverage
+
+
+Using :envvar:`!COCOTB_USER_COVERAGE`
+=====================================
+
+cocotb provides the :envvar:`COCOTB_USER_COVERAGE` environment variable to enable coverage collection for the current regression.
+This solution is ideal for users who only want to collect coverage occasionally or on a per-regression basis,
+or don't want to permanently modify their Python environment.
+
+To enable coverage collection, set :envvar:`!COCOTB_USER_COVERAGE` to ``1`` before running your tests.
+The :mod:`!coverage` module will use the :envvar:`COVERAGE_RCFILE` environment variable to find the configuration file to determine what to measure.
+If :envvar:`!COVERAGE_RCFILE` is not set, cocotb provides a default configuration that collects line and branch coverage for all Python modules
+except those in the ``cocotb``, ``cocotb_tools``, and ``pygpi`` package directories.
+
+.. code-block:: bash
+
+   export COCOTB_USER_COVERAGE=1
+   # optional, only if you want to use a custom config file
+   export COVERAGE_RCFILE=path/to/your/.coveragerc
+
+   pytest
+   # or
+   make
+
+This will create a file named ``.coverage`` in the directory where the test was run.
+
+
+Instrumenting your environment with :mod:`!coverage`'s :mod:`!sitecustomize` hook
+=================================================================================
+
+This approach works well for users who regularly collect coverage across
+subprocesses in their environment and want a single configuration that
+applies everywhere.
+
+The :mod:`!coverage` module provides support for automatically collecting coverage for all packages in a Python environment
+regardless of how Python is invoked (e.g. via embedding a Python interpreter in a simulator) for a process and all its subprocesses.
+This requires installing a :mod:`sitecustomize` hook that starts coverage measurement in any Python process.
+
+Follow the instructions in the `coverage documentation <https://coverage.readthedocs.io/en/latest/subprocess.html#manual-sub-process-coordination>`_ to add this hook.
+
+Then, to collect coverage for your cocotb tests, do the following:
+
+1. Create a ``.coveragerc`` configuration file specifying what to measure:
+
+   .. code-block:: ini
+
+      [run]
+      branch = True
+      source = my_package
+
+2. Set the ``COVERAGE_PROCESS_START`` environment variable and run your
+   tests. The exact command depends on how you run cocotb:
+
+   .. tab-set::
+
+      .. tab-item:: Makefile-based flow
+
+         .. code-block:: bash
+
+            export COVERAGE_PROCESS_START=.coveragerc
+            make
+
+      .. tab-item:: Python Runner
+
+         .. code-block:: bash
+
+            export COVERAGE_PROCESS_START=.coveragerc
+            python my_test_script.py
+
+      .. tab-item:: pytest
+
+         .. code-block:: bash
+
+            export COVERAGE_PROCESS_START=.coveragerc
+            coverage run --parallel-mode -m pytest
+
+This will create a file named ``.coverage`` in the directory where the test was run.
+
+
+Combining coverage data from multiple runs
+==========================================
+
+If you run your tests multiple times with coverage collection enabled from the same directory,
+cocotb will automatically load the configured coverage data from previous runs to append all coverage data together.
+
+However, if you are running tests in multiple directories, or running tests in parallel, you may end up with multiple ``.coverage`` files.
+You can combine the resulting ``.coverage`` files into a single file using the `combine <https://coverage.readthedocs.io/en/latest/commands/cmd_combine.html#cmd-combine>`_ command.
+
+.. code-block:: bash
+
+   coverage combine path/to/.coverage path/to/other/.coverage
+
+This will create a new ``.coverage`` file that combines the data from the specified files.
+
+
+Viewing the coverage data
+=========================
+
+After running your tests with coverage collection enabled, you can use the `coverage command-line tool <https://coverage.readthedocs.io/en/latest/commands/index.html>`_ to view the results.
+
+The simplest way to view the results is to use the `report <https://coverage.readthedocs.io/en/latest/commands/cmd_report.html#cmd-report>`_ command.
+This will print a summary of the coverage including the number of statements that were hit and missed, the missed line numbers, and overall coverage percentage, to the terminal.
+
+.. code-block:: bash
+
+   coverage report
+
+For a more detailed view, you can use the `html <https://coverage.readthedocs.io/en/latest/commands/cmd_html.html#cmd-html>`_ command to generate an HTML report.
+
+.. code-block:: bash
+
+   coverage html
+
+This will create an ``htmlcov`` directory with an ``index.html`` file that you can open in a web browser which will allow you to navigate your testbench and the libraries it uses,
+and will show coverage details annotated on the source code.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -120,6 +120,7 @@ See `cocotb.org <https://cocotb.org>`_ for more details.
    update_indexing
    rotating_logger
    profiling
+   coverage
 
 
 .. todo::

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -1066,11 +1066,10 @@ Debugging
     Default: :data:`False`
 
     Enable to collect Python coverage data for user code.
-    For some simulators, this will also report :term:`HDL` coverage.
-    If :envvar:`COVERAGE_RCFILE` is not set, branch coverage is collected
-    and files in the cocotb package directory are excluded.
+    If :envvar:`COVERAGE_RCFILE` is not set,
+    line and branch coverage is collected and files in the ``cocotb``, ``cocotb_tools``, and ``pygpi`` package directories are excluded.
 
-    This needs the :mod:`coverage` Python module to be installed.
+    This requires the :mod:`coverage` Python module to be installed.
 
     .. versionchanged:: 2.0
 

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import importlib.util
 import logging
 import os
 import random
@@ -99,6 +100,14 @@ def _process_packages() -> None:
     cocotb.packages = SimpleNamespace(**pkg_dict)
 
 
+def _get_package_path(pkg: str) -> Path:
+    """Get the filesystem path of a package."""
+    spec = importlib.util.find_spec(pkg)
+    if spec is None or spec.origin is None:
+        raise ImportError(f"Cannot find package {pkg!r}")
+    return Path(spec.origin).parent.absolute()
+
+
 def _start_user_coverage() -> None:
     enable_coverage: bool = False
 
@@ -123,14 +132,20 @@ def _start_user_coverage() -> None:
         else:
             config_filepath: str = _env.as_str("COVERAGE_RCFILE")
             if not config_filepath:
-                # Exclude cocotb itself from coverage collection.
+                # Exclude cocotb libraries from coverage collection.
                 log.info(
                     "Collecting coverage of user code. No coverage config file supplied via COVERAGE_RCFILE."
                 )
-                cocotb_package_dir = Path(__file__).parent.absolute()
+                cocotb_package_dir = _get_package_path("cocotb")
+                cocotb_tools_package_dir = _get_package_path("cocotb_tools")
+                pygpi_package_dir = _get_package_path("pygpi")
                 user_coverage = coverage.coverage(
                     branch=True,
-                    omit=[f"{cocotb_package_dir}/*"],
+                    omit=[
+                        f"{cocotb_package_dir}/*",
+                        f"{cocotb_tools_package_dir}/*",
+                        f"{pygpi_package_dir}/*",
+                    ],
                 )
             else:
                 log.info(


### PR DESCRIPTION
Supersedes #5473. Closes #5449.

This PR fixes some of the comments in the other PR and also moves everything into the more appropriate How-To Guides section. It also adds a how-to for the existing `COCOTB_USER_COVERAGE` flow, plus an overview of relevant coverage module commands.