### PR TITLE
Change TestManager _tasks attribute from list to dict to speed up complete callback

### DIFF
--- a/docs/source/newsfragments/5603.bugfix.rst
+++ b/docs/source/newsfragments/5603.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a performance regression where the time to remove a completed :class:`~cocotb.task.Task` scaled linearly with the number of concurrently running tasks.

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -55,7 +55,7 @@ class TestManager:
 
         # We create the main task here so that the init checks can be done immediately.
         self._main_task = Task[None](test_coro, name=f"Test {name}")
-        self._tasks: list[Task[Any]] = []
+        self._tasks: dict[Task[Any], None] = {}
         self._excs: list[BaseException] = []
         self._finishing: bool = False
         self._complete: bool = False
@@ -87,7 +87,7 @@ class TestManager:
         # start main task
         self._main_task._add_done_callback(self._test_done_callback)
         self._main_task._ensure_started()
-        self._tasks.append(self._main_task)
+        self._tasks[self._main_task] = None
 
         # start timeout if specified
         if self._timeout is not None:
@@ -146,7 +146,7 @@ class TestManager:
             self._timeout_cb.cancel()
 
         # Cancel Tasks.
-        for task in self._tasks[:]:
+        for task in list(self._tasks):
             task._cancel_now()
 
         # Register function to clean up global state once all Tasks have ended.
@@ -167,11 +167,11 @@ class TestManager:
 
     def add_task(self, task: Task[Any]) -> None:
         task._add_done_callback(self._task_done_callback)
-        self._tasks.append(task)
+        self._tasks[task] = None
         self._done.clear()
 
     def remove_task(self, task: Task[Any]) -> None:
-        self._tasks.remove(task)
+        del self._tasks[task]
         if not self._tasks:
             self._done.set()
 

--- a/tests/benchmarks/test_matrix_multiplier.py
+++ b/tests/benchmarks/test_matrix_multiplier.py
@@ -38,7 +38,7 @@ def build_and_run_matrix_multiplier(benchmark, sim):
         hdl_toplevel="matrix_multiplier",
         sources=sources,
         build_args=build_args,
-        build_dir="sim_build/matrix_multiplier",
+        build_dir=f"sim_build/matrix_multiplier_{sim}",
     )
 
     @benchmark

--- a/tests/benchmarks/test_parameterize_perf/test_parameterize_perf.py
+++ b/tests/benchmarks/test_parameterize_perf/test_parameterize_perf.py
@@ -20,7 +20,7 @@ def test_parameterize_perf_icarus(benchmark) -> None:
     runner.build(
         hdl_toplevel="parametrize_perf_top",
         sources=[THIS_DIR / "parametrize_perf_top.sv"],
-        build_dir="sim_build",
+        build_dir="sim_build/parametrize_perf_icarus",
     )
 
     @benchmark

