### PR TITLE
WIP: Dev Container: Speed up doc preview

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,7 @@
 							"type": "shell",
 							// Run the docs_preview nox session with the virtual environment's Python
 							// (if it exists).
-							"command": "PATH=.venv/bin:$PATH nox -s docs_preview",
+							"command": "PATH=.venv/bin:$PATH nox -s docs_preview --no-venv",
 							"isBackground": true
 						}
 					]

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,8 +5,9 @@ set -eo pipefail
 uv venv --allow-existing --prompt cocotb-devenv .venv
 . .venv/bin/activate
 
-# Install development dependencies and build cocotb.
-bear -- uv sync --dev
+# Install development dependencies (including the ones needed to build a
+# documentation preview) and build cocotb.
+bear -- uv sync --dev --group docs_preview
 
 # Install prerequisites and development tools.
 prek install --overwrite


### PR DESCRIPTION
Reuse the venv created by uv in the project directory to avoid having to rebuild cocotb when running the docs_preview nox session.

Waiting for https://github.com/dantebben/nox-uv/pull/94 to be merged and released.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
