### PR TITLE
Log test arguments and keyword arguments at test start

### DIFF
--- a/docs/source/newsfragments/4036.feature.rst
+++ b/docs/source/newsfragments/4036.feature.rst
@@ -1,0 +1,1 @@
+Test arguments and keyword arguments are now logged on test start, making the parameter values used by :func:`cocotb.parametrize` and :class:`~cocotb.regression.TestFactory` visible in the simulation log.

--- a/docs/source/newsfragments/4036.feature.rst
+++ b/docs/source/newsfragments/4036.feature.rst
@@ -1,1 +1,1 @@
-Test arguments and keyword arguments are now logged on test start, making the parameter values used by :func:`cocotb.parametrize` and :class:`~cocotb.regression.TestFactory` visible in the simulation log.
+Test arguments and keyword arguments are now logged on test start and included in XUnit reports, making the parameter values used by :func:`cocotb.parametrize` and :class:`~cocotb.regression.TestFactory` visible in the simulation log and generated results.

--- a/src/cocotb/_xunit_reporter.py
+++ b/src/cocotb/_xunit_reporter.py
@@ -63,6 +63,17 @@ class XUnitReporter:
         self.last_property = SubElement(testsuite, "property", kwargs)
         return self.last_property
 
+    def add_testcase_property(
+        self, testcase: Element | None = None, **kwargs: str
+    ) -> Element:
+        if testcase is None:
+            testcase = self.last_testcase
+        properties = testcase.find("properties")
+        if properties is None:
+            properties = SubElement(testcase, "properties")
+        self.last_property = SubElement(properties, "property", kwargs)
+        return self.last_property
+
     def add_failure(self, testcase: Element | None = None, **kwargs: str) -> None:
         if testcase is None:
             testcase = self.last_testcase

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -139,13 +139,19 @@ def _format_doc(docstring: str | None) -> str:
         return f"\n    {brief}"
 
 
-def _format_test_arguments(args: Sequence[Any], kwargs: Mapping[str, Any]) -> str:
-    """Format positional and keyword arguments of a test for human-readable logging."""
+def _repr_test_arguments(args: Sequence[Any], kwargs: Mapping[str, Any]) -> str:
+    """Format positional and keyword arguments of a test for reports."""
     parts = [repr(a) for a in args]
     parts.extend(f"{k}={v!r}" for k, v in kwargs.items())
-    if not parts:
+    return ", ".join(parts)
+
+
+def _format_test_arguments(args: Sequence[Any], kwargs: Mapping[str, Any]) -> str:
+    """Format positional and keyword arguments of a test for human-readable logging."""
+    test_arguments = _repr_test_arguments(args, kwargs)
+    if not test_arguments:
         return ""
-    return "\n    Parameters: " + ", ".join(parts)
+    return "\n    Parameters: " + test_arguments
 
 
 class RegressionMode(DocEnum):
@@ -665,6 +671,13 @@ class RegressionManager:
             _format_test_arguments(self._test.args, self._test.kwargs),
         )
 
+    def _add_test_arguments_property(self) -> None:
+        test_arguments = _repr_test_arguments(self._test.args, self._test.kwargs)
+        if test_arguments:
+            self.xunit.add_testcase_property(
+                name="test_arguments", value=bin_xml_escape(test_arguments)
+            )
+
     def _record_test_excluded(self) -> None:
         """Called by :meth:`_execute` when a test is excluded by filters."""
 
@@ -679,6 +692,7 @@ class RegressionManager:
             sim_time_ns=repr(0),
             ratio_time=repr(0),
         )
+        self._add_test_arguments_property()
         self.xunit.add_skipped()
 
         # do not log anything, nor save details for the summary
@@ -717,6 +731,7 @@ class RegressionManager:
             sim_time_ns=repr(0),
             ratio_time=repr(0),
         )
+        self._add_test_arguments_property()
         self.xunit.add_skipped()
 
         # save details for summary
@@ -760,6 +775,7 @@ class RegressionManager:
             sim_time_ns=repr(0),
             ratio_time=repr(0),
         )
+        self._add_test_arguments_property()
         self.xunit.add_failure(msg="Test initialization failed")
 
         # save details for summary
@@ -815,6 +831,7 @@ class RegressionManager:
             sim_time_ns=repr(sim_time_ns),
             ratio_time=repr(ratio_time),
         )
+        self._add_test_arguments_property()
 
         # update running passed/failed/skipped counts
         self.passed += 1
@@ -856,6 +873,7 @@ class RegressionManager:
             sim_time_ns=repr(sim_time_ns),
             ratio_time=repr(ratio_time),
         )