--- a/tests/benchmarks/test_task_churn_perf/task_churn_perf_top.sv
+++ b/tests/benchmarks/test_task_churn_perf/task_churn_perf_top.sv
@@ -1,0 +1,8 @@
+// Copyright cocotb contributors
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+`timescale 1ns / 1ps
+
+module task_churn_perf_top;
+endmodule

--- a/tests/benchmarks/test_task_churn_perf/task_churn_performance_tests.py
+++ b/tests/benchmarks/test_task_churn_perf/task_churn_performance_tests.py
@@ -1,0 +1,90 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import random
+
+import cocotb
+from cocotb.triggers import Timer
+
+
+async def task_resident(period_ns: int) -> None:
+    while True:
+        await Timer(period_ns, "ns")
+
+
+async def task_transient(steps: int) -> None:
+    for _ in range(steps):
+        await Timer(1, "ns")
+
+
+async def task_sleep_then_done(delay_ns: int) -> None:
+    # Single await then completion, for when only the removal time matters and
+    # not how many ticks the task spans.
+    await Timer(delay_ns, "ns")
+
+
+@cocotb.test()
+async def typical(dut) -> None:
+    # A workload typical of cocotb. A modest number of tasks live for the whole
+    # test (resident) plus repeated waves of short lived tasks (transients).
+    resident_tasks = 24
+    transient_tasks = 24
+    waves_tasks = 32
+
+    residents = [cocotb.start_soon(task_resident(5)) for _ in range(resident_tasks)]
+
+    for _ in range(waves_tasks):
+        for _ in range(transient_tasks):
+            cocotb.start_soon(task_transient(2))
+        await Timer(3, "ns")
+
+    for task in residents:
+        task.kill()
+
+
+@cocotb.test()
+async def churn_random(dut) -> None:
+    # Many tasks completing at random times so removals are interleaved across
+    # many scheduler ticks - the removal-sensitive probe for the fix.
+    rng = random.Random(0x1234)
+
+    for _ in range(100000):
+        cocotb.start_soon(task_sleep_then_done(rng.randint(1, 10000)))
+
+    # Wait for worst case time + 1 for all jobs to finish.
+    await Timer(10001, "ns")
+
+
+@cocotb.test()
+async def resident_bulk(dut) -> None:
+    # A large resident population started at time 0 and torn down at test end.
+    residents = [cocotb.start_soon(task_resident(10000)) for _ in range(500000)]
+    await Timer(1, "ns")
+    for task in residents:
+        task.kill()
+
+
+@cocotb.test()
+async def completion_storm(dut) -> None:
+    # Every task completes on the same first tick, so all removals fire in one
+    # scheduler step.
+    for _ in range(500000):
+        cocotb.start_soon(task_transient(1))
+    await Timer(2, "ns")
+
+
+@cocotb.test()
+async def fanout(dut) -> None:
+    async def parent() -> None:
+        for _ in range(50):
+            cocotb.start_soon(task_transient(1))
+            await Timer(1, "ns")
+
+    parents = [cocotb.start_soon(parent()) for _ in range(1000)]
+
+    await Timer(51, "ns")
+
+    for task in parents:
+        task.kill()

--- a/tests/benchmarks/test_task_churn_perf/task_churn_performance_tests.py
+++ b/tests/benchmarks/test_task_churn_perf/task_churn_performance_tests.py
@@ -33,15 +33,13 @@ async def typical(dut) -> None:
     transient_tasks = 24
     waves_tasks = 32
 
-    residents = [cocotb.start_soon(task_resident(5)) for _ in range(resident_tasks)]
+    for _ in range(resident_tasks):
+        cocotb.start_soon(task_resident(5))
 
     for _ in range(waves_tasks):
         for _ in range(transient_tasks):
             cocotb.start_soon(task_transient(2))
         await Timer(3, "ns")
-
-    for task in residents:
-        task.kill()
 
 
 @cocotb.test()
@@ -60,10 +58,9 @@ async def churn_random(dut) -> None:
 @cocotb.test()
 async def resident_bulk(dut) -> None:
     # A large resident population started at time 0 and torn down at test end.
-    residents = [cocotb.start_soon(task_resident(10000)) for _ in range(500000)]
+    for _ in range(500000):
+        cocotb.start_soon(task_resident(10000))
     await Timer(1, "ns")
-    for task in residents:
-        task.kill()
 
 
 @cocotb.test()
@@ -82,9 +79,7 @@ async def fanout(dut) -> None:
             cocotb.start_soon(task_transient(1))
             await Timer(1, "ns")
 
-    parents = [cocotb.start_soon(parent()) for _ in range(1000)]
+    for _ in range(1000):
+        cocotb.start_soon(parent())
 
     await Timer(51, "ns")
-
-    for task in parents:
-        task.kill()

--- a/tests/benchmarks/test_task_churn_perf/test_task_churn_perf.py
+++ b/tests/benchmarks/test_task_churn_perf/test_task_churn_perf.py
@@ -1,0 +1,52 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from cocotb_tools.runner import get_runner
+
+THIS_DIR = Path(__file__).resolve().parent
+
+
+def build_and_run(benchmark, scenario: str) -> None:
+    if str(THIS_DIR) not in sys.path:
+        sys.path.append(str(THIS_DIR))
+
+    runner = get_runner("icarus")
+
+    runner.build(
+        hdl_toplevel="task_churn_perf_top",
+        sources=[THIS_DIR / "task_churn_perf_top.sv"],
+        build_dir="sim_build",
+    )
+
+    @benchmark
+    def run_test() -> None:
+        runner.test(
+            hdl_toplevel="task_churn_perf_top",
+            test_module="task_churn_performance_tests",
+            test_filter=scenario,
+        )
+
+
+def test_task_churn_typical(benchmark) -> None:
+    build_and_run(benchmark, "typical")
+
+
+def test_task_churn_churn_random(benchmark) -> None:
+    build_and_run(benchmark, "churn_random")
+
+
+def test_task_churn_resident_bulk(benchmark) -> None:
+    build_and_run(benchmark, "resident_bulk")
+
+
+def test_task_churn_completion_storm(benchmark) -> None:
+    build_and_run(benchmark, "completion_storm")
+
+
+def test_task_churn_fanout(benchmark) -> None:
+    build_and_run(benchmark, "fanout")

--- a/tests/benchmarks/test_task_churn_perf/test_task_churn_perf.py
+++ b/tests/benchmarks/test_task_churn_perf/test_task_churn_perf.py
@@ -20,7 +20,7 @@ def build_and_run(benchmark, scenario: str) -> None:
     runner.build(
         hdl_toplevel="task_churn_perf_top",
         sources=[THIS_DIR / "task_churn_perf_top.sv"],
-        build_dir="sim_build",
+        build_dir=f"sim_build/test_task_churn_{scenario}",
     )
 
     @benchmark


### PR DESCRIPTION
Update the TaskManager _tasks attribute from a list to a dictionary. This speeds up the teardown of a task once it has completed and attempts to remove itself form the task list.

The performance issues encountered were discussed in this issue: #5602

In the instance where we are running many hundreds of thousands of tasks in a single time step (and a large portion of those tasks are also completing in that time step). The teardown time of those tasks starts to become noticeable. Moving to a dict means we can perform the removal based on the hash without any iteration/comparison and is O(1) time.

This could probably do with more thorough performance unit test though.....