### PR TITLE
Future flags

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -932,6 +932,28 @@ Other Runtime Information
 
     .. versionadded:: 2.1
 
+Future Features
+---------------
+
+.. envvar:: COCOTB_FUTURE
+
+    Type: :ref:`env-list`
+
+    A comma-separated list of experimental features or breaking changes that can be enabled or disabled.
+    If this variable is not defined, all experimental features and breaking changes are disabled.
+
+    See :class:`cocotb.future.Future` for a list of available features.
+    The lowercase name of the feature is used to enable it.
+    Setting the value to ``1``, ``true``, or ``yes`` enables all features,
+    while ``0``, ``false``, or ``no`` disables all features.
+
+    .. versionadded:: 2.1
+
+.. automodule:: cocotb.future
+    :members:
+    :member-order: bysource
+    :synopsis: Experimental features or breaking changes that can be enabled or disabled.
+
 Debugging
 ---------
 

--- a/docs/source/newsfragments/5640.feature.rst
+++ b/docs/source/newsfragments/5640.feature.rst
@@ -1,0 +1,1 @@
+Added :envvar:`COCOTB_FUTURE` envvar to allow users to opt-in to experimental features or breaking changes.

--- a/src/cocotb/_compat.py
+++ b/src/cocotb/_compat.py
@@ -1,0 +1,17 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import sys
+
+__all__ = ("StrEnum",)
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Backport of StrEnum from Python 3.11."""

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -112,7 +112,7 @@ def _start_user_coverage() -> None:
     enable_coverage: bool = False
 
     if _env.exists("COCOTB_USER_COVERAGE"):
-        enable_coverage = _env.as_bool("COCOTB_USER_COVERAGE")
+        enable_coverage = _env.get_bool("COCOTB_USER_COVERAGE")
 
     elif _env.exists("COVERAGE"):
         warnings.warn(
@@ -120,7 +120,7 @@ def _start_user_coverage() -> None:
             DeprecationWarning,
             stacklevel=2,
         )
-        enable_coverage = _env.as_bool("COVERAGE")
+        enable_coverage = _env.get_bool("COVERAGE")
 
     if enable_coverage:
         try:
@@ -130,7 +130,7 @@ def _start_user_coverage() -> None:
                 "Coverage collection requested but coverage module not available. Install it using `pip install coverage`."
             ) from None
         else:
-            config_filepath: str = _env.as_str("COVERAGE_RCFILE")
+            config_filepath: str = _env.get_str("COVERAGE_RCFILE")
             if not config_filepath:
                 # Exclude cocotb libraries from coverage collection.
                 log.info(
@@ -168,14 +168,14 @@ def _setup_random_seed() -> None:
     seed: int = int(time.time())
 
     if _env.exists("COCOTB_RANDOM_SEED"):
-        seed = _env.as_int("COCOTB_RANDOM_SEED", seed)
+        seed = _env.get_int("COCOTB_RANDOM_SEED", seed)
 
     elif _env.exists("RANDOM_SEED"):
         warnings.warn(
             "RANDOM_SEED is deprecated in favor of COCOTB_RANDOM_SEED",
             DeprecationWarning,
         )
-        seed = _env.as_int("RANDOM_SEED", seed)
+        seed = _env.get_int("RANDOM_SEED", seed)
 
     elif "ntb_random_seed" in cocotb.plusargs:
         warnings.warn(

--- a/src/cocotb/_init.py
+++ b/src/cocotb/_init.py
@@ -18,6 +18,7 @@ from typing import cast
 import cocotb
 import cocotb._profiling
 import cocotb._shutdown
+import cocotb.future
 import cocotb.handle
 import cocotb.logging
 import cocotb.simtime
@@ -31,6 +32,7 @@ def init_package_from_simulation() -> None:
     """Initialize the cocotb package from a simulation context."""
 
     # Initialize subsystems
+    cocotb.future._init()
     cocotb._shutdown._init()
     cocotb.logging._init()
     cocotb._profiling._init()

--- a/src/cocotb/_profiling.py
+++ b/src/cocotb/_profiling.py
@@ -16,7 +16,7 @@ from cocotb_tools import _env
 profiling_context: AbstractContextManager[None, None]
 
 
-if _env.as_bool("COCOTB_ENABLE_PROFILING"):
+if _env.get_bool("COCOTB_ENABLE_PROFILING"):
     _profile: cProfile.Profile
 
     def _init() -> None:

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -26,7 +26,7 @@ from cocotb_tools import _env
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
 
-_pdb_on_exception = _env.as_bool("COCOTB_PDB_ON_EXCEPTION")
+_pdb_on_exception = _env.get_bool("COCOTB_PDB_ON_EXCEPTION")
 
 
 class TestManager:

--- a/src/cocotb/_utils.py
+++ b/src/cocotb/_utils.py
@@ -15,15 +15,15 @@ from collections.abc import Iterable
 from enum import Enum, IntEnum
 from functools import wraps
 from types import TracebackType
-from typing import (
-    Any,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import Any, TypeVar, cast, overload
+
+from cocotb._compat import StrEnum
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
+
+if sys.version_info >= (3, 11):
+    from typing import Self
 
 ExceptionTuple: TypeAlias = tuple[type[BaseException], BaseException, TracebackType]
 
@@ -167,14 +167,22 @@ class DocEnum(Enum):
         return self
 
 
-IntEnumT = TypeVar("IntEnumT", bound=IntEnum)
-
-
 class DocIntEnum(IntEnum):
     """Like DocEnum but for :class:`IntEnum` enum types."""
 
-    def __new__(cls: type[IntEnumT], value: int, doc: str | None = None) -> IntEnumT:
+    def __new__(cls, value: int, doc: str | None = None) -> Self:
         self = int.__new__(cls, value)
+        self._value_ = value
+        if doc is not None:
+            self.__doc__ = doc
+        return self
+
+
+class DocStrEnum(StrEnum):
+    """Like DocEnum but for :class:`StrEnum` enum types."""
+
+    def __new__(cls, value: str, doc: str | None = None) -> Self:
+        self = str.__new__(cls, value)
         self._value_ = value
         if doc is not None:
             self.__doc__ = doc

--- a/src/cocotb/debug.py
+++ b/src/cocotb/debug.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from cocotb_tools import _env
 
-debug: bool = _env.as_bool("COCOTB_SCHEDULER_DEBUG")
+debug: bool = _env.get_bool("COCOTB_SCHEDULER_DEBUG")
 """Global flag to enable additional debugging functionality.
 
 Defaults to ``True`` if the :envvar:`COCOTB_SCHEDULER_DEBUG` environment variable is set,