+        self._add_test_arguments_property()
 
         # update running passed/failed/skipped counts
         self.passed += 1
@@ -906,6 +924,7 @@ class RegressionManager:
             sim_time_ns=repr(sim_time_ns),
             ratio_time=repr(ratio_time),
         )
+        self._add_test_arguments_property()
         self.xunit.add_failure(
             error_type=type(result).__name__, error_msg=bin_xml_escape(result)
         )

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -17,6 +17,7 @@ import re
 import sys
 import time
 import warnings
+from collections.abc import Mapping, Sequence
 from enum import Enum, auto
 from importlib import import_module
 from typing import Any, cast
@@ -136,6 +137,15 @@ def _format_doc(docstring: str | None) -> str:
     else:
         brief = docstring.split("\n")[0]
         return f"\n    {brief}"
+
+
+def _format_test_arguments(args: Sequence[Any], kwargs: Mapping[str, Any]) -> str:
+    """Format positional and keyword arguments of a test for human-readable logging."""
+    parts = [repr(a) for a in args]
+    parts.extend(f"{k}={v!r}" for k, v in kwargs.items())
+    if not parts:
+        return ""
+    return "\n    Parameters: " + ", ".join(parts)
 
 
 class RegressionMode(DocEnum):
@@ -645,13 +655,14 @@ class RegressionManager:
         hilight_start = "" if cocotb_logging.strip_ansi else self.COLOR_TEST
         hilight_end = "" if cocotb_logging.strip_ansi else ANSI.DEFAULT
         self.log.info(
-            "%srunning%s %s (%d/%d)%s",
+            "%srunning%s %s (%d/%d)%s%s",
             hilight_start,
             hilight_end,
             self._test.fullname,
             self.count,
             self.total_tests,
             _format_doc(self._test.doc),
+            _format_test_arguments(self._test.args, self._test.kwargs),
         )
 
     def _record_test_excluded(self) -> None:

--- a/src/cocotb_tools/pytest/_regression.py
+++ b/src/cocotb_tools/pytest/_regression.py
@@ -49,6 +49,7 @@ import cocotb.types._resolve
 from cocotb._extended_awaitables import with_timeout
 from cocotb._gpi_triggers import Timer
 from cocotb._test_manager import TestManager
+from cocotb._xunit_reporter import bin_xml_escape
 from cocotb.simtime import TimeUnit, get_sim_time
 from cocotb_tools.pytest._fixture import (
     AsyncFixtureCachedResult,
@@ -66,6 +67,14 @@ When = Literal["setup", "call", "teardown"]
 
 class SimFailure(BaseException):
     """A Test failure due to simulator failure. Used internally."""
+
+
+def _format_test_arguments(item: Item) -> str:
+    callspec: Any = getattr(item, "callspec", None)
+    if callspec is None:
+        return ""
+
+    return ", ".join(f"{name}={value!r}" for name, value in callspec.params.items())
 
 
 def finish_on_exception(method: Callable[..., Any]) -> Callable[..., Any]:
@@ -679,6 +688,7 @@ class RegressionManager:
           `ns`, `us`, `ms` or `sec` (seconds).
         * `runner_nodeid`: Node identifier of cocotb runner (test to run simulator by pytest parent process).
         * `random_seed`: Value of seed used for randomization.
+        * `test_arguments`: Arguments used for parametrized tests.
 
         Above properties are accessible from generated test report and they will be available from
         various generated test report outputs like JUnit XML report.
@@ -704,6 +714,10 @@ class RegressionManager:
             "runner_nodeid": self._nodeid,  # identify cocotb runner
             "random_seed": self._seed,
         }
+
+        test_arguments = _format_test_arguments(item)
+        if test_arguments:
+            properties["test_arguments"] = bin_xml_escape(test_arguments)
 
         # Make properties available for other plugins. The `extra` argument from pytest.TestReport
         # __init__(self, ..., **extra) constructor is doing the same

--- a/tests/pytest/test_parameterize.py
+++ b/tests/pytest/test_parameterize.py
@@ -4,12 +4,17 @@
 from __future__ import annotations
 
 from enum import Enum
+from types import SimpleNamespace
 
 import pytest
 
 import cocotb
 from cocotb._decorators import _repr, _reprs
-from cocotb.regression import _format_test_arguments
+from cocotb._xunit_reporter import XUnitReporter
+from cocotb.regression import _format_test_arguments, _repr_test_arguments
+from cocotb_tools.pytest._regression import (
+    _format_test_arguments as _format_pytest_test_arguments,
+)
 
 
 class MyEnum(Enum):
