### PR TITLE
Ensure the scheduling waiters in gather/select takes priority

### DIFF
--- a/docs/source/newsfragments/5594.bugfix.rst
+++ b/docs/source/newsfragments/5594.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed race between currently scheduled Tasks and waiter Task start-up in :class:`~cocotb.triggers.First` and :class:`~cocotb.triggers.Combine`.

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -8,7 +8,6 @@ from collections.abc import Iterable
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, overload
 
-import cocotb
 from cocotb._base_triggers import _InternalEvent
 from cocotb.task import Task
 
@@ -115,9 +114,9 @@ async def _wait(
                 done.set()
                 complete.set()
 
-    for task in waiters:
+    for task in reversed(waiters):
         task._add_done_callback(done_callback)
-        cocotb.start_soon(task)
+        task._start_next()
 
     try:
         await done

--- a/src/cocotb/_event_loop.py
+++ b/src/cocotb/_event_loop.py
@@ -70,5 +70,12 @@ class EventLoop:
         self._callbacks.append(cb)
         return cb
 
+    def schedule_left(self, func: Callable[[], object]) -> ScheduledCallback:
+        cb = ScheduledCallback(func)
+        if debug.debug:
+            self.log.debug("Scheduling %r to the left", cb)
+        self._callbacks.appendleft(cb)
+        return cb
+
 
 _inst: EventLoop = EventLoop()

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -244,6 +244,13 @@ class Task(Generic[ResultType]):
             raise RuntimeError("Cannot start a finished Task")
         # RUNNING, SCHEDULED, PENDING are already running
 
+    def _start_next(self) -> None:
+        if self._state != _TaskState.UNSTARTED:
+            raise RuntimeError(
+                "Cannot start_next() on a Task that has already been started"
+            )
+        cocotb._event_loop._inst.schedule_left(self._resume)
+
     def _set_outcome(
         self,
         result: ResultType | BaseException,

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -247,7 +247,7 @@ class Task(Generic[ResultType]):
     def _start_next(self) -> None:
         if self._state != _TaskState.UNSTARTED:
             raise RuntimeError(
-                "Cannot start_next() on a Task that has already been started"
+                "Cannot _start_next() on a Task that has already been started"
             )
         cocotb._event_loop._inst.schedule_left(self._resume)
 

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -498,7 +498,6 @@ async def test_5594(_: object) -> None:
         await e1.wait()
 
         # set e2 to let the test know we passed the wait
-        # it will never see it though because `First` delays the await on e2.wait() trigger
         e2.set()
         e2.clear()
 

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -488,3 +488,30 @@ async def test_First_task_being_waited_cancelled(_: Any) -> None:
     assert waiter_task.done()
     for t in tasks[1:]:
         assert not t.done()
+
+
+@cocotb.test(timeout_time=5, timeout_unit="ns")
+async def test_5594(_: object) -> None:
+
+    async def other_coro(e1: Event, e2: Event) -> None:
+        # wait for e1 to be set by the test
+        await e1.wait()
+
+        # set e2 to let the test know we passed the wait
+        # it will never see it though because `First` delays the await on e2.wait() trigger
+        e2.set()
+        e2.clear()
+
+    e1 = Event()
+    e2 = Event()
+    cocotb.start_soon(other_coro(e1, e2))
+
+    # Ensure other_coro is waiting on e1 before we set it
+    await Timer(1, "ns")
+
+    # Wake up other_coro
+    e1.set()
+    e1.clear()
+
+    # Wait for other_coro to set e2
+    await First(e2.wait())

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -423,20 +423,6 @@ async def test_task_repr(_) -> None:
     assert re.match(
         (
             r"<Task \d+ pending coro=coroutine_first\(\) trigger=First\("
-            r"<Task \d+ created coro=coroutine_wait\(\)>, "
-            r"<Timer of 2000.00ps at \w+>"
-            r"\)>"
-        ),
-        repr(coro_task),
-    )
-
-    # wait for coroutine_wait to start
-    await NullTrigger()  # start_soon on _wait_callback
-
-    log.info(repr(coro_task))
-    assert re.match(
-        (
-            r"<Task \d+ pending coro=coroutine_first\(\) trigger=First\("
             r"<Task \d+ scheduled coro=coroutine_wait\(\)>, "
             r"<Timer of 2000.00ps at \w+>"
             r"\)>"


### PR DESCRIPTION
This avoids a race between already scheduled Tasks and gather/selects waiter Tasks. Also includes a test for that case. Fixes #5594. Supersedes #5617.