### PR TITLE
fix: resolve memory leak in VPI callback cleanup

### DIFF
--- a/docs/source/newsfragments/5447.bugfix.rst
+++ b/docs/source/newsfragments/5447.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed memory leak of one-shot callback on VCS/Xcelium.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,6 +319,7 @@ dev_test = [
     "IPython",
     "pexpect",
     "pytest-cov",
+    "psutil",
 ]
 coverage_report = [
     "coverage[toml]>=7.2",

--- a/src/cocotb/share/def/aldec.def
+++ b/src/cocotb/share/def/aldec.def
@@ -31,6 +31,7 @@ vpi_put_userdata
 vpi_put_value
 vpi_register_cb
 vpi_register_systf
+vpi_release_handle
 vpi_remove_cb
 vpi_scan
 vpi_sim_control

--- a/src/cocotb/share/def/ghdl.def
+++ b/src/cocotb/share/def/ghdl.def
@@ -29,6 +29,7 @@ vpi_put_userdata
 vpi_put_value
 vpi_register_cb
 vpi_register_systf
+vpi_release_handle
 vpi_remove_cb
 vpi_scan
 vpi_sim_control

--- a/src/cocotb/share/def/icarus.def
+++ b/src/cocotb/share/def/icarus.def
@@ -29,6 +29,7 @@ vpi_put_userdata
 vpi_put_value
 vpi_register_cb
 vpi_register_systf
+vpi_release_handle
 vpi_remove_cb
 vpi_scan
 vpi_sim_control

--- a/src/cocotb/share/def/modelsim.def
+++ b/src/cocotb/share/def/modelsim.def
@@ -31,6 +31,7 @@ vpi_put_userdata
 vpi_put_value
 vpi_register_cb
 vpi_register_systf
+vpi_release_handle
 vpi_remove_cb
 vpi_scan
 vpi_sim_control

--- a/src/cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
@@ -146,7 +146,7 @@ int VpiCbHdl::run() {
 // sims do not. So we remove all callbacks here after firing because Verilator
 // doesn't seem to mind (other sims do).
 #ifdef VERILATOR
-    // Remove recurring callback once fired
+    // Remove recurring callback once fired for Verilator using vpi_remove_cb
     auto err = vpi_remove_cb(get_handle<vpiHandle>());
     // LCOV_EXCL_START
     if (!err) {
@@ -159,6 +159,11 @@ int VpiCbHdl::run() {
     else {
         delete this;
     }
+#elif defined(IUS) || defined(VCS) || defined(ALDEC)
+    // Some simulators need you to release the handle after firing, despite the
+    // VPI spec not stating that's necessary.
+    vpi_release_handle(get_handle<vpiHandle>());
+    delete this;
 #else
     // For other simulators: VPI spec says one-shot callbacks auto-cleanup
     // their handle after firing. We just need to delete the C++ object.

--- a/tests/test_cases/test_trigger_memory_leak/Makefile
+++ b/tests/test_cases/test_trigger_memory_leak/Makefile
@@ -1,0 +1,19 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
+include ../../designs/sample_module/Makefile
+COCOTB_TEST_MODULES:=test_trigger_memory_leak
+
+endif

--- a/tests/test_cases/test_trigger_memory_leak/test_trigger_memory_leak.py
+++ b/tests/test_cases/test_trigger_memory_leak/test_trigger_memory_leak.py
@@ -1,0 +1,200 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Tests related to timing triggers
+
+* Timer
+* ReadWrite
+* ReadOnly
+* NextTimeStep
+* RisingEdge
+* FallingEdge
+* NullTrigger
+* ValueChange
+* Event
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+
+import psutil
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import (
+    Event,
+    FallingEdge,
+    NextTimeStep,
+    NullTrigger,
+    ReadOnly,
+    ReadWrite,
+    RisingEdge,
+    Timer,
+    ValueChange,
+)
+
+SIM_NAME = cocotb.SIM_NAME.lower()
+proc = psutil.Process(os.getpid())
+# diff less than n * 4k for ASLR, if use THP, maybe lessthan n * 2MB
+MEMORY_LEAK_TH = 2**22 if SIM_NAME.startswith("riviera") else 2**21
+
+
+@cocotb.test
+@cocotb.skipif(
+    SIM_NAME.startswith("modelsim"),
+    reason="Questa behaves erratically with NextTimeStep",
+)
+async def test_next_time_step_leak(dut):
+    clk = Clock(dut.clk, 1, "ns")
+    cocotb.start_soon(clk.start())
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        await NextTimeStep()
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"
+
+
+@cocotb.test()
+async def test_timer_leak(dut):
+    await Timer(1_000, unit="ns")
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        await Timer(1, unit="ns")
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"
+
+
+@cocotb.test()
+async def test_readonly_leak(dut):
+    await Timer(1_000, unit="ns")
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        await ReadOnly()
+        await Timer(1, unit="ns")
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"
+
+
+@cocotb.test()
+async def test_readwrite_leak(dut):
+    await Timer(1_000, unit="ns")
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        await Timer(1, unit="ns")
+        await ReadWrite()
+
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"
+
+
+@cocotb.test()
+@cocotb.xfail(
+    SIM_NAME.startswith("modelsim"),
+    reason="Questa does not support calling vpi_remove_cb in a callback, which causes a memory leak",
+)
+async def test_rising_edge_leak(dut):
+    clk = Clock(dut.clk, 1, "ns")
+    cocotb.start_soon(clk.start())
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        await RisingEdge(dut.clk)
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"
+
+
+@cocotb.test()
+@cocotb.xfail(
+    SIM_NAME.startswith("modelsim"),
+    reason="Questa does not support calling vpi_remove_cb in a callback, which causes a memory leak",
+)
+async def test_falling_edge_leak(dut):
+    clk = Clock(dut.clk, 1, "ns")
+    cocotb.start_soon(clk.start())
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        await FallingEdge(dut.clk)
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"
+
+
+@cocotb.test()
+@cocotb.xfail(
+    SIM_NAME.startswith("modelsim"),
+    reason="Questa does not support calling vpi_remove_cb in a callback, which causes a memory leak",
+)
+async def test_value_change_leak(dut):
+    clk = Clock(dut.clk, 1, "ns")
+    cocotb.start_soon(clk.start())
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        await ValueChange(dut.clk)
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"
+
+
+@cocotb.test()
+async def test_null_triger_leak(dut):
+    await Timer(1_000, unit="ns")
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        await NullTrigger()
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"
+
+
+@cocotb.test()
+async def test_event_leak(dut):
+    e = Event()
+
+    async def wait_event() -> None:
+        for _ in range(100_000):
+            await e.wait()
+
+    cocotb.start_soon(wait_event())
+
+    await Timer(1_000, unit="ns")
+    rss_start = proc.memory_info().rss
+    await Timer(100_000, unit="ns")
+    rss_no_triger = proc.memory_info().rss
+    for _ in range(100_000):
+        e.set()
+        await Timer(1, "ns")
+    gc.collect()
+    rss_triger = proc.memory_info().rss
+    diff = rss_triger - rss_no_triger - rss_no_triger + rss_start
+    assert diff <= MEMORY_LEAK_TH, "Memory leak"

--- a/uv.lock
+++ b/uv.lock
@@ -603,6 +603,7 @@ dev = [
     { name = "nox-uv" },
     { name = "pexpect" },
     { name = "prek" },
+    { name = "psutil" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
@@ -616,6 +617,7 @@ dev-test = [
     { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pexpect" },
+    { name = "psutil" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
@@ -705,6 +707,7 @@ dev = [
     { name = "nox-uv" },
     { name = "pexpect" },
     { name = "prek" },
+    { name = "psutil" },
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -713,6 +716,7 @@ dev-test = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.2" },
     { name = "ipython" },
     { name = "pexpect" },
+    { name = "psutil" },
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-cov" },
 ]
@@ -2261,6 +2265,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #5545

This PR resolves the linear RSS memory leak when repeatedly using `Timer` triggers on Synopsys VCS and Cadence Xcelium.