### PR TITLE
add VpiRefObject resolution using vpiActual

### DIFF
--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -202,8 +202,8 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         }
         type = vpi_get(vpiType, actual_hdl);
         vpi_free_object(actual_hdl);
-        LOG_DEBUG("VPI: Resolved vpiRefObj %s to type %d",
-                  fq_name.c_str(), type);
+        LOG_DEBUG("VPI: Resolved vpiRefObj %s to type %d", fq_name.c_str(), 
+		  type);
     }
 
     /* What sort of instance is this ?*/

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -203,7 +203,7 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         type = vpi_get(vpiType, actual_hdl);
         vpi_free_object(actual_hdl);
         LOG_DEBUG("VPI: Resolved vpiRefObj %s to type %d", fq_name.c_str(),
-		   type);
+                  type);
     }
 
     /* What sort of instance is this ?*/

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -203,7 +203,7 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         type = vpi_get(vpiType, actual_hdl);
         vpi_free_object(actual_hdl);
         LOG_DEBUG("VPI: Resolved vpiRefObj %s to type %d", fq_name.c_str(), 
-		  type);
+		 type);
     }
 
     /* What sort of instance is this ?*/

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -202,7 +202,7 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         }
         type = vpi_get(vpiType, actual_hdl);
         vpi_free_object(actual_hdl);
-        LOG_DEBUG("VPI: Resolved vpiRefObj %s to type %d", fq_name.c_str(), 
+        LOG_DEBUG("VPI: Resolved vpiRefObj %s to type %d", fq_name.c_str(),
 		   type);
     }
 

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -190,6 +190,22 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         return NULL;
     }
 
+    // vpiRefObj is a reference/alias (e.g. an interface passed through a
+    // module port). Resolve via vpiActual to determine the real type rather
+    // than assuming any particular type.
+    if (type == vpiRefObj) {
+        vpiHandle actual_hdl = vpi_handle(vpiActual, new_hdl);
+        if (actual_hdl == NULL) {
+            LOG_WARN("VPI: Could not resolve vpiActual for vpiRefObj %s",
+                     fq_name.c_str());
+            return NULL;
+        }
+        type = vpi_get(vpiType, actual_hdl);
+        vpi_free_object(actual_hdl);
+        LOG_DEBUG("VPI: Resolved vpiRefObj %s to type %d",
+                  fq_name.c_str(), type);
+    }
+
     /* What sort of instance is this ?*/
     switch (type) {
         case vpiNet:

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -203,7 +203,7 @@ GpiObjHdl *VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         type = vpi_get(vpiType, actual_hdl);
         vpi_free_object(actual_hdl);
         LOG_DEBUG("VPI: Resolved vpiRefObj %s to type %d", fq_name.c_str(), 
-		 type);
+		   type);
     }
 
     /* What sort of instance is this ?*/

--- a/src/cocotb/share/lib/gpi/vpi/VpiIterator.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiIterator.cpp
@@ -93,6 +93,15 @@ VpiIterator::VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl)
 
     int type = vpi_get(vpiType, vpi_hdl);
 
+    // Resolve vpiRefObj to the actual type for iteration lookup
+    if (type == vpiRefObj) {
+        vpiHandle actual_hdl = vpi_handle(vpiActual, vpi_hdl);
+        if (actual_hdl != NULL) {
+            type = vpi_get(vpiType, actual_hdl);
+            vpi_free_object(actual_hdl);
+        }
+    }
+
     try {
         selected = &iterate_over.at(type);
     } catch (std::out_of_range const &) {

--- a/tests/test_cases/test_sv_interface/test_sv_if.py
+++ b/tests/test_cases/test_sv_interface/test_sv_if.py
@@ -16,6 +16,9 @@ async def test_sv_if(dut):
     assert hasattr(dut.sv_if_i, "a")
     assert hasattr(dut.sv_if_i, "b")
     assert hasattr(dut.sv_if_i, "c")
+    assert hasattr(dut.child_inst.sv_if, "a")
+    assert hasattr(dut.child_inst.sv_if, "b")
+    assert hasattr(dut.child_inst.sv_if, "c")
 
 
 SIM_NAME = cocotb.SIM_NAME.lower()

--- a/tests/test_cases/test_sv_interface/top.sv
+++ b/tests/test_cases/test_sv_interface/top.sv
@@ -10,10 +10,17 @@ interface sv_if();
   wire c;
 endinterface
 
+module child (
+    sv_if sv_if
+);
+endmodule
+
 module top ();
 
 sv_if sv_if_i();
 
 sv_if sv_if_arr[3]();
+
+child child_inst(.sv_if(sv_if_i));
 
 endmodule


### PR DESCRIPTION
- Add testcase for accessing an interface which is part of a module's ports.
- Fix: add VpiRefObject resolution using vpiActual
- Close #5089

