### PR TITLE
Change `gather`, `select`, and `wait` API

### DIFF
--- a/docs/source/_static/cocotb.css
+++ b/docs/source/_static/cocotb.css
@@ -256,6 +256,10 @@ code.xref {
   font-weight: normal;
 }
 
+span.xref.std-term {
+  color: var(--color-cocotb-blue);
+}
+
 h1:has(code.xref) code.xref, h2:has(code.xref) code.xref, h3:has(code.xref) code.xref, h4:has(code.xref) code.xref, h5:has(code.xref) code.xref, h6:has(code.xref) code.xref {
   font-weight: bold !important;
 }

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -510,6 +510,8 @@ Triggers dealing with Tasks or running multiple Tasks concurrently.
 .. autoclass:: First
     :members:
 
+.. autofunction:: wait
+
 .. autofunction:: gather
 
 .. autofunction:: select

--- a/docs/source/newsfragments/5165.feature.rst
+++ b/docs/source/newsfragments/5165.feature.rst
@@ -1,0 +1,1 @@
+Added :func:`cocotb.triggers.wait` for waiting on multiple awaitables concurrently with a configurable return condition.

--- a/docs/source/scheduler.rst
+++ b/docs/source/scheduler.rst
@@ -10,7 +10,7 @@ including the following topics:
 * :term:`tasks <task>`
 * :term:`concurrency`
 * Running independent concurrent tasks with :func:`cocotb.start_soon`.
-* Waiting for multiple things to finish with :func:`~cocotb.triggers.gather` and :func:`~cocotb.triggers.select`.
+* Waiting for multiple things to finish with :func:`~cocotb.triggers.gather`, :func:`~cocotb.triggers.select`, and :func:`~cocotb.triggers.wait`.
 * Structured concurrency with :class:`~cocotb.triggers.TaskManager`.
 * Inter-task communication with :class:`~cocotb.triggers.Event` and :class:`~cocotb.queue.Queue`.
 * Inter-task synchronization with :class:`~cocotb.triggers.Lock`.
@@ -138,7 +138,7 @@ To best visualize this, consider the following equivalent code below.
 ********************
 
 We mentioned earlier that one of the main reasons we need coroutines is to :keyword:`!await` things that aren't other coroutines.
-In cocotb, that thing is :term:`!triggers <trigger>`; they are another building block of cocotb's concurrency system.
+In cocotb, that thing is :term:`triggers <trigger>`; they are another building block of cocotb's concurrency system.
 
 cocotb provides triggers that represent various events in the simulation, such as a signal changing value or a certain amount of time passing.
 It also provides some triggers that represent user-defined events in Python, such as an :class:`~cocotb.triggers.Event`.
