### PR TITLE
Fix flakey Verilator/MacOS test

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -196,6 +196,7 @@ def dev_test_sim(
     ]
     session.run(
         "pytest",
+        "-s",
         "-v",
         "--doctest-modules",
         "--cov=cocotb",
@@ -211,6 +212,7 @@ def dev_test_sim(
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(
         "pytest",
+        "-s",
         "-v",
         "--cov=cocotb",
         "--cov-branch",
@@ -229,17 +231,20 @@ def dev_test_sim(
         "examples/matrix_multiplier",
         "examples/mixed_language",
     ]
-    session.run(
-        "pytest",
-        "-v",
-        *pytest_example_tree,
-        env=env,
-    )
+    for example in pytest_example_tree:
+        with session.chdir(example):
+            session.run(
+                "pytest",
+                "-s",
+                "-v",
+                env=env,
+            )
 
     # We need to run it separately to avoid loading pytest cocotb plugin for other tests
     session.log(f"Running tests for pytest plugin against a simulator {config_str}")
     session.run(
         "pytest",
+        "-s",
         "-v",
         "tests/pytest_plugin",
         "--cocotb-simulator",
@@ -282,6 +287,7 @@ def dev_test_nosim(session: nox.Session) -> None:
     session.log("Running simulator-agnostic tests with pytest")
     session.run(
         "pytest",
+        "-s",
         "-v",
         "--cov=cocotb",
         "--cov-branch",
@@ -510,6 +516,7 @@ def release_test_sim(
     session.log(f"Running simulator-specific tests against a simulator {config_str}")
     session.run(
         "pytest",
+        "-s",
         "-v",
         "-k",
         "simulator_required",
@@ -525,6 +532,7 @@ def release_test_nosim(session: nox.Session) -> None:
     session.log("Running simulator-agnostic tests")
     session.run(
         "pytest",
+        "-s",
         "-v",
         "-k",
         "not simulator_required",

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -233,9 +233,9 @@ class SimTimeContextFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         try:
             record.created_sim_time = get_sim_time()
-        except RecursionError:
-            # get_sim_time may try to log - if that happens, we can't
-            # attach a simulator time to this message.
+        except (RecursionError, RuntimeError):
+            # RecursionError: get_sim_time may try to log.
+            # RuntimeError: No simulator is loaded. Happens when default_config() is called outside of simulator process.
             record.created_sim_time = None
         return True
 

--- a/tests/pytest/test_logging_with_envs.py
+++ b/tests/pytest/test_logging_with_envs.py
@@ -90,3 +90,20 @@ def test_logging_log_prefix(
             assert caplog.text.rstrip() == f"{value}test message"
         else:
             assert LOG.match(caplog.text)
+
+
+def test_default_config_no_simulator(caplog: LogCaptureFixture) -> None:
+    """Logging after ``default_config`` outside a simulator must not raise.
+
+    Exercises the ``RuntimeError`` branch of
+    :meth:`cocotb.logging.SimTimeContextFilter.filter`, which is hit when
+    ``cocotb.simulator.get_sim_time`` is called with no simulator loaded.
+    """
+    cocotb.logging.default_config()
+
+    with caplog.at_level(INFO):
+        caplog.clear()
+        getLogger("cocotb").info("test message")
+
+    assert caplog.records
+    assert all(record.created_sim_time is None for record in caplog.records)

--- a/tests/pytest/test_logging_with_envs.py
+++ b/tests/pytest/test_logging_with_envs.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
+import logging
 import re
+from collections.abc import Iterator
 from logging import INFO, getLogger
 from random import randint
 
@@ -15,6 +17,22 @@ from pytest import LogCaptureFixture, MonkeyPatch
 
 import cocotb.logging
 import cocotb.simulator
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_handler_filters() -> Iterator[None]:
+    """Undo filters added to root logger handlers by ``cocotb.logging._configure``.
+
+    Without this, the ``SimTimeContextFilter`` installed by ``_configure`` leaks
+    into later tests and calls ``get_sim_time`` with no simulator loaded.
+    """
+    saved = [(h, list(h.filters)) for h in logging.getLogger().handlers]
+    try:
+        yield
+    finally:
+        for handler, filters in saved:
+            handler.filters = filters
+
 
 # X.XX{step,fs,ps,ns,us,ms,sec} <LEVEL> <name> (<file>.py:<line> in <function>)? <message>
 LOG: re.Pattern[str] = re.compile(

--- a/tests/pytest_plugin/test_session.py
+++ b/tests/pytest_plugin/test_session.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 from pytest import FixtureRequest, fixture
 
+import cocotb
 from cocotb_tools.pytest.hdl import HDL
 
 DESIGNS: Path = Path(__file__).parent.parent.resolve() / "designs"
@@ -33,10 +34,14 @@ def my_hdl_project_fixture(hdl_session: HDL, request: FixtureRequest) -> HDL:
             DESIGNS / "sample_module" / "sample_module.vhdl",
         )
     else:
-        hdl_session.sources = (
-            DESIGNS / "array_module" / "array_module.sv",
-            DESIGNS / "sample_module" / "sample_module.sv",
-        )
+        hdl_session.sources = (DESIGNS / "sample_module" / "sample_module.sv",)
+        # Icarus does not support unpacked structs (gh-2592), so omit
+        # array_module.sv from the build; test_array_module is skipped to match.
+        if not hdl_session.simulator.startswith("icarus"):
+            hdl_session.sources = (
+                DESIGNS / "array_module" / "array_module.sv",
+                *hdl_session.sources,
+            )
 
     if hdl_session.simulator == "questa":
         hdl_session.build_args = ["+acc"]
@@ -71,6 +76,10 @@ def sample_module_fixture(hdl: HDL, my_hdl_project: HDL) -> HDL:
 
 
 @pytest.mark.cocotb_runner
+@pytest.mark.skipif(
+    cocotb.SIM_NAME.lower().startswith("icarus"),
+    reason="Icarus does not support unpacked structs (gh-2592)",
+)
 def test_array_module(array_module: HDL) -> None:
     """Run HDL simulator to test ``array_module``."""
     # TODO: Not all runners are supporting build_dir != test_dir :( For now, run only build stage


### PR DESCRIPTION
* Fixes #5311. Runs each test in separate directory to prevent builds from colliding in the same `sim_build`.
* Skip array_module tests for Icarus since it isn't supported. This wasn't seen until now because the previous step was picking up a totally different build.
* Adjust logging handling for pytest so...
   * We can handle logs using cocotb's loggers when no simulation is running. We will need this for non-simulator-context `cocotb.run` support. This is the `RuntimeError` branch of the SimTimeContext
   * We can deregister the cocotb logger after each pytest test so we aren't leaving state around after each test.
* Adds stdout printing on all CI pytest runs for better visibility on what it's doing.