### PR TITLE
Add reference docs for test pass/fail conditions

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -391,24 +391,36 @@ The outcome is determined by what the test coroutine or any running :class:`~coc
 Passing tests
 -------------
 
-A test is considered to have ``passed`` if any of the following occur:
+A test is considered to have ``passed`` if it completes successfully
+and no expected-failure or expected-error condition is set.
+Successful completion occurs if any of the following happen:
 
 * The main test coroutine returns without raising an :exc:`!Exception`.
 * The test coroutine, or any running :class:`~cocotb.task.Task`, calls :func:`cocotb.end_test`.
 * The main test coroutine raises a :exc:`~asyncio.CancelledError`,
   or :keyword:`await`\ s a :class:`~cocotb.task.Task` that is cancelled and does not handle the cancellation.
 
+If an expected-failure or expected-error condition is set,
+successful completion is instead reported as ``failed`` because the expected failure or error did not occur.
+
 .. _test-fail:
 
 Failing tests
 -------------
 
-A test is considered to have ``failed`` if the main test coroutine, or any running :class:`~cocotb.task.Task`, does any of the following:
+A test is considered to have ``failed`` if it completes successfully when it was expected to fail or error,
+or if the main test coroutine, or any running :class:`~cocotb.task.Task`,
+produces an unexpected failure or error.
+Unexpected failures and errors include:
 
 * Fails an :keyword:`assert` statement (raises :exc:`AssertionError`).
 * Raises any other :exc:`!Exception` besides :exc:`!CancelledError`.
 * Fails a :func:`pytest.raises`, :func:`pytest.warns`, or :func:`pytest.deprecated_call` check.
 * Calls :func:`pytest.fail`.
+
+A matching ``expect_fail`` or ``expect_error`` argument to :deco:`cocotb.test`,
+or a matching :deco:`cocotb.xfail` decorator,
+changes the final outcome to ``expected fail`` instead.
 
 When a test fails, a stack trace is printed.
 If :mod:`pytest` is installed and :keyword:`assert` statements are used,
@@ -451,7 +463,9 @@ for example because the condition is only known at runtime.
   so the final outcome can be ``pass``, ``fail``, or ``expected fail``.
 * :func:`pytest.skip` ends the test with a ``skipped`` outcome.
 * :func:`pytest.xfail` ends the test with an ``expected fail`` outcome.
-* :func:`pytest.fail` ends the test with a ``failed`` outcome.
+* :func:`pytest.fail` ends the test like a failing :keyword:`assert` statement.
+  Expected-failure conditions are still respected,
+  so the final outcome can be ``fail`` or ``expected fail``.
 
 .. autofunction:: cocotb.end_test
 

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -375,10 +375,83 @@ Discovering Tests
 
     .. versionadded:: 2.0
 
-Test Management
-===============
+.. _test-pass-fail:
+
+Test Pass and Fail Conditions
+=============================
 
 .. currentmodule:: None
+
+When cocotb runs a test, the test ends with one of the following outcomes:
+``pass``, ``fail``, ``skipped``, or ``expected fail`` (also known as ``xfail``).
+The outcome is determined by what the test coroutine or any running :class:`~cocotb.task.Task` does.
+
+.. _test-pass:
+
+Passing tests
+-------------
+
+A test is considered to have ``passed`` if any of the following occur:
+
+* The main test coroutine returns without raising an :exc:`!Exception`.
+* The test coroutine, or any running :class:`~cocotb.task.Task`, calls :func:`cocotb.end_test`.
+* The main test coroutine raises a :exc:`~asyncio.CancelledError`,
+  or :keyword:`await`\ s a :class:`~cocotb.task.Task` that is cancelled and does not handle the cancellation.
+
+.. _test-fail:
+
+Failing tests
+-------------
+
+A test is considered to have ``failed`` if the main test coroutine, or any running :class:`~cocotb.task.Task`, does any of the following:
+
+* Fails an :keyword:`assert` statement (raises :exc:`AssertionError`).
+* Raises any other :exc:`!Exception` besides :exc:`!CancelledError`.
+* Fails a :func:`pytest.raises`, :func:`pytest.warns`, or :func:`pytest.deprecated_call` check.
+* Calls :func:`pytest.fail`.
+
+When a test fails, a stack trace is printed.
+If :mod:`pytest` is installed and :keyword:`assert` statements are used,
+a more informative stack trace is printed which includes the values that caused the assertion to fail.
+
+.. _test-skip:
+
+Skipping tests
+--------------
+
+A test can be skipped statically before it runs by passing the ``skip`` argument to :deco:`cocotb.test`,
+or by using the :deco:`cocotb.skipif` decorator.
+See :ref:`writing-tests` for details.
+
+A test can also be ended with a ``skipped`` outcome from inside the test coroutine, or any running :class:`~cocotb.task.Task`,
+by calling :func:`pytest.skip`.
+
+.. _test-xfail:
+
+Expected failures
+-----------------
+
+A test can be marked as expected to fail before it runs by passing the ``expect_fail`` or ``expect_error`` arguments to :deco:`cocotb.test`,
+or by using the :deco:`cocotb.xfail` decorator.
+See :ref:`writing-tests` for details.
+
+A test can also be ended with an ``expected fail`` outcome from inside the test coroutine, or any running :class:`~cocotb.task.Task`,
+by calling :func:`pytest.xfail`.
+
+Forcing a test to end
+---------------------
+
+The following functions, when called from the test coroutine or any running :class:`~cocotb.task.Task`,
+will end the test immediately with a given outcome.
+They can be used in places where it is awkward to apply the equivalent decorator,
+for example because the condition is only known at runtime.
+
+* :func:`cocotb.end_test` ends the test as if it returned normally.
+  Any :deco:`cocotb.xfail` decorator, or ``expect_error`` and ``expect_fail`` arguments to :deco:`cocotb.test`, are still respected,
+  so the final outcome can be ``pass``, ``fail``, or ``expected fail``.
+* :func:`pytest.skip` ends the test with a ``skipped`` outcome.
+* :func:`pytest.xfail` ends the test with an ``expected fail`` outcome.
+* :func:`pytest.fail` ends the test with a ``failed`` outcome.
 
 .. autofunction:: cocotb.end_test
 

--- a/docs/source/newsfragments/5394.doc.rst
+++ b/docs/source/newsfragments/5394.doc.rst
@@ -1,0 +1,1 @@
+Moved the reference description of test pass and fail conditions from :ref:`writing_tbs` to :ref:`test-pass-fail` in the library reference, and added documentation for ending a test with :func:`cocotb.end_test`, :func:`pytest.skip`, :func:`pytest.xfail`, and :func:`pytest.fail`.

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -260,8 +260,11 @@ When cocotb tests complete execution, they end with one of four outcomes:
 ``pass``, ``fail``, ``skipped``, or ``expected fail``.
 A reference of the conditions that produce each outcome is given in :ref:`test-pass-fail`.
 
-In short, the main test coroutine simply returns to indicate a passing test,
+In short, the main test coroutine normally returns to indicate a passing test,
 and raises an :exc:`!Exception` (typically by failing an :keyword:`assert` statement) to indicate a failing test.
+Expected-failure settings such as :deco:`cocotb.xfail`,
+or the ``expect_fail`` and ``expect_error`` arguments to :deco:`cocotb.test`,
+can change the final outcome.
 
 .. code-block:: python
 
@@ -302,7 +305,8 @@ a running test can be ended explicitly using one of the following functions:
   Any :deco:`cocotb.xfail` decorator, or ``expect_error`` and ``expect_fail`` arguments to :deco:`cocotb.test`, are still respected.
 * :func:`pytest.skip` to end the test with a ``skipped`` outcome.
 * :func:`pytest.xfail` to end the test with an ``expected fail`` outcome (considered a pass).
-* :func:`pytest.fail` to end the test with a ``failed`` outcome.
+* :func:`pytest.fail` to end the test like a failing :keyword:`assert` statement.
+  Expected-failure settings are still respected.
 
 These functions can be called from any :class:`~cocotb.task.Task` and will end the test immediately.
 They are typically used when the conditions under which a test should be skipped, expected to fail, or ended early

--- a/docs/source/writing_testbenches.rst
+++ b/docs/source/writing_testbenches.rst
@@ -251,18 +251,63 @@ It may appear as one or more attributes here depending on the number of compilat
     cocotb.log.info(cocotb.packages.my_package.foo.value)
 
 
+.. _passing_and_failing_tests:
+
+Passing and failing tests
+=========================
+
+When cocotb tests complete execution, they end with one of four outcomes:
+``pass``, ``fail``, ``skipped``, or ``expected fail``.
+A reference of the conditions that produce each outcome is given in :ref:`test-pass-fail`.
+
+In short, the main test coroutine simply returns to indicate a passing test,
+and raises an :exc:`!Exception` (typically by failing an :keyword:`assert` statement) to indicate a failing test.
+
+.. code-block:: python
+
+    @cocotb.test()
+    async def test_pass(dut):
+        assert 2 > 1  # assertion is correct, then the coroutine ends
+
+    @cocotb.test()
+    async def test_fail(dut):
+        assert 1 > 2, "Testing the obvious"
+
+A passing test prints the following output.
+
+.. code-block::
+
+    0.00ns INFO     Test Passed: test_pass
+
+When a test fails, a stack trace is printed.
+If :mod:`pytest` is installed and :keyword:`assert` statements are used,
+a more informative stack trace is printed which includes the values that caused the assertion to fail.
+For example, the second test above will produce output similar to the following:
+
+.. code-block::
+
+    0.00ns ERROR    Test Failed: test_fail (result was AssertionError)
+                    Traceback (most recent call last):
+                      File "test.py", line 3, in test_fail
+                        assert 1 > 2, "Testing the obvious"
+                    AssertionError: Testing the obvious
+
 Forcing a test to end with a given result
-=========================================
+-----------------------------------------
 
-In addition to the normal ways a test can pass or fail (see :ref:`passing_and_failing_tests`),
-a test can be forced to end with a given result using the following functions:
+In addition to the natural ways for a test to pass or fail,
+a running test can be ended explicitly using one of the following functions:
 
-* :func:`pytest.xfail` to end the test with an expected fail (considered a pass)
-* :func:`pytest.skip` to end the test with a skip
+* :func:`cocotb.end_test` to end the test as if it returned normally.
+  Any :deco:`cocotb.xfail` decorator, or ``expect_error`` and ``expect_fail`` arguments to :deco:`cocotb.test`, are still respected.
+* :func:`pytest.skip` to end the test with a ``skipped`` outcome.
+* :func:`pytest.xfail` to end the test with an ``expected fail`` outcome (considered a pass).
+* :func:`pytest.fail` to end the test with a ``failed`` outcome.
 
-These functions can be called from any Task and will end the test immediately with the given result.
-They are typically used when you cannot use the :deco:`cocotb.skipif` or :deco:`cocotb.xfail` decorators
-to describe the exact conditions under which a test should be skipped or have reached an expected fail state.
+These functions can be called from any :class:`~cocotb.task.Task` and will end the test immediately.
+They are typically used when the conditions under which a test should be skipped, expected to fail, or ended early
+are only known at run time, so the equivalent decorators (:deco:`cocotb.skipif`, :deco:`cocotb.xfail`)
+or arguments to :deco:`cocotb.test` cannot be used.
 
 .. code-block:: python
 
@@ -276,132 +321,6 @@ to describe the exact conditions under which a test should be skipped or have re
         ...
         if dut.read_empty.value == 0:
             pytest.xfail("The read interface is not empty, but this test is expected to fail in this case")
-
-
-.. _passing_and_failing_tests:
-
-Passing and failing tests
-=========================
-
-When cocotb tests complete execution, they have either `passed` or `failed`.
-
-In general, if the main test coroutine completes without raising an :exc:`!Exception`,
-or if the test coroutine or any running :class:`~cocotb.task.Task` calls :func:`cocotb.pass_test`,
-the test is considered to have `passed`.
-Also, if the main test coroutine raises a :exc:`~asyncio.CancelledError`,
-or is :keyword:`await`\ ing a :class:`!Task` that is cancelled and does not handle it (or re-raises it),
-the test will end immediately but it will have `passed`.
-
-Below are examples of `passing` tests.
-
-.. code-block:: python
-
-    @cocotb.test()
-    async def test(dut):
-        assert 2 > 1  # assertion is correct, then the coroutine ends
-
-    @cocotb.test()
-    async def test(dut):
-        cocotb.pass_test("Reason")  # ends test with success early
-        assert 1 > 2  # this would fail, but it isn't run because the test was ended early
-
-    @cocotb.test()
-    async def test(dut):
-        async def ends_test_with_pass():
-            cocotb.pass_test("Reason")
-        cocotb.start_soon(ends_test_with_pass())
-        await Timer(10, 'ns')
-
-    @cocotb.test()
-    async def test(dut):
-        async def cancelled_after_time():
-            await Timer(1, unit='ns')
-            raise CancelledError
-        t = cocotb.start_soon(cancelled_after_time())
-        await t
-
-A passing test will print the following output.
-
-.. code-block::
-
-    0.00ns INFO     Test Passed: test
-
-A cocotb test is considered to have `failed` if the test coroutine or any running :class:`~cocotb.task.Task`
-fails an :keyword:`assert` statement, fails :func:`pytest.raises` or :func:`pytest.warns` checks,
-or raises any other :exc:`!Exception` besides :exc:`!CancelledError`.
-
-Below are examples of `failed` tests that failed assertion statements.
-
-.. code-block:: python
-
-    @cocotb.test()
-    async def test(dut):
-        assert 1 > 2, "Testing the obvious"
-
-    @cocotb.test()
-    async def test(dut):
-        async def fails_test():
-            assert 1 > 2
-        cocotb.start_soon(fails_test())
-        await Timer(10, 'ns')
-
-When a test fails, a stacktrace is printed.
-
-If :mod:`pytest` is installed and assert statements are used,
-a more informative stacktrace is printed which includes the values that caused the assert to fail.
-For example, see the output for the first test from above.
-
-.. code-block::
-
-    0.00ns ERROR    Test Failed: test (result was AssertionError)
-                    Traceback (most recent call last):
-                      File "test.py", line 3, in test
-                        assert 1 > 2, "Testing the obvious"
-                    AssertionError: Testing the obvious
-
-Below are examples of `failed` tests that raised an :exc:`!Exception`.
-
-.. code-block:: python
-
-    @cocotb.test()
-    async def test(dut):
-        await coro_that_does_not_exist()  # NameError
-
-    @cocotb.test()
-    async def test(dut):
-        async def coro_with_an_error():
-            dut.signal_that_does_not_exist.value = 1  # AttributeError
-        cocotb.start_soon(coro_with_an_error())
-        await Timer(10, 'ns')
-
-When a test ends with an :exc:`!Exception`, a stacktrace is printed.
-For example, see the below output for the first test from above.
-
-.. code-block::
-
-    0.00ns ERROR    Test Failed: test (result was NameError)
-                    Traceback (most recent call last):
-                      File "test.py", line 3, in test
-                        await coro_that_does_not_exist()  # NameError
-                    NameError: name 'coro_that_does_not_exist' is not defined
-
-In summary:
-
-+--------------+--------------------------------------------------------------------------+
-|| Test Passed || Test ends without raising :exc:`!Exception`.                            |
-||             || Test or Task calls :func:`cocotb.pass_test`.                            |
-||             || Test raises :exc:`~asyncio.CancelledError`.                             |
-+--------------+--------------------------------------------------------------------------+
-|| Test Failed || Test fails an :keyword:`assert` statement.                              |
-||             || Test or Task raises :exc:`AssertionError`.                              |
-||             || Test or Task fails :func:`pytest.raises` or :func:`pytest.warns` check. |
-||             || Test or Task raises any other :exc:`!Exception`.                        |
-+--------------+--------------------------------------------------------------------------+
-
-.. note::
-    For the purpose of denoting expected test failures that should be marked as passed,
-    and differentiating between specific types of failures,
-    see the ``expect_fail`` and ``expect_error`` arguments of the :func:`cocotb.test` decorator.
 
 
 Cleaning up resources


### PR DESCRIPTION
Closes #5394.

The narrative explanation of how a test is judged to pass, fail, skip, or expected-fail used to live exclusively in ``docs/source/writing_testbenches.rst``, even though the bulk of it was reference material rather than tutorial content. The section also still referenced ``cocotb.pass_test``, which has been deprecated since 2.1 in favor of ``cocotb.end_test``.

This PR moves the reference content into a new "Test Pass and Fail Conditions" section in ``docs/source/library_reference.rst``, where every outcome is documented and given a label (``test-pass-fail``, ``test-pass``, ``test-fail``, ``test-skip``, ``test-xfail``). The section also documents the four functions that can force a running test to end with a given outcome: ``cocotb.end_test``, ``pytest.skip``, ``pytest.xfail``, and ``pytest.fail``.

The "Passing and failing tests" section in ``writing_testbenches.rst`` is now a short tutorial overview that links into the reference, and the previously separate "Forcing a test to end with a given result" heading is folded into it. References to the deprecated ``cocotb.pass_test`` are dropped from the tutorial.

### TODO

- [x] newsfragment