### PR TITLE
feat(pytest-plugin-v2): 1/N: add plugin options, dut fixture, markers

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -250,13 +250,24 @@ def dev_test_sim(
         "pytest",
         "-s",
         "-v",
-        "tests/pytest_plugin",
+        "-p",
+        "pytester",
+        "-p",
+        "cocotb_tools.pytest.plugin",
+        "-m",
+        "simulator_required",
         "--cocotb-simulator",
         sim,
         "--cocotb-gpi-interfaces",
         gpi_interface,
         "--cocotb-toplevel-lang",
         toplevel_lang,
+        # TODO: For now, we need to explicitly list test files because other plugin tests are broken
+        "tests/pytest_plugin/test_simulator.py",
+        "tests/pytest_plugin/test_plugin.py",
+        "tests/pytest_plugin/test_option.py",
+        "tests/pytest_plugin/test_mark.py",
+        "tests/pytest_plugin/test_dut.py",
         env=env,
     )
 
@@ -299,6 +310,26 @@ def dev_test_nosim(session: nox.Session) -> None:
         "--cov-report=",
         "-k",
         "not simulator_required",
+    )
+
+    # Run pytest with the default configuration in setup.cfg.
+    session.log("Running simulator-agnostic plugin tests with pytest")
+    session.run(
+        "pytest",
+        "-s",
+        "-v",
+        "-p",
+        "pytester",
+        "-p",
+        "cocotb_tools.pytest.plugin",
+        "-m",
+        "not simulator_required",
+        # TODO: For now, we need to explicitly list test files because other plugin tests are broken
+        "tests/pytest_plugin/test_simulator.py",
+        "tests/pytest_plugin/test_plugin.py",
+        "tests/pytest_plugin/test_option.py",
+        "tests/pytest_plugin/test_mark.py",
+        "tests/pytest_plugin/test_dut.py",
     )
 
     session.log("All tests passed!")

--- a/src/cocotb_tools/pytest/__init__.py
+++ b/src/cocotb_tools/pytest/__init__.py
@@ -1,0 +1,6 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# TODO: We don't want the __init__.py file here but it is still needed.
+# The pytest plugin module will be not installed without it.

--- a/src/cocotb_tools/pytest/_option.py
+++ b/src/cocotb_tools/pytest/_option.py
@@ -1,0 +1,166 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Handling of pytest plugin options.
+
+Option precedence (from highest to lowest):
+
+1. Command-line argument ``--cocotb-*`` when invoking the ``pytest`` command.
+2. Configuration entry ``cocotb_*`` defined in a pytest configuration file (e.g., ``pyproject.toml``).
+3. Environment variable ``COCOTB_*``.
+4. Default option value.
+"""
+
+from __future__ import annotations
+
+import shlex
+import textwrap
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+from pytest import Config, OptionGroup
+
+from cocotb_tools import _env
+
+#: See https://docs.pytest.org/en/stable/reference/reference.html#pytest.Parser.addini
+IniType = Literal[
+    "string",
+    "paths",
+    "pathlist",
+    "args",
+    "linelist",
+    "bool",
+    "int",
+    "float",
+]
+
+
+class Option:
+    """Representation of a single cocotb option.
+
+    An option can be configured via a configuration file (e.g., ``pyproject.toml``), an environment variable, or a command-line argument.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        default: Any = None,
+        default_in_help: object = None,
+        **kwargs: Any,
+    ) -> None:
+        """Create a new instance of a plugin option.
+
+        Args:
+            name: The name of the option.
+            description: A description of the option for help messages.
+            default: The default value for the option.
+            default_in_help: A custom string to display in the help message instead of the default value.
+            **kwargs: Additional keyword arguments passed directly to the :meth:`argparse.ArgumentParser.add_argument` method.
+        """
+        self.name: str = name
+        self.kwargs: Mapping[str, Any] = kwargs
+        self.default: Any = default
+        self.default_in_help: object = default_in_help
+        self.description: str = description
+
+    def add_to_group(self, group: OptionGroup) -> None:
+        """Add the plugin option to the pytest options parser.
+
+        Args:
+            group: The pytest OptionGroup to which this option will be added.
+        """
+        kind: object = self.kwargs.get("type")
+        nargs: int | str | None = self.kwargs.get("nargs")
+        action: str | None = self.kwargs.get("action")
+        default: Any = self.default
+        choices: Iterable[object] | None = self.kwargs.get("choices")
+        argument: str = self.argument
+        environment: str = self.environment
+
+        ini_type: IniType
+
+        # Map command line argument to option in configuration file
+        # Environment variable set by user can override default value for option
+        if action == "store_true":
+            default = _env.as_bool(environment, default)
+            ini_type = "bool"
+        elif nargs and nargs != "?":
+            default = _env.as_list(environment, default)
+
+            if kind is Path:
+                ini_type = "paths"
+                default = [Path(value) for value in default]
+            else:
+                ini_type = "args"
+        elif kind is int:
+            default = _env.as_int(environment, default)
+            ini_type = "int"
+        elif kind is Path:
+            default = Path(_env.as_str(environment, default))
+            ini_type = "string"
+        elif kind is shlex.split:
+            default = _env.as_args(environment, default)
+            ini_type = "args"
+        elif choices:
+            default = _env.as_str(environment, default).lower()
+            ini_type = "string"
+
+            if default and default not in choices:
+                raise ValueError(
+                    f"Invalid value '{default}' for environment variable {environment}. "
+                    f"Expecting one of {(*choices,)}"
+                )
+        else:
+            default = _env.as_str(environment, default)
+            ini_type = "string"
+
+        group.addoption(argument, help=self.help, **self.kwargs)
+
+        if group.parser:
+            group.parser.addini(
+                name=self.name,
+                type=ini_type,
+                help=f"Default value for {argument}",
+                default=default,
+            )
+
+    @property
+    def environment(self) -> str:
+        """The name of the environment variable associated with the option."""
+        return self.name.upper()
+
+    @property
+    def argument(self) -> str:
+        """The name of the command-line argument associated with the option."""
+        return f"--{self.name.replace('_', '-')}"
+
+    @property
+    def help(self) -> str:
+        """The formatted help text for the option."""
+        entries: list[str] = [
+            textwrap.dedent(self.description),
+            f"Configuration option: ``{self.name}``",
+            f"Environment variable: :envvar:`{self.environment}`",
+        ]
+
+        if self.default_in_help:
+            entries.append(f"Default value: {self.default_in_help}")
+
+        elif self.default or isinstance(self.default, int):
+            entries.append(f"Default value: ``{self.default}``")
+
+        return "\n\n".join(entries)
+
+
+def populate_ini_options(config: Config, options: Iterable[Option]) -> None:
+    """Populate INI options to :attr:`pytest.Config.option`."""
+    for option in options:
+        name: str = option.name
+        value: Any = config.getoption(name)
+
+        # Get option value from pytest configuration file or environment variable
+        if value is None or value is False:
+            setattr(config.option, name, config.getini(name))

--- a/src/cocotb_tools/pytest/_simulator.py
+++ b/src/cocotb_tools/pytest/_simulator.py
@@ -1,0 +1,148 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Functions for detecting and managing HDL simulators in the system."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from shutil import which
+
+from cocotb_tools.runner import (
+    SUPPORTED_RUNNERS,
+    VHDL,
+    PathLike,
+    Runner,
+    VerilatorControlFile,
+    Verilog,
+)
+
+#: Map name of HDL simulator to name of executable used by that HDL simulator.
+#: If HDL simulator is not present in this dictionary, it means that name of HDL simulator == name of executable.
+_SIMULATOR_TO_TOOL: dict[str, str] = {
+    "icarus": "iverilog",
+    "xcelium": "xrun",
+    "questa": "vsim",
+    "riviera": "vsimsa",
+}
+
+#: Map file extension suffix to language.
+_SUFFIX_TO_LANGUAGE: dict[str, str] = {
+    ".v": "verilog",
+    ".sv": "verilog",
+    ".vhd": "vhdl",
+    ".vhdl": "vhdl",
+}
+
+
+def detect_language(
+    source: PathLike | VHDL | Verilog | VerilatorControlFile,
+) -> str | None:
+    """Detect the hardware description language of the provided source file.
+
+    Args:
+        source: The source file path.
+
+    Returns:
+        ``"verilog"`` if the source file is Verilog or SystemVerilog,
+        ``"vhdl"`` if the source file is VHDL,
+        or :data:`None` if the language cannot be determined.
+    """
+    if isinstance(source, Verilog):
+        return "verilog"
+
+    if isinstance(source, VHDL):
+        return "vhdl"
+
+    if not isinstance(source, Path):
+        source = Path(str(source))
+
+    return _SUFFIX_TO_LANGUAGE.get(source.suffix)
+
+
+def detect_languages(
+    sources: Iterable[PathLike | VHDL | Verilog | VerilatorControlFile],
+) -> set[str]:
+    """Detect all hardware description languages from the provided list of source files.
+
+    Args:
+        sources: An iterable of source files.
+
+    Returns:
+        A set of detected language strings (e.g., ``{"verilog", "vhdl"}``).
+    """
+    return set(filter(None, map(detect_language, sources)))
+
+
+def get_supported_languages(simulator: str | None) -> list[str]:
+    """Get list of supported languages by the HDL simulator.
+
+    Args:
+        simulator: Name of the HDL simulator.
+
+    Returns:
+        List of supported languages by the HDL simulator.
+    """
+    if not simulator:
+        return []
+
+    runner: type[Runner] | None = SUPPORTED_RUNNERS.get(simulator)
+
+    return list(runner.supported_gpi_interfaces) if runner else []
+
+
+def are_languages_supported(
+    simulator: str | None, languages: Iterable[str] | str | None
+) -> bool:
+    """Check if the provided languages are supported by the HDL simulator.
+
+    Args:
+        simulator: Name of the HDL simulator.
+        languages: A list or single string of languages (e.g., ``"verilog"``, ``"vhdl"``) to check.
+
+    Returns:
+        :data:`True` if all specified languages are supported by the HDL simulator; otherwise, :data:`False`.
+    """
+    if not languages or languages == "auto":
+        return True
+
+    supported_languages: list[str] = get_supported_languages(simulator)
+
+    if isinstance(languages, str):
+        return languages in supported_languages
+
+    for language in languages:
+        if language not in supported_languages:
+            return False
+
+    return True
+
+
+def is_simulator_available(name: str) -> bool:
+    """Check if the specified HDL simulator is available in the system ``PATH``.
+
+    Args:
+        name: The name of the HDL simulator to check.
+
+    Returns:
+        :data:`True` if the simulator's executable is found; otherwise, :data:`False`.
+    """
+    return which(_SIMULATOR_TO_TOOL.get(name, name)) is not None
+
+
+def find_simulator(languages: Iterable[str] | str | None = None) -> str | None:
+    """Find the most suitable HDL simulator in the current environment that supports the requested languages.
+
+    Args:
+        languages: The required language(s) that the simulator must support.
+
+    Returns:
+        The name of the detected simulator if found; otherwise, :data:`None`.
+    """
+    for name in SUPPORTED_RUNNERS:
+        if are_languages_supported(name, languages) and is_simulator_available(name):
+            return name
+
+    return None

