### PR TITLE
TaskManager refactor

### DIFF
--- a/src/cocotb/_task_manager.py
+++ b/src/cocotb/_task_manager.py
@@ -30,10 +30,6 @@ if sys.version_info >= (3, 10):
 T = TypeVar("T")
 
 
-async def _waiter(aw: Awaitable[T]) -> T:
-    return await aw
-
-
 class TaskManager:
     r"""An :term:`asynchronous context manager` which runs :term:`coroutine function`\ s or :term:`awaitable`\ s concurrently until all finish.
 
@@ -61,30 +57,25 @@ class TaskManager:
             else default_continue_on_error
         )
 
+        # We don't keep all children Tasks around, just the ones that haven't finished yet,
+        # so we have to save the exceptions for the ExceptionGroup we raise at the end of the context block.
         self._exceptions: set[BaseException] = set()
         # dict value is per-Task continue_on_error setting
         self._remaining_tasks: dict[Task[Any], bool] = {}
         self._none_remaining = Event()
+        # Children were cancelled due to a child Task/block failure.
         self._cancelled: bool = False
+        # We started __aexit__. Ensures we dont add more Tasks after the context block has started finishing.
         self._finishing: bool = False
+        # For protecting against adding Tasks before entering the context block
         self._entered: bool = False
-        # parent task will not exist if we aren't using this as a context manager
-        self._parent_task: Task[Any] | None = None
+        # The parent Task which entered the context block.
+        # Used to ensure only the parent Task can add child Tasks,
+        # and to cancel the parent Task if a child Task fails while the block is still running.
+        self._parent_task: Task[Any]
 
         # Start with no remaining tasks
         self._none_remaining.set()
-
-    def _ensure_can_add(self) -> None:
-        if self._cancelled:
-            raise RuntimeError("Cannot add new Tasks to TaskManager after error")
-        elif self._finishing:
-            raise RuntimeError("Cannot add new Tasks to TaskManager after finishing")
-        elif not self._entered:
-            raise RuntimeError(
-                "Cannot add new Tasks to TaskManager before entering context"
-            )
-        if current_task() is not self._parent_task:
-            raise RuntimeError("Cannot add new Tasks to TaskManager from another Task")
 
     def start_soon(
         self,
@@ -105,9 +96,31 @@ class TaskManager:
         Returns:
             A :class:`~cocotb.task.Task` which is awaiting *aw* concurrently.
         """
-        self._ensure_can_add()
+        # Ensure that we can add a new Task to this TaskManager before creating the Task.
+        # We would have to close it if it failed.
+        if self._cancelled:
+            raise RuntimeError("Cannot add new Tasks to TaskManager after error")
+        elif self._finishing:
+            raise RuntimeError("Cannot add new Tasks to TaskManager after finishing")
+        elif not self._entered:
+            raise RuntimeError(
+                "Cannot add new Tasks to TaskManager before entering context"
+            )
+        if current_task() is not self._parent_task:
+            raise RuntimeError("Cannot add new Tasks to TaskManager from another Task")
+
+        # Create the Task and tie it to this TaskManager via the done callback.
         task = Task[T](aw, name=name)
-        self._add_task(task, continue_on_error=continue_on_error)
+        task._add_done_callback(self._done_callback)
+        # Track the Task and store per-Task continue_on_error setting
+        self._remaining_tasks[task] = (
+            continue_on_error
+            if continue_on_error is not None
+            else self._default_continue_on_error
+        )
+        self._none_remaining.clear()
+        # Start the Task to running.
+        task.start_soon()
         return task
 
     @overload