--- a/src/cocotb/future.py
+++ b/src/cocotb/future.py
@@ -1,0 +1,91 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Enable or disable experimental features or breaking changes."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+
+from cocotb._utils import DocStrEnum
+from cocotb_tools import _env
+
+
+class Future(DocStrEnum):
+    """Experimental features or breaking changes that can be enabled.
+
+    .. versionadded:: 2.1
+    """
+
+    PLACEHOLDER = ("placeholder", "This is a placeholder")
+
+
+_future_strs = {future.value for future in Future}
+
+_enabled_futures: set[Future] = set()
+
+
+def enable(future: Future) -> None:
+    """Enable a future.
+
+    Args:
+        future: Future to enable.
+
+    .. versionadded:: 2.1
+    """
+    _enabled_futures.add(future)
+
+
+def disable(future: Future) -> None:
+    """Disable a future.
+
+    Args:
+        future: Future to disable.
+
+    .. versionadded:: 2.1
+    """
+    _enabled_futures.discard(future)
+
+
+def is_enabled(future: Future) -> bool:
+    """Check if a future is enabled.
+
+    Args:
+        future: Future to check.
+
+    Returns:
+        :data:`True` if the future is enabled, otherwise :data:`False`.
+
+    .. versionadded:: 2.1
+    """
+    return future in _enabled_futures
+
+
+def _parse_futures(futures: str) -> Iterable[Future]:
+    for fut in futures.split(","):
+        future = fut.strip()
+        if not future:
+            continue
+        if future not in _future_strs:
+            raise ValueError(f"Unknown future: {future!r}")
+        yield Future(future)
+
+
+def _init() -> None:
+    futures = os.getenv("COCOTB_FUTURE")
+    if not futures:
+        return
+
+    try:
+        bool_flag = _env.as_bool(futures)
+    except ValueError:
+        # if not a bool, try parsing as list of futures
+        requested_futures = list(_parse_futures(futures))
+        _enabled_futures.update(requested_futures)
+    else:
+        # Is bool flag, if False, skip.
+        # If True, enable all futures.
+        if not bool_flag:
+            return
+        _enabled_futures.update(Future)

--- a/src/cocotb/handle.py
+++ b/src/cocotb/handle.py
@@ -762,7 +762,7 @@ class _OldImmediate(_Action[_ValueT]):
 _apply_writes_cb: TriggerCallback | None = None
 
 
-_trust_inertial: bool = _env.as_bool("COCOTB_TRUST_INERTIAL_WRITES")
+_trust_inertial: bool = _env.get_bool("COCOTB_TRUST_INERTIAL_WRITES")
 if _trust_inertial:
 
     def _apply_scheduled_writes() -> None:

