### PR TITLE
Add option to fail nox fast

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -172,7 +172,7 @@ def dev_test_sim(
     if "COCOTB_CI_SKIP_MAKE" not in os.environ:
         session.log(f"Running 'make test' against a simulator {config_str}")
         make_args = ["make"]
-        if "COCOTB_FAIL_FAST" not in os.environ:
+        if "COCOTB_CI_FAIL_FAST" not in os.environ:
             make_args.append("-k")
         make_args.append("test")
         session.run(*make_args, external=True, env=env)

--- a/noxfile.py
+++ b/noxfile.py
@@ -171,7 +171,11 @@ def dev_test_sim(
 
     if "COCOTB_CI_SKIP_MAKE" not in os.environ:
         session.log(f"Running 'make test' against a simulator {config_str}")
-        session.run("make", "-k", "test", external=True, env=env)
+        make_args = ["make"]
+        if "COCOTB_FAIL_FAST" not in os.environ:
+            make_args.append("-k")
+        make_args.append("test")
+        session.run(*make_args, external=True, env=env)
 
     # Run pytest for files which can only be tested in the source tree, not in
     # the installed binary (otherwise we get an "import file mismatch" error


### PR DESCRIPTION
It's not always easy to see which test failed because there are many ways this can go unreported.
