### PR TITLE
Make simulator version objects more useful

### DIFF
--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -1257,13 +1257,7 @@ class Nvc(Runner):
     def __init__(self) -> None:
         super().__init__()
 
-        version_str = subprocess.run(
-            ["nvc", "--version"],
-            check=True,
-            text=True,
-            stdout=subprocess.PIPE,
-        ).stdout
-        version = NvcVersion.from_commandline(version_str)
+        version = NvcVersion.from_commandline()
         if version > NvcVersion("1.16"):
             self._preserve_case = ["--preserve-case"]
         else:

--- a/src/cocotb_tools/sim_versions.py
+++ b/src/cocotb_tools/sim_versions.py
@@ -2,10 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-# type: ignore  # distutils is untyped, so there's little reason to check this file
-
-"""
-Classes to compare simulation versions.
+"""Classes to compare simulation versions.
 
 These are for cocotb-internal use only.
 
@@ -16,23 +13,137 @@ These are for cocotb-internal use only.
 from __future__ import annotations
 
 import re
-import sys
-
-from cocotb_tools._vendor.distutils_version import LooseVersion
-
-if sys.version_info >= (3, 11):
-    from typing import Self
+import subprocess
+from functools import total_ordering
+from typing import ClassVar, Optional
 
 
-class ActivehdlVersion(LooseVersion):
+def _letter_value(letter: str) -> int:
+    if not letter:
+        return -1
+    return ord(letter.lower()) - ord("a")
+
+
+def _normalize_release_numbers(numbers: tuple[int, ...]) -> tuple[int, ...]:
+    result = list(numbers)
+    while result and result[-1] == 0:
+        result.pop()
+    return tuple(result)
+
+
+@total_ordering
+class SimulatorVersion:
+    """Base class for simulator version comparison."""
+
+    command: ClassVar[tuple[str, ...] | None] = None
+
+    def __init__(self, vstring: str) -> None:
+        self.vstring = vstring.strip()
+        self._parsed = self._parse(self.vstring)
+        # Preserve the LooseVersion-compatible attribute name.
+        self.version = self._parsed
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}("{self.vstring}")'
+
+    def __str__(self) -> str:
+        return self.vstring
+
+    def _coerce_other(self, other: object) -> SimulatorVersion:
+        if isinstance(other, str):
+            return type(self)(other)
+        if isinstance(other, SimulatorVersion):
+            return type(self)(str(other))
+        return NotImplemented
+
+    def __eq__(self, other: object) -> bool:
+        other_version = self._coerce_other(other)
+        if other_version is NotImplemented:
+            return NotImplemented
+        return self._parsed == other_version._parsed
+
+    def __lt__(self, other: object) -> bool:
+        other_version = self._coerce_other(other)
+        if other_version is NotImplemented:
+            return NotImplemented
+        return self._parsed < other_version._parsed
+
+    @classmethod
+    def from_sim_version(cls, sim_version: Optional[str] = None) -> SimulatorVersion:
+        if sim_version is None:
+            import cocotb
+
+            sim_version = cocotb.SIM_VERSION
+        return cls(sim_version)
+
+    @classmethod
+    def from_commandline(cls, cmdline: Optional[str] = None) -> SimulatorVersion:
+        if cmdline is None:
+            cmdline = cls._run_version_command()
+        return cls(cls._extract_version_from_commandline(cmdline))
+
+    @classmethod
+    def _run_version_command(cls) -> str:
+        if cls.command is None:
+            raise NotImplementedError(f"{cls.__name__} does not define a version command")
+        result = subprocess.run(
+            list(cls.command),
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        return result.stdout
+
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        return cmdline.strip().splitlines()[0]
+
+    @classmethod
+    def _parse(cls, vstring: str) -> tuple[object, ...]:
+        raise NotImplementedError
+
+
+class _SimpleDottedVersion(SimulatorVersion):
+    _pattern: ClassVar[re.Pattern[str]] = re.compile(r"(\d+(?:\.\d+)*)")
+
+    @classmethod
+    def _parse(cls, vstring: str) -> tuple[object, ...]:
+        match = cls._pattern.search(vstring)
+        if not match:
+            raise ValueError(f"Unable to parse {cls.__name__} from: {vstring}")
+        numbers = tuple(int(part) for part in match.group(1).split("."))
+        return (_normalize_release_numbers(numbers),)
+
+
+class _LetterSuffixedVersion(SimulatorVersion):
+    _pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"(?P<release>\d+(?:\.\d+)*)(?P<letter>[a-z]?)(?:_(?P<patch>\d+))?",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _parse(cls, vstring: str) -> tuple[object, ...]:
+        match = cls._pattern.search(vstring)
+        if not match:
+            raise ValueError(f"Unable to parse {cls.__name__} from: {vstring}")
+        release = tuple(int(part) for part in match.group("release").split("."))
+        letter = match.group("letter") or ""
+        patch = int(match.group("patch")) if match.group("patch") else 0
+        return (_normalize_release_numbers(release), _letter_value(letter), patch)
+
+
+class ActivehdlVersion(_LetterSuffixedVersion):
     """Version numbering class for Aldec Active-HDL.
 
     NOTE: unsupported versions exist, e.g.
     ActivehdlVersion("10.5a.12.6914") > ActivehdlVersion("10.5.216.6767")
     """
 
+    command = ("vsimsa", "-version")
 
-class CvcVersion(LooseVersion):
+
+class CvcVersion(_LetterSuffixedVersion):
     """Version numbering class for Tachyon DA CVC.
 
     Example:
@@ -43,11 +154,34 @@ class CvcVersion(LooseVersion):
     """
 
 
-class GhdlVersion(LooseVersion):
+class GhdlVersion(SimulatorVersion):
     """Version numbering class for GHDL."""
 
+    command = ("ghdl", "--version")
+    _pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"(?P<release>\d+(?:\.\d+)*)(?P<suffix>[- ]?(?:dev|devel|rc\d*))?",
+        re.IGNORECASE,
+    )
 
