### PR TITLE
Set SONAME for libgpi on Linux

### DIFF
--- a/cocotb_build_libs.py
+++ b/cocotb_build_libs.py
@@ -320,6 +320,8 @@ class build_ext(_build_ext):
                     # `GLIBCXX_3.4.29' not found (required by
                     # /path/to/libcocotbvhpi_modelsim.so)."
                     ext.extra_link_args += ["-static-libstdc++"]
+                    if lib_name == "libgpi":
+                        ext.extra_link_args += ["-Wl,-soname,libgpi.so"]
 
                 ext.extra_link_args += [f"-Wl,-rpath,{rpath}" for rpath in rpaths]
 

--- a/docs/source/newsfragments/5636.bugfix.rst
+++ b/docs/source/newsfragments/5636.bugfix.rst
@@ -1,0 +1,1 @@
+Set the Linux SONAME of ``libgpi.so`` to support downstream libraries that depend on libgpi.

--- a/tests/pytest/test_lib_metadata.py
+++ b/tests/pytest/test_lib_metadata.py
@@ -1,0 +1,25 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from cocotb_tools.config import libs_dir
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="SONAME is Linux-specific shared library metadata",
+)
+def test_libgpi_has_soname() -> None:
+    libgpi = libs_dir / "libgpi.so"
+    output = subprocess.check_output(
+        ["readelf", "-d", libgpi],
+        text=True,
+    )
+
+    assert "Library soname: [libgpi.so]" in output


### PR DESCRIPTION
This sets the Linux ELF SONAME for `libgpi.so` to `libgpi.so`.

Downstream extension libraries can depend on libgpi and may preload cocotb's `libgpi.so` with `dlopen(..., RTLD_GLOBAL)` before loading their own library. Without a SONAME, the dynamic linker keys the preloaded library by its full path, so later dependencies on `libgpi.so` may not resolve to the already-loaded library.

The new linker flag is Linux-only. macOS uses install names, which cocotb already sets separately, and Windows uses DLL/import-library mechanisms rather than ELF SONAMEs.

A Linux-only pytest checks the built `libgpi.so` dynamic section with `readelf` and verifies that the SONAME is present.

Fixes #5636.