### PR TITLE
Add `Task.start_soon`

### DIFF
--- a/docs/source/newsfragments/5625.feature.rst
+++ b/docs/source/newsfragments/5625.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`.Task.start_soon` to schedule an unstarted :class:`.Task` to start "soon". This is primarily for users to start a :class:`!Task` after using :func:`!create_task` or manually instantiating :class:`!Task` to create a task.

--- a/src/cocotb/_task_manager.py
+++ b/src/cocotb/_task_manager.py
@@ -205,7 +205,7 @@ class TaskManager:
         self._none_remaining.clear()
 
         # Schedule the Task to run soon
-        task._ensure_started()
+        task.start_soon()
 
     def _done_callback(self, task: Task[Any]) -> None:
         """Callback run when a child Task finishes."""

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -86,7 +86,7 @@ class TestManager:
 
         # start main task
         self._main_task._add_done_callback(self._test_done_callback)
-        self._main_task._ensure_started()
+        self._main_task.start_soon()
         self._tasks[self._main_task] = None
 
         # start timeout if specified
@@ -219,6 +219,8 @@ def start_soon(
     .. versionadded:: 1.6
     """
     task = create_task(coro, name=name)
+    # This is _ensure_started() rather than start_soon() for backwards compatibility.
+    # Calling cocotb.start_soon(task) on a task that already started should not fail.
     task._ensure_started()
     return task
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -230,6 +230,18 @@ class Task(Generic[ResultType]):
         else:
             raise RuntimeError("Task in unknown state")
 
+    def start_soon(self) -> None:
+        """Queues an unstarted Task to start running.
+
+        Raises:
+            RuntimeError: If the Task has already started.
+
+        .. versionadded:: 2.1
+        """
+        if self._state is not _TaskState.UNSTARTED:
+            raise RuntimeError("Can only start_soon() an unstarted Task")
+        self._schedule_resume()
+
     def _ensure_started(self) -> None:
         state = self._state
         if state is _TaskState.UNSTARTED:

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -1138,3 +1138,20 @@ async def test_957_2(dut: Any) -> None:
     # pending coroutine doesn't interfere with this test.
     cocotb.start_soon(wait_edge(dut))
     await Timer(10, "ns")
+
+
+@cocotb.test
+async def test_task_start_soon(_: object) -> None:
+    """Test functionality of Task.start_soon()."""
+
+    async def coro() -> None:
+        await Timer(2)
+
+    task = Task(coro())
+    task.start_soon()
+    await Timer(1)
+    assert not task.done()
+    with pytest.raises(RuntimeError):
+        task.start_soon()
+    await Timer(2)
+    assert task.done()


### PR DESCRIPTION
This adds `Task.start_soon` method which allows users to schedule a Task to start after they may have created an unstarted one using `cocotb.create_task` or by directly instantiating `Task`. This is also used internally for exactly those cases.

- [x] update newsfrag
