### PR TITLE
Remove `wait()`, improve `gather()` and `select()`

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -482,8 +482,6 @@ Triggers dealing with Tasks or running multiple Tasks concurrently.
 .. autoclass:: First
     :members:
 
-.. autofunction:: wait
-
 .. autofunction:: gather
 
 .. autofunction:: select

--- a/docs/source/newsfragments/5165.feature.rst
+++ b/docs/source/newsfragments/5165.feature.rst
@@ -1,1 +1,0 @@
-Added :func:`cocotb.triggers.wait` for waiting on multiple awaitables concurrently with a configurable return condition.

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -253,6 +253,7 @@ async def gather(
 
     When *return_exceptions* is ``False``, if any *awaitable* results in an exception or is cancelled,
     the remaining *awaitables* are cancelled and the exception or :exc:`~asyncio.CancelledError` is re-raised.
+    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments, only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
     When *return_exceptions* is ``True``, all exceptions and cancellations are treated as successful results and returned in the resulting tuple.
     Control returns to the caller after all *awaitables* have completed and/or been cancelled.
 

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -150,12 +150,13 @@ async def select(
 
     Regardless of the value of *return_exceptions*, after the first *awaitable* completes, whether it was cancelled, resulted in an exception, or resulted in a value,
     the remaining *awaitables* are cancelled.
+    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments, only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
     Control returns to the caller after all *awaitables* have completed and/or been cancelled.
 
     Regardless of the value of *return_exceptions*, if the task awaiting a call to this function is cancelled before completion,
     all *awaitables* which have not yet completed are cancelled and :exc:`!CancelledError` is raised.
 
-    Is it possible for multiple *awaitables* to complete at the same time,
+    It is possible for multiple *awaitables* to complete at the same time,
     however due to how the cocotb scheduler works, only one will complete *first*.
     It is good practice to avoid relying on the order of completion of multiple *awaitables* which complete at the same time.
 

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
-import sys
 from asyncio import CancelledError
+from collections.abc import Iterable
+from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 import cocotb
@@ -15,12 +16,12 @@ from cocotb.task import Task
 if TYPE_CHECKING:
     from collections.abc import Awaitable
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
 
-ReturnWhenType: TypeAlias = Literal[
-    "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED"
-]
+class ReturnWhen(Enum):
+    FIRST_COMPLETED = auto()
+    FIRST_EXCEPTION = auto()
+    ALL_COMPLETED = auto()
+
 
 T = TypeVar("T")
 T2 = TypeVar("T2")
@@ -28,57 +29,16 @@ T3 = TypeVar("T3")
 T4 = TypeVar("T4")
 
 
-@overload
-async def wait(
-    a: Awaitable[T],
-    /,
-    *,
-    return_when: ReturnWhenType,
-) -> tuple[Task[T]]: ...
+def _return_exception(task: Task[T]) -> BaseException | T:
+    try:
+        return task.result()
+    except BaseException as e:
+        return e
 
 
-@overload
-async def wait(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    /,
-    *,
-    return_when: ReturnWhenType,
-) -> tuple[Task[T], Task[T2]]: ...
-
-
-@overload
-async def wait(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    c: Awaitable[T3],
-    /,
-    *,
-    return_when: ReturnWhenType,
-) -> tuple[Task[T], Task[T2], Task[T3]]: ...
-
-
-@overload
-async def wait(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    c: Awaitable[T3],
-    d: Awaitable[T4],
-    /,
-    *,
-    return_when: ReturnWhenType,
-) -> tuple[Task[T], Task[T2], Task[T3], Task[T4]]: ...
-
-
-@overload
-async def wait(
-    *aw: Awaitable[T], return_when: ReturnWhenType
-) -> tuple[Task[T], ...]: ...
-
-
-async def wait(
-    *awaitables: Awaitable[Any], return_when: ReturnWhenType
-) -> tuple[Task[Any], ...]:
+async def _wait(
+    awaitables: Iterable[Awaitable[Any]], return_when: ReturnWhen
+) -> tuple[list[Task[Any]], Task[Any] | None]:
     r"""Await on all given *awaitables* concurrently and block until the *return_when* condition is met.
 
     Every :class:`~collections.abc.Awaitable` given to the function is :keyword:`await`\ ed concurrently in its own :class:`~cocotb.task.Task`.
@@ -92,6 +52,8 @@ async def wait(
     - ``"FIRST_EXCEPTION"``: Returns after all *awaitables* complete or after the first *awaitable* that completes due to an exception.
     - ``"ALL_COMPLETED"``: Returns after all *awaitables* complete.
 
+    Must not be called with an empty ``awaitables`` (would hang forever).
+
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
         return_when:
@@ -99,7 +61,8 @@ async def wait(
             One of ``"FIRST_COMPLETED"``, ``"FIRST_EXCEPTION"``, or ``"ALL_COMPLETED"``.
 
     Returns:
-        A tuple of waiter :class:`~cocotb.task.Task`\ s.
+        A tuple of waiter :class:`~cocotb.task.Task`\ s and the first completed :class:`~cocotb.task.Task` in
+        ``FIRST_COMPLETED`` or ``FIRST_EXCEPTION`` mode, or ``None`` in ``ALL_COMPLETED`` mode.
         The order of the return tuple corresponds to the order of the input.
 
     .. versionadded:: 2.1
@@ -108,46 +71,44 @@ async def wait(
     async def waiter(aw: Awaitable[T]) -> T:
         return await aw
 
-    tasks = tuple(Task[Any](waiter(a)) for a in awaitables)
-
-    # Event which is set by done_callback when return condition is met.
+    waiters = [Task[Any](waiter(a)) for a in awaitables]
+    # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
+    remaining = dict.fromkeys(waiters)
     done = Event()
-
-    # order of cancellation may matter, so we use dict(), which is ordered unlike set()
-    remaining = dict.fromkeys(tasks)
-
-    # Cancel all remaining tasks.
-    # Use a flag to prevent multiple cancellation.
-    cancelled: bool = False
+    cancelling: bool = False
+    # The first task to complete, stored regardless of return_when condition.
+    first_completed: Task[Any] | None = None
 
     def cancel() -> None:
-        nonlocal cancelled
-        if cancelled:
+        nonlocal cancelling
+        if cancelling:
             return
-
-        cancelled = True
+        cancelling = True
         for t in remaining:
             t.cancel()
 
-    # Define done_callbacks which set the "done" Event when the return condition is met.
-    if return_when == "FIRST_COMPLETED":
+    if return_when == ReturnWhen.FIRST_COMPLETED:
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
             if not remaining:
                 done.set()
-            else:
-                # Cancel remaining before they have a chance to resume.
+            nonlocal first_completed
+            if first_completed is None:
+                first_completed = task
                 cancel()
 
-    elif return_when == "FIRST_EXCEPTION":
+    elif return_when == ReturnWhen.FIRST_EXCEPTION:
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
             if not remaining:
                 done.set()
-            elif not task.cancelled() and task.exception() is not None:
-                # Cancel remaining before they have a chance to resume.
+            nonlocal first_completed
+            if first_completed is None and (
+                task.cancelled() or task.exception() is not None
+            ):
+                first_completed = task
                 cancel()
 
     else:
@@ -157,46 +118,50 @@ async def wait(
             if not remaining:
                 done.set()
 
-    # Register done_callback to all waiter tasks.
-    for task in tasks:
+    for task in waiters:
         task._add_done_callback(done_callback)
         cocotb.start_soon(task)
 
     try:
         await done.wait()
     except CancelledError:
-        # Cancel waiter tasks if this coroutine was cancelled.
-        for task in tasks:
-            task.cancel()
+        cancel()
         raise
 
-    return tasks
+    return waiters, first_completed
 
 
 @overload
 async def select(
-    *awaitables: Awaitable[T], return_exception: Literal[False] = False
+    *awaitables: Awaitable[T], return_exceptions: Literal[False] = False
 ) -> tuple[int, T]: ...
 
 
 @overload
 async def select(
-    *awaitables: Awaitable[T], return_exception: Literal[True]
+    *awaitables: Awaitable[T], return_exceptions: Literal[True]
 ) -> tuple[int, T | BaseException]: ...
 
 
 async def select(
-    *awaitables: Awaitable[T], return_exception: bool = False
+    *awaitables: Awaitable[T], return_exceptions: bool = False
 ) -> tuple[int, T | BaseException]:
     r"""Await on all given *awaitables* concurrently and return the index and result of the first to complete.
 
-    After the first *awaitable* completes, the remaining waiter tasks are cancelled.
-    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
-    only the internal waiter tasks.
+    Regardless of the value of *return_exceptions*, after the first *awaitable* completes, whether it was cancelled, resulted in an exception, or resulted in a value,
+    the remaining *awaitables* are cancelled.
+    Control returns to the caller after all *awaitables* have completed and/or been cancelled.
+
+    Regardless of the value of *return_exceptions*, if the task awaiting a call to this function is cancelled before completion,
+    all *awaitables* which have not yet completed are cancelled and :exc:`!CancelledError` is raised.
+
+    Is it possible for multiple *awaitables* to complete at the same time,
+    however due to how the cocotb scheduler works, only one will complete *first*.
+    It is good practice to avoid relying on the order of completion of multiple *awaitables* which complete at the same time.
 
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
-        return_exception:
+        return_exceptions:
             If ``False`` (default), re-raises the exception when an *awaitable* results in an exception.
             If ``True``, returns the exception rather than re-raising when an *awaitable* results in an exception.
 
@@ -211,21 +176,18 @@ async def select(
     if len(awaitables) == 0:
         raise ValueError("At least one awaitable required")
 
-    tasks = await wait(*awaitables, return_when="FIRST_COMPLETED")
+    tasks, first_completed = await _wait(
+        awaitables, return_when=ReturnWhen.FIRST_COMPLETED
+    )
+    assert first_completed is not None
 
-    # Find which awaitable completed.
-    idx: int
-    for i, task in enumerate(tasks):
-        if task.done() and not task.cancelled():
-            idx = i
-            break
-    else:  # pragma: no cover
-        raise RuntimeError("Reached unreachable code section")
-
-    if return_exception and (exc := task.exception()) is not None:
-        return idx, exc
+    idx = tasks.index(first_completed)
+    if return_exceptions:
+        return (idx, _return_exception(first_completed))
     else:
-        return idx, task.result()
+        # This will raise CancelledError if the task was cancelled, or the exception if it failed,
+        # or return the result if it succeeded.
+        return idx, first_completed.result()
 
 
 @overload
@@ -288,15 +250,20 @@ async def gather(
 ) -> tuple[Any, ...]:
     r"""Await on all given *awaitables* concurrently and return their results once all have completed.
 
-    After the return condition, based on *return_exceptions*, is met, the remaining waiter tasks are cancelled.
-    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
-    only the internal waiter tasks.
+    When *return_exceptions* is ``False``, if any *awaitable* results in an exception or is cancelled,
+    the remaining *awaitables* are cancelled and the exception or :exc:`~asyncio.CancelledError` is re-raised.
+    When *return_exceptions* is ``True``, all exceptions and cancellations are treated as successful results and returned in the resulting tuple.
+    Control returns to the caller after all *awaitables* have completed and/or been cancelled.
+
+    Regardless of the value of *return_exceptions*, if the task awaiting a call to this function is cancelled before completion,
+    all *awaitables* which have not yet completed are cancelled and :exc:`!CancelledError` is raised.
 
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
         return_exceptions:
-            If ``False`` (default), after the first *awaitable* results in an exception, cancels the remaining *awaitables* and re-raises the exception.
-            If ``True``, returns the exception rather than the result value when an *awaitable* results in an exception.
+            If ``False`` (default), after the first *awaitable* results in an exception or cancellation,
+            cancels the remaining *awaitables* and re-raises the exception or :exc:`!CancelledError`.
+            If ``True``, returns all exceptions or :exc:`!CancelledError` rather than the result value when an *awaitable* results in an exception.
 
     Returns:
         A tuple of the results of awaiting each *awaitable* in the same order they were given.
@@ -307,20 +274,21 @@ async def gather(
     if len(awaitables) == 0:
         return ()
 
-    tasks = await wait(
-        *awaitables,
-        return_when="ALL_COMPLETED" if return_exceptions else "FIRST_EXCEPTION",
+    # When returning exceptions, we behave like continue-on-error: never cancel siblings.
+    # Otherwise, cancel siblings as soon as one fails or is cancelled.
+    tasks, first_completed = await _wait(
+        awaitables,
+        return_when=ReturnWhen.ALL_COMPLETED
+        if return_exceptions
+        else ReturnWhen.FIRST_EXCEPTION,
     )
+
     if return_exceptions:
-        # We now know there were no cancelled Tasks, so get all exceptions or results.
-        return tuple(
-            exc if (exc := task.exception()) is not None else task.result()
-            for task in tasks
-        )
+        return tuple(_return_exception(task) for task in tasks)
+    elif first_completed is not None:
+        # first_completed is only set in FIRST_EXCEPTION mode when a task fails or is cancelled.
+        # Calling result() will cause the exception or CancelledError to be re-raised.
+        # Wrapped in a tuple to make mypy happy about the return type.
+        return (first_completed.result(),)
     else:
-        # Find first error if there is one.
-        for task in tasks:
-            if not task.cancelled() and (exc := task.exception()) is not None:
-                raise exc
-        # We now know there were no cancelled Tasks and no exceptions, so get all results.
         return tuple(task.result() for task in tasks)

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import warnings
 
 from cocotb._base_triggers import Event, Lock, NullTrigger, Trigger
-from cocotb._concurrent_waiters import gather, select, wait
+from cocotb._concurrent_waiters import gather, select
 from cocotb._extended_awaitables import (
     ClockCycles,
     Combine,
@@ -52,7 +52,6 @@ __all__ = (
     "current_gpi_trigger",
     "gather",
     "select",
-    "wait",
     "with_timeout",
 )
 

--- a/tests/test_cases/test_cocotb/test_waiters.py
+++ b/tests/test_cases/test_cocotb/test_waiters.py
@@ -4,12 +4,13 @@
 
 from __future__ import annotations
 
+from asyncio import CancelledError
 from collections.abc import Generator
 
 import pytest
 
 import cocotb
-from cocotb.triggers import NullTrigger, Timer, Trigger, gather, select, wait
+from cocotb.triggers import NullTrigger, Timer, Trigger, gather, select
 
 
 async def coro(wait: int, ret: int = 0) -> int:
@@ -33,69 +34,6 @@ class MyException(Exception): ...
 async def raises_after(wait: int) -> None:
     await Timer(wait)
     raise MyException()
-
-
-@cocotb.test
-async def test_wait(_: object) -> None:
-    a1, b1, c1, d1 = await wait(
-        coro(1),
-        Timer(2),
-        AwaitableThing(3),
-        raises_after(4),
-        return_when="ALL_COMPLETED",
-    )
-    assert a1.done()
-    assert b1.done()
-    assert c1.done()
-    assert d1.exception() is not None
-
-    a2, b2, c2 = await wait(
-        coro(1), Timer(2), AwaitableThing(3), return_when="FIRST_EXCEPTION"
-    )
-    assert a2.done()
-    assert b2.done()
-    assert c2.done()
-
-    a3, b3, c3, d3 = await wait(
-        Timer(1),
-        raises_after(2),
-        AwaitableThing(3),
-        coro(4),
-        return_when="FIRST_EXCEPTION",
-    )
-    # Wait for cancellations to finish
-    await NullTrigger()
-    assert a3.done()
-    assert b3.exception() is not None
-    assert c3.cancelled()
-    assert d3.cancelled()
-
-    a4, b4, c4, d4 = await wait(
-        coro(1),
-        Timer(2),
-        AwaitableThing(3),
-        raises_after(4),
-        return_when="FIRST_COMPLETED",
-    )
-    # Wait for cancellations to finish
-    await NullTrigger()
-    assert a4.done()
-    assert b4.cancelled()
-    assert c4.cancelled()
-    assert d4.cancelled()
-
-
-@cocotb.test
-async def test_wait_doesnt_cancel_tasks(_: object) -> None:
-    async def completes() -> int:
-        await Timer(10)
-        return 123
-
-    task = cocotb.start_soon(completes())
-    await wait(task, Timer(1), return_when="FIRST_COMPLETED")
-    await NullTrigger()
-    assert not task.cancelled()
-    assert await task == 123
 
 
 @cocotb.test
@@ -146,7 +84,7 @@ async def test_select(_: object) -> None:
         raises_after(wait=3),
         AwaitableThing(1, ret=31),
         Timer(2),
-        return_exception=True,
+        return_exceptions=True,
     )
     assert idx == 1
     assert res2 == 31
@@ -163,7 +101,7 @@ async def test_select(_: object) -> None:
         raises_after(wait=1),
         AwaitableThing(2, ret=12),
         Timer(3),
-        return_exception=True,
+        return_exceptions=True,
     )
     assert idx == 0
     assert isinstance(res3, MyException)
@@ -173,11 +111,212 @@ async def test_select(_: object) -> None:
 
 
 @cocotb.test
-async def test_cancel_while_waiting(_: object) -> None:
+async def test_gather_single(_: object) -> None:
+    """gather with one awaitable still returns a single-element tuple."""
+    (result,) = await gather(coro(wait=1, ret=42))
+    assert result == 42
+
+
+@cocotb.test
+async def test_select_single(_: object) -> None:
+    """select with one awaitable returns index 0 and its result."""
+    idx, res = await select(coro(wait=1, ret=42))
+    assert idx == 0
+    assert res == 42
+
+
+@cocotb.test
+async def test_gather_outer_cancel(_: object) -> None:
+    """Cancelling the task awaiting gather propagates CancelledError and cancels children."""
+    child_completed = False
+
+    async def child() -> None:
+        nonlocal child_completed
+        await Timer(10)
+        child_completed = True
+
     async def waiter() -> None:
-        await wait(Timer(2), return_when="ALL_COMPLETED")
+        await gather(child(), Timer(20))
 
     task = cocotb.start_soon(waiter())
     await Timer(1)
     task.cancel()
     await Timer(1)
+    assert task.cancelled()
+    # Children were cancelled before they could finish.
+    assert not child_completed
+
+
+@cocotb.test
+async def test_gather_outer_cancel_return_exceptions(_: object) -> None:
+    """return_exceptions=True must NOT swallow outer cancellation."""
+    child_completed = False
+
+    async def child() -> None:
+        nonlocal child_completed
+        await Timer(10)
+        child_completed = True
+
+    async def waiter() -> None:
+        await gather(child(), Timer(20), return_exceptions=True)
+
+    task = cocotb.start_soon(waiter())
+    await Timer(1)
+    task.cancel()
+    await Timer(1)
+    assert task.cancelled(), (
+        "outer cancellation should propagate even with return_exceptions=True"
+    )
+    assert not child_completed
+
+
+@cocotb.test
+async def test_select_outer_cancel(_: object) -> None:
+    """Cancelling the task awaiting select propagates CancelledError and cancels children."""
+    child_completed = False
+
+    async def child() -> None:
+        nonlocal child_completed
+        await Timer(10)
+        child_completed = True
+
+    async def waiter() -> None:
+        await select(child(), Timer(20))
+
+    task = cocotb.start_soon(waiter())
+    await Timer(1)
+    task.cancel()
+    await Timer(1)
+    assert task.cancelled()
+    assert not child_completed
+
+
+@cocotb.test
+async def test_gather_child_cancelled_default(_: object) -> None:
+    """When a child is cancelled and return_exceptions=False, gather re-raises CancelledError
+    and cancels the remaining children."""
+    sibling_completed = False
+
+    async def sibling() -> None:
+        nonlocal sibling_completed
+        await Timer(10)
+        sibling_completed = True
+
+    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+
+    async def waiter() -> None:
+        await gather(victim_task, sibling())
+
+    task = cocotb.start_soon(waiter())
+    await Timer(1)
+    victim_task.cancel()
+    await Timer(2)
+    assert task.done()
+    assert isinstance(task.exception(), CancelledError)
+    assert not sibling_completed
+
+
+@cocotb.test
+async def test_gather_child_cancelled_return_exceptions(_: object) -> None:
+    """When a child is cancelled and return_exceptions=True, gather returns CancelledError
+    in the tuple and other children continue."""
+    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+
+    async def waiter() -> tuple[object, ...]:
+        return await gather(victim_task, coro(wait=10, ret=99), return_exceptions=True)
+
+    task = cocotb.start_soon(waiter())
+    await Timer(1)
+    victim_task.cancel()
+    await Timer(15)
+    assert task.done()
+    a, b = task.result()
+    assert isinstance(a, CancelledError)
+    assert b == 99
+
+
+@cocotb.test
+async def test_select_child_cancelled(_: object) -> None:
+    """When the winning child was cancelled, select raises CancelledError by default
+    and returns it when return_exception=True."""
+    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+
+    async def waiter_raises() -> None:
+        await select(victim_task, Timer(30))
+
+    t1 = cocotb.start_soon(waiter_raises())
+    await Timer(1)
+    victim_task.cancel()
+    await Timer(2)
+    assert t1.done()
+    assert isinstance(t1.exception(), CancelledError)
+
+    victim_task2 = cocotb.start_soon(coro(wait=20, ret=0))
+
+    async def waiter_returns() -> tuple[int, object]:
+        return await select(victim_task2, Timer(30), return_exception=True)
+
+    t2 = cocotb.start_soon(waiter_returns())
+    await Timer(1)
+    victim_task2.cancel()
+    await Timer(2)
+    assert t2.done()
+    idx, exc = t2.result()
+    assert idx == 0
+    assert isinstance(exc, CancelledError)
+
+
+@cocotb.test
+async def test_gather_preserves_cancel_message(_: object) -> None:
+    """When return_exceptions=True, the original CancelledError instance (with its message)
+    is returned, not a fresh one."""
+    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+
+    async def waiter() -> tuple[object, ...]:
+        return await gather(victim_task, coro(wait=5, ret=1), return_exceptions=True)
+
+    task = cocotb.start_soon(waiter())
+    await Timer(1)
+    victim_task.cancel("specific reason")
+    await Timer(10)
+    assert task.done()
+    a, _ = task.result()
+    assert isinstance(a, CancelledError)
+    assert a.args == ("specific reason",), (
+        f"expected original CancelledError message preserved, got args={a.args!r}"
+    )
+
+
+@cocotb.test
+async def test_gather_does_not_cancel_passed_tasks(_: object) -> None:
+    """Tasks passed to gather are not cancelled when gather tears down its waiters
+    after a sibling fails."""
+
+    async def completes() -> int:
+        await Timer(10)
+        return 7
+
+    task = cocotb.start_soon(completes())
+    # raises_after fires first; gather cancels the waiter wrapping `task`,
+    # but `task` itself must keep running.
+    with pytest.raises(MyException):
+        await gather(task, raises_after(wait=1))
+    await NullTrigger()
+    assert not task.cancelled()
+    assert await task == 7
+
+
+@cocotb.test
+async def test_select_does_not_cancel_passed_tasks(_: object) -> None:
+    """Tasks passed to select are not cancelled when select returns (only internal waiters are)."""
+
+    async def completes() -> int:
+        await Timer(10)
+        return 7
+
+    task = cocotb.start_soon(completes())
+    # Timer(1) wins; the waiter wrapping task is cancelled, but task itself keeps running.
+    await select(task, Timer(1))
+    await NullTrigger()
+    assert not task.cancelled()
+    assert await task == 7


### PR DESCRIPTION
`asyncio.wait()` has a quirky interface which makes it unsuitable to be used to implement `asyncio.gather()`. It also has inferior semantics, so there isn't much point in providing it in cocotb as it is. The version that cocotb adds is resultantly quite a bit different. Because our version is different and `gather` and `select` provide *all* of the functionality of `wait`, we can just remove `wait`.

This commit also improves behavior when children are cancelled by other tasks (likely by them awaiting other cancelled objects). Previously, these cancellations were ignored, but now they cause shutdown and are propagated.

Some other small improvements include:
* `return_exceptions` on `select` was missing the 's'.
* `select` now actually returns the first finishing child rather then the first in the list marked as complete by the time the scheduler switches back to the parent task.
* adds tests for more scenarios.
* `return_exceptions=True` on tasks that are cancelled actually returns the `CancelledError` thrown into the task instead of a new empty instance.

This changes stuff introduced in 2.1, so no newsfrags.