### PR TITLE
Do not include C/C++ source files in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ Documentation = "https://docs.cocotb.org"
 Repository = "https://github.com/cocotb/cocotb"
 Issues = "https://github.com/cocotb/cocotb/issues"
 
+[tool.setuptools]
+# Rely solely on the package_data entries in setup.py to avoid discovering
+# "packages" like `cocotb._vendor` which we don't want to be found.
+include-package-data = false
+
 [tool.setuptools-git-versioning]
 enabled = true
 version_file = "VERSION"


### PR DESCRIPTION
... and fix the "Package would be ignored" warning during wheel build.

When include_package_data is enabled, setuptools includes all files
tracked by version control (or listed in MANIFEST.in) as package
data. For pyproject.toml-based projects, setuptools enables this by
default. It then warns about every file that lives in a directory
which Python would treat as an importable package but that is not
listed in packages:

  Package 'cocotb._vendor' is absent from the `
packages` configuration.
  Package 'cocotb_tools.makefiles' is absent from the 
`
packages` configuration.
  Package 'cocotb_tools.makefiles.simulators' is absent from the 
`
packages` configuration.
  (and more)

Disable include_package_data explicitly and rely solely on the
package_data entries already in setup.py, which cover all files that
belong in the wheel.

This removes the following files from the wheel, saving ~200 KiB on
a Linux wheel.

```
 - cocotb/_vendor/README.md
 - cocotb/_vendor/fli/acc_user.h
 - cocotb/_vendor/fli/acc_vhdl.h
 - cocotb/_vendor/fli/mti.h
 - cocotb/_vendor/tcl/license.terms
 - cocotb/_vendor/tcl/tcl.h
 - cocotb/_vendor/tcl/tclDecls.h
 - cocotb/_vendor/tcl/tclPlatDecls.h
 - cocotb/_vendor/vhpi/vhpi_user.h
 - cocotb/_vendor/vpi/sv_vpi_user.h
 - cocotb/_vendor/vpi/vpi_compatibility.h
 - cocotb/_vendor/vpi/vpi_user.h
 - cocotb/share/lib/gpi/GpiCbHdl.cpp
 - cocotb/share/lib/gpi/GpiCommon.cpp
 - cocotb/share/lib/gpi/dynload.cpp
 - cocotb/share/lib/gpi/fli/FliCbHdl.cpp
 - cocotb/share/lib/gpi/fli/FliImpl.cpp
 - cocotb/share/lib/gpi/fli/FliImpl.hpp
 - cocotb/share/lib/gpi/fli/FliObjHdl.cpp
 - cocotb/share/lib/gpi/gpi_priv.hpp
 - cocotb/share/lib/gpi/logging.cpp
 - cocotb/share/lib/gpi/logging.hpp
 - cocotb/share/lib/gpi/vhpi/VhpiCbHdl.cpp
 - cocotb/share/lib/gpi/vhpi/VhpiImpl.cpp
 - cocotb/share/lib/gpi/vhpi/VhpiImpl.hpp
 - cocotb/share/lib/gpi/vhpi/VhpiIterator.cpp
 - cocotb/share/lib/gpi/vhpi/VhpiObj.cpp
 - cocotb/share/lib/gpi/vhpi/VhpiSignal.cpp
 - cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
 - cocotb/share/lib/gpi/vpi/VpiImpl.cpp
 - cocotb/share/lib/gpi/vpi/VpiImpl.hpp
 - cocotb/share/lib/gpi/vpi/VpiIterator.cpp
 - cocotb/share/lib/gpi/vpi/VpiObj.cpp
 - cocotb/share/lib/gpi/vpi/VpiSignal.cpp
 - cocotb/share/lib/pygpi/bind.cpp
 - cocotb/share/lib/pygpi/embed.cpp
 - cocotb/share/lib/pygpi/logging.cpp
 - cocotb/share/lib/pygpi/pygpi_priv.hpp
 - cocotb/share/lib/utils.hpp
```

```
$ /usr/bin/python3.12 -m build . --wheel --outdir=/tmp/built_wheel
...
/tmp/build-env-es0w0lmb/lib/python3.9/site-packages/setuptools/command/build_py.py:215: _Warning: Package 'cocotb._vendor' is absent from the 
`
packages` configuration.
!!

********************************************************************************
Python recognizes 'cocotb._vendor' as an importable package[^1],
but it is absent from setuptools' 
`
packages` configuration.

This leads to an ambiguous overall configuration. If you want to distribute this
package, please make sure that 'cocotb._vendor' is explicitly added
to the 
`
packages` configuration field.

Alternatively, you can also rely on setuptools' discovery methods
(for example by using 
`
find_namespace_packages(...)`/
`
find_namespace:`
instead of 
`
find_packages(...)`/
`
find:`).

You can read more about "package discovery" on setuptools documentation page:

- 
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

If you don't want 'cocotb._vendor' to be distributed and are
already explicitly excluding 'cocotb._vendor' via
`
find_namespace_packages(...)/find_namespace` or 
`
find_packages(...)/find`,
you can try to use 
`
exclude_package_data`, or 
`
include-package-data=False` in

    ********************************************************************************
    ############################
    # Package would be ignored #
    ############################
    Python recognizes 'cocotb_tools.makefiles' as an importable package[^1],
    but it is absent from setuptools' 
`
packages` configuration.

    This leads to an ambiguous overall configuration. If you want to distribute this
    package, please make sure that 'cocotb_tools.makefiles' is explicitly added
    to the 
`
packages` configuration field.

    Alternatively, you can also rely on setuptools' discovery methods
    (for example by using 
`
find_namespace_packages(...)`/
`
find_namespace:`
    instead of 
`
find_packages(...)`/
`
find:`).

    You can read more about "package discovery" on setuptools documentation page:

    - 
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

    If you don't want 'cocotb_tools.makefiles' to be distributed and are
    already explicitly excluding 'cocotb_tools.makefiles' via
    `
find_namespace_packages(...)/find_namespace` or 
`
find_packages(...)/find`,
    you can try to use 
`
exclude_package_data`, or 
`
include-package-data=False` in
    combination with a more fine grained 
`
package-data` configuration.

    You can read more about "package data files" on setuptools documentation page:

    - 
https://setuptools.pypa.io/en/latest/userguide/datafiles.html

    [^1]: For Python, any directory (with suitable naming) can be imported,
        even if it does not contain any `
.py` files.
        On the other hand, currently there is no concept of package data
        directory, all directories are treated like packages.
    ********************************************************************************
```


Actions run with fully passing release builds: https://github.com/cocotb/cocotb/actions/runs/26455778006?pr=5575