### PR TITLE
CI: Run extended tests on release builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,51 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Reusable workflow: build cocotb release artifacts (wheels + sdist).
+
+name: Build release artifacts
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: '["ubuntu-22.04", "windows-2022", "macos-15-intel", "macos-14"]'
+        description: >
+          JSON array of operating systems to build on.
+          Defaults to all supported platforms.
+
+jobs:
+  build_release:
+    name: Build distribution on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Keep going even if one matrix build fails.
+      matrix:
+        os: ${{ fromJSON(inputs.os) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      - name: Install nox
+        run: python3 -m pip install nox nox-uv
+
+      # Use the cibuildwheel configuration inside nox, instead of the
+      # cibuildwheel GitHub Action, to make the process easy to reproduce
+      # locally.
+      - name: Build cocotb release
+        run: |
+          nox -s release_clean
+          nox -s release_build
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cocotb-dist-${{ matrix.os }}
+          path: |
+            dist/*.whl
+            dist/*.tar.gz

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -23,6 +23,9 @@ on:
       - "stable/**"
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build_release:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -26,40 +26,8 @@ on:
 
 jobs:
   build_release:
-    name: Build distribution on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false # Keep going even if one matrix build fails.
-      matrix:
-        os:
-          - ubuntu-22.04
-          - windows-2022
-          - macos-15-intel  # x86_64
-          - macos-14        # ARM64
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
-      - name: Install nox
-        run: python3 -m pip install nox nox-uv
-
-      # Use the cibuildwheel configuration inside nox, instead of the
-      # cibuildwheel GitHub Action, to make the process easy to reproduce
-      # locally.
-      - name: Build cocotb release
-        run: |
-          nox -s release_clean
-          nox -s release_build
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: cocotb-dist-${{ matrix.os }}
-          path: |
-            dist/*.whl
-            dist/*.tar.gz
+    name: Build release artifacts
+    uses: ./.github/workflows/build-release.yml
 
   # This tests both the sdist and wheel builds in separate venvs back to back with just the pytest tests.
   test_release:

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -12,6 +12,9 @@ on:
     - cron: '0 2 * * 0'
   # Allow triggering a CI run from the web UI.
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build_release:

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -14,11 +14,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_dev:
+  build_release:
     if: github.repository == 'cocotb/cocotb'
+    name: Build release artifacts
+    uses: ./.github/workflows/build-release.yml
+    with:
+      # Extended tests only run on Ubuntu, we don't need builds for other
+      # platforms.
+      os: '["ubuntu-22.04"]'
+
+  test_release:
     name: Regression Tests
+    needs: build_release
     uses: ./.github/workflows/regression-tests.yml
     with:
-      test_task: dev_test
+      test_task: release_test
+      download_artifacts: true
       group: extended
       max_parallel: 5


### PR DESCRIPTION
This change avoids building the wheels as part of each test job,
speeding up the test progress. It also avoids problems we're having
with some commercial simulators which provide an outdated libstdc++ in
LD_LIBRARY_PATH, which then causes the build to fail.

- **CI: Factor out release build into shared workflow**
- **CI: Run extended tests on release builds**

Part of https://github.com/cocotb/cocotb/issues/4948