### PR TITLE
Log callback creation and firing

### DIFF
--- a/src/cocotb/share/lib/gpi/fli/FliCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/fli/FliCbHdl.cpp
@@ -11,11 +11,7 @@
 
 // Main re-entry point for callbacks from simulator
 void handle_fli_callback(void *data) {
-    SIM_TO_GPI(FLI, "callback");
-    if (gpi_is_finalizing()) {
-        LOG_ERROR("FLI: Callback fired during finalization.");
-        return;
-    }
+    SIM_TO_GPI(FLI, data, "callback");
 
     // TODO Add why?
     fflush(stderr);
@@ -39,7 +35,7 @@ void handle_fli_callback(void *data) {
         gpi_end_of_sim_time();
     }
 
-    GPI_TO_SIM(FLI);
+    GPI_TO_SIM(FLI, data);
 }
 
 int FliTimedCbHdl::arm() {
@@ -53,6 +49,7 @@ int FliTimedCbHdl::arm() {
                     (mtiUInt32T)(m_time));
     mti_ScheduleWakeup64(m_proc_hdl, m_time_union_ps);
 #endif
+    LOG_TRACE("FLI: Scheduled timed callback %p for time %lu", this, m_time);
     return 0;
 }
 
@@ -78,6 +75,8 @@ int FliTimedCbHdl::remove() {
 
 int FliSignalCbHdl::arm() {
     mti_Sensitize(m_proc_hdl, m_signal->get_handle<mtiSignalIdT>(), MTI_EVENT);
+    LOG_TRACE("FLI: Scheduled signal callback %p for signal %p", this,
+              m_signal);
     return 0;
 }
 
@@ -122,6 +121,7 @@ int FliSignalCbHdl::remove() {
 int FliSimPhaseCbHdl::arm() {
     mti_ScheduleWakeup(m_proc_hdl, 0);
     m_removed = false;
+    LOG_TRACE("FLI: Scheduled simulation phase callback %p", this);
     return 0;
 }
 
@@ -167,6 +167,7 @@ void FliNextPhaseCbHdl::release() {
 
 int FliStartupCbHdl::arm() {
     mti_AddLoadDoneCB(handle_fli_callback, (void *)this);
+    LOG_TRACE("FLI: Scheduled startup callback %p", this);
     return 0;
 }
 
@@ -184,6 +185,7 @@ int FliStartupCbHdl::remove() {
 
 int FliShutdownCbHdl::arm() {
     mti_AddQuitCB(handle_fli_callback, (void *)this);
+    LOG_TRACE("FLI: Scheduled shutdown callback %p", this);
     return 0;
 }
 

--- a/src/cocotb/share/lib/gpi/gpi_priv.hpp
+++ b/src/cocotb/share/lib/gpi/gpi_priv.hpp
@@ -282,13 +282,13 @@ void *utils_dyn_sym(void *handle, const char *sym_name);
 
 #define USER_CB_TO_GPI(impl) LOG_TRACE("User Callback => [ " xstr(impl) " ]")
 
-#define SIM_TO_GPI(impl, cb_reason) \
-    LOG_TRACE("Sim => [ " xstr(impl) " for %s ]", cb_reason)
+#define SIM_TO_GPI(impl, ptr, cb_reason) \
+    LOG_TRACE("Sim => [ " xstr(impl) " %p for %s ]", ptr, cb_reason)
 
-#define GPI_TO_SIM(impl)                        \
-    do {                                        \
-        gpi_check_cleanup();                    \
-        LOG_TRACE("[ " xstr(impl) " ] => Sim"); \
+#define GPI_TO_SIM(impl, ptr)                           \
+    do {                                                \
+        gpi_check_cleanup();                            \
+        LOG_TRACE("[ " xstr(impl) " %p ] => Sim", ptr); \
     } while (0)
 
 typedef void (*layer_entry_func)();

--- a/src/cocotb/share/lib/gpi/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/vhpi/VhpiCbHdl.cpp
@@ -12,11 +12,8 @@
 
 // Main entry point for callbacks from simulator
 void handle_vhpi_callback(const vhpiCbDataT *cb_data) {
-    SIM_TO_GPI(VHPI, VhpiImpl::reason_to_string(cb_data->reason));
-    if (gpi_is_finalizing()) {
-        LOG_ERROR("VHPI: Callback fired during finalization.");
-        return;
-    }
+    SIM_TO_GPI(VHPI, cb_data->user_data,
+               VhpiImpl::reason_to_string(cb_data->reason));
 
     VhpiCbHdl *cb_hdl = (VhpiCbHdl *)cb_data->user_data;
 
@@ -37,7 +34,7 @@ void handle_vhpi_callback(const vhpiCbDataT *cb_data) {
         gpi_end_of_sim_time();
     }
 
-    GPI_TO_SIM(VHPI);
+    GPI_TO_SIM(VHPI, cb_data->user_data);
 }
 
 VhpiCbHdl::VhpiCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl) {
@@ -71,6 +68,8 @@ int VhpiCbHdl::remove() {
 
 int VhpiCbHdl::arm() {
     vhpiHandleT new_hdl = vhpi_register_cb(&cb_data, vhpiReturnCb);
+    LOG_TRACE("VHPI: Registered callback %p for reason %s", this,
+              VhpiImpl::reason_to_string(cb_data.reason));
 
     // LCOV_EXCL_START
     if (!new_hdl) {

--- a/src/cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
@@ -38,11 +38,8 @@ static int32_t handle_vpi_callback_(VpiCbHdl *cb_hdl) {
 
 // Main re-entry point for callbacks from simulator
 int32_t handle_vpi_callback(p_cb_data cb_data) {
-    SIM_TO_GPI(VPI, VpiImpl::reason_to_string(cb_data->reason));
-    if (gpi_is_finalizing()) {
-        LOG_ERROR("VPI: Callback fired during finalization.");
-        return 0;
-    }
+    SIM_TO_GPI(VPI, cb_data->user_data,
+               VpiImpl::reason_to_string(cb_data->reason));
 
     int ret = 0;
 #ifdef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
@@ -67,7 +64,7 @@ int32_t handle_vpi_callback(p_cb_data cb_data) {
         reacting = false;
     }
 #endif
-    GPI_TO_SIM(VPI);
+    GPI_TO_SIM(VPI, cb_data->user_data);
     return ret;
 }
 
@@ -87,6 +84,8 @@ VpiCbHdl::VpiCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl) {
 
 int VpiCbHdl::arm() {
     vpiHandle new_hdl = vpi_register_cb(&cb_data);
+    LOG_TRACE("VPI: Registered callback %p for reason %s", this,
+              VpiImpl::reason_to_string(cb_data.reason));
 
     if (!new_hdl) {
         LOG_ERROR(


### PR DESCRIPTION
Updated the `SIM_TO_GPI` and `GPI_TO_SIM` macros to log the pointer the GPI callback object that fired, and updated the `arm` functions to log the pointer to the GPI callback object when it's created (or sensitized). This should allow for easier tracing of callback objects.

Finally, I remove the logging if a callback occurs after finalization. There are too many special cases where triggers are just put into a "removed" state rather than actually removed, and they all trigger this code path.