### PR TITLE
feat(xfail): use the XFAIL status for xfailed tests in the terminal results summary

### DIFF
--- a/src/cocotb/_xunit_reporter.py
+++ b/src/cocotb/_xunit_reporter.py
@@ -26,7 +26,7 @@ from traceback import format_exception
 from typing import Any, Literal
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
-Status = Literal["passed", "failed", "skipped", "error"]
+Status = Literal["passed", "failed", "skipped", "error", "xfailed"]
 """Status of test case.
 
 - ``passed`` - Test passed.

--- a/src/cocotb/future.py
+++ b/src/cocotb/future.py
@@ -18,7 +18,10 @@ class Future(DocStrEnum):
     .. versionadded:: 2.1
     """
 
-    PLACEHOLDER = ("placeholder", "This is a placeholder")
+    XFAIL_IN_RESULTS = (
+        "xfail_in_results",
+        "Use the XFAIL status in the terminal results summary for xfailed tests",
+    )
 
 
 _future_strs = {future.value for future in Future}

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -29,13 +29,14 @@ import cocotb._shutdown as shutdown
 import cocotb.handle
 import cocotb.simulator
 import cocotb.types._resolve
+from cocotb import future
 from cocotb import logging as cocotb_logging
 from cocotb._decorators import Test, TestGenerator
 from cocotb._gpi_triggers import Timer
 from cocotb._test_factory import TestFactory
 from cocotb._test_manager import TestManager, TestSuccess
 from cocotb._utils import DocEnum, safe_divide
-from cocotb._xunit_reporter import XUnitReporter
+from cocotb._xunit_reporter import Status, XUnitReporter
 from cocotb.logging import ANSI
 from cocotb.simtime import get_sim_time
 from cocotb_tools import _env
@@ -219,6 +220,8 @@ class RegressionManager:
         """The current number of skipped tests."""
         self.failures = 0
         """The current number of failed tests."""
+        self.xfailed = 0
+        """The current number of xfailed tests."""
         self._tearing_down = False
         self._test_queue: list[Test] = []
         self._filters: list[re.Pattern[str]] = []
@@ -776,7 +779,22 @@ class RegressionManager:
         result: BaseException | None,
         msg: str | None,
     ) -> None:
-        start_hilight = "" if cocotb_logging.strip_ansi else self.COLOR_PASSED
+        status: Status
+
+        if future.is_enabled(future.Future.XFAIL_IN_RESULTS):
+            # Use the XFAIL status for xfailed tests (like pytest)
+            outcome = _TestOutcome.XFAIL
+            color = self.COLOR_XFAILED
+            status = "xfailed"
+            self.xfailed += 1
+        else:
+            # Use the PASS status for xfailed tests
+            outcome = _TestOutcome.PASS
+            color = self.COLOR_PASSED
+            status = "passed"
+            self.passed += 1
+
+        start_hilight = "" if cocotb_logging.strip_ansi else color
         stop_hilight = "" if cocotb_logging.strip_ansi else ANSI.DEFAULT
         if msg is None:
             rest = ""
