### PR TITLE
Simplify passing GPI_EXTRA

### DIFF
--- a/docs/source/custom_flows.rst
+++ b/docs/source/custom_flows.rst
@@ -70,7 +70,7 @@ Aldec Riviera-PRO
       ``-loadvhpi $(cocotb-config --lib-name-path vhpi riviera):vhpi_startup_routines_bootstrap``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
-      ``$(cocotb-config --lib-name-path vpi riviera):cocotbvpi_entry_point``
+      ``$(cocotb-config --gpi-extra vpi riviera)``
       if there are also (System)Verilog modules in the design.
 
    .. tab-item:: Design with a (System)Verilog Toplevel
@@ -79,7 +79,7 @@ Aldec Riviera-PRO
       ``-pli $(cocotb-config --lib-name-path vpi riviera)``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
-      ``$(cocotb-config --lib-name-path vhpi riviera):cocotbvhpi_entry_point``
+      ``$(cocotb-config --gpi-extra vhpi riviera)``
       if there are also VHDL modules in the design.
 
 .. _custom-flows-activehdl:
@@ -97,7 +97,7 @@ Aldec Active-HDL
       ``-loadvhpi $(cocotb-config --lib-name-path vhpi activehdl):vhpi_startup_routines_bootstrap``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
-      ``$(cocotb-config --lib-name-path vpi activehdl):cocotbvpi_entry_point``
+      ``$(cocotb-config --gpi-extra vpi activehdl)``
       if there are also (System)Verilog modules in the design.
 
    .. tab-item:: Design with a (System)Verilog Toplevel
@@ -106,7 +106,7 @@ Aldec Active-HDL
       ``-pli $(cocotb-config --lib-name-path vpi activehdl)``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
-      ``$(cocotb-config --lib-name-path vhpi activehdl):cocotbvhpi_entry_point``
+      ``$(cocotb-config --gpi-extra vhpi activehdl)``
       if there are also VHDL modules in the design.
 
 .. _custom-flows-siemens:
@@ -133,7 +133,7 @@ Questa supports two different flows: the traditional flow using ``vsim``, which 
       ``-pli $(cocotb-config --lib-name-path vpi questa)``.
 
       Set the :envvar:`GPI_EXTRA` environment variable to
-      ``$(cocotb-config --lib-name-path fli questa):cocotbfli_entry_point``
+      ``$(cocotb-config --gpi-extra fli questa)``
       if there are also VHDL modules in the design.
 
 .. _custom-flows-cadence:
@@ -154,7 +154,7 @@ Cadence Incisive and Xcelium
   works but has the downside of initializing cocotb during elaboration, not only simulation.
 
 * If the design contains any VHDL modules, set the :envvar:`GPI_EXTRA` environment variable to
