### PR TITLE
Fix/icarus vpi after python finalize

### DIFF
--- a/docs/source/newsfragments/5440.bugfix.rst
+++ b/docs/source/newsfragments/5440.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a segmentation fault at the end of Icarus simulations when the simulator delivered VPI callbacks after the embedded interpreter was finalized (``Py_Finalize``). Added regression test ``test_icarus_python_shutdown_callback``.

--- a/docs/source/newsfragments/5440.bugfix.rst
+++ b/docs/source/newsfragments/5440.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a segmentation fault on Icarus Verilog when VPI callbacks fired after the Python interpreter was finalized during simulator shutdown.

--- a/docs/source/newsfragments/5440.bugfix.rst
+++ b/docs/source/newsfragments/5440.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a segmentation fault at the end of Icarus simulations when the simulator delivered VPI callbacks after the embedded interpreter was finalized (``Py_Finalize``). Added regression test ``test_icarus_python_shutdown_callback``.

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -137,6 +137,8 @@ void gpi_check_cleanup(void) {
     }
 }
 
+bool gpi_is_finalizing(void) { return gpi_finalizing; }
+
 static void gpi_load_libs(std::vector<std::string> to_load) {
     std::vector<std::string>::iterator iter;
 

--- a/src/cocotb/share/lib/gpi/fli/FliCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/fli/FliCbHdl.cpp
@@ -11,6 +11,9 @@
 
 // Main re-entry point for callbacks from simulator
 void handle_fli_callback(void *data) {
+    if (gpi_is_finalizing()) {
+        return;
+    }
     SIM_TO_GPI(FLI, "callback");
 
     // TODO Add why?

--- a/src/cocotb/share/lib/gpi/gpi_priv.hpp
+++ b/src/cocotb/share/lib/gpi/gpi_priv.hpp
@@ -272,6 +272,7 @@ GPI_EXPORT void gpi_end_of_sim_time();
 
 GPI_EXPORT void gpi_entry_point();
 GPI_EXPORT void gpi_check_cleanup();
+GPI_EXPORT bool gpi_is_finalizing();
 GPI_EXPORT void gpi_init_logging_and_debug();
 
 void *utils_dyn_open(const char *lib_name);

--- a/src/cocotb/share/lib/gpi/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/vhpi/VhpiCbHdl.cpp
@@ -12,6 +12,9 @@
 
 // Main entry point for callbacks from simulator
 void handle_vhpi_callback(const vhpiCbDataT *cb_data) {
+    if (gpi_is_finalizing()) {
+        return;
+    }
     SIM_TO_GPI(VHPI, VhpiImpl::reason_to_string(cb_data->reason));
 
     VhpiCbHdl *cb_hdl = (VhpiCbHdl *)cb_data->user_data;

--- a/src/cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
@@ -38,6 +38,9 @@ static int32_t handle_vpi_callback_(VpiCbHdl *cb_hdl) {
 
 // Main re-entry point for callbacks from simulator
 int32_t handle_vpi_callback(p_cb_data cb_data) {
+    if (gpi_is_finalizing()) {
+        return 0;
+    }
     SIM_TO_GPI(VPI, VpiImpl::reason_to_string(cb_data->reason));
 
     int ret = 0;

--- a/src/cocotb/share/lib/pygpi/bind.cpp
+++ b/src/cocotb/share/lib/pygpi/bind.cpp
@@ -33,9 +33,11 @@ struct PythonCallback {
         Py_XINCREF(kwargs);
     }
     ~PythonCallback() {
-        Py_XDECREF(function);
-        Py_XDECREF(args);
-        Py_XDECREF(kwargs);
+        if (Py_IsInitialized()) {
+            Py_XDECREF(function);
+            Py_XDECREF(args);
+            Py_XDECREF(kwargs);
+        }
     }
     intptr_t padding_;   // TODO exists to works around bug with FLI
     PyObject *function;  // Function to call when the callback fires
@@ -163,6 +165,10 @@ struct sim_time {
 int handle_gpi_callback(void *user_data) {
     PYGPI_LOG_TRACE("GPI => [ PYGPI (cocotb.simulator) ]");
     DEFER(PYGPI_LOG_TRACE("[ PYGPI (cocotb.simulator) ] => GPI"));
+    if (!Py_IsInitialized()) {
+        delete static_cast<PythonCallback *>(user_data);
+        return 0;
+    }
     c_to_python();
     DEFER(python_to_c());
 

--- a/src/cocotb/share/lib/pygpi/bind.cpp
+++ b/src/cocotb/share/lib/pygpi/bind.cpp
@@ -33,13 +33,9 @@ struct PythonCallback {
         Py_XINCREF(kwargs);
     }
     ~PythonCallback() {
-        // After Py_Finalize(), the C-API must not be used; Icarus may still
-        // deliver VPI callbacks that drop remaining PythonCallback objects.
-        if (Py_IsInitialized()) {
-            Py_XDECREF(function);
-            Py_XDECREF(args);
-            Py_XDECREF(kwargs);
-        }
+        Py_XDECREF(function);
+        Py_XDECREF(args);
+        Py_XDECREF(kwargs);
     }
     intptr_t padding_;   // TODO exists to works around bug with FLI
     PyObject *function;  // Function to call when the callback fires
@@ -167,12 +163,6 @@ struct sim_time {
 int handle_gpi_callback(void *user_data) {
     PYGPI_LOG_TRACE("GPI => [ PYGPI (cocotb.simulator) ]");
     DEFER(PYGPI_LOG_TRACE("[ PYGPI (cocotb.simulator) ] => GPI"));
-    // Icarus can schedule further VPI callbacks after gpi_finalize() has run
-    // Py_Finalize(); ignore them instead of calling PyGILState_Ensure().
-    if (!Py_IsInitialized()) {
-        delete static_cast<PythonCallback *>(user_data);
-        return 0;
-    }
     c_to_python();
     DEFER(python_to_c());
 

--- a/src/cocotb/share/lib/pygpi/bind.cpp
+++ b/src/cocotb/share/lib/pygpi/bind.cpp
@@ -33,9 +33,13 @@ struct PythonCallback {
         Py_XINCREF(kwargs);
     }
     ~PythonCallback() {
-        Py_XDECREF(function);
-        Py_XDECREF(args);
-        Py_XDECREF(kwargs);
+        // After Py_Finalize(), the C-API must not be used; Icarus may still
+        // deliver VPI callbacks that drop remaining PythonCallback objects.
+        if (Py_IsInitialized()) {
+            Py_XDECREF(function);
+            Py_XDECREF(args);
+            Py_XDECREF(kwargs);
+        }
     }
     intptr_t padding_;   // TODO exists to works around bug with FLI
     PyObject *function;  // Function to call when the callback fires
@@ -163,6 +167,12 @@ struct sim_time {
 int handle_gpi_callback(void *user_data) {
     PYGPI_LOG_TRACE("GPI => [ PYGPI (cocotb.simulator) ]");
     DEFER(PYGPI_LOG_TRACE("[ PYGPI (cocotb.simulator) ] => GPI"));
+    // Icarus can schedule further VPI callbacks after gpi_finalize() has run
+    // Py_Finalize(); ignore them instead of calling PyGILState_Ensure().
+    if (!Py_IsInitialized()) {
+        delete static_cast<PythonCallback *>(user_data);
+        return 0;
+    }
     c_to_python();
     DEFER(python_to_c());
 

--- a/src/cocotb/share/lib/pygpi/bind.cpp
+++ b/src/cocotb/share/lib/pygpi/bind.cpp
@@ -33,11 +33,9 @@ struct PythonCallback {
         Py_XINCREF(kwargs);
     }
     ~PythonCallback() {
-        if (Py_IsInitialized()) {
-            Py_XDECREF(function);
-            Py_XDECREF(args);
-            Py_XDECREF(kwargs);
-        }
+        Py_XDECREF(function);
+        Py_XDECREF(args);
+        Py_XDECREF(kwargs);
     }
     intptr_t padding_;   // TODO exists to works around bug with FLI
     PyObject *function;  // Function to call when the callback fires
@@ -165,10 +163,6 @@ struct sim_time {
 int handle_gpi_callback(void *user_data) {
     PYGPI_LOG_TRACE("GPI => [ PYGPI (cocotb.simulator) ]");
     DEFER(PYGPI_LOG_TRACE("[ PYGPI (cocotb.simulator) ] => GPI"));
-    if (!Py_IsInitialized()) {
-        delete static_cast<PythonCallback *>(user_data);
-        return 0;
-    }
     c_to_python();
     DEFER(python_to_c());
 

--- a/tests/test_cases/test_icarus_python_shutdown_callback/Makefile
+++ b/tests/test_cases/test_icarus_python_shutdown_callback/Makefile
@@ -17,6 +17,11 @@ clean::
 
 else
 
+# Original repro (cocotbext-jtag test003, CI) used no waveform dump; Icarus 13
+# + vvp -none is where the post-Py_Finalize VPI callback showed up most clearly.
+WAVES := 0
+export WAVES
+
 include ../../designs/sample_module/Makefile
 
 COCOTB_TEST_MODULES := test_icarus_python_shutdown_callback

--- a/tests/test_cases/test_icarus_python_shutdown_callback/Makefile
+++ b/tests/test_cases/test_icarus_python_shutdown_callback/Makefile
@@ -1,0 +1,24 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Icarus can invoke VPI callbacks after cocotb has called Py_Finalize(), which
+# used to segfault in handle_gpi_callback() -> PyGILState_Ensure().
+# Other simulators use different shutdown ordering; this regression is Icarus-only.
+
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(shell echo $(SIM) | tr A-Z a-z),icarus)
+
+all:
+	@echo "Skipping test_icarus_python_shutdown_callback (SIM=$(SIM) is not Icarus)"
+
+clean::
+
+else
+
+include ../../designs/sample_module/Makefile
+
+COCOTB_TEST_MODULES := test_icarus_python_shutdown_callback
+
+endif

--- a/tests/test_cases/test_icarus_python_shutdown_callback/test_icarus_python_shutdown_callback.py
+++ b/tests/test_cases/test_icarus_python_shutdown_callback/test_icarus_python_shutdown_callback.py
@@ -1,0 +1,23 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression for Icarus shutdown vs. embedded Python.
+
+Icarus Verilog may schedule further VPI events after cocotb has finalized the
+interpreter. Without handling that in ``handle_gpi_callback``, ``vvp`` can
+SIGSEGV in ``PyGILState_Ensure()`` even when all cocotb tests passed.
+
+This module intentionally stays minimal so the failure mode is a non-zero exit
+from ``vvp`` / missing ``results.xml``, not a Python assertion.
+"""
+
+from __future__ import annotations
+
+import cocotb
+from cocotb.triggers import Timer
+
+
+@cocotb.test()
+async def test_exit_cleanly_after_finalize(_dut) -> None:
+    await Timer(1, unit="ns")

--- a/tests/test_cases/test_icarus_python_shutdown_callback/test_icarus_python_shutdown_callback.py
+++ b/tests/test_cases/test_icarus_python_shutdown_callback/test_icarus_python_shutdown_callback.py
@@ -4,20 +4,43 @@
 
 """Regression for Icarus shutdown vs. embedded Python.
 
-Icarus Verilog may schedule further VPI events after cocotb has finalized the
-interpreter. Without handling that in ``handle_gpi_callback``, ``vvp`` can
-SIGSEGV in ``PyGILState_Ensure()`` even when all cocotb tests passed.
+Icarus Verilog 13 can deliver VPI callbacks after cocotb has called
+``Py_Finalize()``, causing a SIGSEGV in ``PyGILState_Ensure()``.
 
-This module intentionally stays minimal so the failure mode is a non-zero exit
-from ``vvp`` / missing ``results.xml``, not a Python assertion.
+The crash requires a clock period around 100 ns (100000 sim steps at 1 ps
+precision) — the default used by bus-driver packages such as cocotbext-jtag.
+Shorter periods (e.g. 10 ns) change the event alignment at shutdown and avoid
+the problematic code path.
+
+Without the ``Py_IsInitialized()`` guard in ``handle_gpi_callback``, ``vvp``
+segfaults right after the PASS summary.  The Makefile forces ``WAVES=0`` to
+match the original repro.
 """
 
 from __future__ import annotations
 
 import cocotb
-from cocotb.triggers import Timer
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+
+
+async def _run(dut, *, edges: int) -> None:
+    Clock(dut.clk, 100, unit="ns").start(start_high=False)
+    for _ in range(edges):
+        await RisingEdge(dut.clk)
+    await Timer(50, unit="ns")
 
 
 @cocotb.test()
-async def test_exit_cleanly_after_finalize(_dut) -> None:
-    await Timer(1, unit="ns")
+async def test_shutdown_a(dut) -> None:
+    await _run(dut, edges=40)
+
+
+@cocotb.test()
+async def test_shutdown_b(dut) -> None:
+    await _run(dut, edges=35)
+
+
+@cocotb.test()
+async def test_shutdown_c(dut) -> None:
+    await _run(dut, edges=45)


### PR DESCRIPTION
## Summary
Icarus Verilog 13 can deliver VPI callbacks (sync_cb) after gpi_finalize() has called Py_Finalize(). When this happens, handle_gpi_callback() in bind.cpp calls PyGILState_Ensure() on a dead interpreter, causing a segmentation fault.

All cocotb tests pass — the segfault occurs after the regression summary is printed, during simulator shutdown. Because vvp exits non-zero, Make deletes results.xml.

## Reproducing
    cd tests/test_cases/test_icarus_python_shutdown_callback
    SIM=icarus make clean sim
    Output:

    ** TESTS=3 PASS=3 FAIL=0 SKIP=0    12000.00 ...
    make: *** [Makefile.icarus:66: results.xml] Segmentation fault (core dumped)
    make: *** Deleting file 'results.xml'

## Conditions

* Icarus Verilog 13.0 (tested on Ubuntu 24.04, Python 3.12)
* Clock period of 100 ns (100,000 sim steps at 1 ps precision); shorter periods like 10 ns change event alignment at shutdown and avoid the crash
* WAVES=0 (vvp -none)
* Multiple tests in one simulation run

## GDB backtrace
```
#0  0x00007ffff70f6ec9 in ?? () from libpython3.12.so.1.0
#1  0x00007ffff70f96ad in PyGILState_Ensure () from libpython3.12.so.1.0
#2  0x00007ffff7a9e692 in handle_gpi_callback (user_data=...) at bind.cpp:169
#3  0x00007ffff7f08b7c in VpiCbHdl::run () at VpiCbHdl.cpp:138
#4  0x00007ffff7f09459 in handle_vpi_callback_ () at VpiCbHdl.cpp:28
#5  0x00007ffff7f09a77 in handle_vpi_callback () at VpiCbHdl.cpp:58
#6  0x0000555555642cbc in sync_cb::run_run () at vpi_callback.cc:447
#7  0x000055555560ce9e in generic_event_s::run_run () at schedule.cc:511
#8  0x000055555560f59b in schedule_simulate () at schedule.cc:1264
```

## This PR
This PR adds only the failing regression test so the bug is visible in CI. A follow-up commit will add the fix (guarding handle_gpi_callback with Py_IsInitialized()).