--- a/src/cocotb_tools/pytest/dut.py
+++ b/src/cocotb_tools/pytest/dut.py
@@ -1,0 +1,434 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Design Under Test (DUT) representation and configuration management."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from collections.abc import Sequence
+from hashlib import md5
+from pathlib import Path
+from typing import Any, Callable
+
+from pytest import Config, FixtureRequest, Mark, Module
+
+from cocotb_tools.pytest._simulator import (
+    detect_language,
+    detect_languages,
+    find_simulator,
+    get_supported_languages,
+)
+from cocotb_tools.runner import (
+    VHDL,
+    PathLike,
+    VerilatorControlFile,
+    Verilog,
+)
+
+#: Exclude these attributes when generating unique DUT identifier
+_EXCLUDE_FROM_ID: tuple[str, ...] = (
+    "test_modules",
+    "random_seed",
+    "build_dir",
+    "work_dir",
+    "id",
+)
+
+
+class Dut:
+    """Representation of a Design Under Test (DUT).
+
+    This class holds the configuration and state required to compile, elaborate,
+    and run an HDL module using an HDL simulator and cocotb tests.
+
+    Example:
+        To customize a DUT in a test module or fixture:
+
+        .. code-block:: python
+
+            import pytest
+            from pathlib import Path
+            from cocotb_tools.pytest.dut import Dut
+
+            DIR = Path(__file__).parent.resolve()
+
+
+            @pytest.fixture
+            def my_module(dut: Dut) -> Dut:
+                dut.sources += [DIR / "rtl" / "my_design.v"]
+                dut["WIDTH"] = 16
+
+                return dut
+    """
+
+    def __init__(self, request: FixtureRequest) -> None:
+        """Initialize a new instance of DUT (Design Under Test).
+
+        Args:
+            request: The pytest fixture request object containing configuration and context.
+        """
+        config: Config = request.config
+        option: Namespace = config.option
+
+        self._run: Callable[..., None] = request.config.hook.pytest_cocotb_dut_run
+        self._simulator: str | None
+        self.simulator = option.cocotb_simulator
+
+        # Build options
+        self._defines: dict[str, object]
+        self.defines = option.cocotb_defines
+
+        self._parameters: dict[str, object]
+        self.parameters = option.cocotb_parameters
+
+        self._timescale: tuple[str, str] | None
+        self.timescale = option.cocotb_timescale
+
+        self.library: str = option.cocotb_library
+        """The library name to compile into."""
+
+        self.sources: list[PathLike | VHDL | Verilog | VerilatorControlFile] = (
+            option.cocotb_sources.copy()
+        )
+        """Language-agnostic list of source files to build."""
+
+        self.includes: list[PathLike] = option.cocotb_includes.copy()
+        """Verilog include directories."""
+
+        self.build_args: list[str | VHDL | Verilog] = option.cocotb_build_args.copy()
+        """A list of extra build arguments for the simulator."""
+
+        self._toplevel: str | None = None
+        """Name of the HDL toplevel module."""
+
+        self.always: bool = option.cocotb_always
+        """Always run the build step."""
+
+        self.clean: bool = option.cocotb_clean
+        """Delete *build_dir* before building."""
+
+        self.verbose: bool = option.cocotb_verbose
+        """Enable verbose messages."""
+
+        self.waves: bool = option.cocotb_waves
+        """Record signal traces."""
+
+        self.build_dir: PathLike = option.cocotb_build_dir
+        """Directory to run the build step in."""
+
+        # Test options
+        self._env: dict[str, object]
+        self.env = option.cocotb_env
+
+        self.test_modules: list[str] = []
+        """The name of the Python module(s) with cocotb test(s) to run."""
+
+        self.toplevel_library: str = option.cocotb_toplevel_library
+        """The library name for HDL toplevel module."""
+
+        self._toplevel_lang: str = option.cocotb_toplevel_lang
+        """Language of the HDL toplevel module."""
+
+        self.gpi_interfaces: list[str] = option.cocotb_gpi_interfaces.copy()
+        """List of GPI interfaces to use, with the first one being the entry point."""
+
+        self.random_seed: int = option.cocotb_random_seed
+        """A specific random seed to use."""
+
+        self.elab_args: list[str] = option.cocotb_elab_args.copy()
+        """A list of extra elaboration arguments for the simulator."""
+
+        self.sim_args: list[str] = option.cocotb_sim_args.copy()
+        """A list of extra simulation arguments for the simulator."""
+
+        self.plusargs: list[str] = option.cocotb_plusargs.copy()
+        """'plusargs' to set for the simulator."""
+
+        self.gui: bool = option.cocotb_gui
+        """Run with simulator GUI."""
+
+        self.pre_cmd: list[str] = option.cocotb_pre_cmd.copy()
+        """Commands to run before simulation begins. Typically Tcl commands for simulators that support them."""
+
+        self.test_filter: str = option.cocotb_test_filter
+        """Regular expression which matches test names."""
+
+        self._apply_markers(request.node)
+
+        if not Path(self.build_dir).is_absolute():
+            self.build_dir = request.config.invocation_params.dir / self.build_dir
+
+        if not self.test_modules:
+            module: Module | None = request.node.getparent(Module)
+
+            if module:
+                self.test_modules.append(module.getmodpath(includemodule=True))
+
+    @classmethod
+    def create(cls, request: FixtureRequest) -> Dut:
+        """Create a new instance of DUT (Design Under Test) via the pytest hooks.
+
+        Args:
+            request: The pytest fixture request.
+
+        Returns:
+            The created Dut instance.
+        """
+        return request.config.hook.pytest_cocotb_dut_create(request=request)
+
+    def run(self) -> None:
+        """Compile, elaborate, and run the HDL module using the HDL simulator and cocotb tests."""
+        __tracebackhide__ = True  # Hide the traceback when using PyTest.
+
+        self._run(dut=self)
+
+    @property
+    def simulator(self) -> str | None:
+        """The name of the HDL simulator."""
+        if self._simulator and self._simulator != "auto":
+            return self._simulator
+
+        return find_simulator(
+            languages=detect_languages(self.sources) or self._toplevel_lang
+        )
+
+    @simulator.setter
+    def simulator(self, simulator: str | None) -> None:
+        self._simulator = simulator
+
+    @property
+    def toplevel(self) -> str | None:
+        """The name of the HDL toplevel module.
+
+        If the toplevel module name is not set explicitly, it is inferred from:
+
+        * The filename of the last source file in the :attr:`cocotb_tools.pytest.dut.Dut.sources` attribute, excluding the file extension.
+        * The name of the first Python test module in the :attr:`cocotb_tools.pytest.dut.Dut.test_modules` attribute, excluding the standard pytest ``test_`` prefix or ``_test`` suffix.
+
+        Returns:
+            The toplevel module name, or :data:`None` if it cannot be determined.
+        """
+        if self._toplevel:
+            return self._toplevel
+
+        if self.sources:
+            source = self.sources[-1]
+
+            if isinstance(source, (Verilog, VHDL, VerilatorControlFile)):
+                source = source.value
+
+            if not isinstance(source, Path):
+                source = Path(str(source))
+
+            # In case when filename will contain more dots... Example: <name>.e.vhd
+            return source.name.partition(".")[0]
+
+        if not self.test_modules:
+            return None
+
+        # Pick the first test module
+        # ["tests.test_dut", "tests.test_extra"] -> test_dut
+        test_module: str = self.test_modules[0].rpartition(".")[2]
+
+        if test_module.startswith("test_"):
+            return test_module.removeprefix("test_")
+
+        if test_module.endswith("_test"):
+            return test_module.removesuffix("_test")
+
+        return test_module
+
+    @toplevel.setter
+    def toplevel(self, toplevel: str | None) -> None:
+        self._toplevel = toplevel
+
+    @property
+    def toplevel_lang(self) -> str | None:
+        """The language of the HDL toplevel module.
+
+        If the language is not set explicitly, it is inferred from:
+
+        * The file type or file extension of the last added source file in the :attr:`cocotb_tools.pytest.dut.Dut.sources` attribute.
+
+        Returns:
+            The language string, or :data:`None` if it cannot be determined.
+        """
+        if self._toplevel_lang and self._toplevel_lang != "auto":
+            return self._toplevel_lang
+
+        if self.sources:
+            return detect_language(self.sources[-1])
+
+        supported_languages: list[str] = get_supported_languages(self.simulator)
+
+        # Pick the first supported language
+        return supported_languages[0] if supported_languages else None
+
+    @toplevel_lang.setter
+    def toplevel_lang(self, toplevel_lang: str) -> None:
+        self._toplevel_lang = toplevel_lang
+
+    @property
+    def timescale(self) -> tuple[str, str] | None:
+        """A tuple containing the time unit and time precision for the simulation."""
+        return self._timescale
+
+    @timescale.setter
+    def timescale(self, timescale: str | tuple[str, str] | None) -> None:
+        time_unit: str = ""
+        time_precision: str = ""
+
+        if isinstance(timescale, str):
+            time_unit, _, time_precision = timescale.partition("/")
+
+        elif isinstance(timescale, tuple) and len(timescale) == 2:
+            time_unit, time_precision = timescale
+
+        time_unit = time_unit.strip()
+        time_precision = time_precision.strip()
+
+        self._timescale = (
+            (time_unit, time_precision or time_unit) if time_unit else None
+        )
+
+    @property
+    def parameters(self) -> dict[str, object]:
+        """A dictionary of Verilog parameters or VHDL generics."""
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters: Sequence[str] | dict[str, object]) -> None:
+        if isinstance(parameters, Sequence):
+            self._parameters = {}
+            self._update_dict_with_list(self._parameters, parameters)
+        else:
+            self._parameters = parameters
+
+    @property
+    def defines(self) -> dict[str, object]:
+        """A dictionary of preprocessor defines to set."""
+        return self._defines
+
+    @defines.setter
+    def defines(self, defines: Sequence[str] | dict[str, object]) -> None:
+        if isinstance(defines, Sequence):
+            self._defines = {}
+            self._update_dict_with_list(self._defines, defines)
+        else:
+            self._defines = defines
+
+    @property
+    def env(self) -> dict[str, object]:
+        """A dictionary of extra environment variables to set for the simulation."""
+        return self._env
+
+    @env.setter
+    def env(self, env: Sequence[str] | dict[str, object]) -> None:
+        if isinstance(env, Sequence):
+            self._env = {}
+            self._update_dict_with_list(self._env, env)
+        else:
+            self._env = env
+
+    @property
+    def id(self) -> str:
+        """A unique DUT identifier based on the current build and run configuration of the Dut instance.
+
+        It is used to group cocotb tests that run sequentially within the same HDL simulation process.
+        This identifier is also used as a group name when distributing tests across multiple CPUs
+        using the `pytest-xdist`_ plugin.
+
+        .. _pytest-xdist: https://pytest-xdist.readthedocs.io/en/stable/distribution.html#running-tests-across-multiple-cpus
+        """
+        hashed = md5()
+
+        for name in dir(self):
+            if not name.startswith("_") and name not in _EXCLUDE_FROM_ID:
+                attr = getattr(self, name)
+
+                if not callable(attr):
+                    hashed.update(str(attr).encode("utf-8"))
+
+        return hashed.hexdigest()
+
+    @property
+    def work_dir(self) -> Path:
+        """The absolute path to the unique work directory from which the DUT is compiled, elaborated, and run.
+
+        Schema:
+
+        .. code:: text
+
+           <dut.build_dir>/<dut.toplevel_library>/<dut.toplevel>/<dut.parameters>/<dut.id>
+
+        Example:
+
+        .. code:: text
+
+           build_sim/top/alu/WIDTH_8/d75117a510e1020e864f36822f96eeb8b9427534
+        """
+        parameters: str = (
+            "_".join(f"{k}_{v}" for k, v in self.parameters.items()).strip("_")
+            or "default"
+        )
+
+        return (
+            Path(self.build_dir).resolve()
+            / self.toplevel_library
+            / str(self.toplevel)
+            / parameters
+            / self.id
+        )
+
+    def __setitem__(self, key: str, value: object) -> None:
+        """Set an HDL parameter or VHDL generic value in the design configuration."""
+        self.parameters[key] = value
+
+    def __getitem__(self, key: str) -> object:
+        """Get the configured value of an HDL parameter or VHDL generic."""
+        return self.parameters[key]
+
+    def _apply_markers(self, node: Any) -> None:
+        """Apply all cocotb markers starting from the root (session) to the leaf (test function).
+
+        * Markers with positional arguments are extending targeted attribute.
+        * Markers with named arguments are updating targeted attribute.
+
+        Args:
+            node: The pytest node (session, package, module, class, function, ...).
+        """
+        for marker in reversed(list(node.iter_markers())):
+            self._apply_marker(marker)
+
+    def _apply_marker(self, marker: Mark) -> None:
+        """Apply cocotb marker directly on DUT instance."""
+        name: str = marker.name
+
+        if not name.startswith("cocotb_"):
+            return
+
+        name = name.removeprefix("cocotb_")
+
+        if not name or name[0] == "_" or not hasattr(self, name):
+            return
+
+        attr: Any = getattr(self, name)
+
+        if isinstance(attr, dict):
+            attr.update(marker.kwargs)
+            self._update_dict_with_list(attr, marker.args)
+        elif isinstance(attr, list):
+            attr.extend(marker.args)
+        elif isinstance(attr, bool):
+            setattr(self, name, bool(marker.args[0]) if marker.args else True)
+        elif marker.args:
+            setattr(self, name, marker.args[0])
+
+    def _update_dict_with_list(
+        self, items: dict[str, object], values: Sequence[str]
+    ) -> None:
+        for value in values:
+            key, _, item = value.partition("=")
+            items[key] = item

