### PR TITLE
docs: document remote Python debugging with debugpy

### DIFF
--- a/docs/source/newsfragments/5642.doc.rst
+++ b/docs/source/newsfragments/5642.doc.rst
@@ -1,0 +1,1 @@
+Document remote Python debugging with `debugpy <https://github.com/microsoft/debugpy>`__ and Visual Studio Code in :ref:`troubleshooting <troubleshooting-attaching-debugger-python-debugpy>`.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -120,6 +120,69 @@ accessible via a TCP socket:
       telnet 127.0.0.1 4000
 
 
+.. _troubleshooting-attaching-debugger-python-debugpy:
+
+Python (using ``debugpy`` with an IDE)
+--------------------------------------
+
+`debugpy <https://github.com/microsoft/debugpy>`__ is Microsoft's reference debug
+adapter for Python and integrates with most modern IDEs (VS Code, PyCharm,
+Neovim DAP, etc.). It is typically a smoother alternative to ``remote_pdb``
+for interactive debugging of cocotb tests, especially when running headless
+commercial simulators where ``stdin`` is unavailable.
+
+1. Install ``debugpy``:
+
+   .. code:: shell
+
+      pip install debugpy
+
+2. In your test code, request ``debugpy`` to listen and pause until an IDE
+   attaches:
+
+   .. code:: python
+
+      import debugpy
+
+      listen_host, listen_port = debugpy.listen(("localhost", 5678))
+      cocotb.log.info(f"Waiting for debugger attach on {listen_host}:{listen_port}")
+      debugpy.wait_for_client()
+      breakpoint()  # execution stops here once attached
+
+3. Configure the IDE to attach to ``localhost:5678``. For Visual Studio Code,
+   add an entry to ``.vscode/launch.json``:
+
+   .. code:: json
+
+      {
+          "version": "0.2.0",
+          "configurations": [
+              {
+                  "name": "Python: attach cocotb",
+                  "type": "python",
+                  "request": "attach",
+                  "host": "localhost",
+                  "port": 5678
+              }
+          ]
+      }
+
+4. Start the simulation. After the "Waiting for debugger attach" log line
+   appears, launch the IDE's *attach* configuration. Execution resumes and
+   stops at ``breakpoint()``, with full IDE debugger support (breakpoints,
+   variable inspection, step over/into).
+
+.. note::
+
+   When running cocotb through the :ref:`Python Runner <howto-python-runner>`
+   flow under ``pytest``, the IDE can launch the runner and the embedded
+   simulator interpreter under a single debug session by forwarding the
+   ``debugpy`` adapter port through environment variables and calling
+   :func:`debugpy.connect` inside the test wrapper. See the worked example in
+   `discussion #2652 <https://github.com/cocotb/cocotb/discussions/2652>`__
+   (contributions from ``@marlonjames`` and ``@Jetsama``) for details.
+
+
 Embedding an IPython shell
 ==========================
 


### PR DESCRIPTION
## Summary

Adds a `debugpy`-based recipe to `docs/source/troubleshooting.rst` for
debugging cocotb tests from Visual Studio Code (and other DAP-aware IDEs),
addressing issue #4313.

## Motivation

The existing Python debugging section in `troubleshooting.rst` documents
the `remote_pdb` + `telnet` approach. That recipe still works, but most
contemporary users debug from VS Code / PyCharm / Neovim via the Debug
Adapter Protocol, which is precisely what `debugpy` exposes. Issue #4313
has been open since 2024 requesting this addition, and two community
members have already shared working recipes in
[discussion #2652](https://github.com/cocotb/cocotb/discussions/2652).
This PR distills the simple form into the official documentation.

## Change

New subsection **Python (using debugpy with an IDE)** placed alongside
the existing `remote_pdb` recipe. Covers:

- `pip install debugpy`
- The minimum 4-line `debugpy.listen` / `wait_for_client` / `breakpoint`
  pattern inside a test
- A complete `.vscode/launch.json` *attach* configuration
- A `.. note::` pointer to discussion #2652 for the more advanced
  Python Runner + pytest single-session flow, with credit to
  `@marlonjames` and `@Jetsama` who originally documented those recipes

The advanced runner-integrated flow is intentionally **not** inlined —
it depends on `debugpy.server.cli` internals and is best maintained by
its original authors in the discussion thread.

## Test

- Read the resulting RST locally; renders as a new `----` subsection
  under the existing "Python" section.
- No code changes; no simulator runs required.

## Checklist

- [x] Newsfragment added (renamed to `<PR>.doc.rst` after PR number assigned)
- [x] No code changes
- [x] No new external runtime dependencies (debugpy is documented as
      `pip install`, not added to cocotb requirements)
- [x] Docs follow existing role/section conventions

Closes #4313
