### PR TITLE
fix(runner): place Icarus -s <toplevel> after all sources

### DIFF
--- a/docs/source/newsfragments/5643.bugfix.rst
+++ b/docs/source/newsfragments/5643.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the Icarus Python Runner placing the ``-s <toplevel>`` argument before the source files, which can cause unreliable elaboration. The toplevel selection now follows all sources.

--- a/src/cocotb_tools/runner.py
+++ b/src/cocotb_tools/runner.py
@@ -977,9 +977,14 @@ class Icarus(Runner):
                 )
 
         build_args = [arg.value for arg in self._build_args]
+
+        # Icarus `-s` (toplevel selection) is sensitive to its position in the
+        # argument list; placing it after all sources is the documented robust
+        # ordering. See https://github.com/cocotb/cocotb/issues/4077.
+        toplevel_args: list[str] = ["-s", self.hdl_toplevel]
         if self.waves:
             self._create_iverilog_dump_file()
-            build_args += ["-s", "cocotb_iverilog_dump"]
+            toplevel_args += ["-s", "cocotb_iverilog_dump"]
 
         if self.timescale is not None:
             self._create_cmd_file()
@@ -992,8 +997,6 @@ class Icarus(Runner):
                     "iverilog",
                     "-o",
                     str(self.sim_file),
-                    "-s",
-                    self.hdl_toplevel,
                     "-g2012",
                 ]
                 + self._get_define_options(self.defines)
@@ -1006,6 +1009,7 @@ class Icarus(Runner):
                     for source_file in [self.iverilog_dump_file]
                     if self.waves
                 ]
+                + toplevel_args
             ]
 
         else:


### PR DESCRIPTION
## Summary

Move `-s <hdl_toplevel>` (and `-s cocotb_iverilog_dump` when waves are
enabled) from the head of the `iverilog` command built by the Icarus
Python Runner to the tail, so the toplevel selection follows every
source file. Addresses issue #4077.

## Motivation

Issue #4077 reports that the position of `-s <toplevel>` in the
`iverilog` command line is sensitive: placing it before the sources can
cause unreliable elaboration in some designs. The Icarus Python Runner
currently emits:

```
iverilog -o sim.vvp -s <TOP> -g2012 ... <sources>
```

This PR changes it to:

```
iverilog -o sim.vvp -g2012 ... <sources> -s <TOP>
```

(and analogously moves the wave-dump toplevel selection to the end when
`waves=True`).

## Change

In `src/cocotb_tools/runner.py`, inside `Icarus._build_command`:

- Collect the `-s` arguments into a `toplevel_args` list at the start.
- Append `toplevel_args` to the end of the constructed command instead
  of injecting `-s <TOP>` early and pushing `-s cocotb_iverilog_dump`
  into `build_args`.

No other call sites need to change.

## Test

- No new dedicated unit test: the Icarus build path is already exercised
  by the simulator-required integration tests in
  `tests/pytest/test_runner.py`, which fail loudly if `iverilog`
  rejects the command line.
- Verified locally by inspecting the generated command from a sample
  build that the `-s` arguments now follow the source list.

I am happy to add a focused unit test that captures the command via
`monkeypatch` on `subprocess.run` if reviewers prefer.

## Checklist

- [x] Newsfragment added (`docs/source/newsfragments/<PR>.bugfix.rst`)
- [x] Behavior change is intentional and minimal
- [x] No public API change
- [x] No external dependency change

Refs #4077
