### PR TITLE
Fix LogicArray equality list values

### DIFF
--- a/docs/source/newsfragments/5596.bugfix.rst
+++ b/docs/source/newsfragments/5596.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :class:`~cocotb.types.LogicArray` equality against list and tuple values containing unsupported object types.

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -639,6 +639,8 @@ class LogicArray(AbstractMutableArray[Logic]):
                 other = LogicArray(other)
             except ValueError:
                 return False
+            except TypeError:
+                return NotImplemented
             return self == other
         else:
             return NotImplemented

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -305,6 +305,7 @@ def test_equality():
     assert LogicArray("0101") != "lol"
     assert LogicArray("0101") != 123
     assert LogicArray("0101") != [7, "f", dict]
+    assert LogicArray("0101") != [object()]
     assert LogicArray("1111") == -1
     assert LogicArray("1111") == 15
     assert LogicArray("0111") != -6


### PR DESCRIPTION
Fixes #5596

Catch `TypeError` as well as `ValueError` when normalizing list and tuple
operands in Logic Array's equality operator

Now all unsupported values compare unequal instead
of raising.

Added a regression test for the unsupported-object case.

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
