### PR TITLE
perf(xunit): improve performance of the XUnitReporter.add_testcase method, part 2

### DIFF
--- a/src/cocotb/_xunit_reporter.py
+++ b/src/cocotb/_xunit_reporter.py
@@ -19,6 +19,7 @@ import os
 import re
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
+from functools import cache
 from pathlib import Path
 from platform import node
 from traceback import format_exception
@@ -75,7 +76,6 @@ class XUnitReporter:
         self,
         name: str = "cocotb tests",
         relative_to: Path | str | None = None,
-        default_properties: Mapping[str, Any] | None = None,
         default_attachments: Iterable[Path | str] | None = None,
     ) -> None:
         """Create new instance of xUnit reporter.
@@ -83,7 +83,6 @@ class XUnitReporter:
         Args:
             name: Name of xUnit reporter. Used as name for the XML test suites root element.
             relative_to: If provided, all reported absolute paths will be converted to relative paths.
-            default_properties: Additional common default properties that will be added to all created test cases.
             default_attachments: Additional common default file attachments that will be added to all created test cases.
         """
         # The root of the XML document
@@ -95,16 +94,13 @@ class XUnitReporter:
         # List of all created and cached test suite elements
         self._testsuites: dict[str, TestSuite] = {}
 
-        # Common properties that will be added to all created test cases
-        self._default_properties = dict(default_properties or {})
-
         # If present, all reported absolute paths will be converted to relative paths
         self._relative_to = Path(relative_to).resolve() if relative_to else None
         self._relative_to_str = f"{self._relative_to}{os.path.sep}"
 
         # Common file attachments that will be added to all created test cases
         self._default_attachments: list[str] = [
-            self._normalize_path(attachment) for attachment in default_attachments or ()
+            self.normalize_path(attachment) for attachment in default_attachments or ()
         ]
 
         # A text block with a list of file attachments separated by a newline
@@ -148,23 +144,14 @@ class XUnitReporter:
             time=f"{time:.3f}",
         )
 
-        properties = self._default_properties.copy()
-
-        if extra_properties:
-            properties.update(extra_properties)
-
-        properties_root = SubElement(testcase, "properties")
-
-        for key, item in properties.items():
-            value = self._normalize_path(item) if key == "file" else str(item)
-            properties_root.append(Element("property", name=key, value=value))
-
-        for value in self._default_attachments:
-            properties_root.append(Element("property", name="attachment", value=value))
+        default_attachments: list[str] | None = self._default_attachments
+        text_attachments: str | None = self._text_attachments
 
         if status == "skipped":
             self._add_simple(testcase, "skipped", reason)
             testsuite.skipped += 1
+            default_attachments = None
+            text_attachments = None
 
         elif status == "error":
             self._add_simple(testcase, "error", reason)
@@ -174,8 +161,20 @@ class XUnitReporter:
             self._add_simple(testcase, "failure", reason)
             testsuite.failures += 1
 
-        if self._text_attachments:
-            system_out = _ensure_newline(system_out) + self._text_attachments
+        properties_root = SubElement(testcase, "properties")
+
+        if extra_properties:
+            for key, value in extra_properties.items():
+                properties_root.append(Element("property", name=key, value=str(value)))
+
+        if default_attachments:
+            for value in default_attachments:
+                properties_root.append(
+                    Element("property", name="attachment", value=value)
+                )
+
+        if text_attachments:
+            system_out = _ensure_newline(system_out) + text_attachments
 
         if system_out:
             SubElement(testcase, "system-out").text = self._normalize_text(system_out)
@@ -232,7 +231,8 @@ class XUnitReporter:
 
         return self._testsuite
 
-    def _normalize_path(self, path: Any) -> str:
+    @cache
+    def normalize_path(self, path: Any) -> str:
         """Convert provided path to relative path."""
         if self._relative_to:
             try:

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -238,18 +238,6 @@ class RegressionManager:
             relative_to=os.getenv("COCOTB_RESULTS_RELATIVE_TO"),
             # Common default file attachments that will be added to all created test cases
             default_attachments=_env.as_list("COCOTB_RESULTS_ATTACHMENTS"),
-            # Common default properties that will be added to all created test cases
-            default_properties={
-                # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
-                # especially after merging multiple XML reports from different sources (e. g. CI jobs)
-                "cocotb": True,
-                "random_seed": self._regression_seed,
-                "sim_time_unit": "ns",
-                "sim_time_start": 0.0,
-                "sim_time_stop": 0.0,
-                "sim_time_duration": 0.0,
-                "sim_time_ratio": 0.0,
-            },
         )
 
     def discover_tests(self, *modules: str) -> None:
