### PR TITLE
Dev Container updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,6 +41,12 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Install UV from the official uv container image.
 COPY --from=uv /uv /uvx /usr/local/bin/
 
+# In a Dev Container, the venv tends to be in the git repository, which is
+# mounted from the host and hence a different mount than the cache directory.
+# Avoid the warning about uv being unable to use hardlinks in such an
+# environment.
+ENV UV_LINK_MODE=copy
+
 # Install Verilator from official Verilator container image.
 COPY --from=verilator /usr/local/share/verilator /usr/local/share/verilator
 COPY --from=verilator /usr/local/bin/verilator* /usr/local/bin/

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-ARG VERILATOR_VERSION=5.044
-ARG UV_VERSION=0.10.2
+ARG VERILATOR_VERSION=5.048
+ARG UV_VERSION=0.11.16
 
 # Container images used only to copy binaries out of it (see below).
 FROM verilator/verilator:v${VERILATOR_VERSION} AS verilator
@@ -49,8 +49,8 @@ COPY --from=verilator /usr/local/share/pkgconfig/verilator.pc /usr/local/share/p
 
 # Install NVC from an upstream Debian package.
 # (Use apt instead of dpkg to resolve dependencies automatically.)
-ARG NVC_VERSION=1.18.2
-ARG NVC_SHA256=bb6f19a84a398e13c56649996262db63ed9787e19dd0ad894774e132e170b785
+ARG NVC_VERSION=1.21.0
+ARG NVC_SHA256=d2fc583c0b51b4784886b5180ed7edad3e02f8351add85286c080bfee7a9786d
 RUN mkdir -p /tmp/nvc-install \
     && curl -SLo /tmp/nvc-install/nvc.deb "https://github.com/nickg/nvc/releases/download/r${NVC_VERSION}/nvc_${NVC_VERSION}-1_amd64_ubuntu-24.04.deb" \
     && echo "${NVC_SHA256} /tmp/nvc-install/nvc.deb" | sha256sum --check \

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:3": {
+      "version": "3.0.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ca2508495b01ba29eba93e8153772a2daa65eaa86471cc6863fe2a3d21933df9",
+      "integrity": "sha256:ca2508495b01ba29eba93e8153772a2daa65eaa86471cc6863fe2a3d21933df9"
+    },
+    "ghcr.io/helpers4/devcontainer/shell-history-per-project:1": {
+      "version": "1.0.3",
+      "resolved": "ghcr.io/helpers4/devcontainer/shell-history-per-project@sha256:c9610a8426b9f1ee92a668d3a429077f49105fd60550fab1c8b1c853183fca48",
+      "integrity": "sha256:c9610a8426b9f1ee92a668d3a429077f49105fd60550fab1c8b1c853183fca48"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,9 +29,9 @@
 			"extensions": [
 				"github.vscode-github-actions",
 				"llvm-vs-code-extensions.vscode-clangd",
+				"lramseyer.vaporview",
 				"ms-python.python",
-				"ms-python.vscode-pylance",
-				"lramseyer.vaporview"
+				"ms-python.vscode-pylance"
 			],
 			"settings": {
 				"tasks": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,19 @@
 	"postCreateCommand": ".devcontainer/post-create.sh",
 	"postAttachCommand": "less .devcontainer/README.md",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:3": {}
+		"ghcr.io/devcontainers/features/docker-in-docker:3": {},
+		"ghcr.io/helpers4/devcontainer/shell-history-per-project:1": {
+			"historyDirectory": "/workspaces/.shell-history"
+		}
 	},
+	"mounts": [
+		{
+			// Persist shell history across container rebuilds.
+			"source": "${devcontainerId}-shellhistory",
+			"target": "/workspaces/.shell-history",
+			"type": "volume"
+		}
+	],
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"github.vscode-github-actions",
 				"llvm-vs-code-extensions.vscode-clangd",
 				"ms-python.python",
 				"ms-python.vscode-pylance",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,9 @@
 			"type": "volume"
 		}
 	],
+	"remoteEnv": {
+		"PATH": "/usr/lib/ccache:${containerEnv:PATH}"
+	},
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,9 @@
 	},
 	"postCreateCommand": ".devcontainer/post-create.sh",
 	"postAttachCommand": "less .devcontainer/README.md",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:3": {}
+	},
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,12 +2,11 @@
 set -eo pipefail
 
 # Create and activate a virtual environment.
-python3 -m venv --prompt cocotb-devenv .venv
+uv venv --allow-existing --prompt cocotb-devenv .venv
 . .venv/bin/activate
 
-# Install prerequisites and development tools.
-pre-commit install
-pip3 install nox pytest
+# Install development dependencies and build cocotb.
+bear -- uv sync --dev
 
-# Install cocotb in editable mode.
-bear -- pip3 install -e .
+# Install prerequisites and development tools.
+prek install --overwrite

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -75,12 +75,12 @@ jobs:
         # A fetch depth of 2 provides enough information without fetching the entire history.
         fetch-depth: 2
 
-    - name: setup ccache
+    - name: Setup ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       if: (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')) && matrix.sim == 'verilator'
       with:
         key: ${{ matrix.os }}-${{matrix.cc || 'gcc'}}
-    - name: setup ccache path
+    - name: Setup ccache path
       if: (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')) && matrix.sim == 'verilator'
       run: |
         echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
@@ -89,8 +89,8 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get update
 
-     # Download distribution artifacts (if any).
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+    - name: Download distribution artifacts (if any).
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       if: ${{ inputs.download_artifacts }}
       with:
         path: dist
@@ -120,13 +120,13 @@ jobs:
           gperf
           mingw-w64-x86_64-toolchain
 
-      # Install
-    - name: Install XML-dependencies for Python 3.14
+    - name: Install XML dependencies for Python 3.14
       if: startsWith(matrix.python-version, '3.14') && startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get install -y --no-install-recommends libxml2-dev libxslt-dev
-      # Run tests that don't need a simulator.
+
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
     - name: Install Python testing dependencies
       run: |
         pip install nox nox-uv


### PR DESCRIPTION
Various updates to the Dev Container to use the new uv-based development environment, enable new use cases (e.g., run cibuildwheel), and update the tools used in the Dev Container.

I'm reasonably happy with this setup now, I'll give it another week or so and then add docs on using it locally and in Codespaces.

(I also sneaked in a commit to clean up small stuff in regression-tests.yml while I was at it.)

- **Dev Container: update dependencies**
- **Dev Container: Use uv**
- **Dev Container: Add docker-in-docker for cibuildwheel**
- **Dev Container: update Dev Container features with dependabot**
- **Dev Container: Retain shell history**
- **Dev Container: Enable ccache**
- **Dev Container: install GitHub Actions extension**
- **Dev Container: Sort extensions (cleanup)**
- **Dev Container: Commit lock file**
- **Cleanups to regression-tests.yml**
