### PR TITLE
Fix multiple sdists in release pipeline

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -97,6 +97,10 @@ jobs:
         pattern: cocotb-dist-*
         merge-multiple: true
 
+    - name: Show downloaded artifacts
+      if: ${{ inputs.download_artifacts }}
+      run: ls -R dist
+
       # Install Python
     - name: Set up Python ${{matrix.python-version}} (setup-python)
       if: matrix.setup_python == ''

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # C objects
 *.o
 
+# Windows build artifacts
+*.rc
+
 # Python and C++ code coverage
 .cov.*
 .coverage

--- a/noxfile.py
+++ b/noxfile.py
@@ -450,12 +450,14 @@ def release_install_from_sdist(session: nox.Session) -> None:
     sdists = list(Path(dist_dir).glob("cocotb-*.tar.gz"))
     if not sdists:
         session.error(
-            f"No potential sdist found in the {dist_dir!r} directory. Run the 'release_build_sdist' session first!"
+            f"No potential sdist found in the {dist_dir!r} directory. "
+            f"Run the 'release_build_sdist' session first!"
         )
     elif len(sdists) > 1:
         session.error(
             f"More than one potential sdist found in the {dist_dir!r} "
-            f"directory. Run the 'release_clean' session first!"
+            f"directory: {', '.join(str(p) for p in sdists)}. "
+            f"Run the 'release_clean' session first!"
         )
     sdist_path = sdists[0]
     assert sdist_path.is_file()

--- a/src/cocotb/share/def/.gitignore
+++ b/src/cocotb/share/def/.gitignore
@@ -1,2 +1,4 @@
 # Generated import libraries on Windows
 *.a
+*.exp
+*.lib


### PR DESCRIPTION
Fix the release pipeline, which failed with the following error message:

> nox > Session release_test(source='sdist', sim='nvc', toplevel_lang='vhdl', gpi_interface='vhpi') aborted: More than one potential sdist found in the 'dist' directory: dist/cocotb-2.1.dev0+r18e65407.tar.gz, dist/cocotb-2.1.dev0+r18e65407.dirty.tar.gz. Run the 'release_clean' session first!.

Root cause: The Windows build is producing untracked files. With setuptools-git-versioning, untracked files are marking the tree dirty ([docs](https://setuptools-git-versioning.readthedocs.io/en/stable/options/dirty_template.html#dirty-template-option)). In the test step, we download all releases from Windows, Linux, and mac builds. Every build produces an sdist, but they are all supposed to have the same name and overwrite each other, leaving only a single sdist.

```
Successfully built cocotb-2.1.dev0+r18e65407.dirty.tar.gz
nox > git status
nox > Warning: git is not installed into the virtualenv, it is located at C:\Program Files\Git\bin\git.EXE. This might cause issues! Pass external=True into run() to silence this message.
HEAD detached at pull/5574/merge
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	libcocotbfli_modelsim.rc
	libcocotbvhpi_aldec.rc
	libcocotbvhpi_modelsim.rc
	libcocotbvhpi_nvc.rc
	libcocotbvpi_aldec.rc
	libcocotbvpi_ghdl.rc
	libcocotbvpi_icarus.rc
	libcocotbvpi_modelsim.rc
	libgpi.rc
	simulator.rc
	src/cocotb/share/def/aldec.exp
	src/cocotb/share/def/aldec.lib
	src/cocotb/share/def/ghdl.exp
	src/cocotb/share/def/ghdl.lib
	src/cocotb/share/def/icarus.exp
	src/cocotb/share/def/icarus.lib
	src/cocotb/share/def/modelsim.exp
	src/cocotb/share/def/modelsim.lib
	src/cocotb/share/def/nvcvhpi.exp
	src/cocotb/share/def/nvcvhpi.lib
```

Avoid untracked files by explicitly ignoring them.

Additionally, improve the error message if multiple sdists are found to make debugging easier the next time.

Passing CI run of the release pipeline after the changes: https://github.com/cocotb/cocotb/actions/runs/26444579477?pr=5574