-class IcarusVersion(LooseVersion):
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = cmdline.strip().splitlines()[0]
+        if firstline.lower().startswith("ghdl "):
+            return firstline.split(" ", 1)[1]
+        return firstline
+
+    @classmethod
+    def _parse(cls, vstring: str) -> tuple[object, ...]:
+        match = cls._pattern.search(vstring)
+        if not match:
+            raise ValueError(f"Unable to parse GHDL version from: {vstring}")
+        release = tuple(int(part) for part in match.group("release").split("."))
+        suffix = (match.group("suffix") or "").lower()
+        prerelease = -1 if suffix else 0
+        return (_normalize_release_numbers(release), prerelease, suffix)
+
+
+class IcarusVersion(SimulatorVersion):
     """Version numbering class for Icarus Verilog.
 
     Example:
@@ -57,23 +191,45 @@ class IcarusVersion(LooseVersion):
         True
     """
 
+    command = ("iverilog", "-V")
+    _sim_pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"(?P<release>\d+(?:\.\d+)*)(?:\s*\((?P<tag>[^)]+)\))?",
+        re.IGNORECASE,
+    )
+    _cmd_pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"^Icarus Verilog version (?P<version>\d+(?:\.\d+)*(?:\s*\([^)]+\))?)$",
+        re.IGNORECASE,
+    )
+    _tag_order: ClassVar[dict[str, int]] = {"devel": -1, "stable": 0}
+
     @classmethod
-    def from_commandline(cls, cmdline: str) -> Self:
-        firstline = cmdline.split("\n", 1)[0]
-        m = re.match(r"^Icarus Verilog version (\d+\.\d+)", firstline)
-        if not m:
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = cmdline.strip().splitlines()[0]
+        match = cls._cmd_pattern.match(firstline)
+        if not match:
             raise ValueError(
                 f"Unable to parse Icarus Verilog version from: {firstline}"
             )