@@ -158,8 +171,7 @@ class TaskManager:
                     # Do other stuff in parallel to my_func
                     ...
         """
-        self._ensure_can_add()
-
+        # Handle the case where fork is called as a function and returns the decorator.
         if coro_func is None:
             if continue_on_error is None:
                 raise TypeError(
@@ -176,30 +188,9 @@ class TaskManager:
 
             return deco
 
-        try:
-            task = Task[T](coro_func(), name=coro_func.__name__)
-        except TypeError:
-            raise TypeError(
-                f"fork() expected a coroutine function, got {type(coro_func).__name__}"
-            ) from None
-        self._add_task(task, continue_on_error=continue_on_error)
-        return task
-
-    def _add_task(
-        self,
-        task: Task[Any],
-        *,
-        continue_on_error: bool | None = None,
-    ) -> None:
-        # Track the Task and store per-Task continue_on_error setting
-        task._add_done_callback(self._done_callback)
-        if continue_on_error is None:
-            continue_on_error = self._default_continue_on_error
-        self._remaining_tasks[task] = continue_on_error
-        self._none_remaining.clear()
-
-        # Schedule the Task to run soon
-        task.start_soon()
+        return self.start_soon(
+            coro_func(), name=coro_func.__name__, continue_on_error=continue_on_error
+        )
 
     def _done_callback(self, task: Task[Any]) -> None:
         """Callback run when a child Task finishes."""
@@ -221,7 +212,7 @@ class TaskManager:
 
         # If a child Task fails while we are in the middle of a TaskManager block,
         # cancel the parent Task to force the block to end.
-        if not self._finishing and self._parent_task is not None:
+        if not self._finishing:
             self._parent_task.cancel()
 
         # Cancel all child Tasks.
@@ -240,12 +231,11 @@ class TaskManager:
     ) -> None:
         self._finishing = True
 
-        if self._parent_task is not None and self._cancelled:
+        if self._cancelled:
             # The context block was cancelled due to a child Task failure.
             if isinstance(exc, CancelledError):
                 # Suppress CancelledError in this case to allow child Tasks to finish cancelling.
                 exc = None
-                assert self._parent_task is not None
                 self._parent_task._uncancel()
             else:
                 # The context block ignored the cancellation. Hard fail the test.
@@ -282,11 +272,8 @@ class TaskManager:
             # This is likely because we ignored a CancelledError since there is no other
             # way to fail this await AFAICT. Cancel children and let it pass up as there's
             # nothing we can do.
-            # TODO Make this force a test failure. Special case KeyboardInterrupt/SystemExit/BdbQuit
             self._cancel()
             raise
-
-        self._finished = True
 
         # Build BaseExceptionGroup if there were any errors. Ignore CancelledError.
         if exc is not None and not isinstance(exc, CancelledError):

--- a/src/cocotb/_task_manager.py
+++ b/src/cocotb/_task_manager.py
@@ -12,9 +12,8 @@ from bdb import BdbQuit
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar, overload
 
-from cocotb._base_triggers import NullTrigger
 from cocotb.task import Task, current_task
-from cocotb.triggers import Event
+from cocotb.triggers import Event, NullTrigger
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -231,6 +230,13 @@ class TaskManager:
     ) -> None:
         self._finishing = True
 
+        # Propagate special exceptions immediately.
+        # The GeneratorExit case is there so if the block is cancelled due to a child Task failure,
+        # and the block squashes the CancelledError and does an await, a GeneratorExit is thrown at the await, which may end up here.
+        if isinstance(exc, (KeyboardInterrupt, SystemExit, BdbQuit, GeneratorExit)):
+            self._cancel()
+            return None  # re-raise exception
+
         if self._cancelled:
             # The context block was cancelled due to a child Task failure.
             if isinstance(exc, CancelledError):
@@ -238,22 +244,16 @@ class TaskManager:
                 exc = None
                 self._parent_task._uncancel()
             else:
-                # The context block ignored the cancellation. Hard fail the test.
-                # There is a special case in Task if a cancelled Task finishes without
-                # raising CancelledError, it fails the test. So we just await *something*
-                # here to hit that code path.
-                # TODO Make this force a test failure.
-                self._cancel()
+                # The context block ignored the cancellation and either threw some other exception or finished successfully.
+                # We await a token NullTrigger to allow the parent Task to kill the Task due to ignored CancelledError.
                 await NullTrigger()
+                # This will never run as a GeneratorExit will be thrown at the above await.
+                raise RuntimeError("Reached unreachable code")  # pragma: no cover
         elif exc is not None:
             if isinstance(exc, CancelledError):
-                # Something else cancelled the parent task. Propagate CancelledError.
+                # Something else cancelled the parent task. Propagate CancelledError immediately.
                 self._cancel()
                 return None  # re-raise CancelledError
-            elif isinstance(exc, (KeyboardInterrupt, SystemExit, BdbQuit)):
-                # Certain BaseExceptions should be immediately propagated like they are in Task.
-                self._cancel()
-                return None  # re-raise exception
             elif not self._context_continue_on_error:
                 # Block finished with an exception and we are not continuing on error.
                 self._cancel()

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -236,6 +236,9 @@ def start_soon(
 
             .. versionadded:: 2.0
 
+    Raises:
+        RuntimeError: If a :class:`!Task` was given and it has already completed.
+
     Returns:
         The :class:`~cocotb.task.Task` that is scheduled to be run.
 
@@ -249,9 +252,10 @@ def start_soon(
             read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
     task = create_task(coro, name=name)
-    # This is _ensure_started() rather than start_soon() for backwards compatibility.
-    # Calling cocotb.start_soon(task) on a task that already started should not fail.
-    task._ensure_started()
+    if task._unstarted():
+        task.start_soon()
+    elif task.done():
+        raise RuntimeError("Cannot schedule a Task that has already completed.")
     return task
 
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -351,6 +351,7 @@ class Task(Generic[ResultType]):
             if self._must_cancel:
                 if debug.debug:
                     self._log.debug("Task %r was cancelled but exited normally", self)
+                self._coro.close()
                 self._set_outcome(
                     RuntimeError(
                         "Task was cancelled, but exited normally. Did you forget to re-raise the CancelledError?"
@@ -397,6 +398,7 @@ class Task(Generic[ResultType]):
             if self._must_cancel:
                 if debug.debug:
                     self._log.debug("Task %r was cancelled but continued running", self)
+                self._coro.close()
                 self._set_outcome(
                     RuntimeError(
                         "Task was cancelled, but continued running. Did you forget to re-raise the CancelledError?"

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -273,30 +273,32 @@ class Task(Generic[ResultType]):
         """
         if self._state is not _TaskState.UNSTARTED:
             raise RuntimeError("Can only start_soon() an unstarted Task")
