### PR TITLE
chore(xfail): marking passed xfail test as skipped in generated JUnit XML results file

### DIFF
--- a/docs/source/junit_reference.rst
+++ b/docs/source/junit_reference.rst
@@ -200,12 +200,16 @@ If present, test was skipped.
 List of supported attributes:
 
 * ``message`` - (optional) reason why test was skipped.
+* ``type`` - type of skipped test:
+
+  * ``cocotb.skip`` - when test was decorated with the :deco:`cocotb.skip` decorator.
+  * ``cocotb.xfail`` - when test was decorated with the :deco:`cocotb.xfail` decorator and expected exception was raised.
 
 Example:
 
 .. code:: xml
 
-    <skipped message="Test was skipped" />
+    <skipped type="cocotb.skip" message="Test was skipped" />
 
 
 .. _junit-attributes-error:
@@ -318,7 +322,7 @@ The first test (``dff_simple_test``) passed, the next (``dff_simple_test_failed`
             <property name="file" value="examples/simple_dff/test_dff.py" />
             <property name="line" value="52" />
           </properties>
-          <skipped message="Test was skipped" />
+          <skipped type="cocotb.skip" message="Test was skipped" />
           <system-out>[[ATTACHMENT|sim_build/dff.ghw]]
     </system-out>
         </testcase>

--- a/docs/source/newsfragments/5635.feature.1.rst
+++ b/docs/source/newsfragments/5635.feature.1.rst
@@ -1,0 +1,1 @@
+The ``reason`` argument from the :deco:`cocotb.skip` decorator will be now reported. If not set, the default message will be used.

--- a/docs/source/newsfragments/5635.feature.2.rst
+++ b/docs/source/newsfragments/5635.feature.2.rst
@@ -1,0 +1,1 @@
+Introduced a new experimental feature ``xfail_in_results`` that can be enabled via :venvar:`COCOTB_FUTURE`. If enabled, test decorated with the :deco:`cocotb.xfail` will be reported as ``skipped`` in the generated JUnit XML (``results.xml``) files and as ``xfailed`` in the terminal results summary when an expected exception will be raised.

--- a/docs/source/newsfragments/5635.feature.rst
+++ b/docs/source/newsfragments/5635.feature.rst
@@ -1,0 +1,1 @@
+The ``reason`` argument from the :deco:`cocotb.xfail` decorator will be now reported. If not set, the message from the raised exception will be used.

--- a/src/cocotb/_decorators.py
+++ b/src/cocotb/_decorators.py
@@ -63,6 +63,9 @@ class Test:
         stage:
             Order tests logically into stages.
             Tests from earlier stages are run before tests from later stages.
+
+        reason:
+            Reason why the test function is marked as xfail or skipped.
     """
 
     # TODO Replace with dataclass in Python 3.7+
@@ -84,6 +87,7 @@ class Test:
         ],
         skip: bool,
         stage: int,
+        reason: str | None = None,
     ) -> None:
         self.func = func
         self.args = args
@@ -96,6 +100,7 @@ class Test:
         self.expect_error = expect_error
         self.skip = skip
         self.stage = stage
+        self.reason = reason
 
     @property
     def fullname(self) -> str:
@@ -128,6 +133,7 @@ class TestGenerator:
             tuple[str, Sequence[object]]
             | tuple[Sequence[str], Sequence[Sequence[object]]]
         ] = []
+        self.reason: str | None = None
 
     def generate_tests(self) -> Iterable[Test]:
         option_reprs: dict[str, list[str]] = {}
@@ -185,6 +191,7 @@ class TestGenerator:
                 expect_error=tuple(self.expect_error),
                 skip=self.skip,
                 stage=self.stage,
+                reason=self.reason,
             )
 
 
@@ -539,6 +546,7 @@ def skipif(
         if not isinstance(obj, TestGenerator):
             obj = TestGenerator(obj)
         obj.skip |= condition
+        obj.reason = reason
         return obj
 
     return decorator
@@ -600,6 +608,7 @@ def xfail(
         if not isinstance(obj, TestGenerator):
             obj = TestGenerator(obj)
         if condition:
+            obj.reason = reason
             if raises is not None:
                 if isinstance(raises, _single_exception_types):
                     obj.expect_error.add(raises)

--- a/src/cocotb/_xunit_reporter.py
+++ b/src/cocotb/_xunit_reporter.py
@@ -33,6 +33,7 @@ Status = Literal["passed", "failed", "skipped", "error", "xfailed"]
 - ``failed`` - Test failed. Test case will include the ``failure`` XML element.
 - ``skipped`` - Test was skipped. Test case will include the ``skipped`` XML element.
 - ``error`` - An unexpected error when test was executed. Test case will include the ``error`` XML element.
+- ``xfailed`` - Expected exception was raised when test was executed. Test case will include the ``skipped`` XML element.
 """
 
 
@@ -148,7 +149,7 @@ class XUnitReporter:
         text_attachments: str | None = self._text_attachments
 
         if status == "skipped":
-            self._add_simple(testcase, "skipped", reason)
+            self._add_simple(testcase, "skipped", reason, kind="cocotb.skip")
             testsuite.skipped += 1
             default_attachments = None
             text_attachments = None
@@ -160,6 +161,10 @@ class XUnitReporter:
         elif status == "failed":
             self._add_simple(testcase, "failure", reason)
             testsuite.failures += 1
+
+        elif status == "xfailed":
+            self._add_simple(testcase, "skipped", reason, kind="cocotb.xfail")
+            testsuite.skipped += 1
 
         properties_root = SubElement(testcase, "properties")
 
@@ -247,6 +252,7 @@ class XUnitReporter:
         parent: Element,
         name: str,
         reason: str | BaseException | None = None,
+        kind: str | None = None,
     ) -> Element:
         """Create and add a simple XML element to XML parent.
 
@@ -254,13 +260,17 @@ class XUnitReporter:
             parent: XML parent element.
             name: Name of XML element.
             reason: Reason to be included in created XML element.
+            kind: The value of the ``type`` XML attribute.
 
         Returns:
             Added XML element.
         """
+        if kind:
+            return SubElement(parent, name, type=kind, message=_escape(reason))
+
         if isinstance(reason, BaseException):
             kind = _escape(type(reason).__name__)
-            element = SubElement(parent, name, message=_escape(reason), type=kind)
+            element = SubElement(parent, name, type=kind, message=_escape(reason))
             text = self._normalize_text(
                 "".join(format_exception(type(reason), reason, reason.__traceback__))
             )

--- a/src/cocotb/future.py
+++ b/src/cocotb/future.py
@@ -20,7 +20,7 @@ class Future(DocStrEnum):
 
     XFAIL_IN_RESULTS = (
         "xfail_in_results",
-        "Use the XFAIL status in the terminal results summary for xfailed tests",
+        "Use the ``XFAIL`` status in the terminal results summary and the ``skipped`` XML element in the generated JUnit XML file for xfailed tests",
     )
 
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -698,7 +698,7 @@ class RegressionManager:
             name=self._test.name,
             classname=self._test.module,
             status="skipped",
-            reason="Test was skipped",
+            reason=self._test.reason or msg or "Test was skipped",
             extra_properties={
                 # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
                 # especially after merging multiple XML reports from different sources (e. g. CI jobs)
@@ -823,6 +823,7 @@ class RegressionManager:
             classname=self._test.module,
             time=wall_time_s,
             status=status,
+            reason=self._test.reason or result or msg or "errored as expected",
             extra_properties={
                 # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
                 # especially after merging multiple XML reports from different sources (e. g. CI jobs)

--- a/tests/pytest/test_cocotb.py
+++ b/tests/pytest/test_cocotb.py
@@ -70,7 +70,8 @@ timescale = ("1ps", "1ps")
 
 
 @pytest.mark.parametrize("reduced_log_fmt", ["1", "0"])
-def test_cocotb(reduced_log_fmt):
+@pytest.mark.parametrize("cocotb_future", ["1", "0"])
+def test_cocotb(reduced_log_fmt, cocotb_future):
     runner = get_runner(sim)
 
     runner.build(
@@ -88,7 +89,10 @@ def test_cocotb(reduced_log_fmt):
         gpi_interfaces=gpi_interfaces,
         test_args=sim_args,
         timescale=None if sim in ("xcelium",) else timescale,
-        extra_env={"COCOTB_REDUCED_LOG_FMT": reduced_log_fmt},
+        extra_env={
+            "COCOTB_REDUCED_LOG_FMT": reduced_log_fmt,
+            "COCOTB_FUTURE": cocotb_future,
+        },
     )
 
 

--- a/tests/pytest/test_xunit_reporter.py
+++ b/tests/pytest/test_xunit_reporter.py
@@ -219,7 +219,7 @@ def test_report(tmp_path: Path) -> None:
 
     skipped: Element = testcases[1].findall("skipped")[0]
 
-    assert not skipped.attrib
+    assert skipped.get("type") == "cocotb.skip"
     assert not skipped.text
 
     # Testcase 2
@@ -234,7 +234,8 @@ def test_report(tmp_path: Path) -> None:
 
     skipped = testcases[2].findall("skipped")[0]
 
-    assert len(skipped.attrib) == 1
+    assert len(skipped.attrib) == 2
+    assert skipped.get("type") == "cocotb.skip"
     assert skipped.get("message") == "Test skipped"
     assert not skipped.text
 

--- a/tests/test_cases/test_skip/Makefile
+++ b/tests/test_cases/test_skip/Makefile
@@ -8,6 +8,6 @@ COCOTB_TEST_MODULES := test_skip
 .PHONY: override_for_this_test
 override_for_this_test:
 	$(MAKE) all
-	test $$(grep -o '<skipped[^/]*/>' $(COCOTB_RESULTS_FILE) | wc -l) -eq 4
+	test $$(grep -o '<skipped[^>]*/>' $(COCOTB_RESULTS_FILE) | wc -l) -eq 4
 
 include ../../designs/sample_module/Makefile


### PR DESCRIPTION
Closes https://github.com/cocotb/cocotb/issues/5634

Pytest is marking passed `xfail` tests as skipped in JUnit XML file:

* [src/_pytest/junitxml.py:append_failure](https://github.com/pytest-dev/pytest/blob/9.1.0/src/_pytest/junitxml.py#L191)
* [src/_pytest/junitxml.py:append_append](https://github.com/pytest-dev/pytest/blob/9.1.0/src/_pytest/junitxml.py#L229)

This behavior is similar in other testing frameworks like [TestNG](https://testng.org/):

* [@SkipException](https://www.javadoc.io/doc/org.testng/testng/latest/org/testng/SkipException.html)

This PR will:

* Report passed `xfail` tests as skipped (not as passed) in the generated JUnit XML `results.xml` file
* Propagate the test `reason` to the XML `message` attribute. Pytest is doing the same
* Skipped test will have the XML `type` attribute set to `cocotb.skip`. Pytest is doing the same (`pytest.skip`)
* Passed `xfail` test will have the XML `type` attribute set to `cocotb.xfail`. Pytest is doing the same (`pytest.xfail`)
* ~`xfail` test will have own status and counter in the cocotb tests summary report~
* ~Give cocotb the "pytest" look & feel for xfailed tests~

`test_xfail_skip.py` example:

```python
import pytest

@pytest.mark.skipif(True, reason="msg")
def test_skip() -> None:
    pass

@pytest.mark.xfail(True, reason="msg", strict=False)
def test_xfail() -> None:
    raise RuntimeError("error")

@pytest.mark.xfail(True, reason="msg", strict=True, raises=RuntimeError)
def test_xfail_strict() -> None:
    raise RuntimeError("error")
```

To generate JUnit XML file:

```plaintext
pytest test_xfail_skip.py --junitxml=junit.xml
```

Content of the generated `junit.xml` file from pytest:

```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites name="pytest tests">
  <testsuite name="pytest" errors="0" failures="0" skipped="3" tests="3" time="0.032" timestamp="2026-06-17T22:09:30.618756+02:00" hostname="hostname">
    <testcase classname="test_xfail_skip" name="test_xfail" time="0.002">
      <skipped type="pytest.xfail" message="msg"/>
    </testcase>
    <testcase classname="test_xfail_skip" name="test_xfail_strict" time="0.000">
      <skipped type="pytest.xfail" message="msg"/>
    </testcase>
    <testcase classname="test_xfail_skip" name="test_skip" time="0.000">
      <skipped type="pytest.skip" message="msg">test_xfail_skip.py:11: msg</skipped>
    </testcase>
  </testsuite>
</testsuites>
```

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
