### PR TITLE
perf(xunit): improve XUnit Reporter performance

### DIFF
--- a/src/cocotb/_xunit_reporter.py
+++ b/src/cocotb/_xunit_reporter.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Generator, Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from platform import node
@@ -76,6 +76,7 @@ class XUnitReporter:
         name: str = "cocotb tests",
         relative_to: Path | str | None = None,
         default_properties: Mapping[str, Any] | None = None,
+        default_attachments: Iterable[Path | str] | None = None,
     ) -> None:
         """Create new instance of xUnit reporter.
 
@@ -83,6 +84,7 @@ class XUnitReporter:
             name: Name of xUnit reporter. Used as name for the XML test suites root element.
             relative_to: If provided, all reported absolute paths will be converted to relative paths.
             default_properties: Additional common default properties that will be added to all created test cases.
+            default_attachments: Additional common default file attachments that will be added to all created test cases.
         """
         # The root of the XML document
         self._root = Element("testsuites", name=name)
@@ -98,6 +100,17 @@ class XUnitReporter:
 
         # If present, all reported absolute paths will be converted to relative paths
         self._relative_to = Path(relative_to).resolve() if relative_to else None
+        self._relative_to_str = f"{self._relative_to}{os.path.sep}"
+
+        # Common file attachments that will be added to all created test cases
+        self._default_attachments: list[str] = [
+            self._normalize_path(attachment) for attachment in default_attachments or ()
+        ]
+
+        # A text block with a list of file attachments separated by a newline
+        self._text_attachments: str = "\n".join(
+            f"[[ATTACHMENT|{attachment}]]" for attachment in self._default_attachments
+        )
 
     def add_testcase(
         self,
@@ -123,43 +136,31 @@ class XUnitReporter:
             extra_properties: Additional test case properties.
         """
         testsuite = self._get_testsuite(classname or "cocotb")
-
-        # NOTE: file and line attributes are invalid in Jenkins XML schema version 2.*
-        attributes = {
-            "classname": _escape(classname),
-            "name": _escape(name),
-            "time": f"{time:.3f}",
-        }
-
         testsuite.time += time
         testsuite.tests += 1
 
-        testcase = SubElement(testsuite.element, "testcase", attrib=attributes)
-
-        # Normalize all line endings to \n as that is a requirement of XML.
-        # Ensure a newline at the end. Required when adding file attachments
-        if system_out:
-            system_out = (
-                system_out.rstrip("\r\n").replace("\r\n", "\n").replace("\r", "\n")
-                + "\n"
-            )
-
-        if system_err:
-            system_err = (
-                system_err.rstrip("\r\n").replace("\r\n", "\n").replace("\r", "\n")
-                + "\n"
-            )
+        # NOTE: file and line attributes are invalid in Jenkins XML schema version 2.*
+        testcase = SubElement(
+            testsuite.element,
+            "testcase",
+            classname=_escape(classname),
+            name=_escape(name),
+            time=f"{time:.3f}",
+        )
 
         properties = self._default_properties.copy()
 
         if extra_properties:
             properties.update(extra_properties)
 
-        if properties:
-            property_root = SubElement(testcase, "properties")
+        properties_root = SubElement(testcase, "properties")
 
-            for key, value in properties.items():
-                system_out += "\n".join(self._add_property(property_root, key, value))
+        for key, item in properties.items():
+            value = self._normalize_path(item) if key == "file" else str(item)
+            properties_root.append(Element("property", name=key, value=value))
+
+        for value in self._default_attachments:
+            properties_root.append(Element("property", name="attachment", value=value))
 
         if status == "skipped":
             self._add_simple(testcase, "skipped", reason)
@@ -172,6 +173,9 @@ class XUnitReporter:
         elif status == "failed":
             self._add_simple(testcase, "failure", reason)
             testsuite.failures += 1
+
+        if self._text_attachments:
+            system_out = _ensure_newline(system_out) + self._text_attachments
 
         if system_out:
             SubElement(testcase, "system-out").text = self._normalize_text(system_out)
@@ -229,18 +233,15 @@ class XUnitReporter:
 
         return self._testsuite
 
-    def _normalize_path(self, path: Path | str) -> Path:
+    def _normalize_path(self, path: Any) -> str:
         """Convert provided path to relative path."""
-        if not isinstance(path, Path):
-            path = Path(path)
-
-        if self._relative_to and path.is_absolute():
+        if self._relative_to:
             try:
-                return path.resolve().relative_to(self._relative_to)
+                return str(Path(path).resolve().relative_to(self._relative_to))
             except ValueError:
-                return path.resolve()
+                pass
 
-        return path
+        return str(path)
 
     def _add_simple(
         self,
@@ -258,11 +259,9 @@ class XUnitReporter:
         Returns:
             Added XML element.
         """
-        message = _escape(reason).strip()
-
         if isinstance(reason, BaseException):
             kind = _escape(type(reason).__name__)
-            element = SubElement(parent, name, message=message, type=kind)
+            element = SubElement(parent, name, message=_escape(reason), type=kind)
             text = self._normalize_text(
                 "".join(format_exception(type(reason), reason, reason.__traceback__))
             )
@@ -272,49 +271,34 @@ class XUnitReporter:
 
             return element
 
-        if isinstance(reason, str) and message:
-            return SubElement(parent, name, message=message)
+        if reason:
+            return SubElement(parent, name, message=_escape(reason))
 
         return SubElement(parent, name)
 
     def _normalize_text(self, text: str) -> str:
-        """Replace all absolute paths with relative ones."""
-        if self._relative_to:
-            text = text.replace(f"{self._relative_to}{os.path.sep}", "")
+        """Normalize provided text.
 
-        return _escape(text)
-
-    def _add_property(
-        self, parent: Element, name: str, value: Any
-    ) -> Generator[str, None, None]:
-        """Add property to XML element.
-
-        Args:
-            parent: XML parent element.
-            name: Name of property.
-            value: Value of property.
+        * Replacing all absolute paths with relative ones.
+        * Replacing Windows/macOS newlines with POSIX newlines.
+        * Ensuring a newline at the end of the text.
+        * Removing invalid characters.
 
         Returns:
-            Text content to be added to the ``system-out`` XML element.
+            Normalized text.
         """
-        # Skip empty values
-        if not value and value not in (0, 0.0, False):
-            return
+        if self._relative_to:
+            text = text.replace(self._relative_to_str, "")
 
-        # Handling property as a list. Example: attachment: ["a", "b", "c"]
-        if not isinstance(value, str) and isinstance(value, Iterable):
-            for item in value:
-                yield from self._add_property(parent, name, item)
-            return
+        if "\r" in text:
+            text = text.replace("\r\n", "\n").replace("\r", "\n")
 
-        # Handling paths like files and attachments
-        if isinstance(value, Path) or name in ("file", "attachment"):
-            value = self._normalize_path(value)
+        return _escape(_ensure_newline(text))
 
-        if name == "attachment":
-            yield f"[[ATTACHMENT|{value}]]"
 
-        SubElement(parent, "property", name=_escape(name), value=_escape(value))
+def _ensure_newline(text: str) -> str:
+    """Ensure newline at the end of the provided text."""
+    return text + "\n" if text and text[-1] != "\n" else text
 
 
 def _escape_code(matchobj: re.Match[str]) -> str:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -235,12 +235,14 @@ class RegressionManager:
 
         # Setup xUnit
         ###################
-        attachments = os.getenv("COCOTB_RESULTS_ATTACHMENTS", "").strip().split(",")
-        attachments = [a for a in attachments if a]  # filter out empty fields
         self.xunit = XUnitReporter(
             relative_to=os.getenv("COCOTB_RESULTS_RELATIVE_TO"),
+            # Common default file attachments that will be added to all created test cases
+            default_attachments=_env.as_list("COCOTB_RESULTS_ATTACHMENTS"),
             # Common default properties that will be added to all created test cases
             default_properties={
+                # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
+                # especially after merging multiple XML reports from different sources (e. g. CI jobs)
                 "cocotb": True,
                 "random_seed": self._regression_seed,
                 "sim_time_unit": "ns",
@@ -248,7 +250,6 @@ class RegressionManager:
                 "sim_time_stop": 0.0,
                 "sim_time_duration": 0.0,
                 "sim_time_ratio": 0.0,
-                "attachment": attachments,
             },
         )
 

--- a/tests/pytest/test_xunit_reporter.py
+++ b/tests/pytest/test_xunit_reporter.py
@@ -46,6 +46,7 @@ def test_report(tmp_path: Path) -> None:
 
     xunit: XUnitReporter = XUnitReporter(
         relative_to=tmp_path,
+        default_attachments=attachments,
         # Common default properties that will be added to all created test cases
         default_properties={
             "cocotb": True,
@@ -53,7 +54,6 @@ def test_report(tmp_path: Path) -> None:
             "sim_time_duration": 0.0,
             "sim_time_unit": "ns",
             "sim_time_ratio": 0.0,
-            "attachment": attachments,
         },
     )
 
@@ -183,14 +183,14 @@ def test_report(tmp_path: Path) -> None:
     assert properties[3].get("value") == "ns"
     assert properties[4].get("name") == "sim_time_ratio"
     assert properties[4].get("value") == "2.0"
-    assert properties[5].get("name") == "attachment"
-    assert properties[5].get("value") == "sim.log"
-    assert properties[6].get("name") == "attachment"
-    assert properties[6].get("value") == "wave.vcd"
-    assert properties[7].get("name") == "file"
-    assert properties[7].get("value") == "module.py"
-    assert properties[8].get("name") == "line"
-    assert properties[8].get("value") == "10"
+    assert properties[5].get("name") == "file"
+    assert properties[5].get("value") == "module.py"
+    assert properties[6].get("name") == "line"
+    assert properties[6].get("value") == "10"
+    assert properties[7].get("name") == "attachment"
+    assert properties[7].get("value") == "sim.log"
+    assert properties[8].get("name") == "attachment"
+    assert properties[8].get("value") == "wave.vcd"
 
     assert len(testcases[0].findall("error")) == 0
     assert len(testcases[0].findall("failure")) == 0
@@ -275,7 +275,10 @@ def test_file_outside_workspace(tmp_path: Path) -> None:
     file.parent.mkdir(parents=True, exist_ok=True)
     file.touch(exist_ok=True)
 
-    xunit: XUnitReporter = XUnitReporter(relative_to=results.parent)
+    xunit: XUnitReporter = XUnitReporter(
+        relative_to=results.parent,
+        default_attachments=(file,),
+    )
 
     xunit.add_testcase(
         name="test",
@@ -283,7 +286,6 @@ def test_file_outside_workspace(tmp_path: Path) -> None:
         status="passed",
         extra_properties={
             "file": str(file),
-            "attachment": file,
         },
     )
 
@@ -316,9 +318,6 @@ def test_without_attachments(tmp_path: Path) -> None:
         name="test",
         classname="module",
         status="passed",
-        extra_properties={
-            "attachment": (),
-        },
     )
 
     xunit.write(results)
@@ -335,7 +334,10 @@ def test_properties(tmp_path: Path) -> None:
     """xUnit XML report with properties."""
     results: Path = tmp_path / "results.xml"
 
-    xunit: XUnitReporter = XUnitReporter(relative_to=tmp_path)
+    xunit: XUnitReporter = XUnitReporter(
+        relative_to=tmp_path,
+        default_attachments=(results,),
+    )
 
     xunit.add_testcase(
         name="test",
@@ -346,13 +348,9 @@ def test_properties(tmp_path: Path) -> None:
             "coverage": False,
             "file": results,
             "line": 10,
-            "attachment": str(results),
             "sim_time_unit": "ns",
             "sim_time_ratio": 0.0,
             "sim_time_duration": 0,
-            "list0": (),
-            "list1": ("a",),
-            "list2": ("a", "b"),
         },
     )
 
@@ -369,7 +367,7 @@ def test_properties(tmp_path: Path) -> None:
         for item in testcases[0].iter("property")
     }
 
-    assert len(properties) == 10
+    assert len(properties) == 8
     assert properties["cocotb"] == "True"
     assert properties["coverage"] == "False"
     assert properties["line"] == "10"
@@ -378,8 +376,6 @@ def test_properties(tmp_path: Path) -> None:
     assert properties["sim_time_unit"] == "ns"
     assert properties["sim_time_ratio"] == "0.0"
     assert properties["sim_time_duration"] == "0"
-    assert properties["list1"] == "a"
-    assert properties["list2"] == "b"
 
 
 def test_invalid_characters(tmp_path: Path) -> None:


### PR DESCRIPTION
Context:
* https://github.com/cocotb/cocotb/issues/5615
* https://github.com/cocotb/cocotb/pull/5616

Benchmark test running inside container image with Icarus 13.0, Python 3.12.13 and pytest 9.0.3:

```plaintext
pytest -c /dev/null tests/benchmarks/test_parameterize_perf
```

On the `master` branch:

```plaintext
--------------------------------------------------- benchmark: 1 tests ---------------------------------------------------
Name (time in s)                      Min      Max     Mean  StdDev   Median     IQR  Outliers     OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------
test_parameterize_perf_icarus     11.4430  12.1796  11.8045  0.3143  11.7731  0.5554       2;0  0.0847       5           1
--------------------------------------------------------------------------------------------------------------------------
```

Using this PR:

```plaintext
------------------------------------------------- benchmark: 1 tests -------------------------------------------------
Name (time in s)                     Min     Max    Mean  StdDev  Median     IQR  Outliers     OPS  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------
test_parameterize_perf_icarus     7.5379  7.9263  7.7207  0.1867  7.6984  0.3638       1;0  0.1295       5           1
----------------------------------------------------------------------------------------------------------------------
```

What changed:
- ~Removed XML indentation~ (cannot because of Makefiles :roll_eyes:)
- Prepared the `ATTACHMENT` block text in the reporter constructor and appending it to the `system-out` only if needed
- Prepared list of file attachments as strings in the reporter constructor, normalized paths (relative)
- Prepared the `relative_to_str` path as a string to replace paths in text to relative ones
- Adding properties using a simple for-loop with `xml_element.append(Element("property", name=name, value=value))`
- Avoided type checking and handling different types if don't needed, `str` rules
- ~Removed escaping invalid characters in "trusted" variables like `classname` or `name`~
- ~Using the `_escape` function to escape invalid characters only on potentially untrusted `text`, especially from user and HDL simulators~
- Checking if Windows/macOS newline is present
- Reducing branching and unnecessary calls where possible

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