@@ -787,9 +805,10 @@ class RegressionManager:
         else:
             result_was = f" (result was {type(result).__qualname__})"
         self.log.info(
-            "%s %spassed%s%s%s",
+            "%s %s%s%s%s%s",
             self._test.fullname,
             start_hilight,
+            status,
             stop_hilight,
             rest,
             result_was,
@@ -803,7 +822,7 @@ class RegressionManager:
             name=self._test.name,
             classname=self._test.module,
             time=wall_time_s,
-            status="passed",
+            status=status,
             extra_properties={
                 # Used to distinguish a cocotb testcase from other testcases (C++, Rust, ...),
                 # especially after merging multiple XML reports from different sources (e. g. CI jobs)
@@ -820,14 +839,13 @@ class RegressionManager:
         )
 
         # update running passed/failed/skipped counts
-        self.passed += 1
         self.count += 1
 
         # save details for summary
         self._test_results.append(
             _TestResults(
                 test_fullname=self._test.fullname,
-                outcome=_TestOutcome.PASS,
+                outcome=outcome,
                 sim_time_ns=sim_time_duration,
                 wall_time_s=wall_time_s,
             )
@@ -973,6 +991,9 @@ class RegressionManager:
         REAL_FIELD = "REAL TIME (s)"
         RATIO_FIELD = "RATIO (ns/s)"
         TOTAL_NAME = f"TESTS={self.total_tests} PASS={self.passed} FAIL={self.failures} SKIP={self.skipped}"
+
+        if future.is_enabled(future.Future.XFAIL_IN_RESULTS):
+            TOTAL_NAME += f" XFAIL={self.xfailed}"
 
         TEST_FIELD_LEN = max(
             len(TEST_FIELD),

--- a/tests/pytest/test_futures.py
+++ b/tests/pytest/test_futures.py
@@ -28,13 +28,13 @@ def clear_futures() -> Generator[None, None, None]:
 
 def test_futures() -> None:
     # Enable a future and check it is enabled
-    assert not is_enabled(Future.PLACEHOLDER)
-    enable(Future.PLACEHOLDER)
-    assert is_enabled(Future.PLACEHOLDER)
+    assert not is_enabled(Future.XFAIL_IN_RESULTS)
+    enable(Future.XFAIL_IN_RESULTS)
+    assert is_enabled(Future.XFAIL_IN_RESULTS)
 
     # Ensure does not raise if enabled multiple times
-    enable(Future.PLACEHOLDER)
-    assert is_enabled(Future.PLACEHOLDER)
+    enable(Future.XFAIL_IN_RESULTS)
+    assert is_enabled(Future.XFAIL_IN_RESULTS)
 
 
 def test_envvar_unset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -98,21 +98,21 @@ def test_envvar_false(monkeypatch: pytest.MonkeyPatch, false_value: str) -> None
 
 
 def test_envvar_by_future(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("COCOTB_FUTURE", "placeholder")
+    monkeypatch.setenv("COCOTB_FUTURE", "xfail_in_results")
     cocotb.future._init()
-    assert is_enabled(Future.PLACEHOLDER)
-    # Ensure PLACEHOLDER is the only enabled future
-    disable(Future.PLACEHOLDER)
-    assert not is_enabled(Future.PLACEHOLDER)
+    assert is_enabled(Future.XFAIL_IN_RESULTS)
+    # Ensure XFAIL_IN_RESULTS is the only enabled future
+    disable(Future.XFAIL_IN_RESULTS)
+    assert not is_enabled(Future.XFAIL_IN_RESULTS)
 
 
 def test_envvar_empty_future(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("COCOTB_FUTURE", ",placeholder,,")
+    monkeypatch.setenv("COCOTB_FUTURE", ",xfail_in_results,,")
     cocotb.future._init()
-    assert is_enabled(Future.PLACEHOLDER)
+    assert is_enabled(Future.XFAIL_IN_RESULTS)
     # Ensure it's the only enabled future
-    disable(Future.PLACEHOLDER)
-    assert not is_enabled(Future.PLACEHOLDER)
+    disable(Future.XFAIL_IN_RESULTS)
+    assert not is_enabled(Future.XFAIL_IN_RESULTS)
 
 
 def test_envvar_unknown_future(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Context:
* https://github.com/cocotb/cocotb/issues/5638
* https://github.com/cocotb/cocotb/pull/5635

Features:
* This can be enabled when the `xfail_in_results` option is set in the `COCOTB_FUTURE` environment variable
* It shows status of xfailed tests by using the `XFAIL` and `xfailed` keywords with own counter. Similar to pytest

Example of the terminal output when the `COCOTB_FUTURE` environment variable will contain the `xfail_in_results` option:

<img width="2837" height="1149" alt="image" src="https://github.com/user-attachments/assets/2025bea2-5ed5-4820-b982-418947059bc5" />

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
