### PR TITLE
Support any Awaitable in cocotb.start_soon

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -321,6 +321,34 @@ Test Management
 Task Management
 ===============
 
+.. _awaitable-design-note:
+
+.. warning::
+    If you are passing a bespoke :class:`~collections.abc.Awaitable` object to :class:`Task` :func:`cocotb.start_soon`, :func:`cocotb.start`, or :func:`cocotb.create_task`,
+    you must ensure that the setup and cleanup are handled correctly.
+
+    When passing an object to one of these functions it may schedule the Task to run,
+    but the Task may be cancelled before it is :keyword:`await`\ ed.
+    If you put setup code in the constructor of a bespoke :class:`!Awaitable` and this occurs,
+    cleanup code in :meth:`!__await__` may never be executed.
+
+    It is also not advisable to put cleanup code in :meth:`!__del__` as this may never be called due to the way Python's garbage collector works.
+
+    Instead, prefer putting both setup and cleanup code in :meth:`!__await__` and only use the constructor to store parameters.
+
+    .. code-block:: python
+
+        class MyAwaitable:
+            def __init__(self, param):
+                self.param = param
+
+            def __await__(self):
+                self._setup(self.param)
+                try:
+                    yield some_trigger
+                finally:
+                    self._cleanup()
+
 .. currentmodule:: None
 
 .. autofunction:: cocotb.start_soon

--- a/docs/source/newsfragments/5653.feature.rst
+++ b/docs/source/newsfragments/5653.feature.rst
@@ -1,0 +1,1 @@
+Add support for passing *any* :class:`~collections.abc.Awaitable` to :func:`cocotb.create_task`, :func:`cocotb.start_soon`, and :func:`cocotb.start`. This wraps the :term:`awaitable` in a waiter :term:`coroutine`.

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -4,15 +4,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Awaitable, Iterable
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, overload
+from typing import Any, Callable, Literal, TypeVar, overload
 
 from cocotb._base_triggers import _InternalEvent
 from cocotb.task import Task
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable
 
 
 class ReturnWhen(Enum):
