### PR TITLE
docs: document Verilog parameter and VHDL generic override syntax

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -169,3 +169,58 @@ Make Variables
 The :envvar:`COCOTB_TOPLEVEL` variable is also often used by the Makefile-based build and runner system.
 
 The :envvar:`SIM_CMD_PREFIX` and :envvar:`SIM_CMD_SUFFIX` environment variables are also supported by the Makefile-based build and runner system.
+
+
+Setting Top-Level Parameters and Generics
+=========================================
+
+The Makefile flow does not provide a simulator-agnostic variable for overriding
+top-level Verilog ``parameter`` or VHDL ``generic`` values. Instead, the appropriate
+syntax must be appended to :make:var:`COMPILE_ARGS`, :make:var:`SIM_ARGS`, or
+:make:var:`EXTRA_ARGS` for the simulator in use.
+
+The :reposrc:`matrix_multiplier example <examples/matrix_multiplier/tests/Makefile>`
+demonstrates this pattern across all supported simulators. The table below summarizes
+the syntax. Substitute ``<MODULE>`` with the top-level module/entity name,
+``<PARAM>`` with the parameter/generic name, and ``<VALUE>`` with the desired value.
+
+Verilog ``parameter`` override
+------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Simulator
+     - Makefile snippet
+   * - Icarus Verilog
+     - ``COMPILE_ARGS += -P<MODULE>.<PARAM>=<VALUE>``
+   * - Questa, ModelSim, Riviera-PRO, Active-HDL, NVC
+     - ``SIM_ARGS += -g<PARAM>=<VALUE>``
+   * - Synopsys VCS
+     - ``COMPILE_ARGS += -pvalue+<MODULE>/<PARAM>=<VALUE>``
+   * - Verilator
+     - ``COMPILE_ARGS += -G<PARAM>=<VALUE>``
+   * - Cadence Xcelium, Incisive (IUS)
+     - ``EXTRA_ARGS += -defparam "<MODULE>.<PARAM>=<VALUE>"``
+
+VHDL ``generic`` override
+-------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Simulator
+     - Makefile snippet
+   * - GHDL, Questa, ModelSim, Riviera-PRO, Active-HDL, NVC
+     - ``SIM_ARGS += -g<GENERIC>=<VALUE>``
+   * - Cadence Xcelium, Incisive (IUS)
+     - ``SIM_ARGS += -generic "<MODULE>:<GENERIC>=><VALUE>"``
+
+.. note::
+
+   When using the :ref:`Python Runner <howto-python-runner>` flow, prefer the
+   simulator-agnostic ``parameters`` argument of
+   :meth:`~cocotb_tools.runner.Runner.build` instead of the per-simulator
+   syntax shown above.

--- a/docs/source/newsfragments/5641.doc.rst
+++ b/docs/source/newsfragments/5641.doc.rst
@@ -1,0 +1,1 @@
+Document the per-simulator syntax for overriding top-level Verilog ``parameter`` and VHDL ``generic`` values from the Makefile flow.


### PR DESCRIPTION
<!--
사용법:
1. cocotb GitHub 에서 PR open 시 본 파일 내용을 그대로 붙여넣기
2. PR 번호 받은 뒤 newsfragments/0000.doc.rst → <PR번호>.doc.rst rename + push -f
-->

## Summary

Adds a new "Setting Top-Level Parameters and Generics" section to
`docs/source/building.rst` that documents the per-simulator syntax for
overriding top-level Verilog `parameter` and VHDL `generic` values from
the Makefile flow.

## Motivation

The Makefile flow does not expose a simulator-agnostic variable for
parameter/generic override. The only canonical reference is the
[`matrix_multiplier` example Makefile](../tree/master/examples/matrix_multiplier/tests/Makefile),
which is easy to miss for users coming from `building.rst`. This often
leads to questions on Gitter / Stack Overflow such as "how do I
override DATA_WIDTH at simulation time?" — even though every supported
simulator already handles it, just with different syntax.

## Change

- New section in `building.rst` with two reference tables:
  - **Verilog `parameter` override**: Icarus / Questa-family / VCS / Verilator / Xcelium / IUS
  - **VHDL `generic` override**: GHDL / Questa-family / Xcelium / IUS
- A pointer at the end to the simulator-agnostic `parameters=` argument
  of `Runner.build` for users on the Python Runner flow.

The syntax table is derived from `examples/matrix_multiplier/tests/Makefile`,
so there is a single source of truth between the example and the docs.

## Test

- Reviewed the rendered RST locally; tables format correctly.
- Cross-checked each Makefile snippet against the matrix_multiplier example.
- No code changes; no simulator runs required.

## Checklist

- [x] Newsfragment added (`docs/source/newsfragments/<PR>.doc.rst`)
- [x] No code changes
- [x] No new external dependencies
- [x] Docs follow existing role conventions (`:make:var:`, `:meth:`, `:reposrc:`, `:ref:`)