-        version = m.group(1)
-        return cls(version)
+        return match.group("version")
+
+    @classmethod
+    def _parse(cls, vstring: str) -> tuple[object, ...]:
+        match = cls._sim_pattern.search(vstring)
+        if not match:
+            raise ValueError(f"Unable to parse Icarus Verilog version from: {vstring}")
+        release = tuple(int(part) for part in match.group("release").split("."))
+        tag = (match.group("tag") or "").strip().lower()
+        tag_order = cls._tag_order.get(tag, 0)
+        return (_normalize_release_numbers(release), tag_order, tag)
 
 
-class ModelsimVersion(LooseVersion):
+class ModelsimVersion(_LetterSuffixedVersion):
     """Version numbering class for Mentor ModelSim."""
 
+    command = ("vsim", "-version")
 
-class QuestaVersion(LooseVersion):
+
+class QuestaVersion(_LetterSuffixedVersion):
     """Version numbering class for Mentor Questa.
 
     Example:
@@ -87,21 +243,10 @@ class QuestaVersion(LooseVersion):
         True
     """
 
-    def parse(self, vstring):
-        # A Questa version string, as returned by the simulator, consists of two
-        # space-separated parts. The first part is the actual version number,
-        # the second part seems to be the year and month of the initial release.
-        # We only need the first part, which is also used in public
-        # communication by Siemens.
-        try:
-            first_component = vstring.split(" ", 1)[0]
-        except IndexError:
-            first_component = vstring
-
-        super().parse(first_component)
+    command = ("vsim", "-version")
 
 
-class RivieraVersion(LooseVersion):
+class RivieraVersion(_SimpleDottedVersion):
     """Version numbering class for Aldec Riviera-PRO.
 
     Example:
@@ -109,8 +254,10 @@ class RivieraVersion(LooseVersion):
         True
     """
 
+    command = ("vsimsa", "-version")
 
-class VcsVersion(LooseVersion):
+
+class VcsVersion(SimulatorVersion):
     """Version numbering class for Synopsys VCS.
 
     Example:
@@ -118,8 +265,24 @@ class VcsVersion(LooseVersion):
         True
     """
 
+    _pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"(?P<train>[A-Z])-(?P<year>\d{4})\.(?P<month>\d{2})(?:-(?P<patch>\d+))?",
+    )
 
-class VerilatorVersion(LooseVersion):
+    @classmethod
+    def _parse(cls, vstring: str) -> tuple[object, ...]:
+        match = cls._pattern.search(vstring)
+        if not match:
+            raise ValueError(f"Unable to parse VCS version from: {vstring}")
+        return (
+            _letter_value(match.group("train")),
+            int(match.group("year")),
+            int(match.group("month")),
+            int(match.group("patch")) if match.group("patch") else 0,
+        )
+
+
+class VerilatorVersion(SimulatorVersion):
     """Version numbering class for Verilator.
 
     Example:
@@ -127,31 +290,36 @@ class VerilatorVersion(LooseVersion):
         True
     """
 
+    command = ("verilator", "--version")
+    _sim_pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"(?P<release>\d+(?:\.\d+)*)(?:\s+(?P<tag>devel))?",
+        re.IGNORECASE,
+    )
+    _cmd_pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"^Verilator\s+(?P<version>\d+(?:\.\d+)*(?:\s+devel)?)\b",
+        re.IGNORECASE,
+    )
+
     @classmethod
-    def from_commandline(cls, cmdline: str) -> Self:
-        """Parse the output of ``verilator --version``.
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = cmdline.strip().splitlines()[0]
+        match = cls._cmd_pattern.match(firstline)
+        if not match:
+            raise ValueError(f"Unable to parse Verilator version from: {firstline}")
+        return match.group("version")
 
-        Example:
-            >>> cmdline = "Verilator 5.041 devel rev v5.040-1-g4eb030717"
-            >>> VerilatorVersion.from_commandline(cmdline) >= VerilatorVersion("5.040")
-            True
-
-        Args:
-            cmdline: The command-line output of a call to ``verilator --version``.
-
-        Returns:
-            An instance of :class:`VerilatorVersion`.
-
-        Raises:
-            AssertionError: If *cmdline* does not appear to be generated by Verilator.
-        """
-        firstline = cmdline.split("\n", 1)[0]
-        sim, version, *version_extra = firstline.strip().split(" ")
-        assert sim == "Verilator"
-        return cls(version)
+    @classmethod
+    def _parse(cls, vstring: str) -> tuple[object, ...]:
+        match = cls._sim_pattern.search(vstring)
+        if not match:
+            raise ValueError(f"Unable to parse Verilator version from: {vstring}")
+        release = tuple(int(part) for part in match.group("release").split("."))
+        tag = (match.group("tag") or "").lower()
+        prerelease = -1 if tag == "devel" else 0
+        return (_normalize_release_numbers(release), prerelease)
 
 
-class XceliumVersion(LooseVersion):
+class XceliumVersion(SimulatorVersion):
     """Version numbering class for Cadence Xcelium.
 
     Example:
@@ -160,6 +328,22 @@ class XceliumVersion(LooseVersion):
         >>> XceliumVersion("20.07-e501") > XceliumVersion("20.06-g183")
         True
     """