@@ -68,10 +65,7 @@ async def _wait(
     .. versionadded:: 2.1
     """
 
-    async def waiter(aw: Awaitable[T]) -> T:
-        return await aw
-
-    waiters = [Task[Any](waiter(a)) for a in awaitables]
+    waiters = [Task[Any](a) for a in awaitables]
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
     remaining = dict.fromkeys(waiters)
     # Set when we meet the return condition.

--- a/src/cocotb/_task_manager.py
+++ b/src/cocotb/_task_manager.py
@@ -6,16 +6,15 @@
 
 from __future__ import annotations
 
-import inspect
 import sys
 from asyncio import CancelledError
 from bdb import BdbQuit
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar, overload
 
 from cocotb._base_triggers import NullTrigger
 from cocotb.task import Task, current_task
-from cocotb.triggers import Event, Trigger
+from cocotb.triggers import Event
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -107,16 +106,6 @@ class TaskManager:
             A :class:`~cocotb.task.Task` which is awaiting *aw* concurrently.
         """
         self._ensure_can_add()
-
-        if isinstance(aw, Coroutine):
-            # This must come before Awaitable since Coroutine is a subclass of Awaitable
-            pass
-        elif isinstance(aw, Awaitable):
-            aw = _waiter(aw)
-        else:
-            raise TypeError(
-                f"start_soon() expected an Awaitable, got {type(aw).__name__}"
-            )
         task = Task[T](aw, name=name)
         self._add_task(task, continue_on_error=continue_on_error)
         return task
@@ -124,25 +113,29 @@ class TaskManager:
     @overload
     def fork(
         self,
-        coro_func: Callable[[], Coroutine[Trigger, None, T]],
+        coro_func: Callable[[], Awaitable[T]],
         /,
     ) -> Task[T]: ...
 
     @overload
     def fork(
         self, *, continue_on_error: bool
-    ) -> Callable[[Callable[[], Coroutine[Trigger, None, T]]], Task[T]]: ...
+    ) -> Callable[[Callable[[], Awaitable[T]]], Task[T]]: ...
 
     def fork(
         self,
-        coro_func: Callable[..., Coroutine[Trigger, None, T]] | None = None,
+        coro_func: Callable[..., Awaitable[T]] | None = None,
         *,
         continue_on_error: bool | None = None,
-    ) -> Task[T] | Callable[[Callable[[], Coroutine[Trigger, None, T]]], Task[T]]:
+    ) -> Task[T] | Callable[[Callable[[], Awaitable[T]]], Task[T]]:
         r"""Decorate a coroutine function to run it concurrently.
 
+        .. note::
+            This does not necessarily have to be a coroutine function.
+            Any callable which returns a :class:`~collections.abc.Awaitable` can be used.
+
         Args:
-            coro_func: A :term:`coroutine function` to run concurrently. Typically only passed as a decorator.
+            coro_func: A :term:`coroutine function` to run concurrently. Typically this is the decorated function.
             continue_on_error: Value of *continue_on_error* for this Task only.
 
                 If not specified, defaults to the value of the :class:`!TaskManager`'s *default_continue_on_error* argument.
@@ -174,7 +167,7 @@ class TaskManager:
                 )
 
             def deco(
-                coro: Callable[[], Coroutine[Trigger, None, T]],
+                coro: Callable[[], Awaitable[T]],
             ) -> Task[T]:
                 return self.fork(  # type: ignore[call-overload]
                     coro,
@@ -183,11 +176,12 @@ class TaskManager:
 
             return deco
 
-        if not inspect.iscoroutinefunction(coro_func):
+        try:
+            task = Task[T](coro_func(), name=coro_func.__name__)
+        except TypeError:
             raise TypeError(
                 f"fork() expected a coroutine function, got {type(coro_func).__name__}"
-            )
-        task = Task[T](coro_func(), name=coro_func.__name__)
+            ) from None
         self._add_task(task, continue_on_error=continue_on_error)
         return task
 

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 import pdb
 import sys
 from asyncio import CancelledError
-from collections.abc import Coroutine
+from collections.abc import Awaitable, Coroutine
 from typing import (
     Any,
     Callable,
     NoReturn,
+    TypeVar,
+    overload,
 )
 
 import cocotb
@@ -195,8 +197,29 @@ class TestManager:
             self._abort(e)
 
 
+TriggerT = TypeVar("TriggerT", bound=Trigger)
+
+
+@overload
 def start_soon(
-    coro: Task[ResultType] | Coroutine[Trigger, None, ResultType],
+    coro: Task[ResultType]
+    | Coroutine[Trigger, None, ResultType]
+    | Awaitable[ResultType],
+    *,
+    name: str | None = None,
+) -> Task[ResultType]: ...
+
+
+@overload
+def start_soon(
+    coro: TriggerT,
+    *,
+    name: str | None = None,
+) -> Task[TriggerT]: ...
+
+
+def start_soon(
+    coro: Awaitable[Any],
     *,
     name: str | None = None,
 ) -> Task[ResultType]:
@@ -217,6 +240,13 @@ def start_soon(
         The :class:`~cocotb.task.Task` that is scheduled to be run.
 
     .. versionadded:: 1.6
+
+    .. versionchanged:: 2.1
+        This function now accepts any :class:`~collections.abc.Awaitable` object, not just :term:`coroutines <coroutine>`.
+
+        .. warning::
+            If you are passing a bespoke :class:`~collections.abc.Awaitable` object to this function,
+            read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
     task = create_task(coro, name=name)
     # This is _ensure_started() rather than start_soon() for backwards compatibility.
@@ -225,12 +255,30 @@ def start_soon(
     return task
 
 
-@deprecated("Use ``cocotb.start_soon`` instead.")
+@overload
 async def start(
-    coro: Task[ResultType] | Coroutine[Trigger, None, ResultType],
+    coro: Task[ResultType]
+    | Coroutine[Trigger, None, ResultType]
+    | Awaitable[ResultType],
     *,
     name: str | None = None,
-) -> Task[ResultType]:
+) -> Task[ResultType]: ...
+
+
+@overload
+async def start(
+    coro: TriggerT,
+    *,
+    name: str | None = None,
+) -> Task[TriggerT]: ...
+
+
+@deprecated("Use ``cocotb.start_soon`` instead.")
+async def start(
+    coro: Awaitable[Any],
+    *,
+    name: str | None = None,
+) -> Task[Any]:
     """
     Schedule a :term:`coroutine` to be run concurrently, then yield control to allow pending tasks to execute.
 