--- a/src/cocotb_tools/pytest/hookspecs.py
+++ b/src/cocotb_tools/pytest/hookspecs.py
@@ -1,0 +1,81 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Specification of cocotb-specific hook functions for pytest."""
+
+from __future__ import annotations
+
+from pytest import FixtureRequest, hookspec
+
+from cocotb_tools.pytest.dut import Dut
+
+
+@hookspec(firstresult=True)
+def pytest_cocotb_dut_create(request: FixtureRequest) -> Dut | None:
+    """Create a new instance of :class:`cocotb_tools.pytest.dut.Dut`.
+
+    This hook allows custom plugins or local configuration files to instantiate a custom
+    subclass of :class:`~cocotb_tools.pytest.dut.Dut` with custom configuration defaults or behavior.
+
+    .. note::
+
+        Any ``conftest.py`` file can implement this hook. Execution stops at the first non-:data:`None` result.
+
+    Example:
+
+    .. code-block:: python
+
+        from pytest import hookimpl, FixtureRequest
+        from cocotb_tools.pytest.dut import Dut
+
+
+        class MyDutExt(Dut):
+            pass
+
+
+        @hookimpl(tryfirst=True)
+        def pytest_cocotb_dut_create(request: FixtureRequest) -> Dut | None:
+            return MyDutExt(request)
+
+    Args:
+        request: The pytest fixture request.
+
+    Returns:
+        :data:`None` if pytest should invoke another implementation of this hook;
+        otherwise, an instance of :class:`cocotb_tools.pytest.dut.Dut`.
+    """
+
+
+@hookspec(firstresult=True)
+def pytest_cocotb_dut_run(dut: Dut) -> object:
+    """Compile, elaborate, and run the HDL module with the simulator and cocotb tests.
+
+    This hook allows custom runners or custom build/test orchestrators to be used
+    instead of the default :class:`~cocotb_tools.runner.Runner`.
+
+    .. note::
+
+        Any ``conftest.py`` file can implement this hook. Execution stops at the first non-:data:`None` result.
+
+    Example:
+
+    .. code-block:: python
+
+        from subprocess import run
+        from pytest import hookimpl
+        from cocotb_tools.pytest.dut import Dut
+
+
+        @hookimpl(tryfirst=True)
+        def pytest_cocotb_dut_run(dut: Dut) -> object:
+            run(["make", dut.toplevel], check=True)
+            return True
+
+    Args:
+        dut: An instance of :class:`~cocotb_tools.pytest.dut.Dut` containing the required configuration.
+
+    Returns:
+        :data:`None` if pytest should invoke another implementation of this hook;
+        otherwise, any non-:data:`None` value to stop hook execution.
+    """

--- a/src/cocotb_tools/pytest/mark.py
+++ b/src/cocotb_tools/pytest/mark.py
@@ -1,0 +1,639 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Plugin markers."""
+
+from __future__ import annotations
+
+from inspect import Parameter, signature
+from typing import Callable
+
+from pytest import Config, MarkDecorator, mark
+
+from cocotb.simtime import TimeUnit
+from cocotb_tools.runner import (
+    VHDL,
+    PathLike,
+    VerilatorControlFile,
+    Verilog,
+)
+
+
+def cocotb_simulator(name: str, /) -> MarkDecorator:
+    """Selects the HDL simulator to use.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_simulator("verilator"),)
+
+    Args:
+        name: Name of HDL simulator.
+    """
+    return mark.cocotb_simulator(name)
+
+
+def cocotb_test_modules(*modules: str) -> MarkDecorator:
+    """Adds Python modules containing cocotb tests to run.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (
+            pytest.mark.cocotb_test_modules(
+                "tests.test_module_1",
+                "tests.test_module_2",
+            ),
+        )
+
+    Args:
+        *modules: Name of Python module(s) that will be imported.
+    """
+    return mark.cocotb_test_modules(*modules)
+
+
+def cocotb_toplevel(name: str, /) -> MarkDecorator:
+    """Sets the name of the HDL toplevel module.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_toplevel("top"),)
+
+    Args:
+        name: Name of HDL toplevel module.
+    """
+    return mark.cocotb_toplevel(name)
+
+
+def cocotb_toplevel_lang(name: str, /) -> MarkDecorator:
+    """Sets the language of the HDL toplevel module.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_toplevel_lang("verilog"),)
+
+    Args:
+        name: Language of the HDL toplevel module. Supported values: ``verilog`` or ``vhdl``.
+    """
+    return mark.cocotb_toplevel_lang(name)
+
+
+def cocotb_toplevel_library(name: str, /) -> MarkDecorator:
+    """Sets the library name for the HDL toplevel module.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_toplevel_library("toplib"),)
+
+    Args:
+        name: Library name for the HDL toplevel module.
+    """
+    return mark.cocotb_toplevel_library(name)
+
+
+def cocotb_timeout(duration: float, unit: TimeUnit) -> MarkDecorator:
+    """Marks a coroutine test function with a simulation time limit after which the test is forced to fail.
+
+    Example usage:
+
+    .. code-block:: python
+
+        @pytest.mark.cocotb_timeout(duration=200, unit="ns")
+        async def test_dut_feature_with_timeout(dut) -> None:
+            # Test DUT feature with timeout configured from cocotb marker
+            ...
+
+    Args:
+        duration: The simulation time duration before the test is forced to fail.
+        unit: The simulation time unit (accepts any unit supported by :class:`~cocotb.triggers.Timer`).
+
+    Raises:
+        :exc:`~cocotb.triggers.SimTimeoutError`: The test function timed out.
+
+    Returns:
+        The decorated coroutine function.
+    """
+    return mark.cocotb_timeout(duration=duration, unit=unit)
+
+
+def cocotb_sources(
+    *sources: PathLike | Verilog | VHDL | VerilatorControlFile,
+) -> MarkDecorator:
+    """Adds a list of language-agnostic source files to build.
+
+    Example usage:
+
+    .. code-block:: python
+
+        from pathlib import Path
+        import pytest
+
+        DIR: Path = Path(__file__).parent.resolve()
+
+        pytestmark = (
+            pytest.mark.cocotb_sources(
+                DIR / "rtl" / "adder.sv",
+                DIR / "rtl" / "alu.sv",
+            ),
+        )
+
+    Args:
+        *sources: The source files to be compiled.
+    """
+    return mark.cocotb_sources(*sources)
+
+
+def cocotb_defines(**defines: object) -> MarkDecorator:
+    """Sets Verilog/SystemVerilog preprocessor defines when compiling HDL source files.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (
+            pytest.mark.cocotb_defines(
+                DEFINE1="string",
+                DEFINE2=1234,
+                DEFINE3=3.14,
+                DEFINE4=True,
+            ),
+        )
+
+    Args:
+        **defines: The preprocessor defines to set.
+    """
+    return mark.cocotb_defines(**defines)
+
+
+def cocotb_parameters(**parameters: object) -> MarkDecorator:
+    """Sets Verilog/SystemVerilog parameters and VHDL generics when elaborating the HDL toplevel module.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (
+            pytest.mark.cocotb_parameters(
+                PARAM1="string",
+                PARAM2=1234,
+                PARAM3=3.14,
+            ),
+        )
+
+
+        # test_*.py
+        async def test_dut_feature_1(dut) -> None:
+            assert dut.PARAM1 == "string"
+            assert dut.PARAM2 == 1234
+            assert dut.PARAM3 == 3.14
+
+    Args:
+        **parameters: The parameters and generics to set.
+    """
+    return mark.cocotb_parameters(**parameters)
+
+
+def cocotb_env(**env: object) -> MarkDecorator:
+    """Sets environment variables that will be available to the running HDL simulation and cocotb tests.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import os
+        import pytest
+
+        pytestmark = (
+            pytest.mark.cocotb_env(
+                ENV1="string",
+                ENV2=1234,
+                ENV3=3.14,
+                ENV4=True,
+            ),
+        )
+
+
+        # test_*.py
+        async def test_dut_feature_1(dut) -> None:
+            assert os.getenv("ENV1") == "string"
+            assert int(os.getenv("ENV2", 0)) == 1234
+            assert float(os.getenv("ENV3", 0)) == 3.14
+            assert bool(os.getenv("ENV4", False)) == True
+
+    Args:
+        **env: The environment variables to set.
+    """
+    return mark.cocotb_env(**env)
+
+
+def cocotb_includes(*includes: PathLike) -> MarkDecorator:
+    """Adds include directories for Verilog or SystemVerilog compilation.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        from pathlib import Path
+        import pytest
+
+        DIR: Path = Path(__file__).parent.resolve()
+
+        pytestmark = (
+            pytest.mark.cocotb_includes(
+                DIR / "rtl" / "adder",
+                DIR / "rtl" / "alu",
+            ),
+        )
+
+    Args:
+        *includes: Include directories to add.
+    """
+    return mark.cocotb_includes(*includes)
+
+
+def cocotb_plusargs(*plusargs: str) -> MarkDecorator:
+    """Adds plus arguments (``+arg``) for the simulator.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (
+            pytest.mark.cocotb_plusargs(
+                "+arg1",
+                "+arg2=value",
+            ),
+        )
+
+    Args:
+        *plusargs: Plus arguments to pass to the simulator.
+    """
+    return mark.cocotb_plusargs(*plusargs)
+
+
+def cocotb_timescale(value: str | tuple[str, str] | None, /) -> MarkDecorator:
+    """Sets the time unit and time precision for the simulation.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_timescale("1ns / 1ps"),)
+
+    Args:
+        value: A string (e.g. ``"1ns/1ps"``) or a tuple (e.g. ``("1ns", "1ps")``) specifying the timescale.
+    """
+    return mark.cocotb_timescale(value)
+
+
+def cocotb_random_seed(value: int, /) -> MarkDecorator:
+    """Specifies a random seed to use for the simulation.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_random_seed(1234),)
+
+    Args:
+        value: An integer value used as the seed.
+    """
+    return mark.cocotb_random_seed(value)
+
+
+def cocotb_build_dir(path: PathLike, /) -> MarkDecorator:
+    """Sets the directory in which the build step is run.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_build_dir("build"),)
+
+    Args:
+        path: The path or name of the build directory.
+    """
+    return mark.cocotb_build_dir(path)
+
+
+def cocotb_build_args(*args: str | VHDL | Verilog) -> MarkDecorator:
+    """Adds extra compilation/build arguments for the simulator.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (
+            pytest.mark.cocotb_build_args(
+                "-arg1",
+                "-arg2",
+                "value",
+            ),
+        )
+
+    Args:
+        *args: Extra build arguments to pass to the simulator during compilation.
+    """
+    return mark.cocotb_build_args(*args)
+
+
+def cocotb_elab_args(*args: str) -> MarkDecorator:
+    """Adds extra elaboration arguments for the simulator.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (
+            pytest.mark.cocotb_elab_args(
+                "-arg1",
+                "-arg2",
+                "value",
+            ),
+        )
+
+    Args:
+        *args: Extra elaboration arguments to pass to the simulator.
+    """
+    return mark.cocotb_elab_args(*args)
+
+
+def cocotb_sim_args(*args: str) -> MarkDecorator:
+    """Adds extra simulation (runtime) arguments for the simulator.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_sim_args("-v", "+some_sim_option"),)
+
+    Args:
+        *args: Extra simulation arguments.
+    """
+    return mark.cocotb_sim_args(*args)
+
+
+def cocotb_pre_cmd(*args: str) -> MarkDecorator:
+    """Adds extra commands to run before the simulation begins.
+
+    These are typically Tcl commands for simulators that support them (e.g., ModelSim/Questa).
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_pre_cmd("run 0", "log -r /*"),)
+
+    Args:
+        *args: Commands to run before the simulation starts.
+    """
+    return mark.cocotb_pre_cmd(*args)
+
+
+def cocotb_library(name: str, /) -> MarkDecorator:
+    """Sets the library name to compile HDL sources into.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_library("my_lib"),)
+
+    Args:
+        name: The name of the library.
+    """
+    return mark.cocotb_library(name)
+
+
+def cocotb_waves(enable: bool = True, /) -> MarkDecorator:
+    """Enables or disables recording of signal traces (waveforms).
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_waves,)
+
+    Args:
+        enable: Whether to enable waveform recording.
+    """
+    return mark.cocotb_waves(enable)
+
+
+def cocotb_verbose(enable: bool = True, /) -> MarkDecorator:
+    """Enables or disables verbose output from the simulator runner.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_verbose,)
+
+    Args:
+        enable: Whether to enable verbose messages.
+    """
+    return mark.cocotb_verbose(enable)
+
+
+def cocotb_always(enable: bool = True, /) -> MarkDecorator:
+    """Forces the compilation/build step to run, even if sources have not changed.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_always,)
+
+    Args:
+        enable: Whether to always run the build step.
+    """
+    return mark.cocotb_always(enable)
+
+
+def cocotb_clean(enable: bool = True, /) -> MarkDecorator:
+    """Deletes the build directory before starting a new build.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_clean,)
+
+    Args:
+        enable: Whether to delete the build directory before building.
+    """
+    return mark.cocotb_clean(enable)
+
+
+def cocotb_gui(enable: bool = True, /) -> MarkDecorator:
+    """Enables the GUI mode in the simulator, if supported.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_gui,)
+
+    Args:
+        enable: Whether to enable GUI mode.
+    """
+    return mark.cocotb_gui(enable)
+
+
+def cocotb_gpi_interfaces(*args: str) -> MarkDecorator:
+    """Specifies the list of GPI interfaces to use, with the first one being the entry point.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_gpi_interfaces("vpi", "vhpi"),)
+
+    Args:
+        *args: GPI interfaces to load.
+    """
+    return mark.cocotb_gpi_interfaces(*args)
+
+
+def cocotb_test_filter(regexp: str, /) -> MarkDecorator:
+    """Specifies a regular expression to filter and match names of cocotb test functions to run.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # conftest.py or test_*.py
+        import pytest
+
+        pytestmark = (pytest.mark.cocotb_test_filter("test_alu_.*"),)
+
+    Args:
+        regexp: A regular expression matching names of test functions to run.
+    """
+    return mark.cocotb_test_filter(regexp)
+
+
+def _marker_description(marker: Callable) -> str:
+    """Return a formatted description of the marker.
+
+    Args:
+        marker: The marker callable.
+
+    Returns:
+        A formatted description string for the marker.
+    """
+    args: list[str] = []
+    positional_only: bool = False
+
+    for name, parameter in signature(marker).parameters.items():
+        arg: str = ""
+
+        if parameter.kind == Parameter.VAR_POSITIONAL:
+            arg += "*"
+        elif parameter.kind == Parameter.VAR_KEYWORD:
+            arg += "**"
+
+        if parameter.kind == Parameter.POSITIONAL_ONLY:
+            positional_only = True
+
+        arg += name
+
+        if parameter.default != Parameter.empty:
+            arg += f"={parameter.default}"
+
+        args.append(arg)
+
+    if positional_only:
+        args.append("/")
+
+    description: str = str(marker.__doc__).lstrip().splitlines()[0]
+
+    return f"{marker.__name__}({', '.join(args)}): {description}".rstrip()
+
+
+def _register_markers(config: Config) -> None:
+    """Register all cocotb-specific markers with the pytest configuration.
+
+    Args:
+        config: The pytest configuration object.
+    """
+    for name, value in globals().items():
+        if name.startswith("cocotb") and callable(value):
+            config.addinivalue_line("markers", _marker_description(value))

