### PR TITLE
Improve `resolve()` and `is_resolvable`

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -382,30 +382,50 @@ These are a set of datatypes that model the behavior of common HDL datatypes.
     :members:
     :inherited-members:
 
+.. _x-resolving:
+
+non-``0``/``1`` values of :class:`.Logic`, and :class:`.LogicArray` values can be "resolved" to ``0``\ s and ``1``\ s using the
+:meth:`!resolve` method on those types.
+You can check to see if that call would fail using the :meth:`!is_resolvable` method.
+
+The possible resolvers are:
+
+* ``error``:
+    Any non-``0``\ /\ ``1`` values cause resolution to fail with a :exc:`ValueError` exception.
+
+* ``weak``:
+    ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
+    Remaining non-``0``/``1`` values cause resolution to fail with a :exc:`ValueError` exception.
+
+* ``zeros``:
+    ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
+    Remaining non-``0``/``1`` values are resolved to ``0``.
+
+* ``ones``:
+    ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
+    Remaining non-``0``/``1`` values are resolved to ``1``.
+
+* ``random``:
+    ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
+    Remaining non-``0``/``1`` values are randomly resolved to either ``0`` or ``1``.
+
+.. versionchanged:: 2.1
+    ``weak`` resolver now throws :exc:`ValueError` on ``W``, ``X``, ``Z``, and ``-`` values.
+
+There is a global default resolver that is used when no resolver is specified.
+:func:`get_default_resolve_method` and :func:`set_default_resolve_method` can be used to get and set the global default resolver.
+:envvar:`COCOTB_RESOLVE_X` can be used to set the global default resolver at the start of a simulation.
+
+.. autofunction:: get_default_resolve_method
+
+.. autofunction:: set_default_resolve_method
+
 .. envvar:: COCOTB_RESOLVE_X
 
     Type: :ref:`env-string`
 
-    Defines how to resolve bits with a value of ``X``, ``Z``, ``U``, ``W``, or ``-`` when being converted to integer.
-    Valid settings are:
-
-    ``error``
-        Resolves nothing.
-    ``weak``
-        Resolves ``L`` to ``0`` and ``H`` to ``1``.
-    ``zeros``
-        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values to ``0``.
-    ``ones``
-        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values to ``1``.
-    ``random``
-        Like ``weak``, but resolves all other non-\ ``0``\ /\ ``1`` values randomly to either ``0`` or ``1``.
-
-    There is also a slight difference in behavior of ``bool(logic)`` when this environment variable is set.
-    When this variable is set, ``bool(logic)`` treats all non-\ ``0``\ /\ ``1`` values as equivalent to ``0``.
-    When this variable is *not* set, ``bool(logic)`` will fail on non-\ ``0``\ /\ ``1`` values.
-
-    .. warning::
-        Using this feature is *not* recommended.
+    Accepts the resolver strings ``error``, ``weak``, ``zeros``, ``ones``, and ``random``.
+    Sets the global default resolver at the start of simulation.
 
     .. deprecated:: 2.0
         The previously accepted values ``VALUE_ERROR``, ``ZEROS``, ``ONES``, and ``RANDOM`` are deprecated.

--- a/src/cocotb/types/__init__.py
+++ b/src/cocotb/types/__init__.py
@@ -9,6 +9,7 @@ from ._indexing import IndexingChangedWarning
 from ._logic import Bit, Logic
 from ._logic_array import LogicArray
 from ._range import Range