@@ -267,17 +315,42 @@ async def start(
             task_started = Event()
             task = cocotb.start_soon(coro(task_started))
             await task_started.wait()
+
+    .. versionchanged:: 2.1
+        This function now accepts any :class:`~collections.abc.Awaitable` object, not just :term:`coroutines <coroutine>`.
+
+        .. warning::
+            If you are passing a bespoke :class:`~collections.abc.Awaitable` object to this function,
+            read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
     task = start_soon(coro, name=name)
     await NullTrigger()
     return task
 
 
+@overload
 def create_task(
-    coro: Task[ResultType] | Coroutine[Trigger, None, ResultType],
+    coro: Task[ResultType]
+    | Coroutine[Trigger, None, ResultType]
+    | Awaitable[ResultType],
     *,
     name: str | None = None,
-) -> Task[ResultType]:
+) -> Task[ResultType]: ...
+
+
+@overload
+def create_task(
+    coro: TriggerT,
+    *,
+    name: str | None = None,
+) -> Task[TriggerT]: ...
+
+
+def create_task(
+    coro: Awaitable[Any],
+    *,
+    name: str | None = None,
+) -> Task[Any]:
     """
     Construct a :term:`!coroutine` into a :class:`~cocotb.task.Task` without scheduling the task.
 
@@ -294,6 +367,13 @@ def create_task(
         Either the provided :class:`~cocotb.task.Task` or a new Task wrapping the coroutine.
 
     .. versionadded:: 1.6
+
+    .. versionchanged:: 2.1
+        This function now accepts any :class:`~collections.abc.Awaitable` object, not just :term:`coroutines <coroutine>`.
+
+        .. warning::
+            If you are passing a bespoke :class:`~collections.abc.Awaitable` object to this function,
+            read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
     if _current_test is None:
         raise RuntimeError("No test is currently running; cannot schedule new Task.")
@@ -305,7 +385,7 @@ def create_task(
             coro.set_name(name)
         return coro
 
-    task = Task[ResultType](coro, name=name)
+    task = Task(coro, name=name)
     _current_test.add_task(task)
 
     return task

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -3,14 +3,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import collections.abc
 import inspect
 import logging
 import sys
 import traceback
 from asyncio import CancelledError, InvalidStateError
 from bdb import BdbQuit
-from collections.abc import Coroutine, Generator
+from collections.abc import Awaitable, Coroutine, Generator
 from enum import auto
 from functools import cached_property
 from types import CoroutineType, SimpleNamespace
@@ -20,6 +19,7 @@ from typing import (
     Generic,
     TypeVar,
     cast,
+    overload,
 )
 
 import cocotb
@@ -66,27 +66,61 @@ class Task(Generic[ResultType]):
     """Concurrently executing task.
 
     This class is not intended for users to directly instantiate.
-    Use :func:`cocotb.create_task` to create a Task object
-    or :func:`cocotb.start_soon` to create a Task and schedule it to run.
+    Use :func:`cocotb.create_task` to create a :class:`!Task` object
+    or :func:`cocotb.start_soon` to create a :class:`!Task` and schedule it to run.
+
+    Args:
+        inst: A coroutine to run as a :class:`!Task`, or any :class:`!Awaitable` to wrap in a coroutine and run as a :class:`!Task`.
+        name: Optional name. If not provided, a generic name is generated.
+
+    Raises:
+        TypeError: If *inst* is not Awaitable.
 
     .. versionchanged:: 1.8
-        Moved to the ``cocotb.task`` module.
+        Moved to the :mod:`cocotb.task` module.
 
     .. versionchanged:: 2.0
         The ``retval``, ``_finished``, and ``__bool__`` methods were removed.
         Use :meth:`result`, :meth:`done`, and :meth:`done` methods instead, respectively.
+
+    .. versionadded:: 2.1
+        Added support for giving any :class:`~collections.abc.Awaitable` to the constructor, not just coroutines.
+        This implicitly wraps the Awaitable in a coroutine that :keyword:`await`s it.
+
+        If you are passing a bespoke :class:`~collections.abc.Awaitable` object to this class,
+        read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
 
     _id_count = 0  # used by the scheduler for debug
 