--- a/src/cocotb_tools/pytest/plugin.py
+++ b/src/cocotb_tools/pytest/plugin.py
@@ -1,0 +1,593 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""A pytest plugin to integrate pytest with cocotb.
+
+This plugin allows pytest to manage cocotb simulation runs and execute Python-based
+HDL tests directly. It supports running simulations in subprocesses, compiling HDL
+sources, and running cocotb coroutine tests in the simulator environment.
+
+### Getting Started
+
+To use this plugin, define a test function that accepts the ``dut`` fixture.
+By default, the plugin compiles the HDL source code, launches the selected HDL simulator,
+and runs your cocotb tests inside that simulator.
+
+### Writing a Test
+
+Here is a basic example of a pytest-cocotb test:
+
+.. code-block:: python
+
+    import pytest
+    from pathlib import Path
+    from cocotb.triggers import Timer
+
+
+    # Configure the test using cocotb markers
+    @pytest.mark.cocotb_sources(Path("rtl") / "my_design.sv")
+    @pytest.mark.cocotb_toplevel("my_design")
+    async def test_my_design(dut) -> None:
+        # Drive inputs
+        dut.rst.value = 1
+        await Timer(10, units="ns")
+        dut.rst.value = 0
+        await Timer(10, units="ns")
+
+        # Assert outputs
+        assert dut.ready.value == 1
+
+### Configuration Options
+
+You can configure the plugin in three ways (ordered by precedence):
+
+1. **Command-Line Arguments**: e.g., ``pytest --cocotb-simulator=verilator``
+2. **Pytest Configuration File**: in ``pyproject.toml`` under ``[tool.pytest.ini_options]``:
+
+   .. code-block:: toml
+
+       [tool.pytest.ini_options]
+       cocotb_simulator = "verilator"
+
+3. **Environment Variables**: e.g., ``COCOTB_SIMULATOR=verilator``
+
+For a complete list of configuration options, run ``pytest --help``.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from time import time
+
+from pytest import (
+    Config,
+    FixtureRequest,
+    OptionGroup,
+    Parser,
+    PytestPluginManager,
+    fixture,
+    hookimpl,
+)
+
+import cocotb
+from cocotb.handle import SimHandleBase
+from cocotb_tools.pytest import hookspecs
+from cocotb_tools.pytest._option import Option, populate_ini_options
+from cocotb_tools.pytest.dut import Dut
+from cocotb_tools.pytest.mark import _register_markers
+from cocotb_tools.runner import SUPPORTED_RUNNERS, Runner, get_runner
+
+#: The default list of Python callables that start up the Python cosimulation environment.
+_PYGPI_USERS: tuple[str, ...] = (
+    "cocotb_tools._coverage:start_cocotb_library_coverage",
+    "cocotb.logging:_configure",
+    "cocotb._init:init_package_from_simulation",
+)
+
+#: List of pre-defined entry points with regression managers
+_REGRESSION_MANAGER_ENTRY_POINT: dict[str, str] = {
+    # TODO: Replace with pytest plugin
+    "pytest": "cocotb.regression:_run_regression",
+    "cocotb": "cocotb.regression:_run_regression",
+}
+
+#: List of cocotb options to set as environment variable.
+_OPTION_ENVS: tuple[str, ...] = (
+    "cocotb_trust_inertial_writes",
+    "cocotb_waveform_viewer",
+    "cocotb_scheduler_debug",
+    "cocotb_log_level",
+    "cocotb_resolve_x",
+    "cocotb_attach",
+    "gpi_log_level",
+)
+
+#: List of plugin options.
+_OPTIONS: tuple[Option, ...] = (
+    Option(
+        "cocotb_regression_manager",
+        choices=("pytest", "cocotb", "none"),
+        default="pytest",
+        description="""
+            Select regression manager used to run cocotb tests. Available values:
+
+            * ``pytest``: Use pytest to collect and run cocotb tests.
+              This option allows to use pytest in fullness within HDL simulator and with cocotb tests.
+              Cocotb runner is not needed. DUT is defined by using the pytest ``dut`` fixture and ``@pytest.mark.cocotb_*`` markers.
+            * ``cocotb``: Use built-in cocotb regression manager.
+              Cannot use pytest within HDL simulator or with cocotb tests.
+              It requires to use cocotb runner in a separate test function defined in a separate test file to run cocotb tests.
+            * ``none``: Don't use any pre-defined regression manager.
+              This option, alongside with the :envvar:`PYGPI_USERS`` environment variable, will allow to use a custom regression manager.
+        """,
+    ),
+    Option(
+        "cocotb_summary",
+        action="store_true",
+        description="Show cocotb test summary info.",
+    ),
+    Option(
+        "cocotb_sim_time_unit",
+        choices=("step", "fs", "ps", "ns", "us", "ms", "sec"),
+        default="ns",
+        description="Simulation time unit that will be used during tests reporting.",
+    ),
+    Option(
+        "cocotb_gui",
+        action="store_true",
+        description="Enable the GUI mode in the simulator (if supported).",
+    ),
+    Option(
+        "cocotb_waves",
+        action="store_true",
+        description="Enable wave traces dump for simulator (if supported)",
+    ),
+    Option(
+        "cocotb_waveform_viewer",
+        metavar="NAME",
+        default="surfer",
+        description="""
+            The name of the waveform viewer executable to use (like surfer) when GUI mode is enabled for simulators
+            that do not have a built-in waveform viewer (like Verilator) The executable name will be called with the
+            name of the waveform file as the argument.
+        """,
+    ),
+    Option(
+        "cocotb_random_seed",
+        metavar="INTEGER",
+        default=int(time()),
+        default_in_help="current epoch time in seconds",
+        type=int,
+        description="Seed the Python random module to recreate a previous test stimulus.",
+    ),
+    Option(
+        "cocotb_attach",
+        metavar="SECONDS",
+        type=int,
+        description="""
+            Pause time value in seconds before the simulator start. If set to non-zero value, cocotb will print the
+            process ID (PID) to attach to and wait the specified time in seconds before actually letting the
+            simulator run.
+        """,
+    ),
+    Option(
+        "cocotb_plusargs",
+        nargs="*",
+        metavar="PLUSARG",
+        description="""
+            Plusargs are options that are starting with a plus (``+``) sign.  They are passed to the simulator and are
+            also available within cocotb as cocotb.plusargs. In the simulator, they can be read by the
+            Verilog/SystemVerilog system functions ``$test$plusargs`` and ``$value$plusargs``.
+        """,
+    ),
+    Option(
+        "cocotb_resolve_x",
+        choices=("error", "weak", "zeros", "ones", "random"),
+        description="""
+            Defines how to resolve bits with a value of ``X``, ``Z``, ``U``, ``W``, or ``-`` when being converted to integer. Valid settings are:
+
+            * ``error``:  Resolves nothing.
+            * ``weak``:   Resolves ``L`` to 0 and ``H`` to 1.
+            * ``zeros``:  Like weak, but resolves all other non-0/1 values to ``0``.
+            * ``ones``:   Like weak, but resolves all other non-0/1 values to ``1``.
+            * ``random``: Like weak, but resolves all other non-0/1 values randomly to either 0 or 1.
+
+            There is also a slight difference in behavior of bool(logic).
+            When this is set, bool(logic) treats all non-0/1 values as equivalent to 0.
+            When this is not set, bool(logic) will fail on non-0/1 values.
+            Warning: Using this feature is not recommended.
+        """,
+    ),
+    Option(
+        "cocotb_scheduler_debug",
+        action="store_true",
+        description="""
+            Enable additional log output of the coroutine scheduler. This will default the value of debug, which
+            can later be modified.
+        """,
+    ),
+    Option(
+        "cocotb_simulator",
+        choices=("auto", *SUPPORTED_RUNNERS),
+        default="auto",
+        metavar="NAME",
+        description="""
+            Select HDL simulator for cocotb. The ``auto`` option will automatically pick one of available HDL
+            simulators where precedence order is based on available choices for this argument, from the highest priority
+            (most left) to the lowest priority (most right).
+        """,
+    ),
+    Option(
+        "cocotb_trust_inertial_writes",
+        action="store_true",
+        description="""
+            It enables a mode which allows cocotb to trust that VPI/VHPI/FLI inertial writes are applied properly
+            according to the respective standards. This mode can lead to noticeable performance improvements, and
+            also includes some behavioral difference that are considered by the cocotb maintainers to be “better”.
+            Not all simulators handle inertial writes properly, so use with caution. This is achieved by not
+            scheduling writes to occur at the beginning of the ``ReadWrite`` mode, but instead trusting that the
+            simulator’s inertial write mechanism is correct. This allows cocotb to avoid a VPI callback into Python
+            to apply writes.
+        """,
+    ),
+    Option(
+        "cocotb_pytest_args",
+        type=shlex.split,
+        action="extend",
+        metavar="ARGS",
+        description="""
+            By default, instance of pytest that is running from HDL simulator as regression manager for cocotb tests,
+            will be called with the same command line arguments as pytest invoked by user from command line that
+            is starting cocotb runners (HDL simulators). This option allows user to override it and pass own
+            arguments to pytest instance that is running from HDL simulator process. For example,
+            it can be used to set different verbosity levels or capture modes between them.
+            Example: ``pytest -v --capture=no --cocotb-pytest-args='-vv --capture=fd'``
+        """,
+    ),
+    Option(
+        "cocotb_pytest_dir",
+        default_in_help="current working directory",
+        metavar="PATH",
+        type=Path,
+        description="Override path from where pytest was invoked.",
+    ),
+    Option(
+        "cocotb_build_dir",
+        default="sim_build",
+        metavar="PATH",
+        type=Path,
+        description="Directory to run the build step in.",
+    ),
+    Option(
+        "cocotb_sources",
+        nargs="*",
+        metavar="FILE",
+        description="Extra source files.",
+    ),
+    Option(
+        "cocotb_defines",
+        nargs="*",
+        metavar="NAME[=VALUE]",
+        description="Extra defines to set.",
+    ),
+    Option(
+        "cocotb_includes",
+        nargs="*",
+        metavar="PATH",
+        type=Path,
+        description="Extra Verilog include directories.",
+    ),
+    Option(
+        "cocotb_parameters",
+        nargs="*",
+        metavar="NAME[=VALUE]",
+        description="Extra Verilog parameters or VHDL generics.",
+    ),
+    Option(
+        "cocotb_library",
+        default="top",
+        metavar="NAME",
+        description="The library name to compile into.",
+    ),
+    Option(
+        "cocotb_always",
+        action="store_true",
+        description="Always run the build step.",
+    ),
+    Option(
+        "cocotb_clean",
+        action="store_true",
+        description="Delete build directory before building.",
+    ),
+    Option(
+        "cocotb_verbose",
+        action="store_true",
+        description="Enable verbose messages.",
+    ),
+    Option(
+        "cocotb_timescale",
+        metavar="UNIT[/PRECISION]",
+        description="Timescale containing time unit and time precision for simulation.",
+    ),
+    Option(
+        "cocotb_env",
+        metavar="NAME[=VALUE]",
+        nargs="*",
+        description="Extra environment variables to set.",
+    ),
+    Option(
+        "cocotb_toplevel_library",
+        default="top",
+        metavar="NAME",
+        description="The library name for HDL toplevel module.",
+    ),
+    Option(
+        "cocotb_toplevel_lang",
+        choices=("auto", "verilog", "vhdl"),
+        default="auto",
+        description="""
+            Language of the HDL toplevel module.
+            Can be set to notify tests about preferred language in multi-language HDL design.
+            This is also used by simulators that support more than one interface
+            (:term:`VPI`, :term:`VHPI`, or :term:`FLI`) to select the appropriate interface to start cocotb.
+            When set to ``auto``, value will be automatically evaluated based on selected HDL simulator or
+            list of HDL source files provided during build stage in instance of :class:`cocotb_tools.pytest.dut.Dut`.
+        """,
+    ),
+    Option(
+        "cocotb_gpi_interfaces",
+        nargs="*",
+        metavar="NAME",
+        description="List of GPI interfaces to use, with the first one being the entry point.",
+    ),
+    Option(
+        "cocotb_build_args",
+        type=shlex.split,
+        action="extend",
+        metavar="ARGS",
+        description="Extra build arguments for the simulator.",
+    ),
+    Option(
+        "cocotb_elab_args",
+        type=shlex.split,
+        action="extend",
+        metavar="ARGS",
+        description="Extra elaboration arguments for the simulator.",
+    ),
+    Option(
+        "cocotb_sim_args",
+        type=shlex.split,
+        action="extend",
+        metavar="ARGS",
+        description="Extra simulation arguments for the simulator.",
+    ),
+    Option(
+        "cocotb_pre_cmd",
+        type=shlex.split,
+        action="extend",
+        metavar="ARGS",
+        description="Extra commands to run before simulation begins.",
+    ),
+    Option(
+        "cocotb_test_filter",
+        metavar="REGEXP",
+        description="A regular expression matching names of test function(s) to run.",
+    ),
+    Option(
+        "cocotb_log_level",
+        choices=("trace", "debug", "info", "warning", "error", "critical"),
+        description="""
+            The default log level of all "cocotb" Python loggers. The default is unset, which means that the log
+            level is inherited from the root logger. This behaves similarly to :const:`logging.NOTSET`.
+        """,
+    ),
+    Option(
+        "gpi_log_level",
+        choices=("trace", "debug", "info", "warning", "error", "critical"),
+        description="""
+            The default log level of all "gpi" (the low-level simulator interface) loggers, including both Python
+            and the native GPI logger. The default is unset, which means that the log level is inherited from the
+            root logger. This behaves similarly to :const:`logging.NOTSET`.
+        """,
+    ),
+    Option(
+        "pygpi_users",
+        nargs="*",
+        metavar="MODULE:FUNCTION",
+        default=_PYGPI_USERS,
+        description="""
+            The Python module and callable that starts up the Python cosimulation environment. User overloads can be
+            used to enter alternative Python frameworks or to hook existing cocotb functionality. It is formatted as
+            ``path.to.entry.module:entry_point.function,other_module:other_func``. The string before the colon is the
+            Python module to import and the string following the colon is the object to call as the entry function.
+            The entry function must be a callable matching this form: ``entry_function(argv: List[str]) -> None``
+        """,
+    ),
+)
+
+
+@fixture
+def dut(request: FixtureRequest) -> Dut | SimHandleBase:
+    """A pytest fixture that provides either an instance of :class:`cocotb_tools.pytest.dut.Dut` or a simulation handle to the DUT.
+
+    When running outside the simulation (in the parent pytest process), this fixture retrieves or creates a :class:`~cocotb_tools.pytest.dut.Dut`
+    instance, which is used to define build and simulation options.
+
+    When running inside the simulation (within the simulator process), this fixture returns the simulation handle to the DUT,
+    allowing the test to drive and monitor the design's signals. This handle is equivalent to :data:`cocotb.top`.
+
+    Example usage:
+
+    .. code-block:: python
+
+        import pytest
+        from cocotb.triggers import Timer
+
+
+        @pytest.mark.cocotb_sources("my_design.sv")
+        async def test_dut_reset(dut) -> None:
+            dut.rst.value = 1
+            await Timer(5, units="ns")
+            dut.rst.value = 0
+            await Timer(5, units="ns")
+            assert dut.rst.value == 0
+
+    Args:
+        request: The pytest fixture request.
+
+    Returns:
+        A simulation handle to the DUT (equivalent to :data:`cocotb.top`) when :data:`cocotb.is_simulation` is :data:`True`.
+        An instance of :class:`cocotb_tools.pytest.dut.Dut` when :data:`cocotb.is_simulation` is :data:`False`.
+    """
+    return cocotb.top if cocotb.is_simulation else Dut.create(request)
+
+
+def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager) -> None:
+    """Registers cocotb command-line options and configuration settings with pytest.
+
+    Args:
+        parser: The pytest parser used to parse command-line arguments and configuration settings.
+        pluginmanager: The pytest plugin manager.
+    """
+    group: OptionGroup = parser.getgroup("cocotb", description="cocotb options")
+
+    for option in _OPTIONS:
+        option.add_to_group(group)
+
+
+def pytest_addhooks(pluginmanager: PytestPluginManager) -> None:
+    """Registers cocotb-specific pytest hooks at plugin registration time.
+
+    Args:
+        pluginmanager: The pytest plugin manager.
+    """
+    pluginmanager.add_hookspecs(hookspecs)
+
+
+@hookimpl(tryfirst=True)
+def pytest_configure(config: Config) -> None:
+    """Configures the cocotb plugin by registering markers and exporting settings to environment variables.
+
+    Args:
+        config: The pytest configuration object.
+    """
+    option: Namespace = config.option
+
+    _register_markers(config)
+    populate_ini_options(config, _OPTIONS)
+
+    # All cocotb environment variables are captured as options by pytest plugin
+    for name in _OPTION_ENVS:
+        value: object = getattr(option, name, None)
+        environment: str = name.upper()
+
+        if value:
+            os.environ[environment] = "1" if value is True else str(value)
+        elif environment in os.environ:
+            del os.environ[environment]
+
+    entry_point: str | None = _REGRESSION_MANAGER_ENTRY_POINT.get(
+        option.cocotb_regression_manager
+    )
+
+    if entry_point and entry_point not in option.pygpi_users:
+        option.pygpi_users.append(entry_point)
+
+    os.environ["PYGPI_USERS"] = ",".join(option.pygpi_users)
+
+
+@hookimpl(trylast=True)
+def pytest_cocotb_dut_create(request: FixtureRequest) -> Dut | None:
+    """Creates a new instance of :class:`cocotb_tools.pytest.dut.Dut`.
+
+    This is the default built-in implementation of this hook. It is invoked as a
+    fallback if no other hook implementations are registered or if they return :data:`None`.
+
+    Args:
+        request: The pytest fixture request.
+
+    Returns:
+        A new instance of :class:`cocotb_tools.pytest.dut.Dut`, or :data:`None`.
+    """
+    return Dut(request)
+
+
+@hookimpl(trylast=True)
+def pytest_cocotb_dut_run(dut: Dut) -> object:
+    """Compiles, elaborates, and runs the HDL module with the simulator and cocotb tests using :class:`cocotb_tools.runner.Runner`.
+
+    This is the default built-in implementation of this hook. It is invoked as a
+    fallback if no other hook implementations are registered or if they return :data:`None`.
+
+    Args:
+        dut: An instance of :class:`~cocotb_tools.pytest.dut.Dut` containing the required configuration.
+
+    Returns:
+        A non-:data:`None` value to stop hook execution and indicate success.
+    """
+    # Cache value of the dut.work_dir because dut.id, that is part of work_dir, is re-calculated each time when invoked
+    work_dir: Path = dut.work_dir
+
+    runner: Runner = get_runner(str(dut.simulator))
+
+    runner.build(
+        hdl_library=dut.library or "top",
+        sources=dut.sources,
+        includes=dut.includes,
+        defines=dut.defines,
+        parameters=dut.parameters,
+        build_args=dut.build_args,
+        hdl_toplevel=dut.toplevel,
+        always=dut.always,
+        build_dir=work_dir,
+        cwd=work_dir,
+        clean=dut.clean,
+        verbose=dut.verbose,
+        timescale=dut.timescale,
+        waves=dut.waves,
+    )
+
+    runner.test(
+        test_module=dut.test_modules,
+        hdl_toplevel=dut.toplevel or "",
+        hdl_toplevel_library=dut.library or "top",
+        hdl_toplevel_lang=dut.toplevel_lang,
+        gpi_interfaces=dut.gpi_interfaces or None,
+        seed=dut.random_seed,
+        elab_args=dut.elab_args,
+        test_args=dut.sim_args,
+        extra_env={k: str(v) for k, v in dut.env.items()},
+        waves=dut.waves,
+        gui=dut.gui,
+        parameters=dut.parameters or None,
+        build_dir=work_dir,
+        test_dir=work_dir,
+        pre_cmd=dut.pre_cmd or None,
+        verbose=dut.verbose,
+        timescale=dut.timescale,
+        test_filter=dut.test_filter or None,
+        results_xml=str(work_dir / "results.xml"),
+    )
+
+    return True
+
+
+def _options_for_documentation() -> ArgumentParser:
+    """Exposes the plugin options as an ArgumentParser for Sphinx documentation.
+
+    This function assists the sphinx-argparse extension in generating documentation
+    for the plugin's configuration options.
+
+    Returns:
+        An ArgumentParser populated with the plugin's configuration options.
+    """
+    parser = ArgumentParser()
+
+    for option in _OPTIONS:
+        parser.add_argument(option.argument, help=option.help, **option.kwargs)
+
+    return parser