+from ._resolve import get_default_resolve_method, set_default_resolve_method
 
 __all__ = (
     "AbstractArray",
@@ -19,6 +20,8 @@ __all__ = (
     "Logic",
     "LogicArray",
     "Range",
+    "get_default_resolve_method",
+    "set_default_resolve_method",
 )
 
 # Set __module__ on re-exports

--- a/src/cocotb/types/_logic.py
+++ b/src/cocotb/types/_logic.py
@@ -7,7 +7,13 @@ import sys
 from functools import cache
 from typing import Union
 
-from cocotb.types._resolve import RESOLVE_X, ResolverLiteral, get_str_resolver
+from cocotb.types._resolve import (
+    IsResolvable,
+    IsResolvableLogic,
+    ResolverLiteral,
+    is_resolvable_bool,
+    resolve,
+)
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -238,77 +244,79 @@ class Logic:
     def __str__(self) -> str:
         return ("U", "X", "0", "1", "Z", "W", "L", "H", "-")[self._repr]
 
-    if RESOLVE_X is None:
+    def __bool__(self) -> bool:
+        return self.resolve()._repr == _1
 
-        def __bool__(self) -> bool:
-            if self._repr in (_0, _L):
-                return False
-            elif self._repr in (_1, _H):
-                return True
-            raise ValueError(f"Cannot convert {self!r} to bool")
-
-        def __int__(self) -> int:
-            if self._repr in (_0, _L):
-                return 0
-            elif self._repr in (_1, _H):
-                return 1
-            raise ValueError(f"Cannot convert {self!r} to int")
-
-    else:
-
-        def __bool__(self) -> bool:
-            return self._repr in (_1, _H)
-
-        def __int__(self) -> int:
-            s = str(self)
-            s = RESOLVE_X(s)  # type: ignore
-            return int(s, 2)
+    def __int__(self) -> int:
+        return 1 if self.resolve()._repr == _1 else 0
 
     def __index__(self) -> int:
         return int(self)
 
-    def resolve(self, resolver: ResolverLiteral) -> Self:
+    def resolve(self, resolver: ResolverLiteral | None = None) -> Bit:
         """Resolve non-``0``/``1`` values to ``0``/``1``.
 
-        The possible values of the *resolver* argument are:
-
-        * ``"weak"``:
-            Weak values are resolved to their strong-valued equivalents.
-
-        * ``"zeros"``:
-            ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
-            Remaining non-``0``/``1`` values are resolved to ``0``.
-
-        * ``"ones"``:
-            ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
-            Remaining non-``0``/``1`` values are resolved to ``1``.
-
-        * ``"random"``:
-            ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
-            Remaining non-``0``/``1`` values are randomly resolved to either ``0`` or ``1``.
-
         Args:
-            resolver: How to resolve non-``0``/``1`` values. See possible values above.
+            resolver: How to resolve non-``0``/``1`` values.
+                See :ref:`x-resolving` for more information on resolver values and their behavior.
+                If ``None`` (default), the global default resolver will be used.
 
         Returns:
-            The resolved Logic.
+            The resolved :class:`!Bit`.
 
         Raises:
             ValueError: Invalid *resolver* value.
             TypeError: Unsupported *value* type.
+
+        .. versionchanged:: 2.1
+            This now returns a :class:`Bit` instead of a :class:`!Logic`.
+            Because :class:`!Bit` is a subtype of :class:`!Logic` this should not cause any issues unless there are explicit type checks
+            (e.g. ``type(obj) is Logic``).
+
+        .. versionchanged:: 2.1
+            The *resolver* parameter is now optional.
+            The global default resolver will be used if it is not provided.
+
+        .. versionchanged:: 2.1
+            The ``weak`` resolver now throws :exc:`ValueError` on ``W``, ``X``, ``Z``, and ``-`` values.
         """
-        return type(self)(get_str_resolver(resolver)(str(self)))
+        return Bit(resolve(str(self), resolver))
 
     def __len__(self) -> int:
         return 1
 
     @property
-    def is_resolvable(self) -> bool:
-        """``True`` if value is ``0``, ``1``, ``L``, ``H``.
+    def is_resolvable(self) -> IsResolvable:
+        """Returns ``True`` if the value would not cause :meth:`resolve` to fail with the given resolver.
+
+        This property can be used in boolean checks directly, in which case it will use the global default resolver.
+        Or it can be called with a specific resolver to check against that resolver instead.
+
+        .. code-block:: pycon3
+            >>> if Logic("L").is_resolvable:
+            ...     print("resolvable!")
+            resolvable!
+            >>> Logic("X").is_resolvable("zeros")
+            True
+
+        Args:
+            resolver: How to resolve non-``0``/``1`` values.
+                See :ref:`x-resolving` for more information on resolver values and their behavior.
+                If ``None`` (default), the global default resolver will be used.
+
+        Returns:
+            ``True`` if the value would not cause :meth:`resolve` to fail with the given resolver.
 
         .. versionadded:: 2.0
+
+        .. versionchanged:: 2.1
+            The return type was changed from :class:`bool` to a special object that can be used in boolean checks,
+            or called with a resolver to check against that resolver instead.
+
+        .. versionchanged:: 2.1
+            This property now respects the current default resolver, instead of always checking against the "weak" resolver.
         """
-        return (False, False, True, True, False, False, True, True, False)[self._repr]
+        return IsResolvableLogic(str(self))
 
     def __copy__(self) -> Logic:
         return self
@@ -336,3 +344,63 @@ class Bit(Logic):
     """
 
     _values = {_0, _1}
+
+    def resolve(self, resolver: ResolverLiteral | None = None) -> Bit:
+        """Resolve non-``0``/``1`` values to ``0``/``1``.
+
+        Args:
+            resolver: How to resolve non-``0``/``1`` values.
+                See :ref:`x-resolving` for more information on resolver values and their behavior.
+                If ``None`` (default), the global default resolver will be used.
+
+        Returns:
+            The resolved :class:`!Bit`.
+
+        Raises:
+            ValueError: Invalid *resolver* value.
+            TypeError: Unsupported *value* type.
+
+        .. versionchanged:: 2.1
+            The *resolver* parameter is now optional.
+            The global default resolver will be used if it is not provided.
+        """
+        return self
+
+    @property
+    def is_resolvable(self) -> IsResolvable:
+        """``True`` if the value would not cause :meth:`resolve` to fail with the given resolver.
+
+        This property can be used in boolean checks directly, in which case it will use the global default resolver.
+        Or it can be called with a specific resolver to check against that resolver instead.
+
+        .. code-block:: pycon3
+            >>> if Bit("1").is_resolvable:
+            ...     print("resolvable!")
+            resolvable!
+            >>> Bit("1").is_resolvable("error")
+            True
+
+        Args:
+            resolver: How to resolve non-``0``/``1`` values.
+                See :ref:`x-resolving` for more information on resolver values and their behavior.
+                If ``None`` (default), the global default resolver will be used.
+
+        Returns:
+            ``True`` always.
+
+        .. versionadded:: 2.0
+
+        .. versionchanged:: 2.1
+            The return type was changed from :class:`bool` to a special object that can be used in boolean checks,
+            or called with a resolver to check against that resolver instead.
+
+        .. versionchanged:: 2.1
+            This property now respects the current default resolver, instead of always checking against the "weak" resolver.
+        """
+        return is_resolvable_bool
+
+    def __bool__(self) -> bool:
+        return self._repr == _1
+
+    def __int__(self) -> int:
+        return 1 if self._repr == _1 else 0

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -20,7 +20,7 @@ from cocotb.types._abstract_array import AbstractMutableArray
 from cocotb.types._indexing import IndexingChangedWarning
 from cocotb.types._logic import Logic, LogicConstructibleT
 from cocotb.types._range import Range
-from cocotb.types._resolve import RESOLVE_X, ResolverLiteral, get_str_resolver
+from cocotb.types._resolve import IsResolvableLogicArray, ResolverLiteral, resolve
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -337,19 +337,14 @@ class LogicArray(AbstractMutableArray[Logic]):
             # May convert list to str before converting to int.
             value_as_str = self._get_str()
 
-            # always resolve L and H to 0 and 1
-            value_as_str = value_as_str.translate(_resolve_lh_table)
-
             try:
-                self._value_as_int = int(value_as_str, 2)
+                resolved_str = resolve(value_as_str)
             except ValueError:
-                if RESOLVE_X is None:
-                    raise ValueError(
-                        f"Can't convert {type(self).__qualname__} to int: it contains non-0/1 values"
-                    ) from None
-                else:
-                    value_as_str = RESOLVE_X(value_as_str)
-                    return int(value_as_str, 2)
+                raise ValueError(
+                    f"Can't convert {type(self).__qualname__} to int: it contains non-0/1 values"
+                ) from None
+            else:
+                self._value_as_int = int(resolved_str, 2)
 
         return self._value_as_int
 
@@ -674,9 +669,24 @@ class LogicArray(AbstractMutableArray[Logic]):
         self[:] = value
 
     @property
-    def is_resolvable(self) -> bool:
-        """``True`` if all elements are ``0``, ``1``, ``L``, ``H``."""
-        return all(bit.is_resolvable for bit in self)
+    def is_resolvable(self) -> IsResolvableLogicArray:
+        """``True`` if the value would not cause :meth:`resolve` to fail with the given resolver.
+
+        This property can be used in boolean checks directly, in which case it will use the global default resolver.
+        Or it can be called with a specific resolver to check against that resolver instead.
+
+        See :ref:`x-resolving` for more information on resolver values and their behavior.
+
+        .. versionadded:: 2.0
+
+        .. versionchanged:: 2.1
+            The return type was changed from :class:`bool` to a special object that can be used in boolean checks,
+            or called with a resolver to check against that resolver instead.
+
+        .. versionchanged:: 2.1
+            This property now respects the current default resolver, instead of always checking against the "weak" resolver.
+        """
+        return IsResolvableLogicArray(str(self))
 
     @property
     @deprecated(
@@ -962,51 +972,44 @@ class LogicArray(AbstractMutableArray[Logic]):
     def __invert__(self) -> LogicArray:
         return LogicArray(~v for v in self)
 
-    if RESOLVE_X is None:
+    def __bool__(self) -> bool:
+        if len(self) == 0:
+            return False
+        return bool(self.to_unsigned())
 
-        def __bool__(self) -> bool:
-            if len(self) == 0:
-                return False
-            return bool(int(self))
-
-    else:
-
-        def __bool__(self) -> bool:
-            if len(self) == 0:
-                return False
-            return any(bool(bit) for bit in self)
-
-    def resolve(self, resolver: ResolverLiteral) -> LogicArray:
-        """Resolves non-0/1 values to 0/1.
-
-        The possible values of the *resolver* argument are:
-
-        * ``"weak"``:
-            Weak values are resolved to their strong-valued equivalents.
-
-        * ``"zeros"``:
-            ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
-            Remaining non-``0``/``1`` values are resolved to ``0``.
-
-        * ``"ones"``:
-            ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
-            Remaining non-``0``/``1`` values are resolved to ``1``.
-
-        * ``"random"``:
-            ``L`` and ``H`` are resolved to ``0`` and ``1``, respectively.
-            Remaining non-``0``/``1`` values are randomly resolved to either ``0`` or ``1``.
+    def resolve(self, resolver: ResolverLiteral | None = None) -> LogicArray:
+        """Resolve non-``0``/``1`` values to ``0``/``1``.
 
         Args:
-            resolver: How to resolve non-``0``/``1`` values. See possible values above.
+            resolver: How to resolve non-``0``/``1`` values.
+                See :ref:`x-resolving` for more information on resolver values and their behavior.
+                If ``None`` (default), the global default resolver will be used.
 
         Returns:
-            The resolved Logic.
+            The resolved :class:`!LogicArray`.
 
         Raises:
             ValueError: Invalid *resolver* value.
             TypeError: Unsupported *value* type.
+
+        .. versionchanged:: 2.1
+            The *resolver* parameter is now optional.
+            The global default resolver will be used if it is not provided.
+
+        .. versionchanged:: 2.1
+            The ``weak`` resolver now throws :exc:`ValueError` on ``W``, ``X``, ``Z``, and ``-`` values.
         """
-        return LogicArray(get_str_resolver(resolver)(str(self)), self.range)
+        # We build the output value manually so we can fill in both the string and int representations.
+        # Otherwise when a user goes to use `__bool__` or `__int__` on the resolve value, it would
+        # go through the resolver again, unnecessarily.
+        resolved_self = resolve(self._get_str(), resolver)
+        output = LogicArray.__new__(LogicArray)
+        output._value_as_array = None
+        output._value_as_int = int(resolved_self, 2)
+        output._value_as_str = resolved_self
+        output._range = self._range
+        output._warn_indexing = self._warn_indexing
+        return output
 
     def __copy__(self) -> LogicArray:
         raise NotImplementedError("`copy.copy` on LogicArray is not supported")

--- a/src/cocotb/types/_resolve.py
+++ b/src/cocotb/types/_resolve.py
@@ -3,17 +3,99 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import os
 import sys
-from functools import cache
 from random import Random
-from typing import Callable, Final, Literal, cast
-
-from cocotb_tools import _env
+from typing import Literal, Protocol, cast
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
 
-ResolverLiteral: TypeAlias = Literal["weak", "zeros", "ones", "random"]
+
+ResolverLiteral: TypeAlias = Literal["error", "weak", "zeros", "ones", "random"]
+
+# global resolver, default to "weak" for backwards compatibility of is_resolvable/resolve.
+_resolve_method: ResolverLiteral = "weak"
+
+
+def get_default_resolve_method() -> ResolverLiteral:
+    """Returns the global default resolver method."""
+    return _resolve_method
+
+
+def set_default_resolve_method(method: ResolverLiteral) -> None:
+    """Sets the global default resolver method."""
+    global _resolve_method
+    _resolve_method = method
+
+
+def resolve(value: str, resolver: ResolverLiteral | None = None) -> str:
+    """Resolves a value using the specified resolver method.
+
+    ``None`` resolves using the global default resolver method.
+    """
+    if resolver is None:
+        resolver = get_default_resolve_method()
+
+    if resolver == "random":
+        return "".join(map(_rnd_table.__getitem__, value))
+
+    try:
+        table = _resolve_tables[resolver]
+    except KeyError:
+        raise ValueError(
+            f"Invalid resolver: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}"
+        ) from None
+
+    return value.translate(table)
+
+
+class IsResolvable(Protocol):
+    def __bool__(self) -> bool: ...
+    def __call__(self, resolver: ResolverLiteral | None = None) -> bool: ...
+
+
+class IsResolvableLogic:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def _is_resolvable(self, resolver: ResolverLiteral) -> bool:
+        if resolver not in _VALID_RESOLVERS:
+            raise ValueError(
+                f"Invalid resolver: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}"
+            ) from None
+        # Works for 1 character strings.
+        return self._value in _resolvable_values_table[resolver]
+
+    def __bool__(self) -> bool:
+        return self._is_resolvable(get_default_resolve_method())
+
+    def __call__(self, resolver: ResolverLiteral | None = None) -> bool:
+        if resolver is None:
+            resolver = get_default_resolve_method()
+        return self._is_resolvable(resolver)
+
+
+class IsResolvableLogicArray(IsResolvableLogic):
+    def _is_resolvable(self, resolver: ResolverLiteral) -> bool:
+        if resolver not in _VALID_RESOLVERS:
+            raise ValueError(
+                f"Invalid resolver: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}"
+            ) from None
+        # Works for N character strings. Confirmed faster than `all(c in table for c in self._value)`.
+        return frozenset(self._value).issubset(_resolvable_values_table[resolver])
+
+
+class _IsResolvableBool:
+    def __bool__(self) -> bool:
+        return True
+
+    def __call__(self, resolver: ResolverLiteral | None = None) -> bool:
+        return True
+
+
+# There only needs to be one instance since Bit/BitArray are always resolvable.
+is_resolvable_bool = _IsResolvableBool()
 
 
 _randomResolveRng = Random()
@@ -42,50 +124,34 @@ _resolve_tables: dict[str, dict[int, int]] = {
     "ones": str.maketrans("LHUXZW-", "0111111"),
 }
 
+_resolvable_values_table = {
+    "error": frozenset("01"),
+    "weak": frozenset("01LH"),
+    "zeros": frozenset("01LHUXZW-"),
+    "ones": frozenset("01LHUXZW-"),
+    "random": frozenset("01LHUXZW-"),
+}
+
 _VALID_RESOLVERS = ("error", "weak", "zeros", "ones", "random")
 _VALID_RESOLVERS_ERR_MSG = (
     "Valid values are 'error', 'weak', 'zeros', 'ones', or 'random'"
 )
 
 
-@cache
-def get_str_resolver(resolver: ResolverLiteral) -> Callable[[str], str]:
-    if resolver not in _VALID_RESOLVERS:
-        raise ValueError(f"Invalid resolver: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}")
+def _init() -> None:
+    resolver = os.getenv("COCOTB_RESOLVE_X", "").lower()
 
-    if resolver == "random":
-        # Can't use str.translate for random resolving as it assumes that the mapping
-        # will not change over the course of the call.
-        def resolve_func(value: str) -> str:
-            return "".join(map(_rnd_table.__getitem__, value))
-
-    else:
-        resolve_table = _resolve_tables[resolver]
-
-        def resolve_func(value: str) -> str:
-            return value.translate(resolve_table)
-
-    return resolve_func
-
-
-def _init() -> Callable[[str], str] | None:
-    resolver = _env.as_str("COCOTB_RESOLVE_X").lower()
-
-    # no resolver
+    # no resolver, leave as default
     if not resolver:
-        return None
+        return
 
     # backwards compatibility
     if resolver == "value_error":
         resolver = "error"
 
-    # get resolver
-    try:
-        return get_str_resolver(cast("ResolverLiteral", resolver))
-    except ValueError:
+    # set resolve method
+    if resolver not in _VALID_RESOLVERS:
         raise ValueError(
             f"Invalid COCOTB_RESOLVE_X value: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}"
         ) from None
-
-
-RESOLVE_X: Final = _init()
+    set_default_resolve_method(cast("ResolverLiteral", resolver))

--- a/tests/pytest/test_env.py
+++ b/tests/pytest/test_env.py
@@ -7,15 +7,11 @@ environment variables in a consistent and unified way."""
 
 from __future__ import annotations
 
-import os
 import shlex
-import subprocess
-import sys
 from importlib import reload
 from logging import getLogger
 from pathlib import Path
 from re import escape
-from typing import Callable, cast
 
 import pytest
 from pytest import MonkeyPatch, raises
@@ -26,8 +22,7 @@ import cocotb._profiling
 import cocotb.regression
 import cocotb.types._resolve
 from cocotb.handle import SimHandleBase
-from cocotb.types import Logic, LogicArray
-from cocotb.types._resolve import ResolverLiteral
+from cocotb.types import Logic
 from cocotb_tools import _env
 
 
@@ -339,97 +334,68 @@ def test_env_cocotb_resolve_x_weak(monkeypatch: MonkeyPatch) -> None:
     """Test setting :envvar:`COCOTB_RESOLVE_X` environment variable to ``weak`` value."""
     monkeypatch.setenv("COCOTB_RESOLVE_X", "weak")
 
-    resolve: Callable[[str], str] | None = cocotb.types._resolve._init()
+    cocotb.types._resolve._init()
 
-    assert resolve
-    assert resolve("0") == "0"
-    assert resolve("1") == "1"
-    assert resolve("L") == "0"
-    assert resolve("H") == "1"
-    assert resolve("W") == "X"
+    try:
+        assert Logic("0").resolve() == "0"
+        assert Logic("1").resolve() == "1"
+        assert Logic("L").resolve() == "0"
+        assert Logic("H").resolve() == "1"
+        with pytest.raises(ValueError):
+            Logic("W").resolve()
+        with pytest.raises(ValueError):
+            Logic("U").resolve()
+        with pytest.raises(ValueError):
+            Logic("X").resolve()
+        with pytest.raises(ValueError):
+            Logic("Z").resolve()
+        with pytest.raises(ValueError):
+            Logic("-").resolve()
+
+    finally:
+        cocotb.types.set_default_resolve_method("weak")
 
 
 def test_env_cocotb_resolve_x_value_error(monkeypatch: MonkeyPatch) -> None:
     """Test setting :envvar:`COCOTB_RESOLVE_X` environment variable to deprecated ``value_error``."""
     monkeypatch.setenv("COCOTB_RESOLVE_X", "value_error")
 
-    resolve: Callable[[str], str] | None = cocotb.types._resolve._init()
+    cocotb.types._resolve._init()
 
-    assert resolve
-    assert resolve("0") == "0"
-    assert resolve("1") == "1"
+    try:
+        assert Logic("0").resolve() == "0"
+        assert Logic("1").resolve() == "1"
+        with pytest.raises(ValueError):
+            Logic("L").resolve()
+        with pytest.raises(ValueError):
+            Logic("H").resolve()
+        with pytest.raises(ValueError):
+            Logic("W").resolve()
+        with pytest.raises(ValueError):
+            Logic("U").resolve()
+        with pytest.raises(ValueError):
+            Logic("X").resolve()
+        with pytest.raises(ValueError):
+            Logic("Z").resolve()
+        with pytest.raises(ValueError):
+            Logic("-").resolve()
+
+    finally:
+        cocotb.types.set_default_resolve_method("weak")
 
 
 def test_env_cocotb_resolve_x_invalid(monkeypatch: MonkeyPatch) -> None:
     """Test setting :envvar:`COCOTB_RESOLVE_X` environment variable to invalid value."""
     monkeypatch.setenv("COCOTB_RESOLVE_X", "invalid")
 
-    with pytest.raises(
-        ValueError,
-        match=escape(
-            "Invalid COCOTB_RESOLVE_X value: 'invalid'. Valid values are 'error', 'weak', 'zeros', 'ones', or 'random'"
-        ),
-    ):
-        cocotb.types._resolve._init()
+    try:
+        with pytest.raises(
+            ValueError,
+            match=escape(
+                "Invalid COCOTB_RESOLVE_X value: 'invalid'. Valid values are 'error', 'weak', 'zeros', 'ones', or 'random'"
+            ),
+        ):
+            cocotb.types._resolve._init()
 
-
-@pytest.mark.parametrize("resolver", ["weak", "zeros", "ones", "random", "error"])
-def test_env_cocotb_resolve_x_logic_conversion(resolver: str, tmp_path: Path) -> None:
-    """Test that :envvar:`COCOTB_RESOLVE_X` affects ``int()``/``bool()`` of
-    :class:`~cocotb.types.Logic` and :class:`~cocotb.types.LogicArray`.
-
-    The resolving ``__int__``/``__bool__`` methods are bound at import time
-    based on the env var, so this runs in a subprocess with the variable set.
-    Expected ints are computed in the parent via ``.resolve(resolver)``.
-    """
-    typed_resolver = cast("ResolverLiteral", resolver)
-    chars = "UX01ZWLH-"
-    arrays = ["1010", "01LH", "X01Z", "UXWZ", "1HLH"]
-    lines: list[str] = ["from cocotb.types import Logic, LogicArray"]
-
-    def append_int_check(
-        expr: str, expected: int | None, length: int, random_input: bool
-    ) -> None:
-        if resolver == "random" and random_input:
-            lines.append(f"assert 0 <= int({expr}) < (1 << {length}), {expr!r}")
-        elif expected is None:
-            lines.extend(
-                [
-                    f"try: int({expr})",
-                    "except ValueError: pass",
-                    f"else: raise AssertionError({expr!r})",
-                ]
-            )
-        else:
-            lines.append(f"assert int({expr}) == {expected}, {expr!r}")
-
-    for c in chars:
-        # Logic.__int__ under a resolver does `int(resolver(str(self)), 2)`.
-        # The resolved Logic's str is "0"/"1" iff that int call succeeds.
-        resolved = str(Logic(c).resolve(typed_resolver))
-        expected: int | None = int(resolved) if resolved in ("0", "1") else None
-        append_int_check(f"Logic({c!r})", expected, 1, c not in "01LH")
-        # Under any resolver, only 1/H are truthy; others return False (no raise).
-        lines.append(f"assert bool(Logic({c!r})) is {c in '1H'}, {c!r}")
-
-    for s in arrays:
-        # LogicArray._get_int pre-translates L,H -> 0,1 in both branches, so
-        # int(LogicArray(s).resolve(resolver)) predicts subprocess behavior.
-        try:
-            expected = int(LogicArray(s).resolve(typed_resolver))
-        except ValueError:
-            expected = None
-        random_input = any(c not in "01LH" for c in s)
-        append_int_check(f"LogicArray({s!r})", expected, len(s), random_input)
-        lines.append(
-            f"assert bool(LogicArray({s!r})) is {any(c in '1H' for c in s)}, {s!r}"
-        )
-    lines.append("assert bool(LogicArray('')) is False")
-
-    script = tmp_path / "check.py"
-    script.write_text("\n".join(lines) + "\n")
-    subprocess.run(
-        [sys.executable, str(script)],
-        env={**os.environ, "COCOTB_RESOLVE_X": resolver},
-        check=True,
-    )
+    finally:
+        cocotb.types.set_default_resolve_method("weak")

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -162,8 +162,19 @@ def test_logic_invert():
 
 
 def test_resolve():
-    for inp, exp in zip("UX01ZWLH-", "UX01ZX01-"):
-        assert Logic(inp).resolve("weak") == Logic(exp)
+    for inp, exp in zip("UX01ZWLH-", "!!01!!!!!"):
+        if exp == "!":
+            with pytest.raises(ValueError):
+                Logic(inp).resolve("error")
+        else:
+            assert Logic(inp).resolve("error") == Logic(exp)
+
+    for inp, exp in zip("UX01ZWLH-", "!!01!!01!"):
+        if exp == "!":
+            with pytest.raises(ValueError):
+                Logic(inp).resolve("weak")
+        else:
+            assert Logic(inp).resolve("weak") == Logic(exp)
 
     for inp, exp in zip("UX01ZWLH-", "000100010"):
         assert Logic(inp).resolve("zeros") == Logic(exp)

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -475,7 +475,7 @@ def test_bool_cast():
 
 
 def test_resolve():
-    assert LogicArray("UX01ZWLH-").resolve("weak") == LogicArray("UX01ZX01-")
+    assert LogicArray("01LH").resolve("weak") == LogicArray("0101")
     assert LogicArray("UX01ZWLH-").resolve("zeros") == LogicArray("000100010")
     assert LogicArray("UX01ZWLH-").resolve("ones") == LogicArray("110111011")
     assert LogicArray("01LH").resolve("random") == LogicArray("0101")


### PR DESCRIPTION
These contain some breaking changes, but only to code that was added in 2.0 and in the smallest possible way.

It's designed to make resolve functionality more useful and self-consistent.

* Makes "weak" mode fail on U, X, W, Z, and - instead of mapping them
* Because of that Logic.resolve() now returns a Bit
* Added a user settable global default resolve method
* Made resolve() argument optional and use the global default resolver
* Made is_resolvable property use the global default resolver instead of being hardcoded to use "weak" semantics.
* Added ability to call is_resolvable with a resolver method
* Make COCOTB_RESOLVE_X set the initial global default resolver
* Made "weak" the default global resolve method
* made Logic and LogicArray `bool` cast respect the global default resolver instead of the quirky "use Verilog style checks only when COCOTB_RESOLVE_X is set."

Closes #5611.

- [ ] newsfrags
- [ ] Use Verilog `__bool__` semantics for RANDOM since it's nonsense that it can randomly be `True` or `False`. `ZEROS` and `ONES` should respect `resolve` as they are essentially forcing functions (`__bool__` is False for X or True for X). `WEAK` and `ERROR` fail, which is reasonable.