-        self._schedule_resume()
-
-    def _ensure_started(self) -> None:
-        state = self._state
-        if state is _TaskState.UNSTARTED:
-            if debug.debug:
-                self._log.debug("Starting %r", self)
-            self._schedule_resume()
-        elif state in (
-            _TaskState.FINISHED,
-            _TaskState.ERRORED,
-            _TaskState.CANCELLED,
-        ):
-            raise RuntimeError("Cannot start a finished Task")
-        # RUNNING, SCHEDULED, PENDING are already running
+        if debug.debug:
+            self._log.debug("Starting %r", self)
+        # Schedule the Task to run
+        self._state = _TaskState.SCHEDULED
+        self._exc = None
+        self._schedule_callback = cocotb._event_loop._inst.schedule(self._resume)
 
     def _start_next(self) -> None:
+        """Queues an unstarted Task to start running, but schedules it to run before other scheduled Tasks.
+
+        Currently private until someone needs it.
+        This is a potential footgun in the hands of a novice.
+
+        Raises:
+            RuntimeError: If the Task has already started.
+        """
         if self._state != _TaskState.UNSTARTED:
             raise RuntimeError(
                 "Cannot _start_next() on a Task that has already been started"
             )
+        if debug.debug:
+            self._log.debug("Starting %r", self)
+        # Schedule the Task to run
         self._state = _TaskState.SCHEDULED
         self._exc = None