--- a/tests/pytest_plugin/conftest.py
+++ b/tests/pytest_plugin/conftest.py
@@ -2,101 +2,193 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Configuration for all tests."""
+"""Test :mod:`cocotb_tools.pytest` module."""
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+import os
 from pathlib import Path
-from typing import Any
 
-from pytest import FixtureRequest, Parser, PytestPluginManager, fixture, hookimpl
+from pytest import (
+    FixtureRequest,
+    MonkeyPatch,
+    Parser,
+    Pytester,
+    PytestPluginManager,
+    fixture,
+    hookimpl,
+)
 
-from cocotb.clock import Clock
-from cocotb_tools._pytest.hdl import HDL
+from cocotb_tools.pytest._simulator import find_simulator
+from cocotb_tools.runner import get_runner
 
-PLUGIN: str = "cocotb_tools._pytest.plugin"
-DESIGNS: Path = Path(__file__).parent.parent.resolve() / "designs"
+#: List of plugin to enable
+PLUGINS: tuple[str, ...] = (
+    "pytester",
+    "cocotb_tools.pytest.plugin",
+)
+
+
+TESTS_DIR: Path = Path(__file__).parent.parent.resolve()
+"""Absolute path to the tests directory."""
+
+DESIGNS_DIR: Path = TESTS_DIR / "designs"
+"""Absolute path to the directory with HDL design samples."""
+
+TEST_COCOTB_DIR: Path = TESTS_DIR / "test_cases" / "test_cocotb"
+"""Absolute path to the test_cocotb directory that contains cocotb tests run for HDL design samples."""
 
 
 @hookimpl(tryfirst=True)
 def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager) -> None:
     """Load pytest cocotb plugin in early stage of pytest when adding options to pytest.
-
     This will allow to automatically load plugin when invoking ``pytest`` with ``tests/pytest_plugin`` argument
-    without need of providing additional ``-p cocotb_tools._pytest.plugin`` argument.
-
+    without need of providing additional ``-p cocotb_tools.pytest.plugin`` argument.
     Most users in their projects will load plugin by defining an entry point in ``pyproject.toml`` file:
 
     .. code:: toml
 
         [project.entry-points.pytest11]
