### PR TITLE
Fix extended regressions

### DIFF
--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -41,7 +41,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.19.2",
+        "sim-version": "r1.20.0",
         "os": "ubuntu-22.04",
         "python-version": "3.9",
         "group": "ci-free",
@@ -49,7 +49,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.19.2",
+        "sim-version": "r1.20.0",
         "os": "ubuntu-22.04",
         "python-version": "3.10",
         "group": "ci-free",
@@ -57,7 +57,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.19.2",
+        "sim-version": "r1.20.0",
         "os": "ubuntu-22.04",
         "python-version": "3.11",
         "group": "ci-free",
@@ -65,7 +65,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.19.2",
+        "sim-version": "r1.20.0",
         "os": "ubuntu-22.04",
         "python-version": "3.12",
         "group": "ci-free",
@@ -73,7 +73,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.19.2",
+        "sim-version": "r1.20.0",
         "os": "ubuntu-22.04",
         "python-version": "3.13",
         "group": "ci-free",
@@ -81,7 +81,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.19.2",
+        "sim-version": "r1.20.0",
         "os": "ubuntu-22.04",
         "python-version": "3.14",
         "group": "ci-free",
@@ -144,7 +144,16 @@ ENVS = [
         "python-version": "3.9",
         "group": "experimental",
     },
-    # Testing latest release is covered by the Python version tests
+    # Testing NVC on Ubuntu
+    # latest release is used in Python version test
+    {
+        "lang": "vhdl",
+        "sim": "nvc",
+        "sim-version": "r1.19.3",  # minimum
+        "os": "ubuntu-22.04",
+        "python-version": "3.9",
+        "group": "extended",
+    },
     {
         "lang": "vhdl",
         "sim": "nvc",
@@ -242,7 +251,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.19.2",
+        "sim-version": "r1.20.0",
         "os": "windows-latest",
         "python-version": "3.11",
         "group": "ci-free",
@@ -252,7 +261,7 @@ ENVS = [
     {
         "lang": "vhdl",
         "sim": "nvc",
-        "sim-version": "r1.19.2",
+        "sim-version": "r1.20.0",
         "os": "ubuntu-22.04",
         "python-version": "3.9",
         "cxx": "clang++",

--- a/.github/generate-envs.py
+++ b/.github/generate-envs.py
@@ -386,16 +386,7 @@ for version in verilator_versions:
         },
     ]
 
-nvc_versions = (
-    "r1.11.0",
-    "r1.12.2",
-    "r1.13.3",
-    "r1.14.2",
-    "r1.15.2",
-    "r1.16.0",  # First version with --preserve-case
-    "r1.17.1",
-    "r1.18.2",
-)
+nvc_versions = ()
 for version in nvc_versions:
     ENVS += [
         {

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -77,15 +77,13 @@ jobs:
 
     - name: setup ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      if: (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')) && matrix.sim == 'verilator'
       with:
         key: ${{ matrix.os }}-${{matrix.cc || 'gcc'}}
     - name: setup ccache path
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      if: (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')) && matrix.sim == 'verilator'
       run: |
         echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
-
-     # Use the ccache cache for all compilers.
 
     - name: Update package index (ubuntu)
       if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -275,11 +275,9 @@ jobs:
       continue-on-error: ${{matrix.may-fail || false}}
       timeout-minutes: 40
       run: |
-        if [ "${{matrix.self-hosted}}" == "true" ]; then
-          module load "${{ matrix.sim-version }}"
-        fi
         nox -k "${{ inputs.test_task }} and ${{ matrix.sim }} and ${{ matrix.lang }}"
       env:
+        MODULEFILE: ${{ matrix.self-hosted && matrix.sim-version || '' }}
         COCOTB_ANSI_OUTPUT: 1
 
     # codecov

--- a/docs/source/simulator_support.rst
+++ b/docs/source/simulator_support.rst
@@ -500,12 +500,7 @@ NVC
 
 .. note::
 
-    NVC version **1.11.0** or later is required.
-
-.. note::
-
-    Using NVC versions greater than **1.16.0** will automatically add the ``--preserve-case`` option build commands.
-    This is standards-compliant behavior and may become default behavior in NVC, so think twice before overriding it.
+    NVC version **1.19.1** or later is required.
 
 In order to use this simulator, set :make:var:`SIM` to ``nvc``:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,6 +68,12 @@ def env_vars_for_sim_test(
 def configure_test_env(session: nox.Session) -> None:
     """Set environment variables for any kind of test run."""
 
+    # Load a commercial simulator modulefile if needed.
+    # This must be here so cocotb can be built without the modulefile loaded as they can
+    # sometimes monkey with paths in ways that break builds.
+    if modulefile := os.getenv("MODULEFILE"):
+        session.run("module", "load", modulefile, external=True)
+
     # Do not fail on DeprecationWarning caused by virtualenv, which might come from
     # the site module.
     session.env["PYTHONWARNINGS"] = "error,ignore::DeprecationWarning:site"

--- a/tests/test_cases/test_force_release/test_force_release.py
+++ b/tests/test_cases/test_force_release/test_force_release.py
@@ -12,7 +12,7 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.handle import Force, Release
 from cocotb.triggers import ClockCycles, Timer
-from cocotb_tools.sim_versions import GhdlVersion, RivieraVersion
+from cocotb_tools.sim_versions import GhdlVersion, QuestaVersion, RivieraVersion
 
 SIM_NAME = cocotb.SIM_NAME.lower()
 SIM_VERSION = cocotb.SIM_VERSION
@@ -21,7 +21,13 @@ LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 questa_fli = (
     SIM_NAME.startswith("modelsim")
     and LANGUAGE == "vhdl"
-    and os.getenv("VHDL_GPI_INTERFACE", "") == "fli"
+    and os.getenv("VHDL_GPI_INTERFACE", "vhpi") == "fli"
+)
+
+questa_vhpi = (
+    SIM_NAME.startswith("modelsim")
+    and LANGUAGE == "vhdl"
+    and os.getenv("VHDL_GPI_INTERFACE", "vhpi") == "vhpi"
 )
 
 riviera_vpi_below_2024_10 = (
@@ -120,8 +126,15 @@ async def test_hdl_writes_dont_overwrite_force_registered(dut) -> None:
     assert dut.stream_out_data_registered.value == 4
 
 
-# Force/Release doesn't work on Verilator (gh-3831)
-@cocotb.test(expect_fail=SIM_NAME.startswith("verilator"))
+@cocotb.test
+@cocotb.xfail(
+    SIM_NAME.startswith("verilator"),
+    reason="Force/Release doesn't work on Verilator (gh-3831)",
+)
+@cocotb.xfail(
+    questa_vhpi and QuestaVersion(SIM_VERSION) < "2022.4",
+    reason="Forcing multiple values in the same cycle chooses the oldest value, not the newest",
+)
 async def test_multiple_force_in_same_cycle(dut) -> None:
     """Tests multiple Force in the same eval cycle write the last value."""
     await reset(dut)


### PR DESCRIPTION
* Bumps minimum supported version of NVC to 1.19:
   * <1.16 don't support preseve-case which is the way forward
   * 1.16-1.19 have a bug where `--work` and `--preserve-case` don't work together #1413
* Adds NVC 1.20 to regression
* Fixes a couple extended regression tests, xref #4948.
* Move commercial sim modulefile loading into noxfile

Manual run here: https://github.com/cocotb/cocotb/actions/runs/25894738596