+
+    command = ("xrun", "--version")
+    _pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"(?P<release>\d+(?:\.\d+)*)(?:-(?P<stream>[a-z])(?P<patch>\d+))?",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _parse(cls, vstring: str) -> tuple[object, ...]:
+        match = cls._pattern.search(vstring)
+        if not match:
+            raise ValueError(f"Unable to parse Xcelium version from: {vstring}")
+        release = tuple(int(part) for part in match.group("release").split("."))
+        stream = match.group("stream") or ""
+        patch = int(match.group("patch")) if match.group("patch") else 0
+        return (_normalize_release_numbers(release), _letter_value(stream), patch)
 
 
 class IusVersion(XceliumVersion):  # inherit everything from Xcelium
@@ -171,12 +355,19 @@ class IusVersion(XceliumVersion):  # inherit everything from Xcelium
     """
 
 
-class NvcVersion(LooseVersion):
+class NvcVersion(_SimpleDottedVersion):
     """Version numbering class for NVC."""
 
+    command = ("nvc", "--version")
+    _cmd_pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"^nvc\s+(?P<version>\d+(?:\.\d+)*)\b",
+        re.IGNORECASE,
+    )
+
     @classmethod
-    def from_commandline(cls, cmdline: str) -> Self:
-        firstline = cmdline.split("\n", 1)[0]
-        sim, version, *version_extra = firstline.strip().split(" ")
-        assert sim == "nvc"
-        return cls(version)
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = cmdline.strip().splitlines()[0]
+        match = cls._cmd_pattern.match(firstline)
+        if not match:
+            raise ValueError(f"Unable to parse NVC version from: {firstline}")
+        return match.group("version")

--- a/tests/pytest/test_sim_versions.py
+++ b/tests/pytest/test_sim_versions.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+from cocotb_tools import sim_versions
+from cocotb_tools.sim_versions import (
+    GhdlVersion,
+    IcarusVersion,
+    NvcVersion,
+    QuestaVersion,
+    VerilatorVersion,
+    VcsVersion,
+    XceliumVersion,
+)
+
+
+def test_icarus_commandline_preserves_devel_tag() -> None:
+    version = IcarusVersion.from_commandline(
+        "Icarus Verilog version 12.0 (devel)\n\nCopyright ..."
+    )
+
+    assert version == IcarusVersion("12.0 (devel)")
+    assert version < IcarusVersion("12.0")
+
+
+def test_verilator_commandline_ignores_extra_revision_text() -> None:
+    version = VerilatorVersion.from_commandline(
+        "Verilator 5.041 devel rev v5.040-1-g4eb030717"
+    )
+
+    assert version == VerilatorVersion("5.041 devel")
+    assert version >= VerilatorVersion("5.040")
+
+
+def test_verilator_sim_version_ignores_release_date() -> None:
+    assert VerilatorVersion("5.046 2025-04-06 rev v5.046") == VerilatorVersion(
+        "5.046"
+    )
+
+
+def test_questa_comparison_uses_public_version_component() -> None:
+    assert QuestaVersion("10.7c 2018.08") > QuestaVersion("10.7b 2018.06")
+    assert QuestaVersion("2020.1 2020.01") == QuestaVersion("2020.1")
+    assert QuestaVersion("2023.1_2 2023.03") > QuestaVersion("2023.1_1")
+
+
+def test_vcs_letter_train_is_compared_before_date() -> None:
+    assert VcsVersion("Q-2020.03-1_Full64") > VcsVersion("K-2015.09_Full64")
+
+
+def test_xcelium_patch_comparison_is_numeric() -> None:
+    assert XceliumVersion("24.03-s010") > XceliumVersion("24.03-s004")
+
+
+def test_ghdl_dev_release_sorts_before_final_release() -> None:
+    assert GhdlVersion("5.2.0-dev") < GhdlVersion("5.2")
+
+
+def test_nvc_from_sim_version_uses_argument_or_cocotb_value(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "cocotb", SimpleNamespace(SIM_VERSION="1.18.2"))
+    assert NvcVersion.from_sim_version() == NvcVersion("1.18.2")
+    assert NvcVersion.from_sim_version("1.16.0") == NvcVersion("1.16")
+
+
+def test_from_commandline_without_output_runs_the_version_command(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        assert args == (["verilator", "--version"],)
+        assert kwargs["check"] is True
+        assert kwargs["text"] is True
+        return SimpleNamespace(stdout="Verilator 5.046 2025-04-06 rev v5.046\n")
+
+    monkeypatch.setattr(sim_versions.subprocess, "run", fake_run)
+
+    assert VerilatorVersion.from_commandline() == VerilatorVersion("5.046")

--- a/tests/pytest/test_waves.py
+++ b/tests/pytest/test_waves.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -93,13 +92,7 @@ def test_wave_dump():
 
 skip_saif_dump_test = True
 if sim == "verilator":
-    sim_version_str = subprocess.run(
-        ["verilator", "--version"],
-        check=True,
-        text=True,
-        stdout=subprocess.PIPE,
-    ).stdout
-    sim_version = VerilatorVersion.from_commandline(sim_version_str)
+    sim_version = VerilatorVersion.from_commandline()
     if sim_version >= VerilatorVersion("5.042"):
         skip_saif_dump_test = False
 

--- a/tests/test_cases/test_integers/test_integers.py
+++ b/tests/test_cases/test_integers/test_integers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from subprocess import run
 
 import pytest
 
@@ -14,15 +13,9 @@ from cocotb_tools.sim_versions import IcarusVersion
 
 SIM = os.getenv("SIM", "icarus").lower()
 
-if SIM == "icarus":
-    icarus_version = run(
-        ["iverilog", "-V"], capture_output=True, text=True, check=True
-    ).stdout
-
 
 @pytest.mark.skipif(
-    SIM == "icarus"
-    and IcarusVersion.from_commandline(icarus_version) < IcarusVersion("12.0"),
+    SIM == "icarus" and IcarusVersion.from_commandline() < IcarusVersion("12.0"),
     reason="Icarus v11.0 treats integers as regs and ports cannot be of type reg",
 )
 def test_integers_runner():


### PR DESCRIPTION
Make simulator version objects more useful by replacing the current `LooseVersion`-style behavior with simulator-aware parsing and comparison.

This change adds common constructors for building version objects from `cocotb.SIM_VERSION` and from simulator command output, including a zero-argument `from_commandline()` path that invokes the simulator automatically when possible. It also updates existing call sites to use the new convenience API.

The main motivation is that several supported simulators use version strings that do not compare correctly with the current implementation, especially when they include release metadata, development tags, suffix letters, or train names. This patch makes those comparisons behave more like users expect and makes the version helpers easier to use in tests.

Changes:
- add a `SimulatorVersion` base with explicit parsing/comparison behavior
- add `from_sim_version()` and improved `from_commandline()` constructors
- implement simulator-specific parsing for Icarus, Verilator, Questa, VCS, Xcelium, GHDL, and NVC
- update existing runner/test call sites to use the convenience constructors
- add focused pytest coverage for known simulator version string formats

Testing:
- `$env:PYTHONPATH='d:\cocotb\src'; python -m pytest tests\pytest\test_sim_versions.py`

I could not exercise the zero-argument subprocess path against real simulator executables in this shell because no supported simulators were installed on `PATH`, but the parsing and comparison behavior is covered by unit tests.

Closes #5520