@@ -55,6 +60,7 @@ def test_parametrize_bad_args():
 
 def test_format_test_arguments_empty():
     assert _format_test_arguments((), {}) == ""
+    assert _repr_test_arguments((), {}) == ""
 
 
 def test_format_test_arguments_kwargs_only():
@@ -72,6 +78,7 @@ def test_format_test_arguments_args_and_kwargs():
         _format_test_arguments(("first",), {"x": 1, "y": "z"})
         == "\n    Parameters: 'first', x=1, y='z'"
     )
+    assert _repr_test_arguments(("first",), {"x": 1, "y": "z"}) == "'first', x=1, y='z'"
 
 
 def test_format_test_arguments_complex_values():
@@ -82,3 +89,29 @@ def test_format_test_arguments_complex_values():
         )
         == "\n    Parameters: validFraction=0.872467184172418, numPackets=500"
     )
+
+
+def test_xunit_testcase_arguments_property():
+    reporter = XUnitReporter()
+    testsuite = reporter.add_testsuite(name="suite")
+    testcase = reporter.add_testcase(testsuite, name="case")
+
+    reporter.add_testcase_property(
+        testcase, name="test_arguments", value=_repr_test_arguments((), {"x": 1})
+    )
+
+    properties = testcase.find("properties")
+    assert properties is not None
+    assert [(prop.attrib["name"], prop.attrib["value"]) for prop in properties] == [
+        ("test_arguments", "x=1")
+    ]
+
+
+def test_pytest_format_test_arguments_empty():
+    assert _format_pytest_test_arguments(SimpleNamespace()) == ""
+
+
+def test_pytest_format_test_arguments_from_callspec():
+    item = SimpleNamespace(callspec=SimpleNamespace(params={"x": 1, "y": "z"}))
+
+    assert _format_pytest_test_arguments(item) == "x=1, y='z'"

--- a/tests/pytest/test_parameterize.py
+++ b/tests/pytest/test_parameterize.py
@@ -9,6 +9,7 @@ import pytest
 
 import cocotb
 from cocotb._decorators import _repr, _reprs
+from cocotb.regression import _format_test_arguments
 
 
 class MyEnum(Enum):
@@ -50,3 +51,34 @@ def test_parametrize_bad_args():
         cocotb.parametrize((("not valid", "valid"), [(1, 2), (3, 4)]))
     with pytest.raises(ValueError):
         cocotb.parametrize((("a", "b"), [(1, 2, "too", "many", "args"), (3, 4)]))
+
+
+def test_format_test_arguments_empty():
+    assert _format_test_arguments((), {}) == ""
+
+
+def test_format_test_arguments_kwargs_only():
+    assert (
+        _format_test_arguments((), {"x": 1, "y": "z"}) == "\n    Parameters: x=1, y='z'"
+    )
+
+
+def test_format_test_arguments_args_only():
+    assert _format_test_arguments(("first", 2), {}) == "\n    Parameters: 'first', 2"
+
+
+def test_format_test_arguments_args_and_kwargs():
+    assert (
+        _format_test_arguments(("first",), {"x": 1, "y": "z"})
+        == "\n    Parameters: 'first', x=1, y='z'"
+    )
+
+
+def test_format_test_arguments_complex_values():
+    # Long strings, lists, and other non-simple values use full repr.
+    assert (
+        _format_test_arguments(
+            (), {"validFraction": 0.872467184172418, "numPackets": 500}
+        )
+        == "\n    Parameters: validFraction=0.872467184172418, numPackets=500"
+    )


### PR DESCRIPTION
Closes #4036.

When the regression manager begins running a test, also log the positional and keyword arguments that were passed to it. Previously only the first line of the test docstring was reported. The encoded test name (e.g. ``my_test/x=1/y=2``) uses ``_repr`` which truncates long values and silently substitutes index strings when a value is not representable, so it is not always sufficient for the user to see what parameter values a particular run is using.

For non-parametrized tests (no positional args, no keyword args) the log line is unchanged, so the existing log format is preserved for the common case. When a test does have arguments, an additional ``Parameters:`` line is appended on the same indented continuation as the docstring, so the existing one-line-per-test layout is retained.

This applies to tests generated by both :func:`cocotb.parametrize` and the legacy :class:`~cocotb.regression.TestFactory`, since both populate ``Test.args`` / ``Test.kwargs``.

Sample output for ``@cocotb.parametrize(x=[1, 2], y=[3, 4])``:

```
0.00ns INFO     running module.test/x=1/y=3 (1/4)
                Parameters: x=1, y=3
0.00ns INFO     running module.test/x=1/y=4 (2/4)
                Parameters: x=1, y=4
```

### TODO

- [x] newsfragment
- [x] tests