### PR TITLE
Remove PackedObject

### DIFF
--- a/docs/source/first_steps.rst
+++ b/docs/source/first_steps.rst
@@ -485,8 +485,8 @@ So if we modify the previous example to load ``250`` as the initial counter valu
                                                           File "cocotb/examples/first_steps/counter_tests.py", line 53, in test_self_checking
                                                             assert dut.count.value == expected_value
                                                         AssertionError: assert LogicArray('00000000', Range(7, 'downto', 0)) == 256
-                                                         +  where LogicArray('00000000', Range(7, 'downto', 0)) = PackedObject(counter.count).value
-                                                         +    where PackedObject(counter.count) = HierarchyObject(counter).count
+                                                         +  where LogicArray('00000000', Range(7, 'downto', 0)) = LogicArrayObject(counter.count).value
+                                                         +    where LogicArrayObject(counter.count) = HierarchyObject(counter).count
     91.00ns INFO     cocotb.regression                  ******************************************************************************************
                                                         ** TEST                              STATUS  SIM TIME (ns)  REAL TIME (s)  RATIO (ns/s) **
                                                         ******************************************************************************************

--- a/docs/source/newsfragments/5179.change.rst
+++ b/docs/source/newsfragments/5179.change.rst
@@ -1,1 +1,0 @@
-Verilog packed vectors, structs, and unions no longer map to :class:`~cocotb.handle.LogicArrayObject`, but :class:`~cocotb.handle.PackedObject`.

--- a/docs/source/newsfragments/5179.feature.1.rst
+++ b/docs/source/newsfragments/5179.feature.1.rst
@@ -1,1 +1,0 @@
-Added the :class:`~cocotb.handle.PackedObject` type for Verilog packed vectors, structs, and unions.

