### PR TITLE
Start compound Trigger waiter Tasks eagerly

### DIFF
--- a/docs/source/newsfragments/5617.bugfix.rst
+++ b/docs/source/newsfragments/5617.bugfix.rst
@@ -1,0 +1,1 @@
+:class:`~cocotb.triggers.Combine` and :class:`~cocotb.triggers.First` now schedule their waiter tasks eagerly on :keyword:`await` instead of starting "soon." This fixes a class of races between the waiter :term:`tasks <task>` and any already scheduled :term:`!tasks`, bringing the scheduler back towards 1.9's behavior.

--- a/docs/source/newsfragments/5617.feature.rst
+++ b/docs/source/newsfragments/5617.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`.Task.start_eagerly` to start a :class:`.Task` immediately (in the same stack frame as the caller).

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -8,7 +8,6 @@ from collections.abc import Iterable
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, overload
 
-import cocotb
 from cocotb._base_triggers import _InternalEvent
 from cocotb.task import Task
 
@@ -117,7 +116,7 @@ async def _wait(
 
     for task in waiters:
         task._add_done_callback(done_callback)
-        cocotb.start_soon(task)
+        task.start_eagerly()
 
     try:
         await done

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -230,7 +230,20 @@ class Task(Generic[ResultType]):
         else:
             raise RuntimeError("Task in unknown state")
 
+    def start_eagerly(self) -> None:
+        """Starts an unstarted Task immediately.
+
+        Raises:
+            RuntimeError: If the Task has already started.
+
+        .. versionadded:: 2.1
+        """
+        if self._state is not _TaskState.UNSTARTED:
+            raise RuntimeError("Can only start_eagerly() an unstarted Task")
+        self._resume()
+
     def _ensure_started(self) -> None:
+        """Queues a Task to start running if it is not already started."""
         state = self._state
         if state is _TaskState.UNSTARTED:
             if debug.debug:
@@ -284,6 +297,7 @@ class Task(Generic[ResultType]):
 
         # Set this Task and the current. Unset in finally block.
         global _current_task
+        _previous_task = _current_task
         _current_task = self
 
         try:
@@ -375,7 +389,7 @@ class Task(Generic[ResultType]):
                         self._log.debug("Pending %r on %r", self, trigger)
 
         finally:
-            _current_task = None
+            _current_task = _previous_task
 
     @deprecated("`task.kill()` is deprecated in favor of `task.cancel()`")
     def kill(self) -> None:

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -488,3 +488,30 @@ async def test_First_task_being_waited_cancelled(_: Any) -> None:
     assert waiter_task.done()
     for t in tasks[1:]:
         assert not t.done()
+
+
+@cocotb.test(timeout_time=5, timeout_unit="ns")
+async def test_5594(_: object) -> None:
+
+    async def other_coro(e1: Event, e2: Event) -> None:
+        # wait for e1 to be set by the test
+        await e1.wait()
+
+        # set e2 to let the test know we passed the wait
+        # it will never see it though because `First` delays the await on e2.wait() trigger
+        e2.set()
+        e2.clear()
+
+    e1 = Event()
+    e2 = Event()
+    cocotb.start_soon(other_coro(e1, e2))
+
+    # Ensure other_coro is waiting on e1 before we set it
+    await Timer(1, "ns")
+
+    # Wake up other_coro
+    e1.set()
+    e1.clear()
+
+    # Wait for other_coro to set e2
+    await First(e2.wait())

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -419,20 +419,8 @@ async def test_task_repr(_) -> None:
 
     await NullTrigger()
 
-    log.info(repr(coro_task))
-    assert re.match(
-        (
-            r"<Task \d+ pending coro=coroutine_first\(\) trigger=First\("
-            r"<Task \d+ created coro=coroutine_wait\(\)>, "
-            r"<Timer of 2000.00ps at \w+>"
-            r"\)>"
-        ),
-        repr(coro_task),
-    )
-
-    # wait for coroutine_wait to start
-    await NullTrigger()  # start_soon on _wait_callback
-
+    # The waiter task wrapping `task` inside select runs eagerly, awaits `task`,
+    # which calls `_ensure_started()` and puts the inner task in `scheduled` state.
     log.info(repr(coro_task))
     assert re.match(
         (
@@ -444,7 +432,8 @@ async def test_task_repr(_) -> None:
         repr(coro_task),
     )
 
-    await NullTrigger()  # awaiting Task in _wait_callback
+    # Let coroutine_wait run; it awaits its Timer and becomes pending.
+    await NullTrigger()
 
     log.info(repr(coro_task))
     assert re.match(


### PR DESCRIPTION
Depends on #5645.

The code `await First(e1.wait(), e2.wait())` has a problem: the actual Events are not waited immediately despite there being the `await` on the call. All passed in triggers are awaited on Tasks which are `start_soon`. This creates a race between already scheduled Tasks and the waiters in the First. Starting the waiter Tasks eagerly resolves the issue as each waiter gets to their first `await` before any other scheduled Task resumes. This closes #5594.

`start_eagerly` is made public and intended for users writing compound Triggers. We use `start_eagerly` for the implementation of `wait` that underlies all of the concurrent waiters in the repo. Users would use this for their own similar triggers.