+    @overload
     def __init__(
         self, inst: Coroutine[Trigger, None, ResultType], *, name: str | None = None
-    ) -> None:
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self, inst: Awaitable[ResultType], *, name: str | None = None
+    ) -> None: ...
+
+    def __init__(self, inst: Awaitable[ResultType], *, name: str | None = None) -> None:
         self._native_coroutine: bool
+        self._coro: Coroutine[Trigger, Any, ResultType]
         if inspect.iscoroutine(inst):
             self._native_coroutine = True
-        elif isinstance(inst, collections.abc.Coroutine):
+            self._coro = inst
+        elif isinstance(inst, Coroutine):
             self._native_coroutine = False
+            self._coro = inst
+        elif isinstance(inst, Awaitable):
+            self._native_coroutine = True
+
+            async def waiter() -> ResultType:
+                return await inst
+
+            # TODO consider better naming for this coroutine,
+            # perhaps delegating to the Awaitable.
+            self._coro = waiter()
         elif inspect.iscoroutinefunction(inst):
             raise TypeError(
                 f"Coroutine function {inst} should be called prior to being scheduled."
@@ -97,9 +131,8 @@ class Task(Generic[ResultType]):
                 "You likely used the yield keyword instead of await."
             )
         else:
-            raise TypeError(f"{inst} isn't a valid coroutine!")
+            raise TypeError(f"Expected Awaitable, got {type(inst).__name__}")
 
-        self._coro = inst
         self._state: _TaskState = _TaskState.UNSTARTED
         self._outcome: ResultType | BaseException
         self._trigger: Trigger

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import sys
 import warnings
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -16,7 +17,7 @@ from cocotb._base_triggers import Lock
 from cocotb.clock import Clock
 from cocotb.regression import TestFactory
 from cocotb.task import Join, current_task
-from cocotb.triggers import Edge, Event, First, Timer
+from cocotb.triggers import Edge, Event, First, Timer, Trigger
 from cocotb.utils import get_sim_steps, get_sim_time, get_time_from_sim_steps
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
@@ -367,3 +368,18 @@ async def test_pass_test_in_expect_error(dut: object) -> None:
 async def test_pass_test_in_expect_fail(dut: object) -> None:
     with pytest.warns(DeprecationWarning):
         cocotb.pass_test("Finished test early")
+
+
+@cocotb.test
+async def test_cocotb_start_awaitable(_: object) -> None:
+    """Test that cocotb.start() works with any Awaitable, not just coroutines."""
+
+    class AwaitableThing:
+        def __await__(self) -> Generator[Trigger, None, int]:
+            yield Timer(1)
+            return 42
+
+    with pytest.warns(DeprecationWarning):
+        task = await cocotb.start(AwaitableThing())
+    result = await task
+    assert result == 42

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -1155,3 +1155,17 @@ async def test_task_start_soon(_: object) -> None:
         task.start_soon()
     await Timer(2)
     assert task.done()
+
+
+@cocotb.test
+async def test_start_soon_awaitable(_: object) -> None:
+    """Test that cocotb.start_soon() works with any Awaitable, not just coroutines."""
+
+    class AwaitableThing:
+        def __await__(self) -> Generator[Trigger, None, int]:
+            yield Timer(1)
+            return 42
+
+    task = cocotb.start_soon(AwaitableThing())
+    result = await task
+    assert result == 42

--- a/tests/test_cases/test_cocotb/test_task_manager.py
+++ b/tests/test_cases/test_cocotb/test_task_manager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import sys
 from asyncio import CancelledError
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -1162,3 +1162,14 @@ async def test_context_block_continue_on_error(
         assert task1.cancelled()
         assert task2.cancelled()
         assert task3.cancelled()
+
+
+@cocotb.test
+async def test_fork_on_function_that_returns_awaitable(_: object) -> None:
+    def coro_func() -> Awaitable[Any]:
+        return Timer(1)
+
+    async with TaskManager() as tm:
+        task = tm.fork(coro_func)
+        result = await task
+        assert isinstance(result, Timer)


### PR DESCRIPTION
Passing an Awaitable that isn't a Coroutine to Task automatically wraps the Awaitable in a waiter coroutine.

This not only improves functionality, but reduces duplication as the same "conditionally wrap the Awaitable" is present in both `TaskManager` and `_wait()`.