-  ``$(cocotb-config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point``.
+  ``$(cocotb-config --gpi-extra vhpi xcelium)``.
   This is because directly loading the VHPI library causes an error in Xcelium,
   so always load the VPI library and supply VHPI via ``GPI_EXTRA``.
 

--- a/docs/source/library_reference_c.rst
+++ b/docs/source/library_reference_c.rst
@@ -40,16 +40,11 @@ Environment Variables
 
 .. envvar:: GPI_EXTRA
 
-    A comma-separated list of extra libraries that are dynamically loaded at runtime.
-    A function from each of these libraries will be called as an entry point prior to elaboration,
-    allowing these libraries to register system functions and callbacks.
-    Note that :term:`HDL` objects cannot be accessed at this time.
-    An entry point function must be named following a ``:`` separator,
-    which follows an existing simulator convention.
+    A comma-separated list of additional GPI implementation libraries to load.
 
-    For example:
+    .. code-block:: make
 
-    * ``GPI_EXTRA=libnameA.so:entryA,libnameB.so:entryB`` will first load ``libnameA.so`` with entry point ``entryA`` , then load ``libnameB.so`` with entry point ``entryB``.
+        GPI_EXTRA := $(shell cocotb-config --gpi-extra vpi questa)
 
     .. versionchanged:: 1.4
         Support for the custom entry point via ``:`` was added.
@@ -60,6 +55,11 @@ Environment Variables
         This allows using relative or absolute paths in library names,
         and loading from libraries that `aren't` prefixed with "lib".
         Paths `should not` contain commas.
+
+    .. versionchanged:: 2.1
+        The custom entry point syntax was removed.
+        This environment variable is now only for specifying additional GPI implementation libraries to load.
+        See :envvar:`GPI_USERS` for the custom entry point functionality.
 
 C API
 =====

--- a/docs/source/newsfragments/5519.change.rst
+++ b/docs/source/newsfragments/5519.change.rst
@@ -1,0 +1,1 @@
+The custom entry point for :envvar:`GPI_EXTRA` has been removed. :envvar:`!GPI_EXTRA` is now only for specifying additional GPI implementation libraries to load. See :envvar:`GPI_USERS` for the custom entry point functionality.

--- a/docs/source/newsfragments/5519.feature.1.rst
+++ b/docs/source/newsfragments/5519.feature.1.rst
@@ -1,0 +1,1 @@
+Added :func:`cocotb_tools.config.gpi_extra` to generate entries for the :envvar:`GPI_EXTRA` list.

--- a/docs/source/newsfragments/5519.feature.rst
+++ b/docs/source/newsfragments/5519.feature.rst
@@ -1,0 +1,1 @@
+Added the ``--gpi-extra`` option to :ref:`cocotb-config <cocotb-config>` to generate entries for the :envvar:`GPI_EXTRA` list.

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -139,23 +139,8 @@ void gpi_check_cleanup(void) {
 
 bool gpi_is_finalizing(void) { return gpi_finalizing; }
 
-static void gpi_load_libs(std::vector<std::string> to_load) {
-    std::vector<std::string>::iterator iter;
-
-    for (iter = to_load.begin(); iter != to_load.end(); iter++) {
-        std::string arg = *iter;
-
-        auto const idx = arg.rfind(
-            ':');  // find from right since path could contain colons (Windows)
-        if (idx == std::string::npos) {
-            // no colon in the string
-            printf("cocotb: Error parsing GPI_EXTRA %s\n", arg.c_str());
-            exit(1);
-        }
-
-        std::string const lib_name = arg.substr(0, idx);
-        std::string const func_name = arg.substr(idx + 1, std::string::npos);
-
+static void gpi_load_extra(std::vector<std::string> to_load) {
+    for (const auto &lib_name : to_load) {
         void *lib_handle = utils_dyn_open(lib_name.c_str());
         if (!lib_handle) {
             printf("cocotb: Error loading shared library %s\n",
@@ -163,20 +148,16 @@ static void gpi_load_libs(std::vector<std::string> to_load) {
             exit(1);
         }
 
-        void *entry_point = utils_dyn_sym(lib_handle, func_name.c_str());
+        void *entry_point = utils_dyn_sym(lib_handle, xstr(GPI_REGISTER_IMPL));
         if (!entry_point) {
-            char const *fmt =
-                "cocotb: Unable to find entry point %s for shared library "
-                "%s\n%s";
-            char const *msg =
-                "        Perhaps you meant to use `,` instead of `:` to "
-                "separate library names, as this changed in cocotb 1.4?\n";
-            printf(fmt, func_name.c_str(), lib_name.c_str(), msg);
+            LOG_ERROR(
+                "Unable to find `" xstr(GPI_REGISTER_IMPL) "` function in GPI_EXTRA shared library %s\n",
+                lib_name.c_str());
             exit(1);
         }
 
         layer_entry_func new_lib_entry = (layer_entry_func)entry_point;
-        LOG_TRACE("[ GPI Init ] => Impl Init (%s)", arg.c_str());
+        LOG_TRACE("[ GPI Init ] => Impl Init (%s)", lib_name.c_str());
         new_lib_entry();
         LOG_TRACE("Impl Init => [ GPI Init ]");
     }
@@ -268,7 +249,7 @@ void gpi_entry_point() {
             to_load.push_back(lib_list);
         }
 
-        gpi_load_libs(to_load);
+        gpi_load_extra(to_load);
     }
 
     // Load users

--- a/src/cocotb/share/lib/gpi/fli/FliImpl.cpp
+++ b/src/cocotb/share/lib/gpi/fli/FliImpl.cpp
@@ -1150,15 +1150,14 @@ void FliImpl::main() noexcept {
     gpi_entry_point();
 }
 
-// This is run by GPI when requested for mixed-language simulations
-static void register_impl() {
+extern "C" {
+COCOTBFLI_EXPORT void GPI_REGISTER_IMPL() {
     LOG_TRACE("GPI Init => [ FLI (register_impl) ]");
     auto fli_table = new FliImpl("FLI");
     gpi_register_impl(fli_table);
     LOG_TRACE("[ FLI (register_impl) ] => GPI Init");
 }
 
-extern "C" {
 // This is run by the simulator at startup when this is the main GPI entrypoint
 COCOTBFLI_EXPORT void cocotb_init() {
     gpi_init_logging_and_debug();
@@ -1168,5 +1167,3 @@ COCOTBFLI_EXPORT void cocotb_init() {
     LOG_TRACE("[ FLI (cocotb_init) ] => Sim");
 }
 }
-
-GPI_ENTRY_POINT(cocotbfli, register_impl);

--- a/src/cocotb/share/lib/gpi/gpi_priv.hpp
+++ b/src/cocotb/share/lib/gpi/gpi_priv.hpp
@@ -293,10 +293,6 @@ void *utils_dyn_sym(void *handle, const char *sym_name);
 
 typedef void (*layer_entry_func)();
 
-/* Use this macro in an implementation layer to define an entry point */
-#define GPI_ENTRY_POINT(NAME, func)                     \
-    extern "C" {                                        \
-    COCOTB_EXPORT void NAME##_entry_point() { func(); } \
-    }
+#define GPI_REGISTER_IMPL register_impl
 
 #endif /* COCOTB_GPI_PRIV_H_ */

--- a/src/cocotb/share/lib/gpi/vhpi/VhpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vhpi/VhpiImpl.cpp
@@ -1141,16 +1141,15 @@ static void vhpi_main() {
               from_bootstrap ? "Bootstrap" : "Sim (vhpi_startup_routines)");
 }
 
-// This is run by GPI when requested for mixed-language simulations
-static void register_impl() {
+// pre-defined VHPI registration table
+extern "C" {
+COCOTBVHPI_EXPORT void GPI_REGISTER_IMPL() {
     LOG_TRACE("GPI Init => [ VHPI (register_impl) ]");
     auto vhpi_table = new VhpiImpl("VHPI");
     gpi_register_impl(vhpi_table);
     LOG_TRACE("[ VHPI (register_impl) ] => GPI Init");
 }
 
-// pre-defined VHPI registration table
-extern "C" {
 COCOTBVHPI_EXPORT void (*vhpi_startup_routines[])() = {
     gpi_init_logging_and_debug, vhpi_main, nullptr};
 
@@ -1163,5 +1162,3 @@ COCOTBVHPI_EXPORT void vhpi_startup_routines_bootstrap() {
     LOG_TRACE("[ VHPI (vhpi_startup_routines_bootstrap) ] => Sim");
 }
 }
-
-GPI_ENTRY_POINT(cocotbvhpi, register_impl)

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -838,15 +838,14 @@ static void vpi_main() {
               from_bootstrap ? "Bootstrap" : "Sim (vlog_startup_routines)");
 }
 
-// This is run by GPI when requested for mixed-language simulations
-static void register_impl() {
+extern "C" {
+COCOTBVPI_EXPORT void GPI_REGISTER_IMPL() {
     LOG_TRACE("GPI Init => [ VPI (register_impl) ]");
     auto vpi_table = new VpiImpl("VPI");
     gpi_register_impl(vpi_table);
     LOG_TRACE("[ VPI (register_impl) ] => GPI Init");
 }
 
-extern "C" {
 COCOTBVPI_EXPORT void (*vlog_startup_routines[])() = {
     gpi_init_logging_and_debug, vpi_main, nullptr};
 
@@ -860,5 +859,3 @@ COCOTBVPI_EXPORT void vlog_startup_routines_bootstrap() {
     LOG_TRACE("[ VPI (vlog_startup_routines_bootstrap) ] => Sim");
 }
 }
-
-GPI_ENTRY_POINT(cocotbvpi, register_impl)

--- a/src/cocotb_tools/config.py
+++ b/src/cocotb_tools/config.py
@@ -180,6 +180,11 @@ def lib_name_path(interface: str, simulator: str) -> Path:
     return libs_dir / lib_name(interface, simulator)
 
 
+def gpi_extra(interface: str, simulator: str) -> Path:
+    """Return the GPI_EXTRA value to load the GPI implementation for the given interface and simulator."""
+    return lib_name_path(interface, simulator)
+
+
 def _get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 
@@ -227,6 +232,12 @@ def _get_parser() -> argparse.ArgumentParser:
         metavar=("INTERFACE", "SIMULATOR"),
     )
     group.add_argument(
+        "--gpi-extra",
+        help="Print the GPI_EXTRA value to load the GPI implementation for the given interface and simulator",
+        nargs=2,
+        metavar=("INTERFACE", "SIMULATOR"),
+    )
+    group.add_argument(
         "--version",
         action="store_true",
         help="Print the version of cocotb",
@@ -263,6 +274,9 @@ def main() -> None:
         print(lib_name(*args.lib_name))
     elif args.lib_name_path:
         print(lib_name_path(*args.lib_name_path).as_posix())
+    elif args.gpi_extra:
+        interface_name, simulator_name = args.gpi_extra
+        print(gpi_extra(interface_name, simulator_name).as_posix())
     elif args.pygpi_entry_point:
         print(pygpi_entry_point())
     elif args.version:

--- a/src/cocotb_tools/makefiles/simulators/Makefile.ius
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.ius
@@ -43,7 +43,7 @@ ifneq (,$(findstring timescale,$(EXTRA_ARGS)))
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
-# GPI_EXTRA=$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi ius) if needed.
+# GPI_EXTRA=$(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vhpi ius) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if vpi library name is libvpi.so
 GPI_ARGS = -loadvpi $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi ius):vlog_startup_routines_bootstrap
@@ -54,10 +54,10 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     ROOT_LEVEL = $(COCOTB_TOPLEVEL)
 ifneq ($(VHDL_SOURCES),)
     HDL_SOURCES += $(VHDL_SOURCES)
-    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi ius):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vhpi ius)
 endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi ius):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vhpi ius)
     EXTRA_ARGS += -v93
     EXTRA_ARGS += -top $(COCOTB_TOPLEVEL)
 ifdef RTL_LIBRARY

--- a/src/cocotb_tools/makefiles/simulators/Makefile.questa-compat
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.questa-compat
@@ -67,13 +67,13 @@ else
     VSIM_ARGS += -voptargs="-access=rw+/." -foreign \"vhpi_startup_routines_bootstrap $(call to_tcl_path,$(VHPI_LIB))\"
 endif
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA :=  $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi questa):cocotbvpi_entry_point
+    GPI_EXTRA :=  $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vpi questa)
 endif
 
 else ifeq ($(TOPLEVEL_LANG),verilog)
     VSIM_ARGS += -pli $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi questa)
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA := $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path $(VHDL_GPI_INTERFACE) questa):cocotb$(VHDL_GPI_INTERFACE)_entry_point
+    GPI_EXTRA := $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra $(VHDL_GPI_INTERFACE) questa)
 endif
 
 else

--- a/src/cocotb_tools/makefiles/simulators/Makefile.questa-qisqrun
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.questa-qisqrun
@@ -88,13 +88,13 @@ else
     VSIM_ARGS += -foreign "vhpi_startup_routines_bootstrap $(call to_tcl_path,$(VHPI_LIB))"
 endif
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA :=  $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi questa):cocotbvpi_entry_point
+    GPI_EXTRA :=  $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vpi questa)
 endif
 
 else ifeq ($(TOPLEVEL_LANG),verilog)
     VSIM_ARGS += -pli $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi questa)
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA := $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path $(VHDL_GPI_INTERFACE) questa):cocotb$(VHDL_GPI_INTERFACE)_entry_point
+    GPI_EXTRA := $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra $(VHDL_GPI_INTERFACE) questa)
 endif
 
 else

