### PR TITLE
Wrong path to counter.svg in documentation

### DIFF
--- a/docs/source/first_steps.rst
+++ b/docs/source/first_steps.rst
@@ -55,7 +55,7 @@ On every rising edge of ``clk``, in order of precedence:
 * The counter is incremented if the ``ena`` signal is high.
 * Otherwise, the counter holds its value.
 
-.. image:: ../diagrams/counter.svg
+.. image:: ../diagrams/svg/counter.svg
 
 
 Building your Design and Running Simulations

--- a/docs/source/first_steps.rst
+++ b/docs/source/first_steps.rst
@@ -55,7 +55,7 @@ On every rising edge of ``clk``, in order of precedence:
 * The counter is incremented if the ``ena`` signal is high.
 * Otherwise, the counter holds its value.
 
-.. image:: ../diagrams/svg/counter.svg
+.. image:: diagrams/svg/counter.svg
 
 
 Building your Design and Running Simulations


### PR DESCRIPTION
Closes #5566. The documentation had a broken path to the svg diagram 