### PR TITLE
chore(xunit): remove XML indent

### DIFF
--- a/docs/source/newsfragments/5628.change.rst
+++ b/docs/source/newsfragments/5628.change.rst
@@ -1,1 +1,1 @@
-Disabled two-space characters indentation of generated JUnit XML ``results.xml`` files to reduce their size. They are not pretty-formatted anymore. Use external libraries or tools to reformat and reindent generated JUnit XML files. For example, you can use the ``xmllint --format results.xml`` command for that.
+JUnit XML (``results.xml``) files are no longer pretty-printed to reduce file size and improve serialization performance. Use external tools like `xmllint <https://xmllint.com/>`_ if you need to format these files.

--- a/docs/source/newsfragments/5628.change.rst
+++ b/docs/source/newsfragments/5628.change.rst
@@ -1,0 +1,1 @@
+Disabled two-space characters indentation of generated JUnit XML ``results.xml`` files to reduce their size. They are not pretty-formatted anymore. Use external libraries or tools to reformat and reindent generated JUnit XML files. For example, you can use the ``xmllint --format results.xml`` command for that.

--- a/src/cocotb/_xunit_reporter.py
+++ b/src/cocotb/_xunit_reporter.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from platform import node
 from traceback import format_exception
 from typing import Any, Literal
-from xml.etree.ElementTree import Element, ElementTree, SubElement, indent
+from xml.etree.ElementTree import Element, ElementTree, SubElement
 
 Status = Literal["passed", "failed", "skipped", "error"]
 """Status of test case.
@@ -192,7 +192,6 @@ class XUnitReporter:
         # Create directory
         Path(filename).parent.mkdir(parents=True, exist_ok=True)
 
-        indent(self._root)
         ElementTree(self._root).write(
             str(filename), encoding="utf-8", xml_declaration=True
         )

--- a/tests/test_cases/test_skip/Makefile
+++ b/tests/test_cases/test_skip/Makefile
@@ -8,6 +8,6 @@ COCOTB_TEST_MODULES := test_skip
 .PHONY: override_for_this_test
 override_for_this_test:
 	$(MAKE) all
-	test $$(grep '<skipped.*/>' $(COCOTB_RESULTS_FILE) | wc -l) -eq 4
+	test $$(grep -o '<skipped[^/]*/>' $(COCOTB_RESULTS_FILE) | wc -l) -eq 4
 
 include ../../designs/sample_module/Makefile


### PR DESCRIPTION
Closes https://github.com/cocotb/cocotb/issues/5628

Removing XML `indent` to reduce size of bloated JUnit XML.

One of Makefiles was using `grep` to count number of XML `<skipped/>` elements. This will not work when we remove XML `indent` because everything will be in a single line. We need to improve used regular expression to find a single match of skipped element and print matched pattern in a separate line. This can be achieved by using the `grep -o` option:

```plaintext
       -o, --only-matching
              Print only the matched (non-empty) parts of a matching line, with each such part on a separate output line.
```

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
