### PR TITLE
Ensure all concurrent waiters children are `await`ed at least once and cleaned-up before returning

### DIFF
--- a/docs/source/newsfragments/5645.bugfix.rst
+++ b/docs/source/newsfragments/5645.bugfix.rst
@@ -1,0 +1,1 @@
+:class:`~cocotb.triggers.First` and :class:`~cocotb.triggers.Combine` now only return after all child awaitables have finished, including via cancellation, to ensure any stateful clean-up code was hit before continuing.

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -75,7 +75,10 @@ async def _wait(
     waiters = [Task[Any](waiter(a)) for a in awaitables]
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
     remaining = dict.fromkeys(waiters)
+    # Set when we meet the return condition.
     done = _InternalEvent(_repr)
+    # Set when all tasks have completed, regardless of reason.
+    complete = _InternalEvent(_repr)
     # The first task to complete, stored regardless of return_when condition.
     first_completed: Task[Any] | None = None
 
@@ -83,6 +86,8 @@ async def _wait(
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
+            if not remaining:
+                complete.set()
             nonlocal first_completed
             if first_completed is None:
                 first_completed = task
@@ -94,6 +99,7 @@ async def _wait(
             del remaining[task]
             if not remaining:
                 done.set()
+                complete.set()
             nonlocal first_completed
             if first_completed is None and (
                 task.cancelled() or task.exception() is not None
@@ -107,6 +113,7 @@ async def _wait(
             del remaining[task]
             if not remaining:
                 done.set()
+                complete.set()
 
     for task in waiters:
         task._add_done_callback(done_callback)
@@ -121,6 +128,11 @@ async def _wait(
         # the caller is cancelled.
         for task in remaining:
             task.cancel()
+
+    # Wait until all children tasks have finished before returning.
+    # Ensures any side-effectful clean-up has completed.
+    if not complete.is_set():
+        await complete
 
     return waiters, first_completed
 

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from asyncio import CancelledError
 from collections.abc import Iterable
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, overload
@@ -77,28 +76,17 @@ async def _wait(
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
     remaining = dict.fromkeys(waiters)
     done = _InternalEvent(_repr)
-    cancelling: bool = False
     # The first task to complete, stored regardless of return_when condition.
     first_completed: Task[Any] | None = None
-
-    def cancel() -> None:
-        nonlocal cancelling
-        if cancelling:
-            return
-        cancelling = True
-        for t in remaining:
-            t.cancel()
 
     if return_when == ReturnWhen.FIRST_COMPLETED:
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
-            if not remaining:
-                done.set()
             nonlocal first_completed
             if first_completed is None:
                 first_completed = task
-                cancel()
+                done.set()
 
     elif return_when == ReturnWhen.FIRST_EXCEPTION:
 
@@ -111,7 +99,7 @@ async def _wait(
                 task.cancelled() or task.exception() is not None
             ):
                 first_completed = task
-                cancel()
+                done.set()
 
     else:
 
@@ -126,9 +114,13 @@ async def _wait(
 
     try:
         await done
-    except CancelledError:
-        cancel()
-        raise
+    finally:
+        # Cancel remaining tasks. No-op if everything has finished (ALL_COMPLETED)
+        # or the return_when condition is specified, but all tasks happen to complete
+        # before this Task runs again. Cancels whatever is remaining and rethrows if
+        # the caller is cancelled.
+        for task in remaining:
+            task.cancel()
 
     return waiters, first_completed
 

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -16,7 +16,7 @@ import pytest
 from common import MyException, _check_traceback, assert_takes
 
 import cocotb
-from cocotb.triggers import Combine, Event, First, Timer, Trigger, select
+from cocotb.triggers import Combine, Event, First, Timer, Trigger, gather, select
 
 
 class MyTrigger(Trigger):
@@ -33,8 +33,8 @@ class MyTrigger(Trigger):
 
 
 @cocotb.test
-async def test_First_unfired_triggers_killed(_: object) -> None:
-    """Test that un-fired trigger(s) in First don't later cause a spurious wakeup."""
+async def test_select_unfired_triggers_killed(_: object) -> None:
+    """Test that un-fired trigger(s) in select don't later cause a spurious wakeup."""
 
     triggers = [MyTrigger() for _ in range(3)]
 
@@ -48,8 +48,8 @@ async def test_First_unfired_triggers_killed(_: object) -> None:
 
 
 @cocotb.test
-async def test_First_unfired_triggers_killed_on_exception(_: object) -> None:
-    """Test that un-fired trigger(s) in First after exception don't later cause a spurious wakeup."""
+async def test_select_unfired_triggers_killed_on_exception(_: object) -> None:
+    """Test that un-fired trigger(s) in select after exception don't later cause a spurious wakeup."""
 
     triggers = [MyTrigger() for _ in range(3)]
 
@@ -66,8 +66,8 @@ async def test_First_unfired_triggers_killed_on_exception(_: object) -> None:
 
 
 @cocotb.test
-async def test_Combine_unfired_triggers_killed_on_exception(_: object) -> None:
-    """Test that un-fired trigger(s) in Combine after exception don't later cause a spurious wakeup."""
+async def test_gather_unfired_triggers_killed_on_exception(_: object) -> None:
+    """Test that un-fired trigger(s) in gather after exception don't later cause a spurious wakeup."""
 
     triggers = [MyTrigger() for _ in range(3)]
 
@@ -75,7 +75,35 @@ async def test_Combine_unfired_triggers_killed_on_exception(_: object) -> None:
         raise ValueError("I am a failure")
 
     with pytest.raises(ValueError):
-        await select(fails(), *triggers)
+        await gather(fails(), *triggers)
+
+    # test all triggers were unprimed
+    for t in triggers:
+        assert t.primed == 1
+        assert t.unprimed == 1
+
+
+@cocotb.test
+async def test_nested_unfired_triggers_killed_on_exception(_: object) -> None:
+    """Test that un-fired trigger(s) in nested First after exception don't later cause a spurious wakeup."""
+
+    triggers = [MyTrigger() for _ in range(3)]
+
+    async def fails() -> None:
+        raise ValueError("I am a failure")
+
+    with pytest.raises(ValueError):
+        await select(fails(), gather(*triggers))
+
+    # test all triggers were unprimed
+    for t in triggers:
+        assert t.primed == 1
+        assert t.unprimed == 1
+
+    triggers = [MyTrigger() for _ in range(3)]
+
+    with pytest.raises(ValueError):
+        await select(fails(), select(gather(*triggers)))
 
     # test all triggers were unprimed
     for t in triggers:

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -16,8 +16,7 @@ import pytest
 from common import MyException, _check_traceback, assert_takes
 
 import cocotb
-from cocotb.task import Task
-from cocotb.triggers import Combine, Event, First, Timer, Trigger
+from cocotb.triggers import Combine, Event, First, Timer, Trigger, select
 
 
 class MyTrigger(Trigger):
@@ -34,13 +33,13 @@ class MyTrigger(Trigger):
 
 
 @cocotb.test
-async def test_First_unfired_triggers_killed(_) -> None:
+async def test_First_unfired_triggers_killed(_: object) -> None:
     """Test that un-fired trigger(s) in First don't later cause a spurious wakeup."""
 
     triggers = [MyTrigger() for _ in range(3)]
 
     timer = Timer(1, "ns")
-    res = await First(timer, *triggers)
+    _, res = await select(timer, *triggers)
     assert res is timer
 
     for t in triggers:
@@ -49,7 +48,7 @@ async def test_First_unfired_triggers_killed(_) -> None:
 
 
 @cocotb.test
-async def test_First_unfired_triggers_killed_on_exception(_) -> None:
+async def test_First_unfired_triggers_killed_on_exception(_: object) -> None:
     """Test that un-fired trigger(s) in First after exception don't later cause a spurious wakeup."""
 
     triggers = [MyTrigger() for _ in range(3)]
@@ -57,8 +56,8 @@ async def test_First_unfired_triggers_killed_on_exception(_) -> None:
     async def fails() -> None:
         raise ValueError("I am a failure")
 
-    with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
-        await First(Task(fails()), *triggers)
+    with pytest.raises(ValueError):
+        await select(fails(), *triggers)
 
     # test all triggers were unprimed
     for t in triggers:
@@ -67,7 +66,7 @@ async def test_First_unfired_triggers_killed_on_exception(_) -> None:
 
 
 @cocotb.test
-async def test_Combine_unfired_triggers_killed_on_exception(_) -> None:
+async def test_Combine_unfired_triggers_killed_on_exception(_: object) -> None:
     """Test that un-fired trigger(s) in Combine after exception don't later cause a spurious wakeup."""
 
     triggers = [MyTrigger() for _ in range(3)]
@@ -75,8 +74,8 @@ async def test_Combine_unfired_triggers_killed_on_exception(_) -> None:
     async def fails() -> None:
         raise ValueError("I am a failure")
 
-    with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
-        await Combine(Task(fails()), *triggers)
+    with pytest.raises(ValueError):
+        await select(fails(), *triggers)
 
     # test all triggers were unprimed
     for t in triggers:


### PR DESCRIPTION
This reverts part of the change in #5624. We can't cancel remaining tasks in waiter done callbacks greedily. This is mostly because `coroutine` objects require being awaited to not give off `ResourceWarning`s.