### PR TITLE
Improve simulator version parsing and from_command detection

### DIFF
--- a/docs/source/newsfragments/5581.feature.rst
+++ b/docs/source/newsfragments/5581.feature.rst
@@ -1,0 +1,1 @@
+Added simulator version constructors for ``cocotb.SIM_VERSION`` and command-line output, and improved comparison of simulator-specific version strings.

--- a/src/cocotb_tools/sim_versions.py
+++ b/src/cocotb_tools/sim_versions.py
@@ -16,6 +16,7 @@ These are for cocotb-internal use only.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 
 from cocotb_tools._vendor.distutils_version import LooseVersion
@@ -24,15 +25,116 @@ if sys.version_info >= (3, 11):
     from typing import Self
 
 
-class ActivehdlVersion(LooseVersion):
+def _first_line(cmdline: str) -> str:
+    output = cmdline.strip()
+    if not output:
+        raise ValueError("Unable to parse simulator version from empty output")
+    return output.splitlines()[0]
+
+
+def _first_version_token(cmdline: str) -> str:
+    firstline = _first_line(cmdline)
+    m = re.search(r"\d+(?:\.\d+[a-zA-Z]?)+(?:\.\d+)*", firstline)
+    if not m:
+        raise ValueError(f"Unable to parse simulator version from: {firstline}")
+    return m.group(0)
+
+
+def _run_version_command(command: tuple[str, ...]) -> str:
+    result = subprocess.run(
+        list(command),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return result.stdout
+
+
+class SimulatorVersion(LooseVersion):
+    """Base class for simulator-specific version constructors."""
+
+    _sim_command: tuple[str, ...] | None = None
+
+    def _cmp(self, other):
+        if isinstance(other, str):
+            other = self.__class__(other)
+        elif not isinstance(other, LooseVersion):
+            return NotImplemented
+
+        if self.version == other.version:
+            return 0
+        if self.version < other.version:
+            return -1
+        if self.version > other.version:
+            return 1
+
+    @classmethod
+    def from_commandline(cls, cmdline: str | None = None) -> Self:
+        """Construct from simulator command-line version output.
+
+        If *cmdline* is omitted, the simulator version command is executed.
+        """
+        if cmdline is None:
+            if cls._sim_command is None:
+                raise ValueError(f"{cls.__name__} does not define a version command")
+            cmdline = _run_version_command(cls._sim_command)
+        return cls(cls._extract_version_from_commandline(cmdline))
+
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        return _first_line(cmdline)
+
+    @classmethod
+    def from_sim_version(cls, sim_version: str | None = None) -> Self:
+        """Construct from ``cocotb.SIM_VERSION``.
+
+        If *sim_version* is omitted, ``cocotb.SIM_VERSION`` is read from the
+        active simulation.
+        """
+        if sim_version is None:
+            import cocotb  # noqa: PLC0415
+
+            sim_version = cocotb.SIM_VERSION
+        return cls(sim_version)
+
+
+class ActivehdlVersion(SimulatorVersion):
     """Version numbering class for Aldec Active-HDL.
 
-    NOTE: unsupported versions exist, e.g.
-    ActivehdlVersion("10.5a.12.6914") > ActivehdlVersion("10.5.216.6767")
+    Example:
+        >>> ActivehdlVersion("10.5a.12.6914") > ActivehdlVersion("10.5.216.6767")
+        True
     """
 
+    _sim_command = ("vsimsa", "-version")
 
-class CvcVersion(LooseVersion):
+    def parse(self, vstring):
+        self.vstring = vstring
+        version = []
+
+        for part in vstring.split("."):
+            match = re.fullmatch(r"(\d+)([a-zA-Z]?)", part)
+            if match is None:
+                super().parse(vstring)
+                return
+
+            version.append(int(match.group(1)))
+
+            suffix = match.group(2)
+            if suffix:
+                version.append(ord(suffix.lower()) - ord("a") + 1)
+            else:
+                version.append(0)
+
+        self.version = version
+
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        return _first_version_token(cmdline)
+
+
+class CvcVersion(SimulatorVersion):
     """Version numbering class for Tachyon DA CVC.
 
     Example:
@@ -42,12 +144,37 @@ class CvcVersion(LooseVersion):
         True
     """
 
+    _sim_command = ("cvc64", "-version")
 
-class GhdlVersion(LooseVersion):
+
+class GhdlVersion(SimulatorVersion):
     """Version numbering class for GHDL."""
 
+    _sim_command = ("ghdl", "--version")
 
-class IcarusVersion(LooseVersion):
+    def parse(self, vstring):
+        self.vstring = vstring
+        m = re.match(r"(\d+(?:\.\d+)*)(?:[- ](dev|devel)\b.*|.*)", vstring)
+        if not m:
+            super().parse(vstring)
+            return
+
+        version = [int(component) for component in m.group(1).split(".")]
+        while len(version) < 3:
+            version.append(0)
+        version.append(-1 if m.group(2) else 0)
+        self.version = version
+
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = _first_line(cmdline)
+        m = re.match(r"^GHDL\s+(\S+)", firstline, re.IGNORECASE)
+        if not m:
+            raise ValueError(f"Unable to parse GHDL version from: {firstline}")
+        return m.group(1)
+
+
+class IcarusVersion(SimulatorVersion):
     """Version numbering class for Icarus Verilog.
 
     Example:
@@ -57,23 +184,34 @@ class IcarusVersion(LooseVersion):
         True
     """
 
+    _sim_command = ("iverilog", "-V")
+
     @classmethod
-    def from_commandline(cls, cmdline: str) -> Self:
-        firstline = cmdline.split("\n", 1)[0]
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = _first_line(cmdline)
         m = re.match(r"^Icarus Verilog version (\d+\.\d+)", firstline)
         if not m:
             raise ValueError(
                 f"Unable to parse Icarus Verilog version from: {firstline}"
             )
-        version = m.group(1)
-        return cls(version)
+        return m.group(1)
 
 
-class ModelsimVersion(LooseVersion):
+class ModelsimVersion(SimulatorVersion):
     """Version numbering class for Mentor ModelSim."""
 
+    _sim_command = ("vsim", "-version")
 
-class QuestaVersion(LooseVersion):
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = _first_line(cmdline)
+        m = re.search(r"\bvsim\s+(\S+)", firstline, re.IGNORECASE)
+        if not m:
+            raise ValueError(f"Unable to parse ModelSim version from: {firstline}")
+        return m.group(1)
+
+
+class QuestaVersion(SimulatorVersion):
     """Version numbering class for Mentor Questa.
 
     Example:
@@ -86,6 +224,8 @@ class QuestaVersion(LooseVersion):
         >>> QuestaVersion("2023.1_2 2023.03") > QuestaVersion("2023.1_1")
         True
     """
+
+    _sim_command = ("vsim", "-version")
 
     def parse(self, vstring):
         # A Questa version string, as returned by the simulator, consists of two
@@ -100,8 +240,16 @@ class QuestaVersion(LooseVersion):
 
         super().parse(first_component)
 
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = _first_line(cmdline)
+        m = re.search(r"\bvsim\s+(\S+)", firstline, re.IGNORECASE)
+        if not m:
+            raise ValueError(f"Unable to parse Questa version from: {firstline}")
+        return m.group(1)
 
-class RivieraVersion(LooseVersion):
+
+class RivieraVersion(SimulatorVersion):
     """Version numbering class for Aldec Riviera-PRO.
 
     Example:
@@ -109,8 +257,14 @@ class RivieraVersion(LooseVersion):
         True
     """
 
+    _sim_command = ("vsimsa", "-version")
 
-class VcsVersion(LooseVersion):
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        return _first_version_token(cmdline)
+
+
+class VcsVersion(SimulatorVersion):
     """Version numbering class for Synopsys VCS.
 
     Example:
@@ -118,8 +272,28 @@ class VcsVersion(LooseVersion):
         True
     """
 
+    _sim_command = ("vcs", "-full64", "-version")
 
-class VerilatorVersion(LooseVersion):
+    def parse(self, vstring):
+        self.vstring = vstring
+        m = re.search(r"(\d{4})\.(\d{2})(?:-(\d+))?", vstring)
+        if not m:
+            super().parse(vstring)
+            return
+
+        year, month, patch = m.groups()
+        self.version = [int(year), int(month), int(patch or 0)]
+
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = _first_line(cmdline)
+        m = re.search(r"(?:[A-Z]-)?\d{4}\.\d{2}(?:-\d+)?(?:_Full\d+)?", firstline)
+        if not m:
+            raise ValueError(f"Unable to parse VCS version from: {firstline}")
+        return m.group(0)
+
+
+class VerilatorVersion(SimulatorVersion):
     """Version numbering class for Verilator.
 
     Example:
@@ -127,8 +301,10 @@ class VerilatorVersion(LooseVersion):
         True
     """
 
+    _sim_command = ("verilator", "--version")
+
     @classmethod
-    def from_commandline(cls, cmdline: str) -> Self:
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
         """Parse the output of ``verilator --version``.
 
         Example:
@@ -145,13 +321,13 @@ class VerilatorVersion(LooseVersion):
         Raises:
             AssertionError: If *cmdline* does not appear to be generated by Verilator.
         """
-        firstline = cmdline.split("\n", 1)[0]
+        firstline = _first_line(cmdline)
         sim, version, *version_extra = firstline.strip().split(" ")
         assert sim == "Verilator"
-        return cls(version)
+        return version
 
 
-class XceliumVersion(LooseVersion):
+class XceliumVersion(SimulatorVersion):
     """Version numbering class for Cadence Xcelium.
 
     Example:
@@ -160,6 +336,20 @@ class XceliumVersion(LooseVersion):
         >>> XceliumVersion("20.07-e501") > XceliumVersion("20.06-g183")
         True
     """
+
+    _sim_command = ("xrun", "--version")
+
+    @classmethod
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = _first_line(cmdline)
+        m = re.search(
+            r"(?:xrun[^:]*:\s*)?(\d+\.\d+-[a-z]\d+)",
+            firstline,
+            re.IGNORECASE,
+        )
+        if not m:
+            raise ValueError(f"Unable to parse Xcelium version from: {firstline}")
+        return m.group(1)
 
 
 class IusVersion(XceliumVersion):  # inherit everything from Xcelium
@@ -170,13 +360,17 @@ class IusVersion(XceliumVersion):  # inherit everything from Xcelium
         True
     """
 
+    _sim_command = ("irun", "-version")
 
-class NvcVersion(LooseVersion):
+
+class NvcVersion(SimulatorVersion):
     """Version numbering class for NVC."""
 
+    _sim_command = ("nvc", "--version")
+
     @classmethod
-    def from_commandline(cls, cmdline: str) -> Self:
-        firstline = cmdline.split("\n", 1)[0]
+    def _extract_version_from_commandline(cls, cmdline: str) -> str:
+        firstline = _first_line(cmdline)
         sim, version, *version_extra = firstline.strip().split(" ")
         assert sim == "nvc"
-        return cls(version)
+        return version

--- a/tests/pytest/test_sim_versions.py
+++ b/tests/pytest/test_sim_versions.py
@@ -1,0 +1,91 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from cocotb_tools import sim_versions
+from cocotb_tools.sim_versions import (
+    ActivehdlVersion,
+    GhdlVersion,
+    IcarusVersion,
+    ModelsimVersion,
+    NvcVersion,
+    QuestaVersion,
+    VcsVersion,
+    VerilatorVersion,
+    XceliumVersion,
+)
+
+
+def test_activehdl_letter_suffix_does_not_crash():
+    assert ActivehdlVersion("10.5a.12.6914") > ActivehdlVersion("10.5.216.6767")
+    assert ActivehdlVersion("10.5a.12.6914") > ActivehdlVersion("10.5.12.6914")
+
+
+def test_ghdl_dev_release_is_before_final_release():
+    assert GhdlVersion("2.0.0-dev") < GhdlVersion("2.0.0")
+    assert GhdlVersion("2.0.0-dev") < "2.0.0"
+    assert GhdlVersion("4.1.0 (v4.1.0) [Some edition]") > GhdlVersion("4.0.0")
+
+
+def test_icarus_from_commandline_parses_existing_output():
+    cmdline = "Icarus Verilog version 12.0 (stable)\n\nCopyright ..."
+    assert IcarusVersion.from_commandline(cmdline) == IcarusVersion("12.0")
+
+
+def test_verilator_from_commandline_parses_existing_output():
+    cmdline = "Verilator 5.041 devel rev v5.040-1-g4eb030717\n"
+    assert VerilatorVersion.from_commandline(cmdline) == VerilatorVersion("5.041")
+
+
+def test_modelsim_from_commandline_skips_arch_number():
+    cmdline = "Model Technology ModelSim-64 vsim 10.7c Compiler 2018.08\n"
+    assert ModelsimVersion.from_commandline(cmdline) == ModelsimVersion("10.7c")
+
+
+def test_questa_from_commandline_skips_arch_number():
+    cmdline = "QuestaSim-64 vsim 2023.1_2 Compiler 2023.03 Mar 13 2023\n"
+    assert QuestaVersion.from_commandline(cmdline) == QuestaVersion("2023.1_2")
+
+
+def test_xcelium_from_commandline_skips_xrun_prefix():
+    cmdline = "xrun(64): 24.03-s010 (Release candidate)\n"
+    assert XceliumVersion.from_commandline(cmdline) == XceliumVersion("24.03-s010")
+
+
+def test_vcs_from_commandline_parses_current_ci_style_version():
+    cmdline = "Synopsys VCS simulator X-2025.06_Full64\n"
+    assert VcsVersion.from_commandline(cmdline) == VcsVersion("X-2025.06_Full64")
+
+
+def test_vcs_mixed_format_ordering():
+    assert VcsVersion("2023.03_Full64") > VcsVersion("Q-2020.03-1_Full64")
+
+
+def test_empty_commandline_output_raises_valueerror():
+    with pytest.raises(ValueError, match="empty output"):
+        IcarusVersion.from_commandline("   ")
+
+
+def test_from_commandline_without_argument_runs_version_command(monkeypatch):
+    def run(cmd, **kwargs):
+        assert cmd == ["nvc", "--version"]
+        return SimpleNamespace(stdout="nvc 1.18.2\n")
+
+    monkeypatch.setattr(sim_versions.subprocess, "run", run)
+    assert NvcVersion.from_commandline() == NvcVersion("1.18.2")
+
+
+def test_from_sim_version_uses_explicit_string():
+    assert NvcVersion.from_sim_version("1.18.2") == NvcVersion("1.18.2")
+
+
+def test_from_sim_version_reads_cocotb_sim_version(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cocotb", SimpleNamespace(SIM_VERSION="1.18.2"))
+    assert NvcVersion.from_sim_version() == NvcVersion("1.18.2")


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
closes #5520