### PR TITLE
Implement `Combine` and `First` in terms of `gather` and `select`

### DIFF
--- a/docs/source/newsfragments/5624.change.rst
+++ b/docs/source/newsfragments/5624.change.rst
@@ -1,0 +1,1 @@
+:class:`~cocotb.triggers.Combine` now propagates :exc:`~asyncio.CancelledError`\ s raised by any of its children instead of ignoring them.

--- a/src/cocotb/_base_triggers.py
+++ b/src/cocotb/_base_triggers.py
@@ -267,9 +267,9 @@ class _InternalEvent(Trigger):
     providing a better debugging experience.
     """
 
-    def __init__(self, parent: object) -> None:
+    def __init__(self, repr_func: Callable[[], str]) -> None:
         super().__init__()
-        self._parent = parent
+        self._repr_func = repr_func
         self._fired: bool = False
         self._awaited: bool = False
 
@@ -300,7 +300,7 @@ class _InternalEvent(Trigger):
         return (yield from super().__await__())
 
     def __repr__(self) -> str:
-        return repr(self._parent)
+        return self._repr_func()
 
 
 class _Lock(Trigger):

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 from asyncio import CancelledError
 from collections.abc import Iterable
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, overload
 
 import cocotb
-from cocotb._base_triggers import Event
+from cocotb._base_triggers import _InternalEvent
 from cocotb.task import Task
 
 if TYPE_CHECKING:
@@ -37,7 +37,9 @@ def _return_exception(task: Task[T]) -> BaseException | T:
 
 
 async def _wait(
-    awaitables: Iterable[Awaitable[Any]], return_when: ReturnWhen
+    awaitables: Iterable[Awaitable[Any]],
+    return_when: ReturnWhen,
+    _repr: Callable[[], str],
 ) -> tuple[list[Task[Any]], Task[Any] | None]:
     r"""Await on all given *awaitables* concurrently and block until the *return_when* condition is met.
 