@@ -709,7 +697,10 @@ class RegressionManager:
             status="skipped",
             reason="Test was skipped",
             extra_properties={
-                "file": inspect.getfile(self._test.func),
+                # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
+                # especially after merging multiple XML reports from different sources (e. g. CI jobs)
+                "cocotb": True,
+                "file": self.xunit.normalize_path(inspect.getfile(self._test.func)),
                 "line": self._get_lineno(self._test),
             },
         )
@@ -754,7 +745,11 @@ class RegressionManager:
             reason="Test initialization failed",
             system_err=f"Test failed with COCOTB_RANDOM_SEED={self._regression_seed}",
             extra_properties={
-                "file": inspect.getfile(self._test.func),
+                # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
+                # especially after merging multiple XML reports from different sources (e. g. CI jobs)
+                "cocotb": True,
+                "random_seed": self._regression_seed,
+                "file": self.xunit.normalize_path(inspect.getfile(self._test.func)),
                 "line": self._get_lineno(self._test),
             },
         )
@@ -810,8 +805,13 @@ class RegressionManager:
             time=wall_time_s,
             status="passed",
             extra_properties={
-                "file": inspect.getfile(self._test.func),
+                # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
+                # especially after merging multiple XML reports from different sources (e. g. CI jobs)
+                "cocotb": True,
+                "random_seed": self._regression_seed,
+                "file": self.xunit.normalize_path(inspect.getfile(self._test.func)),
                 "line": self._get_lineno(self._test),
+                "sim_time_unit": "ns",
                 "sim_time_start": sim_time_start,
                 "sim_time_stop": sim_time_stop,
                 "sim_time_duration": sim_time_duration,
@@ -857,8 +857,13 @@ class RegressionManager:
             time=wall_time_s,
             status="passed",
             extra_properties={
-                "file": inspect.getfile(self._test.func),
+                # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
+                # especially after merging multiple XML reports from different sources (e. g. CI jobs)
+                "cocotb": True,
+                "random_seed": self._regression_seed,
+                "file": self.xunit.normalize_path(inspect.getfile(self._test.func)),
                 "line": self._get_lineno(self._test),
+                "sim_time_unit": "ns",
                 "sim_time_start": sim_time_start,
                 "sim_time_stop": sim_time_stop,
                 "sim_time_duration": sim_time_duration,
@@ -915,8 +920,13 @@ class RegressionManager:
             reason=result or msg,
             system_err=f"Test failed with COCOTB_RANDOM_SEED={self._regression_seed}",
             extra_properties={
-                "file": inspect.getfile(self._test.func),
+                # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
+                # especially after merging multiple XML reports from different sources (e. g. CI jobs)
+                "cocotb": True,
+                "random_seed": self._regression_seed,
+                "file": self.xunit.normalize_path(inspect.getfile(self._test.func)),
                 "line": self._get_lineno(self._test),
+                "sim_time_unit": "ns",
                 "sim_time_start": sim_time_start,
                 "sim_time_stop": sim_time_stop,
                 "sim_time_duration": sim_time_duration,

--- a/tests/pytest/test_xunit_reporter.py
+++ b/tests/pytest/test_xunit_reporter.py
@@ -47,14 +47,6 @@ def test_report(tmp_path: Path) -> None:
     xunit: XUnitReporter = XUnitReporter(
         relative_to=tmp_path,
         default_attachments=attachments,
-        # Common default properties that will be added to all created test cases
-        default_properties={
-            "cocotb": True,
-            "random_seed": 100,
-            "sim_time_duration": 0.0,
-            "sim_time_unit": "ns",
-            "sim_time_ratio": 0.0,
-        },
     )
 
     xunit.add_testcase(
@@ -63,7 +55,10 @@ def test_report(tmp_path: Path) -> None:
         status="passed",
         time=4.0,
         extra_properties={
+            "cocotb": True,
+            "random_seed": 100,
             "sim_time_duration": 0.200,
+            "sim_time_unit": "ns",
             "sim_time_ratio": 2.0,
             "file": "module.py",
             "line": 10,
@@ -76,7 +71,10 @@ def test_report(tmp_path: Path) -> None:
         time=8.0,
         status="skipped",
         extra_properties={
+            "cocotb": True,
+            "random_seed": 100,
             "sim_time_duration": 0.400,
+            "sim_time_unit": "ns",
             "sim_time_ratio": 4.0,
             "file": "module.py",
             "line": 12,
@@ -90,7 +88,10 @@ def test_report(tmp_path: Path) -> None:
         status="skipped",
         reason="Test skipped",
         extra_properties={
+            "cocotb": True,
+            "random_seed": 100,
             "sim_time_duration": 0.800,
+            "sim_time_unit": "ns",
             "sim_time_ratio": 8.0,
             "file": "module.py",
             "line": 14,
@@ -109,6 +110,9 @@ def test_report(tmp_path: Path) -> None:
             system_out="Test log",
             system_err="Test failed with COCOTB_RANDOM_SEED=100",
             extra_properties={
+                "cocotb": True,
+                "random_seed": 100,
+                "sim_time_unit": "ns",
                 "sim_time_duration": 0.400,
                 "sim_time_ratio": 4.0,
                 "file": "module.py",
@@ -126,6 +130,11 @@ def test_report(tmp_path: Path) -> None:
             status="error",
             reason=e,
             extra_properties={
+                "cocotb": True,
+                "random_seed": 100,
+                "sim_time_unit": "ns",
+                "sim_time_duration": 0,
+                "sim_time_ratio": 0,
                 "file": "module.py",
                 "line": 18,
             },
@@ -201,11 +210,11 @@ def test_report(tmp_path: Path) -> None:
     # Testcase 1
     properties = testcases[1].findall("properties")[0].findall("property")
 
-    assert len(properties) == 9
+    assert len(properties) == 7
     assert len(testcases[1].findall("error")) == 0
     assert len(testcases[1].findall("failure")) == 0
     assert len(testcases[1].findall("skipped")) == 1
-    assert len(testcases[1].findall("system-out")) == 1
+    assert len(testcases[1].findall("system-out")) == 0
     assert len(testcases[1].findall("system-err")) == 0
 
     skipped: Element = testcases[1].findall("skipped")[0]
@@ -216,11 +225,11 @@ def test_report(tmp_path: Path) -> None:
     # Testcase 2
     properties = testcases[2].findall("properties")[0].findall("property")
 
-    assert len(properties) == 9
+    assert len(properties) == 7
     assert len(testcases[2].findall("error")) == 0
     assert len(testcases[2].findall("failure")) == 0
     assert len(testcases[2].findall("skipped")) == 1
-    assert len(testcases[2].findall("system-out")) == 1
+    assert len(testcases[2].findall("system-out")) == 0
     assert len(testcases[2].findall("system-err")) == 0
 
     skipped = testcases[2].findall("skipped")[0]
@@ -346,7 +355,7 @@ def test_properties(tmp_path: Path) -> None:
         extra_properties={
             "cocotb": True,
             "coverage": False,
-            "file": results,
+            "file": xunit.normalize_path(results),
             "line": 10,
             "sim_time_unit": "ns",
             "sim_time_ratio": 0.0,


### PR DESCRIPTION
Continuation of https://github.com/cocotb/cocotb/pull/5631 and https://github.com/cocotb/cocotb/pull/5627

Context: https://github.com/cocotb/cocotb/issues/5615

What changed:
* Removed dictionary copy + update
* Removed branching `if name == "file"` in the loop that is adding properties
* Some properties will be not added. There is no point to record simulation time for skipped or failed tests during initialization. The XML `<property name="<name>" value="<value>" />` element has the biggest contribution to the final size of generated XML file
* Caching paths, mostly when doing path transformations to relative ones when `COCOTB_RESULTS_RELATIVE_TO="$(pwd)"`
* Attachments will be not included if test was skipped

Benchmark test:

```plaintext
pytest -c /dev/null ./tests/benchmarks/test_parameterize_perf
```

On the `master` branch:

```plaintext
------------------------------------------------- benchmark: 1 tests -------------------------------------------------
Name (time in s)                     Min     Max    Mean  StdDev  Median     IQR  Outliers     OPS  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------
test_parameterize_perf_icarus     7.9606  8.3152  8.1195  0.1554  8.1606  0.2672       3;0  0.1232       5           1
----------------------------------------------------------------------------------------------------------------------
```

From this PR:

```plaintext
------------------------------------------------- benchmark: 1 tests -------------------------------------------------
Name (time in s)                     Min     Max    Mean  StdDev  Median     IQR  Outliers     OPS  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------
test_parameterize_perf_icarus     4.4137  4.6433  4.5423  0.0925  4.5546  0.1476       2;0  0.2202       5           1
----------------------------------------------------------------------------------------------------------------------
```

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