-        cocotb = "cocotb_tools._pytest.plugin"
+        cocotb = "cocotb_tools.pytest.plugin"
 
     Args:
         parser: Instance of command line arguments parser used by pytest.
         pluginmanager: Instance of pytest plugin manager.
     """
-    if not pluginmanager.has_plugin(PLUGIN):
-        pluginmanager.import_plugin(PLUGIN)  # import and register plugin
+    for plugin in PLUGINS:
+        if not pluginmanager.has_plugin(plugin):
+            pluginmanager.import_plugin(plugin)  # import and register plugin
 
 
-@fixture(name="sample_module")
-def sample_module_fixture(hdl: HDL, request: FixtureRequest) -> HDL:
-    """Define HDL design by adding HDL source files.
-
-    To run cocotb tests for HDL design:
-
-    .. code:: python
-
-       import pytest
-       from cocotb_tools._pytest.hdl import HDL
-
-       @pytest.mark.cocotb_runner
-       def test_sample_module(sample_module: HDL) -> None:
-           sample_module.test()
-
-    Args:
-        hdl: HDL design.
-
-    Returns:
-        Defined HDL design with added HDL source files.
-    """
-    hdl.toplevel = "sample_module"
-
-    # Selected based on command line argument --cocotb-toplevel-lang=<verilog|vhdl>
-    # or enforced by HDL simulator choice --cocotb-simulator=<name>
-    if hdl.toplevel_lang == "vhdl":
-        hdl.sources = (
-            DESIGNS / "sample_module" / "sample_module_package.vhdl",
-            DESIGNS / "sample_module" / "sample_module_1.vhdl",
-            DESIGNS / "sample_module" / "sample_module.vhdl",
-        )
-    else:
-        hdl.sources = (DESIGNS / "sample_module" / "sample_module.sv",)
-
-    if hdl.simulator == "questa":
-        hdl.build_args = ["+acc"]
-
-    elif hdl.simulator == "xcelium":
-        hdl.build_args = ["-v93"]
-
-    elif hdl.simulator == "nvc":
-        hdl.build_args = ["--std=08"]
-
-    hdl.build()
-
-    return hdl
+@fixture
+def designs_dir() -> Path:
+    """Absolute path to directory with HDL design samples."""
+    return DESIGNS_DIR
 
 
-@fixture(name="clock_generation", scope="session", autouse=True)
-async def clock_generation_fixture(dut: Any) -> AsyncGenerator[None, None]:
-    """Generate clock for all tests using session scope."""
-    # Test setup (executed before test), create and start clock generation
-    dut.clk.value = 0
+@fixture
+def test_cocotb_dir() -> Path:
+    """Absolute path to directory with cocotb tests."""
+    return TEST_COCOTB_DIR
 
-    Clock(dut.clk, 10, unit="ns").start(start_high=False)
 
-    yield  # Calling test, yield is needed to keep clock generation alive
+@fixture(name="pytester")
+def pytester_fixture(
+    pytester: Pytester, request: FixtureRequest, monkeypatch: MonkeyPatch
+) -> Pytester:
+    """Setup :class:`pytest.Pytester` fixture."""
+    simulator: str | None = request.config.option.cocotb_simulator
+    language: str | None = request.config.option.cocotb_toplevel_lang
+    gpi_interfaces: list[str] = request.config.option.cocotb_gpi_interfaces
 
-    # Test teardown (executed after test), clock generation will be finished here
+    if not simulator or simulator == "auto":
+        simulator = find_simulator(languages=language)
+
+    if simulator:
+        supported_gpi_interfaces: dict[str, list[str]] = get_runner(
+            simulator
+        ).supported_gpi_interfaces
+
+        if not language or language == "auto":
+            # Pick the first supported language by HDL simulator
+            language = list(supported_gpi_interfaces)[0]
+
+        if not gpi_interfaces:
+            gpi_interfaces = supported_gpi_interfaces[language]
+
+    lines: list[str] = [
+        "[pytest]",
+        "addopts = --verbose --capture no --strict-markers -p cocotb_tools.pytest.plugin",
+    ]
+
+    if simulator:
+        lines.append(f"cocotb_simulator = {simulator}")
+
+    if language:
+        lines.append(f"cocotb_toplevel_lang = {language}")
+
+    if gpi_interfaces:
+        lines.append(f"cocotb_gpi_interfaces = {' '.join(gpi_interfaces)}")
+
+    # It creates the 'pytest.ini' file
+    # https://docs.pytest.org/en/stable/reference/customize.html#pytest-ini
+    pytester.makefile(".ini", pytest="\n".join(lines))
+
+    for name in os.environ:
+        if name.startswith("COCOTB_"):
+            monkeypatch.delenv(name, raising=False)
+
+    # Create a SystemVerilog top level module example
+    pytester.makefile(
+        ".sv",
+        top="""
+        module top #(
+            WIDTH = 8
+        ) (
+            input i_clk,
+            input i_rst,
+            input [WIDTH-1:0] i_data,
+            output logic [WIDTH-1:0] o_data
+        );
+            always_ff @(posedge i_clk) begin
+                if (i_rst == 1'b1) begin
+                    o_data <= '0;
+                end else begin
+                    o_data <= i_data;
+                end
+            end
+        endmodule
+        """,
+    )
+
+    # Create a VHDL top level module example
+    pytester.makefile(
+        ".vhd",
+        top="""
+        library ieee;
+        use ieee.std_logic_1164.all;
+
+        entity top is generic (
+            WIDTH: natural := 8
+        );
+        port (
+            i_clk : in std_logic;
+            i_rst : in std_logic;
+            i_data : in std_logic_vector(WIDTH-1 downto 0);
+            o_data : out std_logic_vector(WIDTH-1 downto 0)
+        );
+        end top;
+
+        architecture rtl of top is begin
+            process(i_clk) begin
+                if (rising_edge(i_clk)) then
+                    if i_rst = '1' then
+                        o_data <= (others => '0');
+                    else
+                        o_data <= i_data;
+                    end if;
+                end if;
+            end process;
+        end rtl;
+        """,
+    )
+
+    pytester.makeconftest("""
+        from pathlib import Path
+        from pytest import fixture
+        from cocotb_tools.pytest.dut import Dut
+
+        DIR: Path = Path(__file__).parent.resolve()
+
+        @fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            if dut.toplevel_lang == "verilog":
+                dut.sources += [DIR / "top.sv"]
+
+            elif dut.toplevel_lang == "vhdl":
+                dut.sources += [DIR / "top.vhd"]
+
+            return dut
+        """)
+
+    return pytester

--- a/tests/pytest_plugin/test_dut.py
+++ b/tests/pytest_plugin/test_dut.py
@@ -1,0 +1,729 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test :class:`cocotb_tools.pytest.dut.Dut` class and :func:`cocotb_tools.pytest.plugin.dut` fixture."""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import pytest
+from pytest import MonkeyPatch, Pytester, RunResult, fixture
+
+#: List of possible option values used during plugin testing
+OPTION_VALUE: tuple[tuple[str, object], ...] = (
+    ("cocotb_library", "worklib"),
+    ("cocotb_simulator", "verilator"),
+    ("cocotb_toplevel_lang", "verilog"),
+    ("cocotb_toplevel_lang", "vhdl"),
+    ("cocotb_toplevel_library", "toplib"),
+    ("cocotb_gui", False),
+    ("cocotb_gui", True),
+    ("cocotb_waves", False),
+    ("cocotb_waves", True),
+    ("cocotb_clean", False),
+    ("cocotb_clean", True),
+    ("cocotb_always", False),
+    ("cocotb_always", True),
+    ("cocotb_verbose", False),
+    ("cocotb_verbose", True),
+    ("cocotb_build_dir", "build"),
+    ("cocotb_random_seed", 0),
+    ("cocotb_random_seed", 1234),
+    ("cocotb_sources", []),
+    ("cocotb_sources", ["src1.sv"]),
+    ("cocotb_sources", ["src1.vhd", "src2.vhd"]),
+    ("cocotb_defines", {}),
+    ("cocotb_defines", {"define1": "value1"}),
+    ("cocotb_defines", {"define1": "value1", "define2": "value2"}),
+    ("cocotb_includes", []),
+    ("cocotb_includes", ["incdir1"]),
+    ("cocotb_includes", ["incdir1", "incdir2"]),
+    ("cocotb_parameters", {}),
+    ("cocotb_parameters", {"param1": "value1"}),
+    ("cocotb_parameters", {"param1": "value1", "param2": "value2"}),
+    ("cocotb_timescale", "1ns / 1ps"),
+    ("cocotb_build_args", []),
+    ("cocotb_build_args", ["-sv"]),
+    ("cocotb_build_args", ["-sv", "-uvm", "-tcl", "set x 2"]),
+    ("cocotb_elab_args", []),
+    ("cocotb_elab_args", ["-incr"]),
+    ("cocotb_elab_args", ["-incr", "-stats", "-coverage", "module expr"]),
+    ("cocotb_sim_args", []),
+    ("cocotb_sim_args", ["-snapshot"]),
+    ("cocotb_sim_args", ["-snapshot", "-tcl", "set ignore_warnings 1"]),
+    ("cocotb_env", {}),
+    ("cocotb_env", {"VAR1": "value1"}),
+    ("cocotb_env", {"VAR1": "value1", "VAR2": "value2"}),
+    ("cocotb_plusargs", []),
+    ("cocotb_plusargs", ["+ARG1"]),
+    ("cocotb_plusargs", ["+ARG1=value1", "+ARG2=value2"]),
+    ("cocotb_gpi_interfaces", []),
+    ("cocotb_gpi_interfaces", ["vhdl"]),
+    ("cocotb_gpi_interfaces", ["verilog"]),
+    ("cocotb_gpi_interfaces", ["verilog", "vhdl"]),
+    ("cocotb_pre_cmd", []),
+    ("cocotb_pre_cmd", ["cmd"]),
+    ("cocotb_pre_cmd", ["cmd", "arg1", "arg2 arg3"]),
+    ("cocotb_test_filter", "^test_.*$"),
+)
+
+
+@fixture(name="pytester")
+def pytester_fixture(pytester: Pytester) -> Pytester:
+    """Setup :class:`pytest.Pytester` fixture."""
+    pytester.makeconftest("")  # Nuke conftest.py
+
+    return pytester
+
+
+def make_test_file(
+    pytester: Pytester,
+    option: str,
+    value: object,
+    marker: str = "",
+) -> None:
+    """Create ``test_*.py`` file that will be used to test plugin."""
+    attr: str = option.split("_", maxsplit=1)[1]
+
+    if option == "cocotb_timescale" and isinstance(value, str):
+        value = tuple(map(str.strip, value.split("/", maxsplit=1)))
+
+    # It creates the 'pytest.ini' file
+    # https://docs.pytest.org/en/stable/reference/customize.html#pytest-ini
+    pytester.makefile(
+        ".ini",
+        pytest="""
+        [pytest]
+        addopts = --verbose --capture no --strict-markers -p cocotb_tools.pytest.plugin
+        """,
+    )
+
+    pytester.makepyfile(f"""
+        from pathlib import Path
+
+        import pytest
+
+        from cocotb_tools.pytest.dut import Dut
+
+        def normalize(value):
+            if isinstance(value, Path):
+                return str(value.name)
+
+            return value
+
+        {marker}
+        def test_option(dut: Dut) -> None:
+            value = dut.{attr}
+
+            if isinstance(value, list):
+                value = list(map(normalize, value))
+            else:
+                value = normalize(value)
+
+            assert value == {value!r}
+    """)
+
+
+@pytest.mark.parametrize("option,value", OPTION_VALUE)
+def test_dut_option_from_environment_variable(
+    pytester: Pytester,
+    monkeypatch: MonkeyPatch,
+    option: str,
+    value: object,
+) -> None:
+    """Test configuring :class:`cocotb_tools.pytest.dut.Dut` fixture from environment variables."""
+    make_test_file(pytester, option, value)
+
+    if isinstance(value, Mapping):
+        value = ",".join(f"{k}={v}" for k, v in value.items())
+    elif isinstance(value, Sequence) and not isinstance(value, str):
+        if option.endswith("_args") or option == "cocotb_pre_cmd":
+            value = shlex.join(value)
+        else:
+            value = ",".join(value)
+    else:
+        value = str(value)
+
+    monkeypatch.setenv(option.upper(), value)
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize("option,value", OPTION_VALUE)
+def test_dut_option_from_configuration_file(
+    pytester: Pytester,
+    monkeypatch: MonkeyPatch,
+    option: str,
+    value: object,
+) -> None:
+    """Test configuring :class:`cocotb_tools.pytest.dut.Dut` fixture from pytest configuration file."""
+    make_test_file(pytester, option, value)
+
+    if isinstance(value, Mapping):
+        value = " ".join(f'"{k}={v}"' for k, v in value.items())
+    elif isinstance(value, Sequence) and not isinstance(value, str):
+        if option.endswith("_args") or option == "cocotb_pre_cmd":
+            value = shlex.join(value)
+        else:
+            value = " ".join(value)
+
+    # It creates the 'pytest.ini' file
+    # https://docs.pytest.org/en/stable/reference/customize.html#pytest-ini
+    pytester.makefile(
+        ".ini",
+        pytest=f"""
+        [pytest]
+        addopts = --verbose --capture no --strict-markers -p cocotb_tools.pytest.plugin
+        {option} = {value}
+        """,
+    )
+
+    monkeypatch.delenv(option.upper(), raising=False)
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize("option,value", OPTION_VALUE)
+def test_dut_option_from_command_line(
+    pytester: Pytester,
+    monkeypatch: MonkeyPatch,
+    option: str,
+    value: object,
+) -> None:
+    """Test configuring :class:`cocotb_tools.pytest.dut.Dut` fixture from pytest command line interface."""
+    make_test_file(pytester, option, value)
+
+    args: list[str] = [f"--{option.replace('_', '-')}"]
+
+    if value is False:
+        args = []
+    elif value is True:
+        pass
+    elif isinstance(value, Mapping):
+        args.extend(f"{k}={v}" for k, v in value.items())
+    elif isinstance(value, Sequence) and not isinstance(value, str):
+        if option.endswith("_args") or option == "cocotb_pre_cmd":
+            args = [args[0] + "=" + shlex.join(value)]
+        else:
+            args.extend(map(str, value))
+    else:
+        args.append(str(value))
+
+    monkeypatch.delenv(option.upper(), raising=False)
+    result: RunResult = pytester.runpytest(*args)
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize("option,value", OPTION_VALUE)
+def test_dut_option_from_marker(
+    pytester: Pytester,
+    monkeypatch: MonkeyPatch,
+    option: str,
+    value: object,
+) -> None:
+    """Test configuring :class:`cocotb_tools.pytest.dut.Dut` fixture from pytest ``@pytest.mark.cocotb_*`` markers."""
+    marker: str = f"@pytest.mark.{option}"
+
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        marker += "(" + ", ".join(f"{arg!r}" for arg in value) + ")"
+    elif isinstance(value, Mapping):
+        marker += "(" + ", ".join(f"{key}={arg!r}" for key, arg in value.items()) + ")"
+    elif value is not True:
+        marker += f"({value!r})"
+
+    make_test_file(pytester, option, value, marker=marker)
+
+    monkeypatch.delenv(option.upper(), raising=False)
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize(
+    "option,default",
+    (
+        ("cocotb_library", "top"),
+        ("cocotb_toplevel", "dut_option_default"),
+        ("cocotb_toplevel_library", "top"),
+        ("cocotb_gui", False),
+        ("cocotb_waves", False),
+        ("cocotb_clean", False),
+        ("cocotb_always", False),
+        ("cocotb_verbose", False),
+        ("cocotb_build_dir", "sim_build"),
+        ("cocotb_sources", []),
+        ("cocotb_defines", {}),
+        ("cocotb_includes", []),
+        ("cocotb_parameters", {}),
+        ("cocotb_timescale", None),
+        ("cocotb_build_args", []),
+        ("cocotb_elab_args", []),
+        ("cocotb_sim_args", []),
+        ("cocotb_env", {}),
+        ("cocotb_plusargs", []),
+        ("cocotb_gpi_interfaces", []),
+        ("cocotb_pre_cmd", []),
+        ("cocotb_test_modules", ["test_dut_option_default"]),
+        ("cocotb_test_filter", ""),
+    ),
+)
+def test_dut_option_default(
+    pytester: Pytester,
+    monkeypatch: MonkeyPatch,
+    option: str,
+    default: object,
+) -> None:
+    """Test default values of :class:`cocotb_tools.pytest.dut.Dut` fixture."""
+    make_test_file(pytester, option, default)
+
+    monkeypatch.delenv(option.upper(), raising=False)
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.simulator_required
+def test_dut_run(pytester: Pytester, designs_dir: Path, test_cocotb_dir: Path) -> None:
+    """Test invocation of the :meth:`cocotb_tools.pytest.dut.Dut.run` method."""
+    pytester.makeconftest(f"""
+        import pytest
+        from pathlib import Path
+        from cocotb_tools.pytest.dut import Dut
+
+        DESIGNS_DIR: Path = Path(r"{designs_dir.as_posix()}")
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            if dut.toplevel_lang == "vhdl":
+                dut.sources += [
+                    DESIGNS_DIR / "sample_module" / "sample_module_package.vhdl",
+                    DESIGNS_DIR / "sample_module" / "sample_module_1.vhdl",
+                    DESIGNS_DIR / "sample_module" / "sample_module.vhdl",
+                ]
+            elif dut.toplevel_lang == "verilog":
+                dut.sources += [
+                    DESIGNS_DIR / "sample_module" / "sample_module.sv",
+                ]
+
+            dut.test_modules = [
+                "test_async_coroutines",
+                "test_async_generators",
+                "test_clock",
+                "test_first_combine",
+                "test_deprecated",
+                "test_edge_triggers",
+                "test_handle",
+                "test_logging",
+                "pytest_assertion_rewriting",
+                "test_queues",
+                "test_scheduler",
+                "test_synchronization_primitives",
+                "test_testfactory",
+                "test_tests",
+                "test_timing_triggers",
+                "test_sim_time_utils",
+            ]
+
+            if dut.simulator == "questa":
+                dut.build_args += ["+acc"]
+                dut.sim_args += ["-t", "ps"]
+
+            elif dut.simulator == "xcelium":
+                dut.build_args += ["-v93"]
+
+            elif dut.simulator == "nvc":
+                dut.build_args += ["--std=08"]
+
+            if dut.simulator not in ("xcelium",):
+                # test_timing_triggers.py requires a 1ps time precision.
+                dut.timescale = ("1ps", "1ps")
+
+            return dut
+    """)
+
+    pytester.makepyfile("""
+        from cocotb_tools.pytest.dut import Dut
+
+        def test_cocotb_runner(dut: Dut) -> None:
+            dut.run()
+    """)
+
+    result: RunResult = pytester.runpytest(
+        "--cocotb-regression-manager=cocotb",
+        f"--override-ini=pythonpath={test_cocotb_dir.as_posix()}",
+    )
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize(
+    "marker",
+    (
+        "xoxotb_",
+        "cocotb_",
+        "cocotb_unknown",
+        "cocotb__private",
+    ),
+)
+def test_dut_marker_invalid(pytester: Pytester, marker: str) -> None:
+    """Test invalid markers."""
+    pytester.makepyfile(f"""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        @pytest.mark.{marker}
+        def test_invalid_marker(dut: Dut) -> None:
+            pass
+    """)
+
+    result: RunResult = pytester.runpytest(f"--override-ini=markers={marker}")
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize(
+    "marker",
+    (
+        "cocotb_sources('adder.sv', 'top.v')",
+        "cocotb_sources('adder.sv', 'top.sv')",
+        "cocotb_sources('adder.sv', 'top.vlt')",
+        "cocotb_sources('adder.sv', 'top.vhd')",
+        "cocotb_sources('adder.sv', 'top.vhdl')",
+        "cocotb_sources('adder.sv', 'top.e.vhd')",
+        "cocotb_sources('adder.sv', 'top.e.vhdl')",
+        "cocotb_sources('adder.sv', Verilog('top.v'))",
+        "cocotb_sources('adder.sv', VHDL('top.vhd'))",
+        "cocotb_sources('adder.sv', VerilatorControlFile('top.vlt'))",
+    ),
+)
+def test_dut_toplevel_from_sources(pytester: Pytester, marker: str) -> None:
+    """Test toplevel based on source file."""
+    pytester.makepyfile(f"""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+        from cocotb_tools.runner import Verilog, VHDL, VerilatorControlFile
+
+        @pytest.mark.{marker}
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.toplevel == "top"
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize(
+    "marker",
+    (
+        "cocotb_test_modules('tests.test_top')",
+        "cocotb_test_modules('tests.top_test')",
+        "cocotb_test_modules('tests.top')",
+        "cocotb_test_modules('tests.test_top', 'tests.extra')",
+        "cocotb_test_modules('tests.top_test', 'tests.extra')",
+        "cocotb_test_modules('tests.top', 'tests.extra')",
+    ),
+)
+def test_dut_toplevel_from_test_modules(pytester: Pytester, marker: str) -> None:
+    """Test toplevel based on test module."""
+    pytester.makepyfile(f"""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        @pytest.mark.{marker}
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.toplevel == "top"
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_toplevel_from_attribute(pytester: Pytester) -> None:
+    """Test toplevel set from the :attr:`cocotb_tools.pytest.dut.Dut.toplevel` attribute."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            dut.toplevel = "top"
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.toplevel == "top"
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_toplevel_from_marker(pytester: Pytester) -> None:
+    """Test toplevel set from the ``@pytest.mark.cocotb_toplevel`` marker."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        @pytest.mark.cocotb_toplevel("top")
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.toplevel == "top"
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_toplevel_none(pytester: Pytester) -> None:
+    """Test toplevel when test modules are empty."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            dut.test_modules = []
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.toplevel == None
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize(
+    "marker",
+    (
+        "cocotb_sources('adder.vhd', 'top.v')",
+        "cocotb_sources('adder.vhd', 'top.sv')",
+        "cocotb_sources('adder.vhd', Verilog('top.v'))",
+    ),
+)
+def test_dut_toplevel_lang_verilog(pytester: Pytester, marker: str) -> None:
+    """Test toplevel language based on source file."""
+    pytester.makefile(
+        ".ini",
+        pytest="""
+        [pytest]
+        addopts = --verbose --capture no --strict-markers -p cocotb_tools.pytest.plugin
+        """,
+    )
+
+    pytester.makepyfile(f"""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+        from cocotb_tools.runner import Verilog, VerilatorControlFile
+
+        @pytest.mark.{marker}
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.toplevel_lang == "verilog"
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize(
+    "marker",
+    (
+        "cocotb_sources('adder.sv', 'top.vhd')",
+        "cocotb_sources('adder.sv', 'top.vhdl')",
+        "cocotb_sources('adder.sv', 'top.e.vhd')",
+        "cocotb_sources('adder.sv', 'top.e.vhdl')",
+        "cocotb_sources('adder.sv', VHDL('top.vhd'))",
+    ),
+)
+def test_dut_toplevel_lang_vhdl(pytester: Pytester, marker: str) -> None:
+    """Test toplevel language based on source file."""
+    pytester.makefile(
+        ".ini",
+        pytest="""
+        [pytest]
+        addopts = --verbose --capture no --strict-markers -p cocotb_tools.pytest.plugin
+        """,
+    )
+
+    pytester.makepyfile(f"""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+        from cocotb_tools.runner import VHDL
+
+        @pytest.mark.{marker}
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.toplevel_lang == "vhdl"
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_defines_attr_dict(pytester: Pytester) -> None:
+    """Test defines."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        DEFINES: dict[str, object] = {
+            "DEFINE1": "string",
+            "DEFINE2": 1234,
+            "DEFINE3": 1.25,
+            "DEFINE4": True,
+        }
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            dut.defines = DEFINES
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.defines == DEFINES
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_defines_attr_list(pytester: Pytester) -> None:
+    """Test defines."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            dut.defines = ["DEFINE1=VALUE1", "DEFINE2=VALUE2"]
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.defines == {
+                "DEFINE1": "VALUE1",
+                "DEFINE2": "VALUE2",
+            }
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_parameters_attr_dict(pytester: Pytester) -> None:
+    """Test parameters."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        PARAMS: dict[str, object] = {
+            "PARAM1": "string",
+            "PARAM2": 1234,
+            "PARAM3": 1.25,
+            "PARAM4": True,
+        }
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            dut.parameters = PARAMS
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.parameters == PARAMS
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_parameters_attr_set(pytester: Pytester) -> None:
+    """Test parameters."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        PARAMS: dict[str, object] = {
+            "PARAM1": "string",
+            "PARAM2": 1234,
+            "PARAM3": 1.25,
+            "PARAM4": True,
+        }
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            for name, value in PARAMS.items():
+                dut[name] = value
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            for name, value in PARAMS.items():
+                assert dut[name] == value
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_parameters_attr_list(pytester: Pytester) -> None:
+    """Test parameters."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            dut.parameters = ["PARAM1=VALUE1", "PARAM2=VALUE2"]
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.parameters == {
+                "PARAM1": "VALUE1",
+                "PARAM2": "VALUE2",
+            }
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_env_attr_dict(pytester: Pytester) -> None:
+    """Test env."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        ENVS: dict[str, object] = {
+            "ENV1": "string",
+            "ENV2": 1234,
+            "ENV3": 1.25,
+            "ENV4": True,
+        }
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            dut.env = ENVS
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.env == ENVS
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_dut_env_attr_list(pytester: Pytester) -> None:
+    """Test env."""
+    pytester.makepyfile("""
+        import pytest
+        from cocotb_tools.pytest.dut import Dut
+
+        @pytest.fixture(name="dut")
+        def dut_fixture(dut: Dut) -> Dut:
+            dut.env = ["ENV1=VALUE1", "ENV2=VALUE2"]
+            return dut
+
+        def test_toplevel(dut: Dut) -> None:
+            assert dut.env == {
+                "ENV1": "VALUE1",
+                "ENV2": "VALUE2",
+            }
+    """)
+
+    result: RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1)

--- a/tests/pytest_plugin/test_mark.py
+++ b/tests/pytest_plugin/test_mark.py
@@ -1,0 +1,275 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test :class:`cocotb_tools.pytest.mark` module."""
+
+from __future__ import annotations
+
+from pytest import MarkDecorator
+
+from cocotb_tools.pytest import mark
+
+
+def test_mark_cocotb_simulator() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_simulator` marker."""
+    marker: MarkDecorator = mark.cocotb_simulator("verilator")
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == "verilator"
+    assert marker.__doc__
+
+
+def test_mark_cocotb_test_modules() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_test_modules` marker."""
+    marker: MarkDecorator = mark.cocotb_test_modules("test_module_1", "test_module_2")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("test_module_1", "test_module_2")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_toplevel() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_toplevel` marker."""
+    marker: MarkDecorator = mark.cocotb_toplevel("top")
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == "top"
+    assert marker.__doc__
+
+
+def test_mark_cocotb_toplevel_lang() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_toplevel_lang` marker."""
+    marker: MarkDecorator = mark.cocotb_toplevel_lang("verilog")
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == "verilog"
+    assert marker.__doc__
+
+
+def test_mark_cocotb_toplevel_library() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_toplevel_library` marker."""
+    marker: MarkDecorator = mark.cocotb_toplevel_library("toplib")
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == "toplib"
+    assert marker.__doc__
+
+
+def test_mark_cocotb_timeout() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_timeout` marker."""
+    marker: MarkDecorator = mark.cocotb_timeout(100, "ns")
+    assert len(marker.args) == 0
+    assert len(marker.kwargs) == 2
+    assert marker.kwargs["duration"] == 100
+    assert marker.kwargs["unit"] == "ns"
+    assert marker.__doc__
+
+
+def test_mark_cocotb_sources() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_sources` marker."""
+    marker: MarkDecorator = mark.cocotb_sources("adder.sv", "alu.sv")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("adder.sv", "alu.sv")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_defines() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_defines` marker."""
+    marker: MarkDecorator = mark.cocotb_defines(
+        DEFINE1="string", DEFINE2=1234, DEFINE3=1.25, DEFINE4=True
+    )
+    assert len(marker.args) == 0
+    assert len(marker.kwargs) == 4
+    assert marker.kwargs["DEFINE1"] == "string"
+    assert marker.kwargs["DEFINE2"] == 1234
+    assert marker.kwargs["DEFINE3"] == 1.25
+    assert marker.kwargs["DEFINE4"]
+    assert marker.__doc__
+
+
+def test_mark_cocotb_parameters() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_parameters` marker."""
+    marker: MarkDecorator = mark.cocotb_parameters(
+        PARAM1="string", PARAM2=1234, PARAM3=1.25, PARAM4=True
+    )
+    assert len(marker.args) == 0
+    assert len(marker.kwargs) == 4
+    assert marker.kwargs["PARAM1"] == "string"
+    assert marker.kwargs["PARAM2"] == 1234
+    assert marker.kwargs["PARAM3"] == 1.25
+    assert marker.kwargs["PARAM4"]
+    assert marker.__doc__
+
+
+def test_mark_cocotb_env() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_env` marker."""
+    marker: MarkDecorator = mark.cocotb_env(
+        ENV1="string", ENV2=1234, ENV3=1.25, ENV4=True
+    )
+    assert len(marker.args) == 0
+    assert len(marker.kwargs) == 4
+    assert marker.kwargs["ENV1"] == "string"
+    assert marker.kwargs["ENV2"] == 1234
+    assert marker.kwargs["ENV3"] == 1.25
+    assert marker.kwargs["ENV4"]
+    assert marker.__doc__
+
+
+def test_mark_cocotb_includes() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_includes` marker."""
+    marker: MarkDecorator = mark.cocotb_includes("incdir1", "incdir2")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("incdir1", "incdir2")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_plusargs() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_plusargs` marker."""
+    marker: MarkDecorator = mark.cocotb_plusargs("+arg1", "+arg2")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("+arg1", "+arg2")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_timescale() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_timescale` marker."""
+    marker: MarkDecorator = mark.cocotb_timescale("1ns/1ps")
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == "1ns/1ps"
+    assert marker.__doc__
+
+
+def test_mark_cocotb_random_seed() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_random_seed` marker."""
+    marker: MarkDecorator = mark.cocotb_random_seed(1234)
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == 1234
+    assert marker.__doc__
+
+
+def test_mark_cocotb_build_dir() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_build_dir` marker."""
+    marker: MarkDecorator = mark.cocotb_build_dir("build")
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == "build"
+    assert marker.__doc__
+
+
+def test_mark_cocotb_build_args() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_build_args` marker."""
+    marker: MarkDecorator = mark.cocotb_build_args("arg1", "arg2")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("arg1", "arg2")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_elab_args() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_elab_args` marker."""
+    marker: MarkDecorator = mark.cocotb_elab_args("arg1", "arg2")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("arg1", "arg2")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_sim_args() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_sim_args` marker."""
+    marker: MarkDecorator = mark.cocotb_sim_args("arg1", "arg2")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("arg1", "arg2")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_pre_cmd() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_pre_cmd` marker."""
+    marker: MarkDecorator = mark.cocotb_pre_cmd("arg1", "arg2")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("arg1", "arg2")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_library() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_library` marker."""
+    marker: MarkDecorator = mark.cocotb_library("top")
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == "top"
+    assert marker.__doc__
+
+
+def test_mark_cocotb_gui() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_gui` marker."""
+    marker: MarkDecorator = mark.cocotb_gui()
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0]
+    assert marker.__doc__
+    assert not mark.cocotb_gui(False).args[0]
+
+
+def test_mark_cocotb_waves() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_waves` marker."""
+    marker: MarkDecorator = mark.cocotb_waves()
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0]
+    assert marker.__doc__
+    assert not mark.cocotb_waves(False).args[0]
+
+
+def test_mark_cocotb_verbose() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_verbose` marker."""
+    marker: MarkDecorator = mark.cocotb_verbose()
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0]
+    assert marker.__doc__
+    assert not mark.cocotb_verbose(False).args[0]
+
+
+def test_mark_cocotb_clean() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_clean` marker."""
+    marker: MarkDecorator = mark.cocotb_clean()
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0]
+    assert marker.__doc__
+    assert not mark.cocotb_clean(False).args[0]
+
+
+def test_mark_cocotb_always() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_always` marker."""
+    marker: MarkDecorator = mark.cocotb_always()
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0]
+    assert marker.__doc__
+    assert not mark.cocotb_always(False).args[0]
+
+
+def test_mark_cocotb_gpi_interfaces() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_gpi_interfaces` marker."""
+    marker: MarkDecorator = mark.cocotb_gpi_interfaces("vpi", "vhpi")
+    assert len(marker.args) == 2
+    assert len(marker.kwargs) == 0
+    assert marker.args == ("vpi", "vhpi")
+    assert marker.__doc__
+
+
+def test_mark_cocotb_test_filter() -> None:
+    """Test signature of :deco:`cocotb_tools.pytest.mark.cocotb_test_filter` marker."""
+    marker: MarkDecorator = mark.cocotb_test_filter("^test_.*$")
+    assert len(marker.args) == 1
+    assert len(marker.kwargs) == 0
+    assert marker.args[0] == "^test_.*$"
+    assert marker.__doc__

--- a/tests/pytest_plugin/test_option.py
+++ b/tests/pytest_plugin/test_option.py
@@ -1,0 +1,103 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test :class:`cocotb_tools.pytest._option` module."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from unittest import mock
+
+import pytest
+from pytest import MonkeyPatch, Pytester, RunResult
+
+
+@pytest.mark.parametrize(
+    "env",
+    (
+        "COCOTB_REGRESSION_MANAGER",
+        "COCOTB_SIM_TIME_UNIT",
+        "COCOTB_TOPLEVEL_LANG",
+        "COCOTB_SIMULATOR",
+        "COCOTB_RESOLVE_X",
+        "COCOTB_LOG_LEVEL",
+        "GPI_LOG_LEVEL",
+    ),
+)
+def test_option_invalid_choice_from_env(
+    pytester: Pytester, monkeypatch: MonkeyPatch, env: str
+) -> None:
+    """Test invalid option choice when set from environment variable."""
+    monkeypatch.setenv(env, "<invalid>")
+    result: RunResult = pytester.runpytest()
+    assert result.ret
+
+
+@pytest.mark.parametrize(
+    "option,value",
+    (
+        ("cocotb_trust_inertial_writes", True),
+        ("cocotb_trust_inertial_writes", False),
+        ("cocotb_waveform_viewer", "surfer"),
+        ("cocotb_waveform_viewer", "gtkwave"),
+        ("cocotb_scheduler_debug", True),
+        ("cocotb_scheduler_debug", False),
+        ("cocotb_log_level", None),
+        ("cocotb_log_level", "info"),
+        ("cocotb_resolve_x", None),
+        ("cocotb_resolve_x", "error"),
+        ("cocotb_attach", None),
+        ("cocotb_attach", 10),
+        ("gpi_log_level", None),
+        ("gpi_log_level", "info"),
+    ),
+)
+def test_option_envs_set(
+    pytester: Pytester,
+    monkeypatch: MonkeyPatch,
+    option: str,
+    value: object,
+) -> None:
+    """Test options that must be set as environment variables."""
+    environment: str = option.upper()
+    argument: str = f"--{option.replace('_', '-')}"
+    expected: str | None
+    args: list[str]
+
+    if not value:
+        args = []
+        expected = None
+    elif value is True:
+        args = [argument]
+        expected = "1"
+    elif isinstance(value, str):
+        args = [argument, value]
+        expected = value
+    elif isinstance(value, Sequence):
+        args = [argument] + [str(arg) for arg in value]
+        expected = ",".join(value)
+    else:
+        args = [argument, str(value)]
+        expected = str(value)
+
+    pytester.makepyfile(f"""
+        import os
+        from cocotb_tools.pytest.dut import Dut
+
+        def test_option(dut: Dut) -> None:
+            if {expected!r}:
+                assert os.environ.get({environment!r}) == {expected!r}
+            else:
+                assert {environment!r} not in os.environ
+    """)
+
+    with mock.patch.dict(os.environ, clear=True):
+        if not value:
+            # Plugin should unset this environment variable
+            monkeypatch.setenv(environment, "")
+
+        result: RunResult = pytester.runpytest(*args)
+
+    result.assert_outcomes(passed=1)

--- a/tests/pytest_plugin/test_plugin.py
+++ b/tests/pytest_plugin/test_plugin.py
@@ -1,0 +1,19 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test the :mod:`cocotb_tools.pytest.plugin` module."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+from cocotb_tools.pytest.plugin import _options_for_documentation
+
+
+def test_plugin_option_for_documentation() -> None:
+    """Test the :func:`cocotb_tools.pytest.plugin._options_for_documentation` function."""
+    parser: ArgumentParser = _options_for_documentation()
+
+    assert parser is not None
+    assert isinstance(parser, ArgumentParser)

--- a/tests/pytest_plugin/test_simulator.py
+++ b/tests/pytest_plugin/test_simulator.py
@@ -1,0 +1,105 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test the :mod:`cocotb_tools.pytest._simulator` module."""
+
+from __future__ import annotations
+
+from pytest import MonkeyPatch
+
+from cocotb_tools.pytest._simulator import (
+    are_languages_supported,
+    detect_language,
+    detect_languages,
+    find_simulator,
+    get_supported_languages,
+)
+from cocotb_tools.runner import VHDL, Verilog
+
+
+def test_simulator_detect_language() -> None:
+    """Test the :func:`cocotb_tools.pytest._simulator.detect_language` function."""
+    assert detect_language("top.v") == "verilog"
+    assert detect_language("top.sv") == "verilog"
+    assert detect_language(Verilog("top.v")) == "verilog"
+    assert detect_language("top.vhd") == "vhdl"
+    assert detect_language("top.vhdl") == "vhdl"
+    assert detect_language(VHDL("top.vhdl")) == "vhdl"
+    assert detect_language("top.xyz") is None
+
+
+def test_simulator_detect_languages() -> None:
+    """Test the :func:`cocotb_tools.pytest._simulator.detect_languages` function."""
+    for sources, languages in (
+        (
+            ("top.v",),
+            ("verilog",),
+        ),
+        (
+            ("top.vhd",),
+            ("vhdl",),
+        ),
+        (
+            ("top.v", "top.vhd"),
+            ("verilog", "vhdl"),
+        ),
+    ):
+        assert sorted(detect_languages(sources)) == sorted(languages)
+
+
+def test_simulator_are_languages_supported() -> None:
+    """Test the :func:`cocotb_tools.pytest._simulator.are_languages_supported` function."""
+    for simulator in ("nvc", "ghdl"):
+        assert are_languages_supported(simulator, None)
+        assert are_languages_supported(simulator, "auto")
+        assert are_languages_supported(simulator, ())
+        assert are_languages_supported(simulator, "vhdl")
+        assert are_languages_supported(simulator, ("vhdl",))
+        assert not are_languages_supported(simulator, "verilog")
+        assert not are_languages_supported(simulator, ("verilog",))
+        assert not are_languages_supported(simulator, ("verilog", "vhdl"))
+
+    for simulator in ("verilator", "icarus"):
+        assert are_languages_supported(simulator, None)
+        assert are_languages_supported(simulator, "auto")
+        assert are_languages_supported(simulator, ())
+        assert are_languages_supported(simulator, "verilog")
+        assert are_languages_supported(simulator, ("verilog",))
+        assert not are_languages_supported(simulator, "vhdl")
+        assert not are_languages_supported(simulator, ("vhdl",))
+        assert not are_languages_supported(simulator, ("vhdl", "verilog"))
+
+    for simulator in ("questa", "xcelium"):
+        assert are_languages_supported(simulator, None)
+        assert are_languages_supported(simulator, "auto")
+        assert are_languages_supported(simulator, ())
+        assert are_languages_supported(simulator, "vhdl")
+        assert are_languages_supported(simulator, "verilog")
+        assert are_languages_supported(simulator, ("vhdl",))
+        assert are_languages_supported(simulator, ("verilog",))
+        assert are_languages_supported(simulator, ("vhdl", "verilog"))
+        assert are_languages_supported(simulator, ("verilog", "vhdl"))
+
+
+def test_simulator_find_simulator_none(monkeypatch: MonkeyPatch) -> None:
+    """Test the :func:`cocotb_tools.pytest._simulator.find_simulator` function."""
+    monkeypatch.delenv("PATH", raising=False)
+
+    for simulator in ("nvc", "ghdl", "verilator", "icarus", "questa", "xcelium"):
+        assert find_simulator(simulator) is None
+
+
+def test_simulator_get_supported_languages() -> None:
+    """Test the :func:`cocotb_tools.pytest._simulator.get_supported_languages` function."""
+    for simulator in (None, "", "auto", "unknown"):
+        assert get_supported_languages(simulator) == []
+
+    for simulator in ("nvc", "ghdl"):
+        assert get_supported_languages(simulator) == ["vhdl"]
+
+    for simulator in ("verilator", "icarus"):
+        assert get_supported_languages(simulator) == ["verilog"]
+
+    for simulator in ("questa", "xcelium"):
+        assert sorted(get_supported_languages(simulator)) == ["verilog", "vhdl"]