--- a/docs/source/newsfragments/5179.feature.rst
+++ b/docs/source/newsfragments/5179.feature.rst
@@ -1,1 +1,1 @@
-:class:`~cocotb.handle.LogicArrayObject` (VHDL arrays of ``logic`` and ``bit``) now support indexing single elements.
+:class:`~cocotb.handle.LogicArrayObject` now supports indexing single elements.

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -1254,8 +1254,9 @@ class LogicArrayObject(
 
     Inherits from :class:`SimHandleBase` and :class:`ValueObjectBase`.
 
-    Verilog packed vectors, structs, and unions do not map to this type, but :class:`PackedObject`.
-    Unpacked vectors of type ``logic`` and ``bit`` map to :class:`ArrayObject`.
+    Verilog types that map to this object:
+
+        * All packed arrays, structs, and unions
 
     VHDL types that map to this object:
 
@@ -1266,12 +1267,18 @@ class LogicArrayObject(
         * ``sfixed``
         * ``float``
 
-    .. versionchanged:: 2.1
-        Verilog packed objects no longer map to this type, but :class:`PackedObject`.
+    Individual bits may be accessed by index.
+    The result is a :class:`LogicObject`.
+    An :class:`IndexError` is raised if no bit exists at the given index.
+
+    .. code-block:: python
+
+        bit_0 = dut.my_vec[0]
     """
 
     def __init__(self, handle: cocotb.simulator.sim_obj, path: str | None) -> None:
         super().__init__(handle, path)
+        self._sub_handles: dict[int, SimHandleBase] = {}
 
     def _set_value(
         self,
@@ -1381,12 +1388,17 @@ class LogicArrayObject(
         # and this object needs to support multi-dimensional packed arrays.
         return self._handle.get_num_elems()
 
-    def __getitem__(self, index: int) -> LogicObject:
-        handle = self._handle.get_handle_by_index(index)
+    def __getitem__(self, key: int) -> LogicObject:
+        try:
+            return cast("LogicObject", self._sub_handles[key])
+        except KeyError:
+            pass
+        handle = self._handle.get_handle_by_index(key)
         if handle is None:
-            raise IndexError
-
-        return LogicObject(handle, self._path)
+            raise IndexError(f"{self._path} contains no object at index {key}")
+        sub = LogicObject(handle, f"{self._path}[{key}]")
+        self._sub_handles[key] = sub
+        return sub
 
     @cached_property
     def _min_val(self) -> int:
@@ -1415,26 +1427,6 @@ class LogicArrayObject(
         if self.is_const:
             raise TypeError("Can't get FallingEdge on immutable signal")
         return FallingEdge._make(self)
-
-
-class PackedObject(LogicArrayObject):
-    """A packed Verilog struct, union, or vector simulation object.
-
-    Verilog types that map to this object:
-
-        * packed any-dimensional vectors of ``logic`` or ``bit``.
-        * packed any-dimensional vectors of packed structures or unions.
-
-    .. versionadded:: 2.1
-    """
-
-    def __getitem__(self, _: object) -> NoReturn:
-        raise TypeError(
-            "Indexing into Verilog packed objects (arrays, structs, or unions) is not currently supported.\n"
-            "Try instead reading the whole value and slicing: `t = handle.value; t[0:3]`.\n"
-            "If you need to use an element in an Edge Trigger, consider making the array or struct unpacked.\n"
-            "Alternatively, use `ValueChange` on the whole object and check the bit(s) you care about for changes afterwards."
-        )
 
 
 class RealObject(_NonIndexableValueObjectBase[float, float]):
@@ -1762,7 +1754,6 @@ _ConcreteHandleTypes = Union[
     HierarchyArrayObject[SimHandleBase],
     LogicObject,
     LogicArrayObject,
-    PackedObject,
     ArrayObject[Any, ValueObjectBase[Any, Any]],
     RealObject,
     IntegerObject,
@@ -1782,7 +1773,6 @@ _type2cls: dict[int, type[_ConcreteHandleTypes]] = {
     cocotb.simulator.PACKED_STRUCTURE: LogicArrayObject,
     cocotb.simulator.LOGIC: LogicObject,
     cocotb.simulator.LOGIC_ARRAY: LogicArrayObject,
-    cocotb.simulator.PACKED_OBJECT: PackedObject,
     cocotb.simulator.NETARRAY: ArrayObject[Any, ValueObjectBase[Any, Any]],
     cocotb.simulator.REAL: RealObject,
     cocotb.simulator.INTEGER: IntegerObject,

--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -211,7 +211,6 @@ typedef enum gpi_objtype_e {
     GPI_PACKED_STRUCTURE = 14,
     GPI_LOGIC = 15,
     GPI_LOGIC_ARRAY = 16,
-    GPI_PACKED_OBJECT = 17,
 } gpi_objtype;
 
 /** Direction of range constraint of an object. */

--- a/src/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -35,7 +35,6 @@ const char *GpiObjHdl::get_type_str() {
         CASE_OPTION(GPI_PACKAGE);
         CASE_OPTION(GPI_LOGIC);
         CASE_OPTION(GPI_LOGIC_ARRAY);
-        CASE_OPTION(GPI_PACKED_OBJECT);
         default:
             ret = "unknown";
     }

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -90,7 +90,7 @@ static gpi_objtype to_gpi_objtype(int32_t vpitype, int num_elements = 0,
         case vpiPackedArrayVar:
         case vpiPackedArrayNet:
             if (is_vector || num_elements > 1) {
-                return GPI_PACKED_OBJECT;
+                return GPI_LOGIC_ARRAY;
             } else {
                 return GPI_LOGIC;
             }
@@ -165,7 +165,7 @@ static gpi_objtype const_type_to_gpi_objtype(int32_t const_type) {
         case vpiOctConst:
         case vpiHexConst:
         case vpiIntConst:
-            return GPI_PACKED_OBJECT;
+            return GPI_LOGIC_ARRAY;
         case vpiRealConst:
             return GPI_REAL;
         case vpiStringConst:
@@ -176,7 +176,7 @@ static gpi_objtype const_type_to_gpi_objtype(int32_t const_type) {
                 "Unable to map vpiConst type %d onto GPI type, "
                 "guessing this is a logic vector",
                 const_type);
-            return GPI_PACKED_OBJECT;
+            return GPI_LOGIC_ARRAY;
     }
 }
 

--- a/src/cocotb/share/lib/gpi/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiSignal.cpp
@@ -29,7 +29,7 @@ int VpiSignalObjHdl::initialise(const std::string &name,
             m_range_left = 0;
             m_range_right = m_num_elems - 1;
         } else if (GpiObjHdl::get_type() == GPI_LOGIC ||
-                   GpiObjHdl::get_type() == GPI_PACKED_OBJECT) {
+                   GpiObjHdl::get_type() == GPI_LOGIC_ARRAY) {
             vpiHandle hdl = GpiObjHdl::get_handle<vpiHandle>();
             m_indexable = vpi_get(vpiVector, hdl);
 

--- a/src/cocotb/share/lib/pygpi/bind.cpp
+++ b/src/cocotb/share/lib/pygpi/bind.cpp
@@ -1050,8 +1050,6 @@ static int add_module_constants(PyObject *simulator) {
         PyModule_AddIntConstant(simulator, "LOGIC", GPI_LOGIC) < 0 ||
         PyModule_AddIntConstant(simulator, "LOGIC_ARRAY", GPI_LOGIC_ARRAY) <
             0 ||
-        PyModule_AddIntConstant(simulator, "PACKED_OBJECT", GPI_PACKED_OBJECT) <
-            0 ||
         false) {
         return -1;
     }

--- a/src/cocotb/simulator.pyi
+++ b/src/cocotb/simulator.pyi
@@ -16,7 +16,6 @@ INTEGER: int
 LOADS: int
 LOGIC: int
 LOGIC_ARRAY: int
-PACKED_OBJECT: int
 MEMORY: int
 MODULE: int
 NETARRAY: int

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -439,12 +439,12 @@ async def type_check_verilog(dut):
     test_handles = [
         (dut.stream_in_ready, "GPI_LOGIC"),
         (dut.register_array, "GPI_ARRAY"),
-        (dut.temp, "GPI_PACKED_OBJECT"),
+        (dut.temp, "GPI_LOGIC_ARRAY"),
         (dut.logic_b, "GPI_LOGIC"),
         (dut.logic_c, "GPI_LOGIC"),
-        (dut.INT_PARAM, "GPI_PACKED_OBJECT"),
+        (dut.INT_PARAM, "GPI_LOGIC_ARRAY"),
         (dut.REAL_PARAM, "GPI_REAL"),
-        (dut.stream_in_data, "GPI_PACKED_OBJECT"),
+        (dut.stream_in_data, "GPI_LOGIC_ARRAY"),
         (dut.and_output, "GPI_LOGIC"),
         (dut.logic_a, "GPI_LOGIC"),
     ]
@@ -452,7 +452,7 @@ async def type_check_verilog(dut):
     # Verilator returns vpiReg rather than vpiNet
     # Verilator (correctly) treats parameters with implicit type, that are assigned a string literal value, as an unsigned integer. See IEEE 1800-2017 Section 5.9 and Section 6.20.2
     if SIM_NAME.startswith("verilator"):
-        test_handles.append((dut.STRING_PARAM, "GPI_PACKED_OBJECT"))
+        test_handles.append((dut.STRING_PARAM, "GPI_LOGIC_ARRAY"))
     else:
         test_handles.append((dut.STRING_PARAM, "GPI_STRING"))
 

--- a/tests/test_cases/test_logic_array_indexing/test_logic_array_indexing.py
+++ b/tests/test_cases/test_logic_array_indexing/test_logic_array_indexing.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
-import pytest
-
 import cocotb
-from cocotb.handle import LogicArrayObject, LogicObject, PackedObject
+from cocotb.handle import LogicArrayObject, LogicObject
 from cocotb.triggers import RisingEdge, Timer
 
 
@@ -31,16 +29,16 @@ SIM = cocotb.SIM_NAME.lower()
 )
 async def test_debug_array_verilog(dut: Any) -> None:
     inspect_signal(dut.test_a, "dut.test_a")
-    assert type(dut.test_a) is PackedObject
-
-    with pytest.raises(TypeError):
-        dut.test_a[0]
+    assert type(dut.test_a) is LogicArrayObject
+    inspect_signal(dut.test_a[0], "dut.test_a[0]")
+    assert type(dut.test_a[0]) is LogicObject
 
 
 @cocotb.test
 @cocotb.skipif(TOPLEVEL_LANG != "vhdl", reason="This test is only applicable to VHDL")
 @cocotb.xfail(
     SIM.startswith("ghdl"),
+    raises=IndexError,
     reason="GHDL uses VPI, which does not support array indexing",
 )
 async def test_debug_array_vhdl(dut: Any) -> None:
@@ -51,7 +49,7 @@ async def test_debug_array_vhdl(dut: Any) -> None:
     inspect_signal(dut.test_b, "dut.test_b")
     assert type(dut.test_b) is LogicArrayObject
 
-    inspect_signal(dut.test_a[0], "test_a[0]")
+    inspect_signal(dut.test_a[0], "dut.test_a[0]")
     assert type(dut.test_a[0]) is LogicObject
 
     handle = dut.test_a[0]

--- a/tests/test_cases/test_struct/test_struct.py
+++ b/tests/test_cases/test_struct/test_struct.py
@@ -22,10 +22,7 @@ LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
 )
 async def test_packed_struct_format(dut):
     """Test that the correct objects are returned for a struct"""
-    assert repr(dut.my_struct) in (
-        "LogicArrayObject(sample_module.my_struct)",
-        "PackedObject(sample_module.my_struct)",
-    )
+    assert repr(dut.my_struct) == "LogicArrayObject(sample_module.my_struct)"
 
     # Riviera-PRO initializes the struct with X, Verilator with 0, and others
     # with Z. Since we don't want to explicitly set dut.my_struct (write tests


### PR DESCRIPTION
Allow opportunistic indexing into packed objects again since we are dedicated to supporting that going forward.