-        cocotb._event_loop._inst.schedule_left(self._resume)
+        self._schedule_callback = cocotb._event_loop._inst.schedule_left(self._resume)
 
     def _set_outcome(
         self,
@@ -603,6 +605,10 @@ class Task(Generic[ResultType]):
         if self._must_cancel > 0:
             self._must_cancel -= 1
 
+    def _unstarted(self) -> bool:
+        """Return ``True`` if the Task has not started executing."""
+        return self._state is _TaskState.UNSTARTED
+
     def cancelled(self) -> bool:
         """Return ``True`` if the Task was cancelled."""
         return self._state is _TaskState.CANCELLED
@@ -665,8 +671,9 @@ class Task(Generic[ResultType]):
         self._done_callbacks.append(callback)
 
     def __await__(self) -> Generator[Trigger, None, ResultType]:
+        if self._unstarted():
+            self.start_soon()
         if not self.done():
-            self._ensure_started()
             yield self.complete
         return self.result()
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -294,6 +294,8 @@ class Task(Generic[ResultType]):
             raise RuntimeError(
                 "Cannot _start_next() on a Task that has already been started"
             )
+        self._state = _TaskState.SCHEDULED
+        self._exc = None
         cocotb._event_loop._inst.schedule_left(self._resume)
 
     def _set_outcome(

--- a/tests/test_cases/test_cocotb/test_task_manager.py
+++ b/tests/test_cases/test_cocotb/test_task_manager.py
@@ -678,12 +678,13 @@ async def test_external_cancel_in_nested_child_aexit(
 ) -> None:
     outer_task: Task[Any] | None = None
     inner_task: Task[Any] | None = None
+    inner_block_task: Task[Any] | None = None
 
     async def run_task_manager() -> None:
         async with TaskManager(
             default_continue_on_error=outer_continue_on_error
         ) as tm_outer:
-            nonlocal outer_task
+            nonlocal outer_task, inner_block_task
             outer_task = tm_outer.start_soon(coro(5, ret=9))
 
             @tm_outer.fork
@@ -693,6 +694,8 @@ async def test_external_cancel_in_nested_child_aexit(
                 ) as tm_inner:
                     nonlocal inner_task
                     inner_task = tm_inner.start_soon(coro(5, ret=9))
+
+            inner_block_task = inner_block
 
     task = cocotb.start_soon(run_task_manager())
 
@@ -712,6 +715,8 @@ async def test_external_cancel_in_nested_child_aexit(
     assert inner_task.result() == 9
     assert outer_task is not None
     assert outer_task.cancelled()
+    assert inner_block_task is not None
+    assert inner_block_task.cancelled()
 
 
 @cocotb.test
@@ -1116,7 +1121,7 @@ async def test_bad_args(_: object) -> None:
         with pytest.raises(TypeError):
             tm.fork(123)  # type: ignore
 
-        async def oops_async_generator() -> AsyncGenerator[None, None, None]:
+        async def oops_async_generator() -> AsyncGenerator[None]:
             yield None
 
         c = oops_async_generator()
@@ -1173,3 +1178,246 @@ async def test_fork_on_function_that_returns_awaitable(_: object) -> None:
         task = tm.fork(coro_func)
         result = await task
         assert isinstance(result, Timer)
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_cancel_inner_child_task_in_nested_block(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    cancelled = False
+    task_outer: Task[Any] | None = None
+    other: Task[Any] | None = None
+
+    async with TaskManager(
+        default_continue_on_error=outer_continue_on_error
+    ) as tm_outer:
+        task_outer = tm_outer.start_soon(coro(4, ret=9))
+
+        async with TaskManager(
+            default_continue_on_error=inner_continue_on_error
+        ) as tm_inner:
+
+            @tm_inner.fork
+            async def child() -> None:
+                try:
+                    await Timer(5)
+                finally:
+                    nonlocal cancelled
+                    cancelled = True
+
+            await Timer(1)
+            child.cancel()
+
+            @tm_inner.fork
+            async def other() -> None:
+                await Timer(1)
+
+    assert cancelled
+    assert other is not None
+    assert other.done()
+    assert task_outer.result() == 9
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_cancel_inner_child_task_in_nested_child_block(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    cancelled = False
+    task_outer: Task[Any] | None = None
+    other: Task[Any] | None = None
+
+    async with TaskManager(
+        default_continue_on_error=outer_continue_on_error
+    ) as tm_outer:
+        task_outer = tm_outer.start_soon(coro(4, ret=9))
+
+        @tm_outer.fork
+        async def inner_block() -> None:
+            async with TaskManager(
+                default_continue_on_error=inner_continue_on_error
+            ) as tm_inner:
+
+                @tm_inner.fork
+                async def child() -> None:
+                    try:
+                        await Timer(5)
+                    finally:
+                        nonlocal cancelled
+                        cancelled = True
+
+                await Timer(1)
+                child.cancel()
+
+                nonlocal other
+
+                @tm_inner.fork
+                async def other() -> None:
+                    await Timer(1)
+
+    assert cancelled
+    assert other is not None
+    assert other.done()
+    assert task_outer.result() == 9
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_external_cancel_in_nested_block_ignored_at_end_of_block(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    async def run_task_manager() -> None:
+        async with TaskManager(default_continue_on_error=outer_continue_on_error):
+            async with TaskManager(default_continue_on_error=inner_continue_on_error):
+                try:
+                    await Timer(2)
+                except CancelledError:
+                    pass
+
+    task = cocotb.start_soon(run_task_manager())
+
+    await Timer(1)
+
+    task.cancel()
+    await task.complete
+    assert not task.cancelled()
+    assert task.exception() is not None
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_external_cancel_in_nested_block_ignored_new_raise(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    async def run_task_manager() -> None:
+        async with TaskManager(default_continue_on_error=outer_continue_on_error):
+            async with TaskManager(default_continue_on_error=inner_continue_on_error):
+                try:
+                    await Timer(2)
+                except CancelledError:
+                    raise MyException()
+
+    task = cocotb.start_soon(run_task_manager())
+
+    await Timer(1)
+
+    task.cancel()
+    await task.complete
+    assert not task.cancelled()
+    assert task.exception() is not None
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_external_cancel_in_nested_block_ignored_and_await(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    async def run_task_manager() -> None:
+        async with TaskManager(default_continue_on_error=outer_continue_on_error):
+            async with TaskManager(default_continue_on_error=inner_continue_on_error):
+                try:
+                    await Timer(2)
+                except CancelledError:
+                    pass
+
+                await Timer(1)
+
+    task = cocotb.start_soon(run_task_manager())
+
+    await Timer(1)
+
+    task.cancel()
+    await task.complete
+    assert not task.cancelled()
+    assert task.exception() is not None
+
+
+@cocotb.test
+@cocotb.parametrize(continue_on_error=[True, False])
+async def test_two_children_fail_simultaneously(
+    _: object, continue_on_error: bool
+) -> None:
+    try:
+        async with TaskManager(default_continue_on_error=continue_on_error) as tm:
+            task1 = tm.start_soon(raises_after(1))
+            task2 = tm.start_soon(raises_after(1))
+
+    except BaseExceptionGroup as e:
+        my_exc, rest = e.split(MyException)
+        assert rest is None
+        assert my_exc is not None
+        if continue_on_error:
+            # We expect both tasks fail, since we keep going after the first failure.
+            assert len(my_exc.exceptions) == 2
+        else:
+            # One task will fail, and the other will be cancelled before it can run again to "fail."
+            assert len(my_exc.exceptions) == 1
+
+    if continue_on_error:
+        # We expect both tasks fail
+        assert task1.exception() is not None
+        assert task2.exception() is not None
+
+
+@cocotb.test
+async def test_second_child_fails_after_group_cancelled(_: object) -> None:
+    try:
+        async with TaskManager(default_continue_on_error=False) as tm:
+            task1 = tm.start_soon(raises_after(1))
+
+            @tm.fork
+            async def task2() -> None:
+                try:
+                    await Timer(5)
+                except CancelledError:
+                    raise MyException()
+
+    except BaseExceptionGroup as e:
+        my_exc, rest = e.split(MyException)
+        assert rest is None
+        assert my_exc is not None
+        assert len(my_exc.exceptions) == 2
+
+    assert task1.exception() is not None
+    assert task2.exception() is not None
+
+
+@cocotb.test
+async def test_cancel_child_during_wait_cannot_be_swallowed(_: object) -> None:
+    child: Task[int] | None = None
+
+    async def run_task_manager() -> None:
+        nonlocal child
+
+        try:
+            async with TaskManager() as tm:
+
+                @tm.fork
+                async def child() -> int:
+                    try:
+                        await Timer(5)
+                    except CancelledError:
+                        pass
+                    return 42
+        except BaseExceptionGroup as e:
+            my_exc, rest = e.split(RuntimeError)
+            assert rest is None
+            assert my_exc is not None
+            assert len(my_exc.exceptions) == 1
+
+    tm_task = cocotb.start_soon(run_task_manager())
+
+    # wait until block has exited and __aexit__ is waiting on the child
+    await Timer(1)
+
+    assert child is not None
+    child.cancel()
+
+    await tm_task.complete
+    assert isinstance(child.exception(), RuntimeError)


### PR DESCRIPTION
Depends on #5625 and #5653.

I set out to change the TaskManager to work in the same way as `gather` and `select`, and also tried carving out a `TaskManager.create_task` to support the future TaskContext object (I abandoned this, but kept the refactor) and realized a few things:
1. TaskManager already waits for all children to finish before returning.
2. `Task._start_next` doesn't set the `Task._state` properly (ends up causing a test failure in a later change)
3. Found the source of the GeneratorExit warnings at end of sim and fixed it.
4. Refactor TaskManager for clarity.
5. Refactor `Task._ensure_started` out of existence so we only have two start methods.