### PR TITLE
Fix test deps

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -23,6 +23,7 @@ on:
       - "stable/**"
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build_release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,15 +316,19 @@ release_build_sdist = [
     "build",
 ]
 test_common = [
-    "pytest>=8.4"  # need RaisesExc and RaisesGroup
+    # Needed for RaisesExc and RaisesGroup testing.
+    "pytest>=8.4",
+    # Needed for IPython shell interactive testing.
+    "IPython",
+    "pexpect",
+    # Needed for leak testing.
+    "psutil",
 ]
 dev_test = [
     {include-group = "test_common"},
+    # We only collect coverage on dev workflows.
     "coverage[toml]>=7.2",
-    "IPython",
-    "pexpect",
     "pytest-cov",
-    "psutil",
 ]
 coverage_report = [
     "coverage[toml]>=7.2",
@@ -340,6 +344,7 @@ release_test = [
     # PyPi, and then installing cocotb itself from the local dist directory.
     "exceptiongroup; python_version<'3.11'",
     "find_libpython",
+    "pytest>=6",
 ]
 
 [tool.uv.dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -677,10 +677,22 @@ release-build-wheel = [
 release-test = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "find-libpython" },
+    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pexpect" },
+    { name = "psutil" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 test-common = [
+    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pexpect" },
+    { name = "psutil" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -768,9 +780,18 @@ release-build-wheel = [{ name = "cibuildwheel", marker = "python_full_version >=
 release-test = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "find-libpython" },
+    { name = "ipython" },
+    { name = "pexpect" },
+    { name = "psutil" },
+    { name = "pytest", specifier = ">=6" },
     { name = "pytest", specifier = ">=8.4" },
 ]
-test-common = [{ name = "pytest", specifier = ">=8.4" }]
+test-common = [
+    { name = "ipython" },
+    { name = "pexpect" },
+    { name = "psutil" },
+    { name = "pytest", specifier = ">=8.4" },
+]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
This is currently breaking regressions.

* Moved deps used by the regression to test_common
* Fixed a missing dep. release tests need all cocotb deps copied, when pytest was added this wasn't done. It works because we specify a higher version of pytest in test_common for RaisesExc and RaisesGroup testing.