--- a/src/cocotb/logging.py
+++ b/src/cocotb/logging.py
@@ -144,16 +144,18 @@ def _init() -> None:
     """
     global strip_ansi
 
-    strip_ansi = not _env.as_bool(
+    strip_ansi = not _env.get_bool(
         "COCOTB_ANSI_OUTPUT",
-        sys.stdout.isatty() and not _env.as_str("NO_COLOR") and not _env.as_bool("GUI"),
+        sys.stdout.isatty()
+        and not _env.get_str("NO_COLOR")
+        and not _env.get_bool("GUI"),
     )
 
     _setup_gpi_logger()
 
     # Set "cocotb" and "gpi" logger based on environment variables
     def set_level(logger_name: str, envvar: str) -> None:
-        log_level: str = _env.as_str(envvar).upper()
+        log_level: str = _env.get_str(envvar).upper()
         if not log_level:
             return
 
@@ -195,7 +197,7 @@ def _setup_gpi_logger() -> None:
 
 def _configure() -> None:
     """Configure basic logging."""
-    reduced_log_fmt: bool = _env.as_bool("COCOTB_REDUCED_LOG_FMT", True)
+    reduced_log_fmt: bool = _env.get_bool("COCOTB_REDUCED_LOG_FMT", True)
     prefix_format: str = os.getenv("COCOTB_LOG_PREFIX", "")
     default_config(reduced_log_fmt=reduced_log_fmt, prefix_format=prefix_format)
 

--- a/src/cocotb/regression.py
+++ b/src/cocotb/regression.py
@@ -225,11 +225,11 @@ class RegressionManager:
         self._mode = RegressionMode.REGRESSION
         self._regression_terminated: BaseException | None = None
         self._regression_seed = cocotb.RANDOM_SEED
-        self._random_test_order = _env.as_bool(
+        self._random_test_order = _env.get_bool(
             "COCOTB_RANDOM_TEST_ORDER", default=False
         )
         self._random_state: Any
-        self._max_failures = _env.as_int("COCOTB_MAX_FAILURES", default=0)
+        self._max_failures = _env.get_int("COCOTB_MAX_FAILURES", default=0)
         self._random_x_resolver_state: Any
 
         # Setup xUnit
@@ -237,7 +237,7 @@ class RegressionManager:
         self.xunit = XUnitReporter(
             relative_to=os.getenv("COCOTB_RESULTS_RELATIVE_TO"),
             # Common default file attachments that will be added to all created test cases
-            default_attachments=_env.as_list("COCOTB_RESULTS_ATTACHMENTS"),
+            default_attachments=_env.get_list("COCOTB_RESULTS_ATTACHMENTS"),
         )
 
     def discover_tests(self, *modules: str) -> None:
@@ -1126,7 +1126,7 @@ def _setup_regression_manager() -> None:
     _manager_inst = RegressionManager()
 
     # discover tests
-    modules: list[str] = _env.as_list("COCOTB_TEST_MODULES")
+    modules: list[str] = _env.get_list("COCOTB_TEST_MODULES")
     if not modules:
         raise RuntimeError(
             "Environment variable COCOTB_TEST_MODULES, which defines the module(s) to execute, is not defined or empty."
@@ -1135,8 +1135,8 @@ def _setup_regression_manager() -> None:
     _manager_inst.discover_tests(*modules)
 
     # filter tests
-    testcases: list[str] = _env.as_list("COCOTB_TESTCASE")
-    test_filter: str = _env.as_str("COCOTB_TEST_FILTER")
+    testcases: list[str] = _env.get_list("COCOTB_TESTCASE")
+    test_filter: str = _env.get_str("COCOTB_TEST_FILTER")
     if testcases and test_filter:
         raise RuntimeError("Specify only one of COCOTB_TESTCASE or COCOTB_TEST_FILTER")
     elif testcases:
@@ -1168,7 +1168,7 @@ def _run_regression() -> None:
 
     _setup_regression_manager()
 
-    if _env.as_bool("COCOTB_LIST_TESTS", False):
+    if _env.get_bool("COCOTB_LIST_TESTS", False):
         _manager_inst.list_tests()
     else:
         _manager_inst.start_regression()

--- a/src/cocotb/types/_indexing.py
+++ b/src/cocotb/types/_indexing.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from cocotb.types._range import Range
 from cocotb_tools import _env
 
-do_indexing_changed_warning: bool = _env.as_bool("COCOTB_INDEXING_CHANGED_WARNING")
+do_indexing_changed_warning: bool = _env.get_bool("COCOTB_INDEXING_CHANGED_WARNING")
 
 
 def indexing_changed(range: Range) -> bool:

--- a/src/cocotb/types/_resolve.py
+++ b/src/cocotb/types/_resolve.py
@@ -69,7 +69,7 @@ def get_str_resolver(resolver: ResolverLiteral) -> Callable[[str], str]:
 
 
 def _init() -> Callable[[str], str] | None:
-    resolver = _env.as_str("COCOTB_RESOLVE_X").lower()
+    resolver = _env.get_str("COCOTB_RESOLVE_X").lower()
 
     # no resolver
     if not resolver:

--- a/src/cocotb_tools/_coverage.py
+++ b/src/cocotb_tools/_coverage.py
@@ -7,7 +7,7 @@ from cocotb_tools import _env
 
 
 def start_cocotb_library_coverage() -> None:  # pragma: no cover
-    if not _env.as_bool("COCOTB_LIBRARY_COVERAGE"):
+    if not _env.get_bool("COCOTB_LIBRARY_COVERAGE"):
         return
     try:
         import coverage  # noqa: PLC0415

--- a/src/cocotb_tools/_env.py
+++ b/src/cocotb_tools/_env.py
@@ -60,21 +60,37 @@ def get_bool(name: str, default: bool | None = None) -> bool:
     Raises:
         :exc:`ValueError` in case of an unexpected value.
     """
-    envvar: str = get_str(name)  # Keep original case for ValueError
-    value: str = envvar.lower()
+    value = get_str(name)  # Keep original case for ValueError
 
     if not value:
         return default or False
 