### PR DESCRIPTION
Implementing a new API for pytest plugin proposed in this issue: https://github.com/cocotb/cocotb/issues/5425

I'm trying to introduce smaller and separate Pull Requests but still functional in some way.

The original plugin (v1) was moved from public module `src/cocotb_tools/pytest/` to private module `src/cocotb_tools/_pytest/`. This will allow to introduce changes in this and future Pull Requests with minimal diff but with some copy-paste from that private module. Later we can nuke that private module in separate PR.

The PR 1/N introduces the bare minimum for a very minimalistic functional plugin:

- Plugin options that can be set from the `pytest` command line interface, pytest configuration files and environment variables. They are the same like in the v1 
- The new `Dut` class that is representing the Design Under Test. It acts as a middleware between user and plugin where user is providing all necessary information required to compile and run HDL design that will be used by plugin. These information can be set by using plugin options, markers and/or `Dut` attributes from fixture functions. The `Dut` class is improved and refactored version of the `HDL` class from v1 where the `HDL` class was nuked in v2
- The dual-purpose `dut` fixture. From a non-simulation environment, it creates and returns an instance of `Dut` that will be passed to plugin. From a simulation environment, it returns the standard `cocotb.top` handler to drive and monitor signals from cocotb test. The diff from v1 is just `cocotb.top if cocotb.is_simulation else Dut.create(request)`
- `@pytest.mark.cocotb_*` markers that will allow to configure an instance of `Dut` returned from the `dut` fixture. They are the same like in the v1
- This PR already allows to use current implementation of plugin with built-in cocotb regression manager and approach with cocotb runners by invoking the `Dut.run()` method from a pytest test function. This was improved compared to v1