@@ -506,9 +506,9 @@ We are also taking advantage of the fact that cancellation raises a :exc:`!Cance
             self._task = None
 
 
-***********************************
-:func:`!gather` and :func:`!select`
-***********************************
+***************************************************
+:func:`!gather`, :func:`!select`, and :func:`!wait`
+***************************************************
 
 Another common concurrency use case you may run into is needing to wait for multiple tasks to finish before proceeding.
 For specific examples:
@@ -517,20 +517,90 @@ For specific examples:
 * Waiting for multiple testbench components to quiesce during test end.
 * Timing out an operation.
 
-cocotb provides two functions for this purpose, :func:`~cocotb.triggers.gather` and :func:`~cocotb.triggers.select`.
+cocotb provides three functions for this purpose, :func:`~cocotb.triggers.gather`, :func:`~cocotb.triggers.select`, and :func:`~cocotb.triggers.wait`.
+These functions not only allow you to wait for multiple *anything* to finish,
+but provide useful return values and provide cancellation and clean-up guarantees.
+These cancellation and clean-up guarantees are what is meant by "structured concurrency."
 
-Both of these functions take a variable number of :term:`awaitable objects <awaitable>` and wait for all (:func:`!gather`) or any (:func:`!select`) of them to finish before proceeding.
-:func:`!gather` returns a list of results corresponding to each of the :term:`!awaitable objects <awaitable>` passed in,
-while :func:`!select` returns a tuple of the result of the first awaitable to return and the index in the argument list it corresponds to.
+:func:`!gather`
+===============
 
-This is accomplished by creating an "internal waiter Task" that :keyword:`await`\ s each of the :term:`!awaitable objects <awaitable>`.
-These functions provide value by guaranteeing that no internal waiter task will be left running unintentionally after they finish.
-If any of the :term:`!awaitable objects <awaitable>` raise an exception, that exception is propagated to the caller of :func:`!gather` or :func:`!select`.
-After an exception is raised, all unfinished internal waiter :class:`!Task`\ s are cancelled.
-Likewise, as soon as the first awaitable in a :func:`!select` returns, all unfinished internal waiter :class:`!Task`\ s are cancelled.
-These guarantees are what is meant by "structured concurrency."
+:func:`~cocotb.triggers.gather` waits for all :term:`!awaitables` to complete and returns a list of their results in the same order as the :term:`!awaitables` were passed in.
+If any of the :term:`!awaitables` raise an exception, that exception is propagated to the caller of :func:`!gather` and all unfinished :term:`!awaitables` are cancelled.
 
-These two functions compose with each other easily to create more complex waiting conditions.
+.. code-block:: python
+
+    @cocotb.test()
+    async def my_test(dut):
+        # Wait for the design and scoreboard to quiesce before finishing the test.
+        results = await gather(
+            RisingEdge(dut.done),
+            scoreboard.quiesce(),
+        )
+
+:func:`!select`
+===============
+
+:func:`~cocotb.triggers.select` waits for the first ``awaitable`` in its argument list to complete
+and returns a tuple of the index (0-based into the argument list) of the first completed ``awaitable`` and its result.
+Once the first ``awaitable`` completes, all unfinished :term:`!awaitables` are cancelled.
+
+.. code-block:: python
+
+    @cocotb.test()
+    async def my_test(dut):
+        # Ensure that the design meets the timing requirement.
+        i, result = await select(
+            RisingEdge(dut.condition),
+            Timer(10, "us")
+        )
+        if i == 0:
+            cocotb.log.info("Condition met!")
+        else:
+            cocotb.log.error("Condition not met within 10 us!")
+
+:func:`!wait`
+=============
+
+:func:`~cocotb.triggers.wait` is the lower-level building block that :func:`!gather` and :func:`!select` are built on.
+It waits for multiple :term:`!awaitables` to finish, using the keyword argument *return_when* to determine when to return.
+
+* ``"FIRST_COMPLETED"``: Returns when the first awaitable finishes, for any reason.
+* ``"FIRST_EXCEPTION"``: Returns when the first awaitable raises an exception or is cancelled, or when all complete successfully.
+* ``"ALL_COMPLETED"``: Returns when all awaitables finish regardless of outcome.
+
+:func:`!wait` returns a tuple of the index (0-based into the argument list) of the first completed awaitable or ``None`` if no *first* event occurred,
+and a tuple of the waiter :class:`~cocotb.task.Task` objects.
+
+The caller is expected to inspect these :class:`!Task`\ s with :meth:`~cocotb.task.Task.result`, :meth:`~cocotb.task.Task.exception`, and :meth:`~cocotb.task.Task.cancelled`.
+
+Reach for :func:`!wait` when you don't want exceptions thrown to the caller, but instead want to handle them yourself.
+
+One special use-case for :func:`!wait` over :func:`!gather` and :func:`!select` is when you want to continue execution after an exception is raised in one of the siblings.
+In this case, use the ``"ALL_COMPLETED"`` return condition and inspect the returned :class:`!Task`\ s for exceptions.
+
+.. code-block:: python
+
+    @cocotb.test()
+    async def my_test(dut):
+        ...  # set up test
+
+        _, tasks = await wait(
+            sequencer_a.run(10000),
+            sequencer_b.run(10000),
+            check_for_data_loss(),
+            return_when="ALL_COMPLETED",
+        )
+        if (exc := tasks[2].exception()) is not None:
+            cocotb.log.error("Lost data: %r", exc)
+
+        ...  # check other results
+
+Composing :func:`!gather`, :func:`!select`, and :func:`!wait`
+=============================================================
+
+These functions compose with each other easily to create more complex waiting conditions,
+which we can see by joining the two examples from the :func:`!gather` and :func:`!select` sections above.
 
 .. code-block:: python
 
@@ -538,41 +608,33 @@ These two functions compose with each other easily to create more complex waitin
     async def my_test(arbitrator):
         ...  # set up test
 
-        # 10k transactions on each sequencer running simultaneously
-        await gather(
-            sequencer_a.run(10000),
-            sequencer_b.run(10000),
-        )
-
-        res, i = await select(
-            # Wait for scoreboard and the design to quiesce
+        # Implement a timeout after 10us.
+        i, res = await select(
+            # Wait for scoreboard and the design to quiesce.
             gather(
-                scoreboard.wait_for_quiescence(),
-                RisingEdge(dut.empty),
+                RisingEdge(dut.done),
+                scoreboard.quiesce(),
             ),
-            # Timeout after 100 us
-            Timer(100, unit="us"),
+            Timer(10, unit="us"),
         )
         if i == 0:
-            print("Design quiesced!")
+            cocotb.log.info("Design quiesced successfully!")
+            # continue checking results
         else:
-            raise TimeoutError("Design did not quiesce within 100 us!")
-
-        ...  # check results of the test
+            raise TimeoutError("Design did not quiesce within 10 us!")
 
 .. note::
-   If you pass a :class:`Task <cocotb.task.Task>` object to :func:`!gather` or :func:`!select` and an exception occurs
-   or :func:`!select` returns before that task finishes,
-   the passed in task will *not* be cancelled, only the internal waiter Task.
+   If you pass a :class:`Task <cocotb.task.Task>` object to :func:`!gather`, :func:`!select`, or :func:`!wait` and the call returns before that task finishes,
+   the passed in task will *not* be cancelled.
 
 .. note::
     You may be familiar with :class:`~cocotb.triggers.First` and :class:`~cocotb.triggers.Combine` which can also be used to wait for multiple things,
-    but they are limited to waiting for :term:`triggers <trigger>` only, not :term:`coroutines <coroutine>` or other :term:`!awaitables <awaitable>`.
+    but they are limited to waiting for :term:`triggers <trigger>` only, not :term:`coroutines <coroutine>` or other :term:`!awaitables`.
 
     This often forces the user to use :func:`cocotb.start_soon` and manage task lifetimes themselves
     which is verbose and rarely done correctly leading to :term:`!tasks` "leaking".
 
-    They also do not return useful results like :func:`!gather` and :func:`!select` do.
+    They also do not return useful results like :func:`!gather`, :func:`!select`, and :func:`!wait` do.
 
     For those reasons they are no longer recommended except for passing to functions or objects where specifically :term:`!triggers` are expected.
 

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -4,18 +4,22 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Awaitable, Iterable
-from enum import Enum, auto
-from typing import Any, Callable, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, overload
 
 from cocotb._base_triggers import _InternalEvent
 from cocotb.task import Task
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
-class ReturnWhen(Enum):
-    FIRST_COMPLETED = auto()
-    FIRST_EXCEPTION = auto()
-    ALL_COMPLETED = auto()
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+
+ReturnWhenType: TypeAlias = Literal[
+    "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED"
+]
 
 
 T = TypeVar("T")
@@ -24,32 +28,71 @@ T3 = TypeVar("T3")
 T4 = TypeVar("T4")
 
 
-def _return_exception(task: Task[T]) -> BaseException | T:
-    try:
-        return task.result()
-    except BaseException as e:
-        return e
+@overload
+async def wait(
+    a: Awaitable[T], /, *, return_when: ReturnWhenType
+) -> tuple[int | None, tuple[Task[T]]]: ...
 
 
-async def _wait(
-    awaitables: Iterable[Awaitable[Any]],
-    return_when: ReturnWhen,
-    _repr: Callable[[], str],
-) -> tuple[list[Task[Any]], Task[Any] | None]:
+@overload
+async def wait(
+    a: Awaitable[T], b: Awaitable[T2], /, *, return_when: ReturnWhenType
+) -> tuple[int | None, tuple[Task[T], Task[T2]]]: ...
+
+
+@overload
+async def wait(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    c: Awaitable[T3],
+    /,
+    *,
+    return_when: ReturnWhenType,
+) -> tuple[int | None, tuple[Task[T], Task[T2], Task[T3]]]: ...
+
+
+@overload
+async def wait(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    c: Awaitable[T3],
+    d: Awaitable[T4],
+    /,
+    *,
+    return_when: ReturnWhenType,
+) -> tuple[int | None, tuple[Task[T], Task[T2], Task[T3], Task[T4]]]: ...
+
+
+async def wait(
+    *awaitables: Awaitable[Any], return_when: ReturnWhenType
+) -> tuple[int | None, tuple[Task[Any], ...]]:
     r"""Await on all given *awaitables* concurrently and block until the *return_when* condition is met.
 
     Every :class:`~collections.abc.Awaitable` given to the function is :keyword:`await`\ ed concurrently in its own :class:`~cocotb.task.Task`.
     When the return conditions specified by *return_when* are met, this function returns those :class:`!Task`\ s.
     Once the return conditions are met, any waiter tasks which are still running are cancelled.
-    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments, only the waiter tasks.
 
-    The *return_when* condition must be one of the following:
+    .. note::
+        This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
+        only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
+
+    The behavior of this function depends on the *return_when* condition:
 
     - ``"FIRST_COMPLETED"``: Returns after the first of the *awaitables* completes, regardless if that was due to an exception or not.
     - ``"FIRST_EXCEPTION"``: Returns after all *awaitables* complete or after the first *awaitable* that completes due to an exception.
     - ``"ALL_COMPLETED"``: Returns after all *awaitables* complete.
 
-    Must not be called with an empty ``awaitables`` (would hang forever).
+    The index value in the result is the 0-based index into the argument list and has the following meanings, depending on the *return_when* condition:
+
+    - ``"FIRST_COMPLETED"``: The index of the first *awaitable* to complete, regardless of whether it completed successfully or with an exception.
+    - ``"FIRST_EXCEPTION"``: The index of the first *awaitable* to complete with an exception, or ``None`` if all completed successfully.
+    - ``"ALL_COMPLETED"``: Always ``None``, since all *awaitables* must complete before returning.
+
+    Guarantees:
+        This function guarantees that all *awaitables* are cancelled in the event of the cancellation of the caller.
+        This function guarantees that all *awaitables* are cancelled after the *return_when* condition is met, if any are still running.
+        This function guarantees that in the event of child cancellation, all *awaitables* have finished cancellation before returning to the caller,
+        ensuring that any side-effectful clean-up has completed.
 
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
@@ -57,13 +100,30 @@ async def _wait(
             The condition that must be met before returning.
             One of ``"FIRST_COMPLETED"``, ``"FIRST_EXCEPTION"``, or ``"ALL_COMPLETED"``.
 
+    Raises:
+        ValueError: If no *awaitables* are provided.
+
     Returns:
-        A tuple of waiter :class:`~cocotb.task.Task`\ s and the first completed :class:`~cocotb.task.Task` in
-        ``FIRST_COMPLETED`` or ``FIRST_EXCEPTION`` mode, or ``None`` in ``ALL_COMPLETED`` mode.
-        The order of the return tuple corresponds to the order of the input.
+        The index into the argument list (0-based) or ``None`` based on meanings described above,
+        and a tuple of waiter :class:`~cocotb.task.Task`\ s corresponding to the *awaitables* given as arguments.
 
     .. versionadded:: 2.1
     """
+    if len(awaitables) == 0:
+        raise ValueError("At least one awaitable required")
+
+    return await _wait(
+        awaitables,
+        return_when,
+        lambda: f"wait({', '.join(repr(a) for a in awaitables)})",
+    )
+
+
+async def _wait(
+    awaitables: Iterable[Awaitable[Any]],
+    return_when: ReturnWhenType,
+    _repr: Callable[[], str],
+) -> tuple[int | None, tuple[Task[Any], ...]]:
 
     waiters = [Task[Any](a) for a in awaitables]
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
@@ -75,7 +135,7 @@ async def _wait(
     # The first task to complete, stored regardless of return_when condition.
     first_completed: Task[Any] | None = None
 
-    if return_when == ReturnWhen.FIRST_COMPLETED:
+    if return_when == "FIRST_COMPLETED":
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
@@ -86,7 +146,7 @@ async def _wait(
                 first_completed = task
                 done.set()
 
-    elif return_when == ReturnWhen.FIRST_EXCEPTION:
+    elif return_when == "FIRST_EXCEPTION":
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
@@ -127,48 +187,34 @@ async def _wait(
     if not complete.is_set():
         await complete
 
-    return waiters, first_completed
+    idx = waiters.index(first_completed) if first_completed is not None else None
+    return idx, tuple(waiters)
 
 
-@overload
-async def select(
-    *awaitables: Awaitable[T], return_exceptions: Literal[False] = False
-) -> tuple[int, T]: ...
-
-
-@overload
-async def select(
-    *awaitables: Awaitable[T], return_exceptions: Literal[True]
-) -> tuple[int, T | BaseException]: ...
-
-
-async def select(
-    *awaitables: Awaitable[T],
-    return_exceptions: bool = False,
-    _repr: Callable[[], str] | None = None,
-) -> tuple[int, T | BaseException]:
+async def select(*awaitables: Awaitable[T]) -> tuple[int, T]:
     r"""Await on all given *awaitables* concurrently and return the index and result of the first to complete.
 
-    Regardless of the value of *return_exceptions*, after the first *awaitable* completes, whether it was cancelled, resulted in an exception, or resulted in a value,
+    After the first *awaitable* completes, whether through cancellation, exception, or success,
     the remaining *awaitables* are cancelled.
-    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments, only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
-    Control returns to the caller after all *awaitables* have completed and/or been cancelled.
+    Control returns to the caller after all remaining *awaitables* have finished cancelling.
+    The result of the first completed *awaitable* is returned, or the exception is re-raised, if it failed.
 
-    Regardless of the value of *return_exceptions*, if the task awaiting a call to this function is cancelled before completion,
-    all *awaitables* which have not yet completed are cancelled and :exc:`!CancelledError` is raised.
+    This function makes the same safety guarantees as :func:`!wait` regarding cancellation and clean-up.
 
-    It is possible for multiple *awaitables* to complete at the same time,
-    however due to how the cocotb scheduler works, only one will complete *first*.
-    It is good practice to avoid relying on the order of completion of multiple *awaitables* which complete at the same time.
+    .. note::
+        This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
+        only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
+
+    .. note::
+        It is possible for multiple *awaitables* to complete at the same time,
+        however due to how the cocotb scheduler works, only one will complete *first*.
+        It is good practice to avoid relying on the order of completion of multiple *awaitables* which complete at the same time.
 
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
-        return_exceptions:
-            If ``False`` (default), re-raises the exception when an *awaitable* results in an exception.
-            If ``True``, returns the exception rather than re-raising when an *awaitable* results in an exception.
 
     Returns:
-        A tuple comprised of the index into the argument list (0-based) of the first *awaitable* to complete, and the *awaitable*'s result.
+        A tuple comprised of the index into the argument list (0-based) of the first *awaitable* to complete and the *awaitable*'s result.
 
     Raises:
         ValueError: If no *awaitables* are provided.
@@ -178,103 +224,53 @@ async def select(
     if len(awaitables) == 0:
         raise ValueError("At least one awaitable required")
 
-    # select is being called on its own and not part of First.
-    # So we add a repr here since this is not a class.
-    if _repr is None:
+    def _repr() -> str:
+        return f"select({', '.join(repr(a) for a in awaitables)})"
 
-        def _repr() -> str:
-            return f"select({', '.join(repr(a) for a in awaitables)})"
+    idx, tasks = await _wait(awaitables, "FIRST_COMPLETED", _repr)
+    assert idx is not None
+    return idx, tasks[idx].result()
 
-    tasks, first_completed = await _wait(
-        awaitables, return_when=ReturnWhen.FIRST_COMPLETED, _repr=_repr
-    )
-    assert first_completed is not None
 
-    idx = tasks.index(first_completed)
-    if return_exceptions:
-        return (idx, _return_exception(first_completed))
-    else:
-        # This will raise CancelledError if the task was cancelled, or the exception if it failed,
-        # or return the result if it succeeded.
-        return idx, first_completed.result()
+@overload
+async def gather(a: Awaitable[T], /) -> tuple[T]: ...
+
+
+@overload
+async def gather(a: Awaitable[T], b: Awaitable[T2], /) -> tuple[T, T2]: ...
 
 
 @overload
 async def gather(
-    a: Awaitable[T],
-    /,
-    *,
-    return_exceptions: Literal[False] = False,
-) -> tuple[T]: ...
-
-
-@overload
-async def gather(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    /,
-    *,
-    return_exceptions: Literal[False] = False,
-) -> tuple[T, T2]: ...
-
-
-@overload
-async def gather(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    c: Awaitable[T3],
-    /,
-    *,
-    return_exceptions: Literal[False] = False,
+    a: Awaitable[T], b: Awaitable[T2], c: Awaitable[T3], /
 ) -> tuple[T, T2, T3]: ...
 
 
 @overload
 async def gather(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    c: Awaitable[T3],
-    d: Awaitable[T4],
-    /,
-    *,
-    return_exceptions: Literal[False] = False,
+    a: Awaitable[T], b: Awaitable[T2], c: Awaitable[T3], d: Awaitable[T4], /
 ) -> tuple[T, T2, T3, T4]: ...
 
 
 @overload
-async def gather(
-    *aw: Awaitable[T], return_exceptions: Literal[False] = False
-) -> tuple[T, ...]: ...
+async def gather(*aw: Awaitable[T]) -> tuple[T, ...]: ...
 
 
-@overload
-async def gather(
-    *aw: Awaitable[T], return_exceptions: Literal[True]
-) -> tuple[T | BaseException, ...]: ...
-
-
-async def gather(
-    *awaitables: Awaitable[Any],
-    return_exceptions: bool = False,
-    _repr: Callable[[], str] | None = None,
-) -> tuple[Any, ...]:
+async def gather(*awaitables: Awaitable[Any]) -> tuple[Any, ...]:
     r"""Await on all given *awaitables* concurrently and return their results once all have completed.
 
-    When *return_exceptions* is ``False``, if any *awaitable* results in an exception or is cancelled,
-    the remaining *awaitables* are cancelled and the exception or :exc:`~asyncio.CancelledError` is re-raised.
-    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments, only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
-    When *return_exceptions* is ``True``, all exceptions and cancellations are treated as successful results and returned in the resulting tuple.
-    Control returns to the caller after all *awaitables* have completed and/or been cancelled.
+    If any *awaitable* results in an exception or is cancelled,
+    the remaining *awaitables* are cancelled.
+    Once all remaining *awaitables* have been cancelled, the call to :func:`!gather` re-raises the exception.
 
-    Regardless of the value of *return_exceptions*, if the task awaiting a call to this function is cancelled before completion,
-    all *awaitables* which have not yet completed are cancelled and :exc:`!CancelledError` is raised.
+    This function makes the same safety guarantees as :func:`!wait` regarding cancellation and clean-up.
+
+    .. note::
+        This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
+        only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
 
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
-        return_exceptions:
-            If ``False`` (default), after the first *awaitable* results in an exception or cancellation,
-            cancels the remaining *awaitables* and re-raises the exception or :exc:`!CancelledError`.
-            If ``True``, returns all exceptions or :exc:`!CancelledError` rather than the result value when an *awaitable* results in an exception.
 
     Returns:
         A tuple of the results of awaiting each *awaitable* in the same order they were given.
@@ -285,29 +281,14 @@ async def gather(
     if len(awaitables) == 0:
         return ()
 
-    # gather is being called on its own and not part of Combine.
-    # So we add a repr here since this is not a class.
-    if _repr is None:
+    def _repr() -> str:
+        return f"gather({', '.join(repr(a) for a in awaitables)})"
 
-        def _repr() -> str:
-            return f"gather({', '.join(repr(a) for a in awaitables)})"
+    idx, tasks = await _wait(awaitables, "FIRST_EXCEPTION", _repr)
 
-    # When returning exceptions, we behave like continue-on-error: never cancel siblings.
-    # Otherwise, cancel siblings as soon as one fails or is cancelled.
-    tasks, first_completed = await _wait(
-        awaitables,
-        return_when=ReturnWhen.ALL_COMPLETED
-        if return_exceptions
-        else ReturnWhen.FIRST_EXCEPTION,
-        _repr=_repr,
-    )
-
-    if return_exceptions:
-        return tuple(_return_exception(task) for task in tasks)
-    elif first_completed is not None:
-        # first_completed is only set in FIRST_EXCEPTION mode when a task fails or is cancelled.
-        # Calling result() will cause the exception or CancelledError to be re-raised.
-        # Wrapped in a tuple to make mypy happy about the return type.
-        return (first_completed.result(),)
+    if idx is not None:
+        # There was a failure, so re-raise it.
+        return tasks[idx].result()
     else:
+        # All tasks completed successfully, so return their results.
         return tuple(task.result() for task in tasks)

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -16,7 +16,7 @@ from typing import Any, TypeVar, cast, overload
 
 import cocotb.handle
 from cocotb._base_triggers import NullTrigger, Trigger
-from cocotb._concurrent_waiters import gather, select
+from cocotb._concurrent_waiters import _wait, select
 from cocotb._deprecation import deprecated
 from cocotb._gpi_triggers import FallingEdge, RisingEdge, Timer, ValueChange
 from cocotb.simtime import RoundMode, TimeUnit
@@ -93,7 +93,12 @@ class Combine(Waitable["Combine"]):
         if len(self._triggers) == 0:
             await NullTrigger()
         else:
-            await gather(*self._triggers, _repr=self.__repr__)  # type: ignore[call-overload]
+            idx, tasks = await _wait(
+                self._triggers, return_when="FIRST_EXCEPTION", _repr=self.__repr__
+            )
+            if idx is not None:
+                tasks[idx].result()
+            return self
         return self
 
     def __repr__(self) -> str:
@@ -177,8 +182,11 @@ class First(Waitable[object]):
         self._triggers = triggers
 
     async def _wait(self) -> object:
-        _, result = await select(*self._triggers, _repr=self.__repr__)  # type: ignore[call-overload]
-        return result
+        idx, tasks = await _wait(
+            self._triggers, return_when="FIRST_COMPLETED", _repr=self.__repr__
+        )
+        assert idx is not None
+        return tasks[idx].result()
 
     def __repr__(self) -> str:
         # no _pointer_str here, since this is not a trigger, so identity

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import warnings
 
 from cocotb._base_triggers import Event, Lock, NullTrigger, Trigger
-from cocotb._concurrent_waiters import gather, select
+from cocotb._concurrent_waiters import gather, select, wait
 from cocotb._extended_awaitables import (
     ClockCycles,
     Combine,
@@ -52,6 +52,7 @@ __all__ = (
     "current_gpi_trigger",
     "gather",
     "select",
+    "wait",
     "with_timeout",
 )
 

--- a/tests/test_cases/test_cocotb/test_waiters.py
+++ b/tests/test_cases/test_cocotb/test_waiters.py
@@ -10,29 +10,29 @@ from collections.abc import Generator
 import pytest
 
 import cocotb
-from cocotb.triggers import NullTrigger, Timer, Trigger, gather, select
+from cocotb.triggers import NullTrigger, Timer, Trigger, gather, select, wait
 
 
-async def coro(wait: int, ret: int = 0) -> int:
-    await Timer(wait)
+async def coro(delay: int, ret: int = 0) -> int:
+    await Timer(delay)
     return ret
 
 
 class AwaitableThing:
-    def __init__(self, wait: int, ret: int = 0) -> None:
-        self._wait = wait
+    def __init__(self, delay: int, ret: int = 0) -> None:
+        self._delay = delay
         self._ret = ret
 
     def __await__(self) -> Generator[Trigger, None, int]:
-        yield from coro(self._wait).__await__()
+        yield from coro(self._delay).__await__()
         return self._ret
 
 
 class MyException(Exception): ...
 
 
-async def raises_after(wait: int) -> None:
-    await Timer(wait)
+async def raises_after(delay: int) -> None:
+    await Timer(delay)
     raise MyException()
 
 
@@ -40,7 +40,7 @@ async def raises_after(wait: int) -> None:
 async def test_gather(_: object) -> None:
     timer1 = Timer(1)
     a1, b1, c1 = await gather(
-        coro(wait=3, ret=123),
+        coro(delay=3, ret=123),
         AwaitableThing(2, ret=9),
         timer1,
     )
@@ -50,21 +50,10 @@ async def test_gather(_: object) -> None:
 
     with pytest.raises(MyException):
         await gather(
-            raises_after(wait=3),
+            raises_after(delay=3),
             AwaitableThing(2, ret=9),
             Timer(1),
         )
-
-    timer2 = Timer(2)
-    a2, b2, c2 = await gather(
-        raises_after(wait=3),
-        AwaitableThing(1, ret=56),
-        timer2,
-        return_exceptions=True,
-    )
-    assert isinstance(a2, MyException)
-    assert b2 == 56
-    assert c2 == timer2
 
     assert await gather() == ()
 
@@ -73,54 +62,102 @@ async def test_gather(_: object) -> None:
 async def test_select(_: object) -> None:
     timer1 = Timer(1)
     idx, res1 = await select(
-        coro(wait=3, ret=123),
+        coro(delay=3, ret=123),
         AwaitableThing(2, ret=9),
         timer1,
     )
     assert idx == 2
     assert res1 == timer1
 
-    idx, res2 = await select(
-        raises_after(wait=3),
-        AwaitableThing(1, ret=31),
-        Timer(2),
-        return_exceptions=True,
-    )
-    assert idx == 1
-    assert res2 == 31
-    await Timer(5)  # ensure failing task was killed
-
     with pytest.raises(MyException):
         await select(
-            raises_after(wait=1),
+            raises_after(delay=1),
             AwaitableThing(2, ret=9),
             Timer(3),
         )
-
-    idx, res3 = await select(
-        raises_after(wait=1),
-        AwaitableThing(2, ret=12),
-        Timer(3),
-        return_exceptions=True,
-    )
-    assert idx == 0
-    assert isinstance(res3, MyException)
 
     with pytest.raises(ValueError):
         await select()
 
 
 @cocotb.test
+async def test_wait_empty(_: object) -> None:
+    """wait() with no awaitables raises ValueError for every return_when mode."""
+    with pytest.raises(ValueError):
+        await wait(return_when="FIRST_COMPLETED")  # type: ignore[call-overload]
+    with pytest.raises(ValueError):
+        await wait(return_when="FIRST_EXCEPTION")  # type: ignore[call-overload]
+    with pytest.raises(ValueError):
+        await wait(return_when="ALL_COMPLETED")  # type: ignore[call-overload]
+
+
+@cocotb.test
+async def test_wait_all_completed(_: object) -> None:
+    """wait() with ALL_COMPLETED returns after every awaitable is done, regardless of exceptions."""
+    timer2 = Timer(2)
+    idx, tasks = await wait(
+        raises_after(delay=3),
+        AwaitableThing(1, ret=56),
+        timer2,
+        return_when="ALL_COMPLETED",
+    )
+    assert idx is None
+    assert isinstance(tasks[0].exception(), MyException)
+    assert tasks[1].result() == 56
+    assert tasks[2].result() == timer2
+
+
+@cocotb.test
+async def test_wait_first_completed(_: object) -> None:
+    """wait() with FIRST_COMPLETED returns after the first awaitable completes."""
+    idx, tasks = await wait(
+        raises_after(delay=3),
+        AwaitableThing(1, ret=31),
+        Timer(2),
+        return_when="FIRST_COMPLETED",
+    )
+    assert idx == 1
+    assert tasks[1].result() == 31
+    await Timer(5)  # ensure remaining tasks were killed
+    assert tasks[0].cancelled()
+    assert tasks[2].cancelled()
+
+
+@cocotb.test
+async def test_wait_first_exception(_: object) -> None:
+    """wait() with FIRST_EXCEPTION returns at the first exception, or after all complete."""
+    idx, tasks = await wait(
+        raises_after(delay=1),
+        AwaitableThing(2, ret=12),
+        Timer(3),
+        return_when="FIRST_EXCEPTION",
+    )
+    assert idx == 0
+    assert isinstance(tasks[0].exception(), MyException)
+    assert tasks[1].cancelled()
+    assert tasks[2].cancelled()
+
+    idx2, tasks2 = await wait(
+        coro(delay=1, ret=7),
+        AwaitableThing(2, ret=8),
+        return_when="FIRST_EXCEPTION",
+    )
+    assert idx2 is None
+    assert tasks2[0].result() == 7
+    assert tasks2[1].result() == 8
+
+
+@cocotb.test
 async def test_gather_single(_: object) -> None:
     """gather with one awaitable still returns a single-element tuple."""
-    (result,) = await gather(coro(wait=1, ret=42))
+    (result,) = await gather(coro(delay=1, ret=42))
     assert result == 42
 
 
 @cocotb.test
 async def test_select_single(_: object) -> None:
     """select with one awaitable returns index 0 and its result."""
-    idx, res = await select(coro(wait=1, ret=42))
+    idx, res = await select(coro(delay=1, ret=42))
     assert idx == 0
     assert res == 42
 
@@ -148,8 +185,8 @@ async def test_gather_outer_cancel(_: object) -> None:
 
 
 @cocotb.test
-async def test_gather_outer_cancel_return_exceptions(_: object) -> None:
-    """return_exceptions=True must NOT swallow outer cancellation."""
+async def test_wait_outer_cancel_all_completed(_: object) -> None:
+    """Cancelling the task awaiting wait(ALL_COMPLETED) propagates CancelledError and cancels children."""
     child_completed = False
 
     async def child() -> None:
@@ -158,14 +195,14 @@ async def test_gather_outer_cancel_return_exceptions(_: object) -> None:
         child_completed = True
 
     async def waiter() -> None:
-        await gather(child(), Timer(20), return_exceptions=True)
+        await wait(child(), Timer(20), return_when="ALL_COMPLETED")
 
     task = cocotb.start_soon(waiter())
     await Timer(1)
     task.cancel()
     await Timer(1)
     assert task.cancelled(), (
-        "outer cancellation should propagate even with return_exceptions=True"
+        "outer cancellation should propagate even with ALL_COMPLETED"
     )
     assert not child_completed
 
@@ -193,8 +230,7 @@ async def test_select_outer_cancel(_: object) -> None:
 
 @cocotb.test
 async def test_gather_child_cancelled_default(_: object) -> None:
-    """When a child is cancelled and return_exceptions=False, gather re-raises CancelledError
-    and cancels the remaining children."""
+    """When a child is cancelled, gather re-raises CancelledError and cancels the remaining children."""
     sibling_completed = False
 
     async def sibling() -> None:
@@ -202,7 +238,7 @@ async def test_gather_child_cancelled_default(_: object) -> None:
         await Timer(10)
         sibling_completed = True
 
-    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
     async def waiter() -> None:
         await gather(victim_task, sibling())
@@ -217,29 +253,33 @@ async def test_gather_child_cancelled_default(_: object) -> None:
 
 
 @cocotb.test
-async def test_gather_child_cancelled_return_exceptions(_: object) -> None:
-    """When a child is cancelled and return_exceptions=True, gather returns CancelledError
-    in the tuple and other children continue."""
-    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+async def test_wait_child_cancelled_all_completed(_: object) -> None:
+    """With wait(ALL_COMPLETED) a cancelled child does not stop other children, and the
+    cancellation is observable as a cancelled waiter task."""
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
-    async def waiter() -> tuple[object, ...]:
-        return await gather(victim_task, coro(wait=10, ret=99), return_exceptions=True)
+    async def waiter() -> tuple[int | None, tuple[object, ...]]:
+        idx, tasks = await wait(
+            victim_task, coro(delay=10, ret=99), return_when="ALL_COMPLETED"
+        )
+        return idx, tuple(t.exception() if t.cancelled() else t.result() for t in tasks)
 
     task = cocotb.start_soon(waiter())
     await Timer(1)
     victim_task.cancel()
     await Timer(15)
     assert task.done()
-    a, b = task.result()
+    idx, results = task.result()
+    assert idx is None
+    a, b = results
     assert isinstance(a, CancelledError)
     assert b == 99
 
 
 @cocotb.test
 async def test_select_child_cancelled(_: object) -> None:
-    """When the winning child was cancelled, select raises CancelledError by default
-    and returns it when return_exception=True."""
-    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+    """When the winning child was cancelled, select raises CancelledError."""
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
     async def waiter_raises() -> None:
         await select(victim_task, Timer(30))
@@ -251,36 +291,44 @@ async def test_select_child_cancelled(_: object) -> None:
     assert t1.done()
     assert isinstance(t1.exception(), CancelledError)
 
-    victim_task2 = cocotb.start_soon(coro(wait=20, ret=0))
 
-    async def waiter_returns() -> tuple[int, object]:
-        return await select(victim_task2, Timer(30), return_exception=True)
+@cocotb.test
+async def test_wait_first_completed_child_cancelled(_: object) -> None:
+    """When the winning child was cancelled, wait(FIRST_COMPLETED) returns it as a cancelled waiter task."""
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
-    t2 = cocotb.start_soon(waiter_returns())
+    async def waiter() -> tuple[int | None, bool]:
+        idx, tasks = await wait(victim_task, Timer(30), return_when="FIRST_COMPLETED")
+        assert idx is not None
+        return idx, tasks[idx].cancelled()
+
+    t = cocotb.start_soon(waiter())
     await Timer(1)
-    victim_task2.cancel()
+    victim_task.cancel()
     await Timer(2)
-    assert t2.done()
-    idx, exc = t2.result()
+    assert t.done()
+    idx, was_cancelled = t.result()
     assert idx == 0
-    assert isinstance(exc, CancelledError)
+    assert was_cancelled
 
 
 @cocotb.test
-async def test_gather_preserves_cancel_message(_: object) -> None:
-    """When return_exceptions=True, the original CancelledError instance (with its message)
-    is returned, not a fresh one."""
-    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+async def test_wait_preserves_cancel_message(_: object) -> None:
+    """The original CancelledError instance (with its message) is preserved on the waiter task."""
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
-    async def waiter() -> tuple[object, ...]:
-        return await gather(victim_task, coro(wait=5, ret=1), return_exceptions=True)
+    async def waiter() -> BaseException | None:
+        _, tasks = await wait(
+            victim_task, coro(delay=5, ret=1), return_when="ALL_COMPLETED"
+        )
+        return tasks[0].exception()
 
     task = cocotb.start_soon(waiter())
     await Timer(1)
     victim_task.cancel("specific reason")
     await Timer(10)
     assert task.done()
-    a, _ = task.result()
+    a = task.result()
     assert isinstance(a, CancelledError)
     assert a.args == ("specific reason",), (
         f"expected original CancelledError message preserved, got args={a.args!r}"
@@ -300,7 +348,7 @@ async def test_gather_does_not_cancel_passed_tasks(_: object) -> None:
     # raises_after fires first; gather cancels the waiter wrapping `task`,
     # but `task` itself must keep running.
     with pytest.raises(MyException):
-        await gather(task, raises_after(wait=1))
+        await gather(task, raises_after(delay=1))
     await NullTrigger()
     assert not task.cancelled()
     assert await task == 7
@@ -320,3 +368,20 @@ async def test_select_does_not_cancel_passed_tasks(_: object) -> None:
     await NullTrigger()
     assert not task.cancelled()
     assert await task == 7
+
+
+@cocotb.test
+async def test_wait_second_exception(_: object) -> None:
+    async def do_nothing() -> int:
+        return 123
+
+    idx, tasks = await wait(
+        do_nothing(),  # Will pass before the next two raise exceptions
+        raises_after(delay=1),  # Will fail and kill the next task
+        raises_after(delay=2),  # Will be cancelled
+        return_when="FIRST_EXCEPTION",
+    )
+    assert idx == 1
+    assert tasks[0].result() == 123
+    assert isinstance(tasks[1].exception(), MyException)
+    assert tasks[2].cancelled()


### PR DESCRIPTION
Depends on #5653.

The return_exceptions API on gather and select are kinda difficult. For
gather in particular, return_exceptions=True and =False have different
completion criteria (first failed vs continue on error), but also
changes the result type. Additionally, returning exceptions is slightly
ambiguous as functions can return exception object, theoretically.

For these reasons we decided we wanted to return Task objects instead
and split the FIRST_EXCEPTION and ALL_COMPLETED behaviors.

The best way we've found to accomplish this is to remove
return_exceptions from gather and select, and reintroduce wait. wait
also now returns an optional index value which has meaning depending
upon the return_when condition.

No newsfrags necessary, changing APIs introduced in 2.1 dev cycle.