@@ -74,7 +76,7 @@ async def _wait(
     waiters = [Task[Any](waiter(a)) for a in awaitables]
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
     remaining = dict.fromkeys(waiters)
-    done = Event()
+    done = _InternalEvent(_repr)
     cancelling: bool = False
     # The first task to complete, stored regardless of return_when condition.
     first_completed: Task[Any] | None = None
@@ -123,7 +125,7 @@ async def _wait(
         cocotb.start_soon(task)
 
     try:
-        await done.wait()
+        await done
     except CancelledError:
         cancel()
         raise
@@ -144,7 +146,9 @@ async def select(
 
 
 async def select(
-    *awaitables: Awaitable[T], return_exceptions: bool = False
+    *awaitables: Awaitable[T],
+    return_exceptions: bool = False,
+    _repr: Callable[[], str] | None = None,
 ) -> tuple[int, T | BaseException]:
     r"""Await on all given *awaitables* concurrently and return the index and result of the first to complete.
 
@@ -177,8 +181,15 @@ async def select(
     if len(awaitables) == 0:
         raise ValueError("At least one awaitable required")
 
+    # select is being called on its own and not part of First.
+    # So we add a repr here since this is not a class.
+    if _repr is None:
+
+        def _repr() -> str:
+            return f"select({', '.join(repr(a) for a in awaitables)})"
+
     tasks, first_completed = await _wait(
-        awaitables, return_when=ReturnWhen.FIRST_COMPLETED
+        awaitables, return_when=ReturnWhen.FIRST_COMPLETED, _repr=_repr
     )
     assert first_completed is not None
 
@@ -248,6 +259,7 @@ async def gather(
 async def gather(
     *awaitables: Awaitable[Any],
     return_exceptions: bool = False,
+    _repr: Callable[[], str] | None = None,
 ) -> tuple[Any, ...]:
     r"""Await on all given *awaitables* concurrently and return their results once all have completed.
 
@@ -276,6 +288,13 @@ async def gather(
     if len(awaitables) == 0:
         return ()
 
+    # gather is being called on its own and not part of Combine.
+    # So we add a repr here since this is not a class.
+    if _repr is None:
+
+        def _repr() -> str:
+            return f"gather({', '.join(repr(a) for a in awaitables)})"
+
     # When returning exceptions, we behave like continue-on-error: never cancel siblings.
     # Otherwise, cancel siblings as soon as one fails or is cancelled.
     tasks, first_completed = await _wait(
@@ -283,6 +302,7 @@ async def gather(
         return_when=ReturnWhen.ALL_COMPLETED
         if return_exceptions
         else ReturnWhen.FIRST_EXCEPTION,
+        _repr=_repr,
     )
 
     if return_exceptions:

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -15,8 +15,8 @@ from decimal import Decimal
 from typing import Any, TypeVar, cast, overload
 
 import cocotb.handle
-from cocotb._base_triggers import NullTrigger, Trigger, _InternalEvent
-from cocotb._concurrent_waiters import select
+from cocotb._base_triggers import NullTrigger, Trigger
+from cocotb._concurrent_waiters import gather, select
 from cocotb._deprecation import deprecated
 from cocotb._gpi_triggers import FallingEdge, RisingEdge, Timer, ValueChange
 from cocotb.simtime import RoundMode, TimeUnit
@@ -39,14 +39,10 @@ class Waitable(Awaitable[T]):
         return self._wait().__await__()
 
 
-async def _wait_callback(trigger: Awaitable[T]) -> T:
-    return await trigger
-
-
 class Combine(Waitable["Combine"]):
     r"""Trigger that fires when all *triggers* have fired.
 
-    :keyword:`await`\ ing this returns the :class:`Combine` object.
+    :keyword:`await`\ ing this returns the :class:`!Combine` object.
     This is similar to Verilog's ``join``.
     See :ref:`combine-tutorial` for an example.
 
@@ -59,6 +55,11 @@ class Combine(Waitable["Combine"]):
     .. deprecated:: 2.1
         Passing :class:`~cocotb.task.Task` objects to :class:`!Combine` is deprecated.
         Use :func:`~cocotb.triggers.gather` instead and pass coroutines directly instead of wrapping them in :func:`cocotb.start_soon`.
+
+    .. versionchanged:: 2.1
+        Previously when a child *trigger* was cancelled, the cancellation was ignored.
+        Now, if a child *trigger* is cancelled, the entire :class:`!Combine`, including all other child triggers, is cancelled,
+        and a :exc:`~asyncio.CancelledError` is raised at the point the :class:`!Combine` is :keyword:`await` ed.
     """
 
     _task_deprecation_str = (
@@ -91,51 +92,8 @@ class Combine(Waitable["Combine"]):
     async def _wait(self) -> Combine:
         if len(self._triggers) == 0:
             await NullTrigger()
-        elif len(self._triggers) == 1:
-            await self._triggers[0]
         else:
-            waiters: list[Task[object]] = []
-            completed: list[Task[object]] = []
-            done = _InternalEvent(self)
-            exception: BaseException | None = None
-
-            def on_done(
-                task: Task[object],
-            ) -> None:
-                # have to check cancelled first otherwise exception() will throw
-                if task.cancelled():
-                    completed.append(task)
-                    if len(completed) == len(waiters):
-                        done.set()
-                    return
-                e = task.exception()
-                if e is not None:
-                    nonlocal exception
-                    exception = e
-                    done.set()
-                else:
-                    completed.append(task)
-                    if len(completed) == len(waiters):
-                        done.set()
-
-            # start a parallel task for each trigger
-            for t in self._triggers:
-                task = Task[object](_wait_callback(t))
-                task._add_done_callback(on_done)
-                cocotb.start_soon(task)
-                waiters.append(task)
-
-            try:
-                # wait for the last waiter to complete
-                await done
-            finally:
-                # kill remaining waiters
-                for w in waiters:
-                    w.cancel()
-
-            if exception is not None:
-                raise exception
-
+            await gather(*self._triggers, _repr=self.__repr__)  # type: ignore[call-overload]
         return self
 
     def __repr__(self) -> str:
@@ -219,33 +177,8 @@ class First(Waitable[object]):
         self._triggers = triggers
 
     async def _wait(self) -> object:
-        if len(self._triggers) == 1:
-            return await self._triggers[0]
-
-        waiters: list[Task[object]] = []
-        done = _InternalEvent(self)
-        completed: list[Task[object]] = []
-
-        def on_done(task: Task[object]) -> None:
-            completed.append(task)
-            done.set()
-
-        # start a parallel task for each trigger
-        for t in self._triggers:
-            task = Task[object](_wait_callback(t))
-            task._add_done_callback(on_done)
-            cocotb.start_soon(task)
-            waiters.append(task)
-
-        try:
-            # wait for a waiter to complete
-            await done
-        finally:
-            # kill all the other waiters
-            for w in waiters:
-                w.cancel()
-
-        return completed[0].result()
+        _, result = await select(*self._triggers, _repr=self.__repr__)  # type: ignore[call-overload]
+        return result
 
     def __repr__(self) -> str:
         # no _pointer_str here, since this is not a trigger, so identity

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -58,8 +58,9 @@ async def test_First_unfired_triggers_killed_on_exception(_) -> None:
         raise ValueError("I am a failure")
 
     with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
-        await First(cocotb.start_soon(Task(fails())), *triggers)
+        await First(Task(fails()), *triggers)
 
+    # test all triggers were unprimed
     for t in triggers:
         assert t.primed == 1
         assert t.unprimed == 1
@@ -75,8 +76,9 @@ async def test_Combine_unfired_triggers_killed_on_exception(_) -> None:
         raise ValueError("I am a failure")
 
     with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
-        await Combine(cocotb.start_soon(Task(fails())), *triggers)
+        await Combine(Task(fails()), *triggers)
 
+    # test all triggers were unprimed
     for t in triggers:
         assert t.primed == 1
         assert t.unprimed == 1
@@ -429,17 +431,7 @@ async def test_Combine_task_being_waited_cancelled(_: Any) -> None:
     # cancel just one task
     tasks[0].cancel()
 
-    # check other tasks haven't been cancelled and the Combine isn't finished.
-    await Timer(1, "ns")
-    assert not waiter_task.done()
-    for t in tasks[1:]:
-        assert not t.done()
-
-    # cancel remaining tasks
-    for t in tasks[1:]:
-        t.cancel()
-
-    # see if that finishes the Combine
+    # check all Tasks have been cancelled and the Combine is finished.
     await Timer(1, "ns")
     assert waiter_task.done()
 

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -116,8 +116,8 @@ async def test_lock_repr(dut):
 @cocotb.test()
 async def test_internalevent(dut):
     """Test _InternalEvent trigger."""
-    e = _InternalEvent("test parent")
-    assert repr(e) == "'test parent'"
+    e = _InternalEvent(lambda: "test parent")
+    assert repr(e) == "test parent"
 
     async def set_internalevent():
         await Timer(1, unit="ns")
@@ -133,7 +133,6 @@ async def test_internalevent(dut):
         await e
 
     e = _InternalEvent(None)
-    assert repr(e) == "None"
     ran = False
 
     async def await_internalevent():


### PR DESCRIPTION
This also pipes parents into `_InternalEvent` to maintain the existing debugging prints.

I had to change the interface for `_InternalEvent` to take a repr function instead of a parent object, as `gather` and `select` are not classes.

Depends on #5623.