+    try:
+        return as_bool(value)
+    except ValueError:
+        raise ValueError(
+            f"Unexpected value {value!r} for environment variable: {name!r}. "
+            f"Expecting one of {(*TRUE,)} or {(*FALSE,)} (case-insensitive)"
+        ) from None
+
+
+def as_bool(value: str) -> bool:
+    """Convert envvar string value to Python boolean type.
+
+    Args:
+        value: String value to convert. Case-insensitive.
+
+    Returns:
+        :data:`True` if the value is ``1``, ``yes``, ``y``, ``on``, ``true`` or ``enable``.
+        :data:`False` if the value is ``0``, ``no``, ``n``, ``off``, ``false`` or ``disable``.
+    """
+    value = value.lower()
     if value in TRUE:
         return True
-
     if value in FALSE:
         return False
-
     raise ValueError(
-        f"Unexpected value {envvar!r} for environment variable: {name!r}. "
-        f"Expecting one of {(*TRUE,)} or {(*FALSE,)} (case-insensitive)"
+        f"Unexpected value: {value!r}. Expecting one of {(*TRUE,)} or {(*FALSE,)} (case-insensitive)"
     )
 
 

--- a/src/cocotb_tools/_env.py
+++ b/src/cocotb_tools/_env.py
@@ -30,7 +30,7 @@ def exists(name: str) -> bool:
     return name in os.environ
 
 
-def as_str(name: str, default: str | None = None) -> str:
+def get_str(name: str, default: str | None = None) -> str:
     """Convert value of environment variable to Python string type.
 
     Args:
@@ -43,7 +43,7 @@ def as_str(name: str, default: str | None = None) -> str:
     return os.environ.get(name, "").strip() or default or ""
 
 
-def as_bool(name: str, default: bool | None = None) -> bool:
+def get_bool(name: str, default: bool | None = None) -> bool:
     """Convert value of environment variable to Python boolean type.
 
     Function is case-insensitive.
@@ -60,7 +60,7 @@ def as_bool(name: str, default: bool | None = None) -> bool:
     Raises:
         :exc:`ValueError` in case of an unexpected value.
     """
-    envvar: str = as_str(name)  # Keep original case for ValueError
+    envvar: str = get_str(name)  # Keep original case for ValueError
     value: str = envvar.lower()
 
     if not value:
@@ -78,7 +78,7 @@ def as_bool(name: str, default: bool | None = None) -> bool:
     )
 
 
-def as_list(
+def get_list(
     name: str, default: Iterable[str] | None = None, separator: str = ","
 ) -> list[str]:
     """Convert value of environment variable to Python list of strings type.