--- a/src/cocotb_tools/makefiles/simulators/Makefile.riviera
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.riviera
@@ -69,13 +69,13 @@ GPI_EXTRA:=
 ifeq ($(TOPLEVEL_LANG),verilog)
     GPI_ARGS = -pli $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi riviera)
 ifneq ($(VHDL_SOURCES),)
-    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi riviera):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vhpi riviera)
 endif
 
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     GPI_ARGS = -loadvhpi $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi riviera):vhpi_startup_routines_bootstrap
 ifneq ($(VERILOG_SOURCES),)
-    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi riviera):cocotbvpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vpi riviera)
 endif
 
 else

--- a/src/cocotb_tools/makefiles/simulators/Makefile.xcelium
+++ b/src/cocotb_tools/makefiles/simulators/Makefile.xcelium
@@ -51,7 +51,7 @@ ifneq (,$(filter -timescale%,$(EXTRA_ARGS)))
 endif
 
 # Loading the VHPI library causes an error, so we always load the VPI library and supply
-# GPI_EXTRA=$(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi xcelium) if needed.
+# GPI_EXTRA=$(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vhpi xcelium) if needed.
 
 # Xcelium will use default vlog_startup_routines symbol only if VPI library name is libvpi.so
 GPI_ARGS = -loadvpisim $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap
@@ -61,10 +61,10 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     EXTRA_ARGS += -top $(COCOTB_TOPLEVEL)
     ifneq ($(VHDL_SOURCES),)
         HDL_SOURCES += $(VHDL_SOURCES)
-        GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point
+        GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vhpi xcelium)
     endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
-    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --lib-name-path vhpi xcelium):cocotbvhpi_entry_point
+    GPI_EXTRA = $(shell $(PYTHON_BIN) -m cocotb_tools.config --gpi-extra vhpi xcelium)
     EXTRA_ARGS += -top $(COCOTB_TOPLEVEL)
     # Xcelium 23.09.004 fixes cocotb issue #1076 as long as the following define
     # is set.


### PR DESCRIPTION
This also makes this variable only used for loading GPI implementations. Once the GPI Implementations are merged per-simulator, the value will change from being a path to a library to just an identifier (e.g. "vpi") so this creates an abstraction layer to prevent even more future changes.