A working example can be seen in the `test_dut_run` test function implemented in the `tests/pytest_plugin/test_dut.py` test file.

This already implements a suggestion from this comment: https://github.com/cocotb/cocotb/issues/5425#issuecomment-4083743585

> Would it make sense to separate the plugin into two? One for adding the Runner CLI configuration options (`--cocotb-sim` and friends) that is more likely to be mature and ready soon and can be used by those old projects.

That's why the `--cocotb-regression-manager` option was added. Invoking the `pytest` with the `--cocotb-regression-manager=cocotb` option will use the built-in cocotb regression manager to run cocotb tests and still allowing to use goodies from this PR (pytest plugin options, `dut` fixture, `@pytest.mark.cocotb_*` markers).

Final version of this plugin will automatically invoke the `Dut.run()` method in separate process. And declaring a separate pytest test function with a cocotb runner will be not needed anymore.

This PR also improves few things compared to plugin v1:

- Using the pytest built-in [pytester](https://docs.pytest.org/en/stable/how-to/writing_plugins.html#testing-plugins) plugin to test plugin in isolation
- Separate tests that require simulation environment or not by using the pytest `simulator_required` marker
- 330 tests only for this PR hitting 100% code coverage
- More docstrings
- Plugin is "smart" and, if not requested explicitly, it will automatically detect and use proper HDL simulator

To run these tests without nox (they are also included in `noxfile.py`):

```plaintext
pytest ./tests/pytest_plugin/test_{dut,mark,option,plugin,simulator}.py
```

Incoming n/N PRs:

- 2/N: Collecting `Dut` fixtures, implicitly creating pytest Items from them that will invoke the `Dut.run` method. This will allow to remove need of explicitly using cocotb runners in separate test functions and even it will work with the built-in cocotb regression manager.
- Running cocotb tests via pytest (by moving Python files related with pytest as regression manager from private module `src/cocotb_tools/_pytest/` to public module)
- Documentation about pytest plugin. Removing information about usage of cocotb runners, adding more examples with `dut` fixture and markers, migration steps from cocotb runner to pytest plugin (this will be joyful because it will require only to replace existing cocotb runners with fixtures and it should just "work" :tm: with existing cocotb tests)

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