@@ -93,12 +93,14 @@ def as_list(
     Returns:
         List of stripped and non-empty strings.
     """
-    items: list[str] = list(filter(None, map(str.strip, as_str(name).split(separator))))
+    items: list[str] = list(
+        filter(None, map(str.strip, get_str(name).split(separator)))
+    )
 
     return list(items or default or ())
 
 
-def as_int(name: str, default: int | None = None) -> int:
+def get_int(name: str, default: int | None = None) -> int:
     """Convert value of environment variable to Python integer type.
 
     Args:
@@ -108,10 +110,10 @@ def as_int(name: str, default: int | None = None) -> int:
     Returns:
         Integer. If value was not set, it will return zero (0).
     """
-    return int(as_str(name) or default or 0)
+    return int(get_str(name) or default or 0)
 
 
-def as_path(name: str, default: Path | str | None = None) -> Path:
+def get_path(name: str, default: Path | str | None = None) -> Path:
     """Convert value of environment variable to Python path type.
 
     Args:
@@ -121,10 +123,10 @@ def as_path(name: str, default: Path | str | None = None) -> Path:
     Returns:
         The resolved path. If not set, the current working directory will be returned.
     """
-    return Path(as_str(name) or default or "").resolve()
+    return Path(get_str(name) or default or "").resolve()
 
 
-def as_args(name: str, default: str | None = None) -> list[str]:
+def get_args(name: str, default: str | None = None) -> list[str]:
     """Convert value of environment variable to list of arguments respecting shell syntax.
 
     Args:
@@ -134,4 +136,4 @@ def as_args(name: str, default: str | None = None) -> list[str]:
     Returns:
         List of arguments split based on shell syntax.
     """
-    return shlex.split(as_str(name) or default or "")
+    return shlex.split(get_str(name) or default or "")

--- a/src/cocotb_tools/_pytest/_init.py
+++ b/src/cocotb_tools/_pytest/_init.py
@@ -22,29 +22,29 @@ def run_regression() -> None:
 
     manager: RegressionManager = RegressionManager(
         # Use the same command line arguments as from the main pytest parent process
-        *_env.as_args("COCOTB_PYTEST_ARGS"),
+        *_env.get_args("COCOTB_PYTEST_ARGS"),
         # Node identifier of cocotb runner
-        nodeid=_env.as_str("COCOTB_PYTEST_NODEID"),
+        nodeid=_env.get_str("COCOTB_PYTEST_NODEID"),
         # List of cocotb runner keywords
-        keywords=_env.as_list("COCOTB_PYTEST_KEYWORDS"),
+        keywords=_env.get_list("COCOTB_PYTEST_KEYWORDS"),
         # Provide list of test modules (Python modules with cocotb tests) to be loaded
-        test_modules=_env.as_list("COCOTB_TEST_MODULES"),
+        test_modules=_env.get_list("COCOTB_TEST_MODULES"),
         # Cocotb runner is using generated JUnit XML results file to determine
         # if executed cocotb tests passed or failed. Test function (cocotb runner)
         # from the main pytest parent process will also fail if any of cocotb test failed.
-        xmlpath=_env.as_str("COCOTB_RESULTS_FILE"),
+        xmlpath=_env.get_str("COCOTB_RESULTS_FILE"),
         # Path to directory location from where pytest was invoked
-        invocation_dir=_env.as_path("COCOTB_PYTEST_DIR"),
+        invocation_dir=_env.get_path("COCOTB_PYTEST_DIR"),
         # IPC address (Unix socket, Windows pipe, TCP, ...) to tests reporter
-        reporter_address=_env.as_str("COCOTB_PYTEST_REPORTER_ADDRESS"),
+        reporter_address=_env.get_str("COCOTB_PYTEST_REPORTER_ADDRESS"),
         # Name of HDL top level design
-        toplevel=_env.as_str("COCOTB_TOPLEVEL"),
+        toplevel=_env.get_str("COCOTB_TOPLEVEL"),
         # Initialization value for the random generator
         seed=cocotb.RANDOM_SEED,
         # If defined, convert all absolute paths to relative ones
-        relative_to=_env.as_str("COCOTB_RESULTS_RELATIVE_TO"),
+        relative_to=_env.get_str("COCOTB_RESULTS_RELATIVE_TO"),
         # List of file attachments to be included in created test reports
-        attachments=_env.as_list("COCOTB_RESULTS_ATTACHMENTS"),
+        attachments=_env.get_list("COCOTB_RESULTS_ATTACHMENTS"),
     )
 
     manager.start_regression()

--- a/src/cocotb_tools/_pytest/_option.py
+++ b/src/cocotb_tools/_pytest/_option.py
@@ -77,22 +77,22 @@ class Option:
         # Map command line argument to option in configuration file
         # Environment variable set by user can override default value for option
         if action == "store_true":
-            default = _env.as_bool(self.environment, default)
+            default = _env.get_bool(self.environment, default)
             ini_type = "bool"
         elif nargs:
-            default = _env.as_list(self.environment, default)
+            default = _env.get_list(self.environment, default)
             ini_type = "paths" if argtype == Path else "args"
         elif argtype is int:
-            default = _env.as_int(self.environment, default)
+            default = _env.get_int(self.environment, default)
             ini_type = "int"
         elif argtype is Path:
-            default = _env.as_path(self.environment, default)
+            default = _env.get_path(self.environment, default)
             ini_type = "string"
         elif argtype is shlex.split:
-            default = _env.as_args(self.environment, default)
+            default = _env.get_args(self.environment, default)
             ini_type = "args"
         elif choices:
-            default = _env.as_str(self.environment, default).lower()
+            default = _env.get_str(self.environment, default).lower()
             ini_type = "string"
 
             # Resolve values passed from environment variables
@@ -108,7 +108,7 @@ class Option:
                     f"Expecting one of {(*choices,)}"
                 )
         else:
-            default = _env.as_str(self.environment, default)
+            default = _env.get_str(self.environment, default)
             ini_type = "string"
 
         # Add option entry to configuration files (pyproject.toml, pytest.ini, ...)

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -455,7 +455,7 @@ class Runner(ABC):
         self.log_file: PathLike | None = log_file
         self.cwd = self.build_dir if cwd is None else cwd
 
-        self.waves = _env.as_bool("WAVES", waves)
+        self.waves = _env.get_bool("WAVES", waves)
 
         self._set_env_build()
 
@@ -587,8 +587,8 @@ class Runner(ABC):
             self.env["COCOTB_RANDOM_SEED"] = str(seed)
 
         self.log_file = log_file
-        self.waves = _env.as_bool("WAVES", waves)
-        self.gui = _env.as_bool("GUI", gui)
+        self.waves = _env.get_bool("WAVES", waves)
+        self.gui = _env.get_bool("GUI", gui)
         self.timescale = timescale
 
         waves_file: str | None = self._waves_file() if self.waves else None
@@ -610,7 +610,7 @@ class Runner(ABC):
             self.verbose = verbose
 
         # Pytest test name is used by the next couple sections.
-        pytest_current_test: str = _env.as_str("PYTEST_CURRENT_TEST")
+        pytest_current_test: str = _env.get_str("PYTEST_CURRENT_TEST")
 
         if pytest_current_test:
             self.current_test_name = pytest_current_test.rsplit(":", maxsplit=1)[
@@ -677,7 +677,7 @@ class Runner(ABC):
             sys.exit(simulator_exit_code)
 
         if pytest_current_test and self._use_external_viewer() and self.gui:
-            viewer: str = _env.as_str("COCOTB_WAVEFORM_VIEWER")
+            viewer: str = _env.get_str("COCOTB_WAVEFORM_VIEWER")
             if viewer:
                 viewer_path = shutil.which(viewer)
                 if viewer_path is None:

--- a/src/pygpi/entry.py
+++ b/src/pygpi/entry.py
@@ -10,7 +10,7 @@ from cocotb_tools import _env
 def load_entry() -> None:
     """Gather entry point information by parsing :envvar:`PYGPI_USERS`."""
 
-    entry_points_str: list[str] = _env.as_list(
+    entry_points_str: list[str] = _env.get_list(
         "PYGPI_USERS",
         (
             "cocotb_tools._coverage:start_cocotb_library_coverage",

--- a/tests/pytest/test_env.py
+++ b/tests/pytest/test_env.py
@@ -49,40 +49,40 @@ def test_env_exists_undefined(monkeypatch: MonkeyPatch) -> None:
 
 
 def test_env_bool_empty(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_bool` when environment variable is defined but empty."""
+    """Test :func:`cocotb_tools._env.get_bool` when environment variable is defined but empty."""
     monkeypatch.setenv("TEST_BOOL", "")
-    assert not _env.as_bool("TEST_BOOL")
+    assert not _env.get_bool("TEST_BOOL")
 
 
 def test_env_bool_undefined(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_bool` when environment variable is undefined."""
+    """Test :func:`cocotb_tools._env.get_bool` when environment variable is undefined."""
     monkeypatch.delenv("TEST_BOOL", raising=False)
-    assert not _env.as_bool("TEST_BOOL")
+    assert not _env.get_bool("TEST_BOOL")
 
 
 def test_env_bool_default(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_bool` with default value."""
+    """Test :func:`cocotb_tools._env.get_bool` with default value."""
     monkeypatch.delenv("TEST_BOOL", raising=False)
-    assert _env.as_bool("TEST_BOOL", True)
-    assert not _env.as_bool("TEST_BOOL", False)
+    assert _env.get_bool("TEST_BOOL", True)
+    assert not _env.get_bool("TEST_BOOL", False)
 
 
 def test_env_bool_true(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_bool` with environment variable set to true."""
+    """Test :func:`cocotb_tools._env.get_bool` with environment variable set to true."""
     for value in ("1", "yes", "y", "ON", "True", "Enable"):
         monkeypatch.setenv("TEST_BOOL", value)
-        assert _env.as_bool("TEST_BOOL")
+        assert _env.get_bool("TEST_BOOL")
 
 
 def test_env_bool_false(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_bool` with environment variable set to false."""
+    """Test :func:`cocotb_tools._env.get_bool` with environment variable set to false."""
     for value in ("0", "no", "n", "OFF", "False", "Disable"):
         monkeypatch.setenv("TEST_BOOL", value)
-        assert not _env.as_bool("TEST_BOOL")
+        assert not _env.get_bool("TEST_BOOL")
 
 
 def test_env_bool_invalid(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_bool` with environment variable set to invalid value."""
+    """Test :func:`cocotb_tools._env.get_bool` with environment variable set to invalid value."""
     for value in ("-1", "2", "l", "x", "y3s", "0N", "Tru3", "3n4b13"):
         with raises(
             ValueError,
@@ -92,133 +92,133 @@ def test_env_bool_invalid(monkeypatch: MonkeyPatch) -> None:
             ),
         ):
             monkeypatch.setenv("TEST_BOOL", value)
-            _env.as_bool("TEST_BOOL")
+            _env.get_bool("TEST_BOOL")
 
 
 def test_env_path_empty(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_path` when environment variable is defined but empty."""
+    """Test :func:`cocotb_tools._env.get_path` when environment variable is defined but empty."""
     monkeypatch.setenv("TEST_PATH", "")
-    assert _env.as_path("TEST_PATH") == Path().resolve()
+    assert _env.get_path("TEST_PATH") == Path().resolve()
 
 
 def test_env_path_undefined(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_path` when environment variable is undefined."""
+    """Test :func:`cocotb_tools._env.get_path` when environment variable is undefined."""
     monkeypatch.delenv("TEST_PATH", raising=False)
-    assert _env.as_path("TEST_PATH") == Path().resolve()
+    assert _env.get_path("TEST_PATH") == Path().resolve()
 
 
 def test_env_path_default(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-    """Test :func:`cocotb_tools._env.as_path` with default value."""
+    """Test :func:`cocotb_tools._env.get_path` with default value."""
     monkeypatch.delenv("TEST_PATH", raising=False)
-    assert _env.as_path("TEST_PATH", tmp_path) == tmp_path.resolve()
+    assert _env.get_path("TEST_PATH", tmp_path) == tmp_path.resolve()
 
 
 def test_env_path_set(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-    """Test :func:`cocotb_tools._env.as_path` with environment variable set to path."""
+    """Test :func:`cocotb_tools._env.get_path` with environment variable set to path."""
     monkeypatch.setenv("TEST_PATH", str(tmp_path))
-    assert _env.as_path("TEST_PATH") == tmp_path.resolve()
-    assert _env.as_path("TEST_PATH", "default") == tmp_path.resolve()
+    assert _env.get_path("TEST_PATH") == tmp_path.resolve()
+    assert _env.get_path("TEST_PATH", "default") == tmp_path.resolve()
 
 
 def test_env_str_empty(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_str` when environment variable is defined but empty."""
+    """Test :func:`cocotb_tools._env.get_str` when environment variable is defined but empty."""
     monkeypatch.setenv("TEST_STRING", "")
-    assert _env.as_str("TEST_STRING") == ""
+    assert _env.get_str("TEST_STRING") == ""
 
 
 def test_env_str_undefined(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_str` when environment variable is undefined."""
+    """Test :func:`cocotb_tools._env.get_str` when environment variable is undefined."""
     monkeypatch.delenv("TEST_STRING", raising=False)
-    assert _env.as_str("TEST_STRING") == ""
+    assert _env.get_str("TEST_STRING") == ""
 
 
 def test_env_str_default(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_str` with default value."""
+    """Test :func:`cocotb_tools._env.get_str` with default value."""
     monkeypatch.delenv("TEST_STRING", raising=False)
-    assert _env.as_str("TEST_STRING", "default") == "default"
+    assert _env.get_str("TEST_STRING", "default") == "default"
 
 
 def test_env_str_set(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_str` with environment variable set to string."""
+    """Test :func:`cocotb_tools._env.get_str` with environment variable set to string."""
     monkeypatch.setenv("TEST_STRING", "  value ")
-    assert _env.as_str("TEST_STRING") == "value"
+    assert _env.get_str("TEST_STRING") == "value"
 
 
 def test_env_int_empty(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_int` when environment variable is defined but empty."""
+    """Test :func:`cocotb_tools._env.get_int` when environment variable is defined but empty."""
     monkeypatch.setenv("TEST_INT", "")
-    assert _env.as_int("TEST_INT") == 0
+    assert _env.get_int("TEST_INT") == 0
 
 
 def test_env_int_undefined(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_int` when environment variable is undefined."""
+    """Test :func:`cocotb_tools._env.get_int` when environment variable is undefined."""
     monkeypatch.delenv("TEST_INT", raising=False)
-    assert _env.as_int("TEST_INT") == 0
+    assert _env.get_int("TEST_INT") == 0
 
 
 def test_env_int_default(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_int` with default value."""
+    """Test :func:`cocotb_tools._env.get_int` with default value."""
     monkeypatch.delenv("TEST_INT", raising=False)
 
     for value in (-13, -1, 0, 1, 20):
-        assert _env.as_int("TEST_INT", value) == value
+        assert _env.get_int("TEST_INT", value) == value
 
 
 def test_env_int_set(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_int` with environment variable set to integer."""
+    """Test :func:`cocotb_tools._env.get_int` with environment variable set to integer."""
     for value in (-13, -1, 0, 1, 20):
         monkeypatch.setenv("TEST_INT", str(value))
-        assert _env.as_int("TEST_INT") == value
+        assert _env.get_int("TEST_INT") == value
 
 
 def test_env_args_empty(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_args` when environment variable is defined but empty."""
+    """Test :func:`cocotb_tools._env.get_args` when environment variable is defined but empty."""
     monkeypatch.setenv("TEST_ARGS", "")
-    assert _env.as_args("TEST_ARGS") == []
+    assert _env.get_args("TEST_ARGS") == []
 
 
 def test_env_args_undefined(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_args` when environment variable is undefined."""
+    """Test :func:`cocotb_tools._env.get_args` when environment variable is undefined."""
     monkeypatch.delenv("TEST_ARGS", raising=False)
-    assert _env.as_args("TEST_ARGS") == []
+    assert _env.get_args("TEST_ARGS") == []
 
 
 def test_env_args_default(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_args` with default value."""
+    """Test :func:`cocotb_tools._env.get_args` with default value."""
     expected: str = "arg1 arg2 'arg3 arg4' arg5"
     monkeypatch.delenv("TEST_ARGS", raising=False)
-    assert _env.as_args("TEST_ARGS", expected) == shlex.split(expected)
+    assert _env.get_args("TEST_ARGS", expected) == shlex.split(expected)
 
 
 def test_env_args_set(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_args` with environment variable set to arguments."""
+    """Test :func:`cocotb_tools._env.get_args` with environment variable set to arguments."""
     expected: str = "arg1 arg2 'arg3 arg4' arg5"
     monkeypatch.setenv("TEST_ARGS", expected)
-    assert _env.as_args("TEST_ARGS", "default") == shlex.split(expected)
+    assert _env.get_args("TEST_ARGS", "default") == shlex.split(expected)
 
 
 def test_env_list_empty(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_list` when environment variable is defined but empty."""
+    """Test :func:`cocotb_tools._env.get_list` when environment variable is defined but empty."""
     monkeypatch.setenv("TEST_LIST", "")
-    assert _env.as_list("TEST_LIST") == []
+    assert _env.get_list("TEST_LIST") == []
 
 
 def test_env_list_undefined(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_list` when environment variable is undefined."""
+    """Test :func:`cocotb_tools._env.get_list` when environment variable is undefined."""
     monkeypatch.delenv("TEST_LIST", raising=False)
-    assert _env.as_list("TEST_LIST") == []
+    assert _env.get_list("TEST_LIST") == []
 
 
 def test_env_list_default(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_list` with default value."""
+    """Test :func:`cocotb_tools._env.get_list` with default value."""
     monkeypatch.delenv("TEST_LIST", raising=False)
-    assert _env.as_list("TEST_LIST", ["a", "b", "c", "d"]) == ["a", "b", "c", "d"]
+    assert _env.get_list("TEST_LIST", ["a", "b", "c", "d"]) == ["a", "b", "c", "d"]
 
 
 def test_env_list_set(monkeypatch: MonkeyPatch) -> None:
-    """Test :func:`cocotb_tools._env.as_list` with environment variable set to arguments."""
+    """Test :func:`cocotb_tools._env.get_list` with environment variable set to arguments."""
     monkeypatch.setenv("TEST_LIST", " a,  b ,c,,d ,")
-    assert _env.as_list("TEST_LIST", "default") == ["a", "b", "c", "d"]
+    assert _env.get_list("TEST_LIST", "default") == ["a", "b", "c", "d"]
 
 
 def test_env_cocotb_testcase_deprecated(monkeypatch: MonkeyPatch) -> None:

--- a/tests/pytest/test_futures.py
+++ b/tests/pytest/test_futures.py
@@ -1,0 +1,122 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+import cocotb.future
+from cocotb.future import Future, disable, enable, is_enabled
+
+
+def none_enabled() -> bool:
+    return not cocotb.future._enabled_futures
+
+
+def all_enabled() -> bool:
+    return cocotb.future._enabled_futures == set(Future)
+
+
+@pytest.fixture(autouse=True)
+def clear_futures() -> Generator[None, None, None]:
+    """Clear enabled futures before each test."""
+    cocotb.future._enabled_futures.clear()
+    yield None
+
+
+def test_futures() -> None:
+    # Enable a future and check it is enabled
+    assert not is_enabled(Future.PLACEHOLDER)
+    enable(Future.PLACEHOLDER)
+    assert is_enabled(Future.PLACEHOLDER)
+
+    # Ensure does not raise if enabled multiple times
+    enable(Future.PLACEHOLDER)
+    assert is_enabled(Future.PLACEHOLDER)
+
+
+def test_envvar_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COCOTB_FUTURE", raising=False)
+    cocotb.future._init()
+    assert none_enabled()
+
+
+def test_envvar_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COCOTB_FUTURE", "")
+    cocotb.future._init()
+    assert none_enabled()
+
+
+@pytest.mark.parametrize(
+    "true_value",
+    [
+        "1",
+        "true",
+        "True",
+        "TRUE",
+        "on",
+        "On",
+        "ON",
+        "yes",
+        "Yes",
+        "YES",
+        "enable",
+        "Enable",
+        "ENABLE",
+    ],
+)
+def test_envvar_true(monkeypatch: pytest.MonkeyPatch, true_value: str) -> None:
+    monkeypatch.setenv("COCOTB_FUTURE", true_value)
+    cocotb.future._init()
+    assert all_enabled()
+
+
+@pytest.mark.parametrize(
+    "false_value",
+    [
+        "0",
+        "false",
+        "False",
+        "FALSE",
+        "off",
+        "Off",
+        "OFF",
+        "no",
+        "No",
+        "NO",
+        "disable",
+        "Disable",
+        "DISABLE",
+    ],
+)
+def test_envvar_false(monkeypatch: pytest.MonkeyPatch, false_value: str) -> None:
+    monkeypatch.setenv("COCOTB_FUTURE", false_value)
+    cocotb.future._init()
+    assert none_enabled()
+
+
+def test_envvar_by_future(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COCOTB_FUTURE", "placeholder")
+    cocotb.future._init()
+    assert is_enabled(Future.PLACEHOLDER)
+    # Ensure PLACEHOLDER is the only enabled future
+    disable(Future.PLACEHOLDER)
+    assert not is_enabled(Future.PLACEHOLDER)
+
+
+def test_envvar_empty_future(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COCOTB_FUTURE", ",placeholder,,")
+    cocotb.future._init()
+    assert is_enabled(Future.PLACEHOLDER)
+    # Ensure it's the only enabled future
+    disable(Future.PLACEHOLDER)
+    assert not is_enabled(Future.PLACEHOLDER)
+
+
+def test_envvar_unknown_future(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COCOTB_FUTURE", ",unknown")
+    with pytest.raises(ValueError, match=".*'unknown'.*"):
+        cocotb.future._init()
+    assert none_enabled()


### PR DESCRIPTION
Closes #5638.

This introduces `COCOTB_FUTURE` which is an environment variable which will switch on either new experimental features, or enable breaking changes. The intent is that on the next major version these future features will become standard.

Changed behavior will have a deprecation warning and this flag will allow people to opt-in to breaking changes to see what's going to change, which will also silence the deprecation warnings.

It allows us to require users to explicitly opt into experimental features so there's an established contract that such features are subject to change.