### PR TITLE
Revert "Move commercial sim module load into noxfile"

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -275,9 +275,11 @@ jobs:
       continue-on-error: ${{matrix.may-fail || false}}
       timeout-minutes: 40
       run: |
+        if [ "${{matrix.self-hosted}}" == "true" ]; then
+          module load "${{ matrix.sim-version }}"
+        fi
         nox -k "${{ inputs.test_task }} and ${{ matrix.sim }} and ${{ matrix.lang }}"
       env:
-        MODULEFILE: ${{ matrix.self-hosted && matrix.sim-version || '' }}
         COCOTB_ANSI_OUTPUT: 1
 
     # codecov

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,12 +68,6 @@ def env_vars_for_sim_test(
 def configure_test_env(session: nox.Session) -> None:
     """Set environment variables for any kind of test run."""
 
-    # Load a commercial simulator modulefile if needed.
-    # This must be here so cocotb can be built without the modulefile loaded as they can
-    # sometimes monkey with paths in ways that break builds.
-    if modulefile := os.getenv("MODULEFILE"):
-        session.run("module", "load", modulefile, external=True)
-
     # Do not fail on DeprecationWarning caused by virtualenv, which might come from
     # the site module.
     session.env["PYTHONWARNINGS"] = "error,ignore::DeprecationWarning:site"


### PR DESCRIPTION
This reverts commit 6159a0913da233e18d50faed21e8f86e1238d6a2.

This does not work. 1. `module` is a bash function. 2. Setting envvars in that `subprocess.run` does not propagate to other callers.