### PR TITLE
Kill `gather`/`select` children in done callback

### DIFF
--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -510,6 +510,8 @@ Triggers dealing with Tasks or running multiple Tasks concurrently.
 .. autoclass:: First
     :members:
 
+.. autofunction:: wait
+
 .. autofunction:: gather
 
 .. autofunction:: select

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -339,6 +339,34 @@ Task Management
 
 .. autofunction:: current_task
 
+.. _awaitable-design-note:
+
+.. warning::
+    If you are passing a bespoke :class:`~collections.abc.Awaitable` object to :class:`Task` :func:`cocotb.start_soon`, :func:`cocotb.start`, or :func:`cocotb.create_task`,
+    you must ensure that the setup and cleanup are handled correctly.
+
+    When passing an object to one of these functions it may schedule the Task to run,
+    but the Task may be cancelled before it is :keyword:`await`ed.
+    If you put setup code in the constructor of a bespoke :class:`!Awaitable` and this occurs,
+    cleanup code in :meth:`!__await__` may never be executed.
+
+    It is also not advisable to put cleanup code in :meth:`!__del__` as this may never be called due to the way Python's garbage collector works.
+
+    Instead, prefer putting both setup and cleanup code in :meth:`!__await__` and only use the constructor to store parameters.
+
+    .. code-block:: python
+
+        class MyAwaitable:
+            def __init__(self, param):
+                self.param = param
+
+            def __await__(self):
+                self._setup(self.param)
+                try:
+                    yield some_trigger
+                finally:
+                    self._cleanup()
+
 Bridging through non-`async` code
 ---------------------------------
 

--- a/docs/source/newsfragments/5165.feature.rst
+++ b/docs/source/newsfragments/5165.feature.rst
@@ -1,0 +1,1 @@
+Added :func:`cocotb.triggers.wait` for waiting on multiple awaitables concurrently with a configurable return condition.

--- a/docs/source/newsfragments/5625.feature.rst
+++ b/docs/source/newsfragments/5625.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`.Task.start_soon` to schedule an unstarted :class:`.Task` to start "soon". This is primarily for users to start a :class:`!Task` after using :func:`!create_task` or manually instantiating :class:`!Task` to create a task.

--- a/docs/source/newsfragments/5653.feature.rst
+++ b/docs/source/newsfragments/5653.feature.rst
@@ -1,0 +1,1 @@
+Add support for passing *any* :class:`~collections.abc.Awaitable` to :func:`cocotb.create_task`, :func:`cocotb.start_soon`, and :func:`cocotb.start`. This wraps the :term:`awaitable` in a waiter :term:`coroutine`.

--- a/docs/source/scheduler.rst
+++ b/docs/source/scheduler.rst
@@ -10,7 +10,7 @@ including the following topics:
 * :term:`tasks <task>`
 * :term:`concurrency`
 * Running independent concurrent tasks with :func:`cocotb.start_soon`.
-* Waiting for multiple things to finish with :func:`~cocotb.triggers.gather` and :func:`~cocotb.triggers.select`.
+* Waiting for multiple things to finish with :func:`~cocotb.triggers.gather`, :func:`~cocotb.triggers.select`, and :func:`~cocotb.triggers.wait`.
 * Structured concurrency with :class:`~cocotb.triggers.TaskManager`.
 * Inter-task communication with :class:`~cocotb.triggers.Event` and :class:`~cocotb.queue.Queue`.
 * Inter-task synchronization with :class:`~cocotb.triggers.Lock`.
@@ -506,9 +506,9 @@ We are also taking advantage of the fact that cancellation raises a :exc:`!Cance
             self._task = None
 
 
-***********************************
-:func:`!gather` and :func:`!select`
-***********************************
+***************************************************
+:func:`!gather`, :func:`!select`, and :func:`!wait`
+***************************************************
 
 Another common concurrency use case you may run into is needing to wait for multiple tasks to finish before proceeding.
 For specific examples:
@@ -517,20 +517,90 @@ For specific examples:
 * Waiting for multiple testbench components to quiesce during test end.
 * Timing out an operation.
 
-cocotb provides two functions for this purpose, :func:`~cocotb.triggers.gather` and :func:`~cocotb.triggers.select`.
+cocotb provides three functions for this purpose, :func:`~cocotb.triggers.gather`, :func:`~cocotb.triggers.select`, and :func:`~cocotb.triggers.wait`.
+These functions not only allow you to wait for multiple *anything* to finish,
+but provide useful return values and provide cancellation and clean-up guarantees.
+These cancellation and clean-up guarantees are what is meant by "structured concurrency."
 
-Both of these functions take a variable number of :term:`awaitable objects <awaitable>` and wait for all (:func:`!gather`) or any (:func:`!select`) of them to finish before proceeding.
-:func:`!gather` returns a list of results corresponding to each of the :term:`!awaitable objects <awaitable>` passed in,
-while :func:`!select` returns a tuple of the result of the first awaitable to return and the index in the argument list it corresponds to.
+:func:`!gather`
+===============
 
-This is accomplished by creating an "internal waiter Task" that :keyword:`await`\ s each of the :term:`!awaitable objects <awaitable>`.
-These functions provide value by guaranteeing that no internal waiter task will be left running unintentionally after they finish.
-If any of the :term:`!awaitable objects <awaitable>` raise an exception, that exception is propagated to the caller of :func:`!gather` or :func:`!select`.
-After an exception is raised, all unfinished internal waiter :class:`!Task`\ s are cancelled.
-Likewise, as soon as the first awaitable in a :func:`!select` returns, all unfinished internal waiter :class:`!Task`\ s are cancelled.
-These guarantees are what is meant by "structured concurrency."
+:func:`!gather` waits for all ``awaitables`` to complete and returns a list of their results in the same order as the ``awaitables`` were passed in.
+If any of the ``awaitables`` raise an exception, that exception is propagated to the caller of :func:`!gather` and all unfinished ``awaitables`` are cancelled.
 
-These two functions compose with each other easily to create more complex waiting conditions.
+.. code-block:: python
+
+    @cocotb.test()
+    async def my_test(dut):
+        # Wait for the design and scoreboard to quiesce before finishing the test.
+        results = await gather(
+            RisingEdge(dut.done),
+            scoreboard.quiesce(),
+        )
+
+:func:`!select`
+===============
+
+:func:`!select` waits for the first ``awaitable`` in its argument list to complete
+and returns a tuple of the index (0-based into the argument list) of the first completed ``awaitable`` and its result.
+Once the first ``awaitable`` completes, all unfinished ``awaitables`` are cancelled.
+
+.. code-block:: python
+
+    @cocotb.test()
+    async def my_test(dut):
+        # Ensure that the design meets the timing requirement.
+        i, result = await select(
+            RisingEdge(dut.condition),
+            Timer(10, "us")
+        )
+        if i == 0:
+            cocotb.log.info("Condition met!")
+        else:
+            cocotb.log.error("Condition not met within 10 us!")
+
+:func:`!wait`
+=============
+
+:func:`!wait` is the lower-level building block that :func:`!gather` and :func:`!select` are built on.
+It waits for multiple ``awaitables`` to finish, using the keyword argument *return_when* to determine when to return.
+
+* ``"FIRST_COMPLETED"``: Returns when the first awaitable finishes, for any reason.
+* ``"FIRST_EXCEPTION"``: Returns when the first awaitable raises an exception or is cancelled, or when all complete successfully.
+* ``"ALL_COMPLETED"``: Returns when all awaitables finish regardless of outcome.
+
+:func:`!wait` returns a tuple of the index (0-based into the argument list) of the first completed awaitable or ``None`` if no *first* event occurred,
+and a tuple of the waiter :class:`~cocotb.task.Task` objects.
+
+The caller is expected to inspect these :class:`!Task`\ s with :meth:`~cocotb.task.Task.result`, :meth:`~cocotb.task.Task.exception`, and :meth:`~cocotb.task.Task.cancelled`.
+
+Reach for :func:`!wait` when you don't want exceptions thrown to the caller, but instead want to handle them yourself.
+
+One special use-case for :func:`!wait` over :func:`!gather` and :func:`!select` is when you want to continue execution after an exception is raised in one of the siblings.
+In this case, use the ``"ALL_COMPLETED"`` return condition and inspect the returned :class:`!Task`\ s for exceptions.
+
+.. code-block:: python
+
+    @cocotb.test()
+    async def my_test(dut):
+        ...  # set up test
+
+        _, tasks = await wait(
+            sequencer_a.run(10000),
+            sequencer_b.run(10000),
+            check_for_data_loss(),
+            return_when="ALL_COMPLETED",
+        )
+        if (exc := tasks[2].exception()) is not None:
+            cocotb.log.error("Lost data: %r", exc)
+
+        ...  # check other results
+
+Composing :func:`!gather`, :func:`!select`, and :func:`!wait`
+=============================================================
+
+These functions compose with each other easily to create more complex waiting conditions,
+which we can see by joining the two examples from the :func:`!gather` and :func:`!select` sections above.
 
 .. code-block:: python
 
@@ -538,32 +608,24 @@ These two functions compose with each other easily to create more complex waitin
     async def my_test(arbitrator):
         ...  # set up test
 
-        # 10k transactions on each sequencer running simultaneously
-        await gather(
-            sequencer_a.run(10000),
-            sequencer_b.run(10000),
-        )
-
-        res, i = await select(
-            # Wait for scoreboard and the design to quiesce
+        # Implement a timeout after 10us.
+        i, res = await select(
+            # Wait for scoreboard and the design to quiesce.
             gather(
-                scoreboard.wait_for_quiescence(),
-                RisingEdge(dut.empty),
+                RisingEdge(dut.done),
+                scoreboard.quiesce(),
             ),
-            # Timeout after 100 us
-            Timer(100, unit="us"),
+            Timer(10, unit="us"),
         )
         if i == 0:
-            print("Design quiesced!")
+            cocotb.log.info("Design quiesced successfully!")
+            # continue checking results
         else:
-            raise TimeoutError("Design did not quiesce within 100 us!")
-
-        ...  # check results of the test
+            raise TimeoutError("Design did not quiesce within 10 us!")
 
 .. note::
-   If you pass a :class:`Task <cocotb.task.Task>` object to :func:`!gather` or :func:`!select` and an exception occurs
-   or :func:`!select` returns before that task finishes,
-   the passed in task will *not* be cancelled, only the internal waiter Task.
+   If you pass a :class:`Task <cocotb.task.Task>` object to :func:`!gather`, :func:`!select`, or :func:`!wait` and the call returns before that task finishes,
+   the passed in task will *not* be cancelled.
 
 .. note::
     You may be familiar with :class:`~cocotb.triggers.First` and :class:`~cocotb.triggers.Combine` which can also be used to wait for multiple things,
@@ -572,7 +634,7 @@ These two functions compose with each other easily to create more complex waitin
     This often forces the user to use :func:`cocotb.start_soon` and manage task lifetimes themselves
     which is verbose and rarely done correctly leading to :term:`!tasks` "leaking".
 
-    They also do not return useful results like :func:`!gather` and :func:`!select` do.
+    They also do not return useful results like :func:`!gather`, :func:`!select`, and :func:`!wait` do.
 
     For those reasons they are no longer recommended except for passing to functions or objects where specifically :term:`!triggers` are expected.
 

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -4,15 +4,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Awaitable, Iterable
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, overload
+from typing import Any, Callable, Literal, TypeVar, overload
 
 from cocotb._base_triggers import _InternalEvent
 from cocotb.task import Task
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable
 
 
 class ReturnWhen(Enum):
@@ -68,10 +65,7 @@ async def _wait(
     .. versionadded:: 2.1
     """
 
-    async def waiter(aw: Awaitable[T]) -> T:
-        return await aw
-
-    waiters = [Task[Any](waiter(a)) for a in awaitables]
+    waiters = [Task[Any](a) for a in awaitables]
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
     remaining = dict.fromkeys(waiters)
     # Set when we meet the return condition.

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -125,45 +125,58 @@ async def _wait(
     waiters = [Task[Any](a) for a in awaitables]
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
     remaining = dict.fromkeys(waiters)
-    # Set when we meet the return condition.
+    # Set when all tasks have complete, regardless if cancelled or ended naturally.
     done = _InternalEvent(_repr)
-    # Set when all tasks have completed, regardless of reason.
-    complete = _InternalEvent(_repr)
     # The first task to complete, stored regardless of return_when condition.
     first_completed: Task[Any] | None = None
+    # We are cancelling remaining tasks, so don't try to cancel them again.
+    cancelled: bool = False
+
+    def cancel_remaining() -> None:
+        nonlocal cancelled
+        if cancelled:
+            return
+        cancelled = True
+        for task in remaining:
+            task.cancel()
 
     if return_when == "FIRST_COMPLETED":
 
         def done_callback(task: Task[Any]) -> None:
+            # Finish once all tasks have completed.
             del remaining[task]
             if not remaining:
-                complete.set()
+                done.set()
+
+            # Record first and cancel remaining if we met the return_when condition
             nonlocal first_completed
             if first_completed is None:
                 first_completed = task
-                done.set()
+                cancel_remaining()
 
     elif return_when == "FIRST_EXCEPTION":
 
         def done_callback(task: Task[Any]) -> None:
+            # Finish once all tasks have completed.
             del remaining[task]
             if not remaining:
                 done.set()
-                complete.set()
+
+            # Record first and cancel remaining if we met the return_when condition
             nonlocal first_completed
             if first_completed is None and (
                 task.cancelled() or task.exception() is not None
             ):
                 first_completed = task
-                done.set()
+                cancel_remaining()
 
     else:
 
         def done_callback(task: Task[Any]) -> None:
+            # Finish once all tasks have completed.
             del remaining[task]
             if not remaining:
                 done.set()
-                complete.set()
 
     for task in reversed(waiters):
         task._add_done_callback(done_callback)
@@ -171,18 +184,14 @@ async def _wait(
 
     try:
         await done
-    finally:
-        # Cancel remaining tasks. No-op if everything has finished (ALL_COMPLETED)
-        # or the return_when condition is specified, but all tasks happen to complete
-        # before this Task runs again. Cancels whatever is remaining and rethrows if
-        # the caller is cancelled.
-        for task in remaining:
-            task.cancel()
-
-    # Wait until all children tasks have finished before returning.
-    # Ensures any side-effectful clean-up has completed.
-    if not complete.is_set():
-        await complete
+    except BaseException:
+        # This is mostly limited to:
+        # * CancelledError: if the parent is cancelled before we're done.
+        # * GeneratorExit: if the parent ignored CancelledError and this is the next await.
+        # * Possibly SystemExit, BdbQuit, or KeyboardInterrupt.
+        # Regardless, we can't squash any of them, so do a token cancellation and re-raise immediately.
+        cancel_remaining()
+        raise
 
     idx = waiters.index(first_completed) if first_completed is not None else None
     return idx, tuple(waiters)

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -4,18 +4,19 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Awaitable, Iterable
-from enum import Enum, auto
 from typing import Any, Callable, Literal, TypeVar, overload
 
 from cocotb._base_triggers import _InternalEvent
 from cocotb.task import Task
 
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
 
-class ReturnWhen(Enum):
-    FIRST_COMPLETED = auto()
-    FIRST_EXCEPTION = auto()
-    ALL_COMPLETED = auto()
+ReturnWhenType: TypeAlias = Literal[
+    "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED"
+]
 
 
 T = TypeVar("T")
@@ -24,32 +25,71 @@ T3 = TypeVar("T3")
 T4 = TypeVar("T4")
 
 
-def _return_exception(task: Task[T]) -> BaseException | T:
-    try:
-        return task.result()
-    except BaseException as e:
-        return e
+@overload
+async def wait(
+    a: Awaitable[T], /, *, return_when: ReturnWhenType
+) -> tuple[int | None, tuple[Task[T]]]: ...
 
 
-async def _wait(
-    awaitables: Iterable[Awaitable[Any]],
-    return_when: ReturnWhen,
-    _repr: Callable[[], str],
-) -> tuple[list[Task[Any]], Task[Any] | None]:
+@overload
+async def wait(
+    a: Awaitable[T], b: Awaitable[T2], /, *, return_when: ReturnWhenType
+) -> tuple[int | None, tuple[Task[T], Task[T2]]]: ...
+
+
+@overload
+async def wait(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    c: Awaitable[T3],
+    /,
+    *,
+    return_when: ReturnWhenType,
+) -> tuple[int | None, tuple[Task[T], Task[T2], Task[T3]]]: ...
+
+
+@overload
+async def wait(
+    a: Awaitable[T],
+    b: Awaitable[T2],
+    c: Awaitable[T3],
+    d: Awaitable[T4],
+    /,
+    *,
+    return_when: ReturnWhenType,
+) -> tuple[int | None, tuple[Task[T], Task[T2], Task[T3], Task[T4]]]: ...
+
+
+async def wait(
+    *awaitables: Awaitable[Any], return_when: ReturnWhenType
+) -> tuple[int | None, tuple[Task[Any], ...]]:
     r"""Await on all given *awaitables* concurrently and block until the *return_when* condition is met.
 
     Every :class:`~collections.abc.Awaitable` given to the function is :keyword:`await`\ ed concurrently in its own :class:`~cocotb.task.Task`.
     When the return conditions specified by *return_when* are met, this function returns those :class:`!Task`\ s.
     Once the return conditions are met, any waiter tasks which are still running are cancelled.
-    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments, only the waiter tasks.
 
-    The *return_when* condition must be one of the following:
+    .. note::
+        This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
+        only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
+
+    The behavior of this function depends on the *return_when* condition:
 
     - ``"FIRST_COMPLETED"``: Returns after the first of the *awaitables* completes, regardless if that was due to an exception or not.
     - ``"FIRST_EXCEPTION"``: Returns after all *awaitables* complete or after the first *awaitable* that completes due to an exception.
     - ``"ALL_COMPLETED"``: Returns after all *awaitables* complete.
 
-    Must not be called with an empty ``awaitables`` (would hang forever).
+    The index value in the result is the 0-based index into the argument list and has the following meanings, depending on the *return_when* condition:
+
+    - ``"FIRST_COMPLETED"``: The index of the first *awaitable* to complete, regardless of whether it completed successfully or with an exception.
+    - ``"FIRST_EXCEPTION"``: The index of the first *awaitable* to complete with an exception, or ``None`` if all completed successfully.
+    - ``"ALL_COMPLETED"``: Always ``None``, since all *awaitables* must complete before returning.
+
+    Guarantees:
+        This function guarantees that all *awaitables* are cancelled in the event of the cancellation of the caller.
+        This function guarantees that all *awaitables* are cancelled after the *return_when* condition is met, if any are still running.
+        This function guarantees that in the event of child cancellation, all *awaitables* have finished cancellation before returning to the caller,
+        ensuring that any side-effectful clean-up has completed.
 
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
@@ -57,13 +97,30 @@ async def _wait(
             The condition that must be met before returning.
             One of ``"FIRST_COMPLETED"``, ``"FIRST_EXCEPTION"``, or ``"ALL_COMPLETED"``.
 
+    Raises:
+        ValueError: If no *awaitables* are provided.
+
     Returns:
-        A tuple of waiter :class:`~cocotb.task.Task`\ s and the first completed :class:`~cocotb.task.Task` in
-        ``FIRST_COMPLETED`` or ``FIRST_EXCEPTION`` mode, or ``None`` in ``ALL_COMPLETED`` mode.
-        The order of the return tuple corresponds to the order of the input.
+        The index into the argument list (0-based) or ``None`` based on meanings described above,
+        and a tuple of waiter :class:`~cocotb.task.Task`\ s corresponding to the *awaitables* given as arguments.
 
     .. versionadded:: 2.1
     """
+    if len(awaitables) == 0:
+        raise ValueError("At least one awaitable required")
+
+    return await _wait(
+        awaitables,
+        return_when,
+        lambda: f"wait({', '.join(repr(a) for a in awaitables)})",
+    )
+
+
+async def _wait(
+    awaitables: Iterable[Awaitable[Any]],
+    return_when: ReturnWhenType,
+    _repr: Callable[[], str],
+) -> tuple[int | None, tuple[Task[Any], ...]]:
 
     waiters = [Task[Any](a) for a in awaitables]
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
@@ -75,7 +132,7 @@ async def _wait(
     # The first task to complete, stored regardless of return_when condition.
     first_completed: Task[Any] | None = None
 
-    if return_when == ReturnWhen.FIRST_COMPLETED:
+    if return_when == "FIRST_COMPLETED":
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
@@ -86,7 +143,7 @@ async def _wait(
                 first_completed = task
                 done.set()
 
-    elif return_when == ReturnWhen.FIRST_EXCEPTION:
+    elif return_when == "FIRST_EXCEPTION":
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
@@ -127,48 +184,34 @@ async def _wait(
     if not complete.is_set():
         await complete
 
-    return waiters, first_completed
+    idx = waiters.index(first_completed) if first_completed is not None else None
+    return idx, tuple(waiters)
 
 
-@overload
-async def select(
-    *awaitables: Awaitable[T], return_exceptions: Literal[False] = False
-) -> tuple[int, T]: ...
-
-
-@overload
-async def select(
-    *awaitables: Awaitable[T], return_exceptions: Literal[True]
-) -> tuple[int, T | BaseException]: ...
-
-
-async def select(
-    *awaitables: Awaitable[T],
-    return_exceptions: bool = False,
-    _repr: Callable[[], str] | None = None,
-) -> tuple[int, T | BaseException]:
+async def select(*awaitables: Awaitable[T]) -> tuple[int, T]:
     r"""Await on all given *awaitables* concurrently and return the index and result of the first to complete.
 
-    Regardless of the value of *return_exceptions*, after the first *awaitable* completes, whether it was cancelled, resulted in an exception, or resulted in a value,
+    After the first *awaitable* completes, whether through cancellation, exception, or success,
     the remaining *awaitables* are cancelled.
-    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments, only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
-    Control returns to the caller after all *awaitables* have completed and/or been cancelled.
+    Control returns to the caller after all remaining *awaitables* have finished cancelling.
+    The result of the first completed *awaitable* is returned, or the exception is re-raised, if it failed.
 
-    Regardless of the value of *return_exceptions*, if the task awaiting a call to this function is cancelled before completion,
-    all *awaitables* which have not yet completed are cancelled and :exc:`!CancelledError` is raised.
+    This function makes the same safety guarantees as :func:`!wait` regarding cancellation and clean-up.
 
-    It is possible for multiple *awaitables* to complete at the same time,
-    however due to how the cocotb scheduler works, only one will complete *first*.
-    It is good practice to avoid relying on the order of completion of multiple *awaitables* which complete at the same time.
+    .. note::
+        This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
+        only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
+
+    .. note::
+        It is possible for multiple *awaitables* to complete at the same time,
+        however due to how the cocotb scheduler works, only one will complete *first*.
+        It is good practice to avoid relying on the order of completion of multiple *awaitables* which complete at the same time.
 
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
-        return_exceptions:
-            If ``False`` (default), re-raises the exception when an *awaitable* results in an exception.
-            If ``True``, returns the exception rather than re-raising when an *awaitable* results in an exception.
 
     Returns:
-        A tuple comprised of the index into the argument list (0-based) of the first *awaitable* to complete, and the *awaitable*'s result.
+        A tuple comprised of the index into the argument list (0-based) of the first *awaitable* to complete and the *awaitable*'s result.
 
     Raises:
         ValueError: If no *awaitables* are provided.
@@ -178,103 +221,53 @@ async def select(
     if len(awaitables) == 0:
         raise ValueError("At least one awaitable required")
 
-    # select is being called on its own and not part of First.
-    # So we add a repr here since this is not a class.
-    if _repr is None:
+    def _repr() -> str:
+        return f"select({', '.join(repr(a) for a in awaitables)})"
 
-        def _repr() -> str:
-            return f"select({', '.join(repr(a) for a in awaitables)})"
+    idx, tasks = await _wait(awaitables, "FIRST_COMPLETED", _repr)
+    assert idx is not None
+    return idx, tasks[idx].result()
 
-    tasks, first_completed = await _wait(
-        awaitables, return_when=ReturnWhen.FIRST_COMPLETED, _repr=_repr
-    )
-    assert first_completed is not None
 
-    idx = tasks.index(first_completed)
-    if return_exceptions:
-        return (idx, _return_exception(first_completed))
-    else:
-        # This will raise CancelledError if the task was cancelled, or the exception if it failed,
-        # or return the result if it succeeded.
-        return idx, first_completed.result()
+@overload
+async def gather(a: Awaitable[T], /) -> tuple[T]: ...
+
+
+@overload
+async def gather(a: Awaitable[T], b: Awaitable[T2], /) -> tuple[T, T2]: ...
 
 
 @overload
 async def gather(
-    a: Awaitable[T],
-    /,
-    *,
-    return_exceptions: Literal[False] = False,
-) -> tuple[T]: ...
-
-
-@overload
-async def gather(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    /,
-    *,
-    return_exceptions: Literal[False] = False,
-) -> tuple[T, T2]: ...
-
-
-@overload
-async def gather(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    c: Awaitable[T3],
-    /,
-    *,
-    return_exceptions: Literal[False] = False,
+    a: Awaitable[T], b: Awaitable[T2], c: Awaitable[T3], /
 ) -> tuple[T, T2, T3]: ...
 
 
 @overload
 async def gather(
-    a: Awaitable[T],
-    b: Awaitable[T2],
-    c: Awaitable[T3],
-    d: Awaitable[T4],
-    /,
-    *,
-    return_exceptions: Literal[False] = False,
+    a: Awaitable[T], b: Awaitable[T2], c: Awaitable[T3], d: Awaitable[T4], /
 ) -> tuple[T, T2, T3, T4]: ...
 
 
 @overload
-async def gather(
-    *aw: Awaitable[T], return_exceptions: Literal[False] = False
-) -> tuple[T, ...]: ...
+async def gather(*aw: Awaitable[T]) -> tuple[T, ...]: ...
 
 
-@overload
-async def gather(
-    *aw: Awaitable[T], return_exceptions: Literal[True]
-) -> tuple[T | BaseException, ...]: ...
-
-
-async def gather(
-    *awaitables: Awaitable[Any],
-    return_exceptions: bool = False,
-    _repr: Callable[[], str] | None = None,
-) -> tuple[Any, ...]:
+async def gather(*awaitables: Awaitable[Any]) -> tuple[Any, ...]:
     r"""Await on all given *awaitables* concurrently and return their results once all have completed.
 
-    When *return_exceptions* is ``False``, if any *awaitable* results in an exception or is cancelled,
-    the remaining *awaitables* are cancelled and the exception or :exc:`~asyncio.CancelledError` is re-raised.
-    This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments, only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
-    When *return_exceptions* is ``True``, all exceptions and cancellations are treated as successful results and returned in the resulting tuple.
-    Control returns to the caller after all *awaitables* have completed and/or been cancelled.
+    If any *awaitable* results in an exception or is cancelled,
+    the remaining *awaitables* are cancelled.
+    Once all remaining *awaitables* have been cancelled, the call to :func:`!gather` re-raises the exception.
 
-    Regardless of the value of *return_exceptions*, if the task awaiting a call to this function is cancelled before completion,
-    all *awaitables* which have not yet completed are cancelled and :exc:`!CancelledError` is raised.
+    This function makes the same safety guarantees as :func:`!wait` regarding cancellation and clean-up.
+
+    .. note::
+        This does not cancel :class:`~cocotb.task.Task`\ s passed as arguments,
+        only :term:`coroutines <coroutine>`,  :term:`triggers <trigger>`, or other user-defined :term:`!awaitables`.
 
     Args:
         awaitables: The :class:`~collections.abc.Awaitable`\ s to concurrently :keyword:`!await` upon.
-        return_exceptions:
-            If ``False`` (default), after the first *awaitable* results in an exception or cancellation,
-            cancels the remaining *awaitables* and re-raises the exception or :exc:`!CancelledError`.
-            If ``True``, returns all exceptions or :exc:`!CancelledError` rather than the result value when an *awaitable* results in an exception.
 
     Returns:
         A tuple of the results of awaiting each *awaitable* in the same order they were given.
@@ -285,29 +278,16 @@ async def gather(
     if len(awaitables) == 0:
         return ()
 
-    # gather is being called on its own and not part of Combine.
-    # So we add a repr here since this is not a class.
-    if _repr is None:
-
-        def _repr() -> str:
-            return f"gather({', '.join(repr(a) for a in awaitables)})"
+    def _repr() -> str:
+        return f"gather({', '.join(repr(a) for a in awaitables)})"
 
     # When returning exceptions, we behave like continue-on-error: never cancel siblings.
     # Otherwise, cancel siblings as soon as one fails or is cancelled.
-    tasks, first_completed = await _wait(
-        awaitables,
-        return_when=ReturnWhen.ALL_COMPLETED
-        if return_exceptions
-        else ReturnWhen.FIRST_EXCEPTION,
-        _repr=_repr,
-    )
+    idx, tasks = await _wait(awaitables, "FIRST_EXCEPTION", _repr)
 
-    if return_exceptions:
-        return tuple(_return_exception(task) for task in tasks)
-    elif first_completed is not None:
-        # first_completed is only set in FIRST_EXCEPTION mode when a task fails or is cancelled.
-        # Calling result() will cause the exception or CancelledError to be re-raised.
-        # Wrapped in a tuple to make mypy happy about the return type.
-        return (first_completed.result(),)
+    if idx is not None:
+        # There was a failure, so re-raise it.
+        return tasks[idx].result()
     else:
+        # All tasks completed successfully, so return their results.
         return tuple(task.result() for task in tasks)

--- a/src/cocotb/_extended_awaitables.py
+++ b/src/cocotb/_extended_awaitables.py
@@ -16,7 +16,7 @@ from typing import Any, TypeVar, cast, overload
 
 import cocotb.handle
 from cocotb._base_triggers import NullTrigger, Trigger
-from cocotb._concurrent_waiters import gather, select
+from cocotb._concurrent_waiters import _wait, select
 from cocotb._deprecation import deprecated
 from cocotb._gpi_triggers import FallingEdge, RisingEdge, Timer, ValueChange
 from cocotb.simtime import RoundMode, TimeUnit
@@ -93,7 +93,12 @@ class Combine(Waitable["Combine"]):
         if len(self._triggers) == 0:
             await NullTrigger()
         else:
-            await gather(*self._triggers, _repr=self.__repr__)  # type: ignore[call-overload]
+            idx, tasks = await _wait(
+                self._triggers, return_when="FIRST_EXCEPTION", _repr=self.__repr__
+            )
+            if idx is not None:
+                tasks[idx].result()
+            return self
         return self
 
     def __repr__(self) -> str:
@@ -177,8 +182,11 @@ class First(Waitable[object]):
         self._triggers = triggers
 
     async def _wait(self) -> object:
-        _, result = await select(*self._triggers, _repr=self.__repr__)  # type: ignore[call-overload]
-        return result
+        idx, tasks = await _wait(
+            self._triggers, return_when="FIRST_COMPLETED", _repr=self.__repr__
+        )
+        assert idx is not None
+        return tasks[idx].result()
 
     def __repr__(self) -> str:
         # no _pointer_str here, since this is not a trigger, so identity

--- a/src/cocotb/_task_manager.py
+++ b/src/cocotb/_task_manager.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import inspect
 import sys
 from asyncio import CancelledError
 from bdb import BdbQuit
@@ -107,16 +106,6 @@ class TaskManager:
             A :class:`~cocotb.task.Task` which is awaiting *aw* concurrently.
         """
         self._ensure_can_add()
-
-        if isinstance(aw, Coroutine):
-            # This must come before Awaitable since Coroutine is a subclass of Awaitable
-            pass
-        elif isinstance(aw, Awaitable):
-            aw = _waiter(aw)
-        else:
-            raise TypeError(
-                f"start_soon() expected an Awaitable, got {type(aw).__name__}"
-            )
         task = Task[T](aw, name=name)
         self._add_task(task, continue_on_error=continue_on_error)
         return task
@@ -183,11 +172,12 @@ class TaskManager:
 
             return deco
 
-        if not inspect.iscoroutinefunction(coro_func):
+        try:
+            task = Task[T](coro_func(), name=coro_func.__name__)
+        except TypeError:
             raise TypeError(
                 f"fork() expected a coroutine function, got {type(coro_func).__name__}"
-            )
-        task = Task[T](coro_func(), name=coro_func.__name__)
+            ) from None
         self._add_task(task, continue_on_error=continue_on_error)
         return task
 

--- a/src/cocotb/_task_manager.py
+++ b/src/cocotb/_task_manager.py
@@ -30,10 +30,6 @@ if sys.version_info >= (3, 10):
 T = TypeVar("T")
 
 
-async def _waiter(aw: Awaitable[T]) -> T:
-    return await aw
-
-
 class TaskManager:
     r"""An :term:`asynchronous context manager` which runs :term:`coroutine function`\ s or :term:`awaitable`\ s concurrently until all finish.
 
@@ -61,30 +57,25 @@ class TaskManager:
             else default_continue_on_error
         )
 
+        # We don't keep all children Tasks around, just the ones that haven't finished yet,
+        # so we have to save the exceptions for the ExceptionGroup we raise at the end of the context block.
         self._exceptions: set[BaseException] = set()
         # dict value is per-Task continue_on_error setting
         self._remaining_tasks: dict[Task[Any], bool] = {}
         self._none_remaining = Event()
+        # Children were cancelled due to a child Task/block failure.
         self._cancelled: bool = False
+        # We started __aexit__. Ensures we dont add more Tasks after the context block has started finishing.
         self._finishing: bool = False
+        # For protecting against adding Tasks before entering the context block
         self._entered: bool = False
-        # parent task will not exist if we aren't using this as a context manager
-        self._parent_task: Task[Any] | None = None
+        # The parent Task which entered the context block.
+        # Used to ensure only the parent Task can add child Tasks,
+        # and to cancel the parent Task if a child Task fails while the block is still running.
+        self._parent_task: Task[Any]
 
         # Start with no remaining tasks
         self._none_remaining.set()
-
-    def _ensure_can_add(self) -> None:
-        if self._cancelled:
-            raise RuntimeError("Cannot add new Tasks to TaskManager after error")
-        elif self._finishing:
-            raise RuntimeError("Cannot add new Tasks to TaskManager after finishing")
-        elif not self._entered:
-            raise RuntimeError(
-                "Cannot add new Tasks to TaskManager before entering context"
-            )
-        if current_task() is not self._parent_task:
-            raise RuntimeError("Cannot add new Tasks to TaskManager from another Task")
 
     def start_soon(
         self,
@@ -105,9 +96,31 @@ class TaskManager:
         Returns:
             A :class:`~cocotb.task.Task` which is awaiting *aw* concurrently.
         """
-        self._ensure_can_add()
+        # Ensure that we can add a new Task to this TaskManager before creating the Task.
+        # We would have to close it if it failed.
+        if self._cancelled:
+            raise RuntimeError("Cannot add new Tasks to TaskManager after error")
+        elif self._finishing:
+            raise RuntimeError("Cannot add new Tasks to TaskManager after finishing")
+        elif not self._entered:
+            raise RuntimeError(
+                "Cannot add new Tasks to TaskManager before entering context"
+            )
+        if current_task() is not self._parent_task:
+            raise RuntimeError("Cannot add new Tasks to TaskManager from another Task")
+
+        # Create the Task and tie it to this TaskManager via the done callback.
         task = Task[T](aw, name=name)
-        self._add_task(task, continue_on_error=continue_on_error)
+        task._add_done_callback(self._done_callback)
+        # Track the Task and store per-Task continue_on_error setting
+        self._remaining_tasks[task] = (
+            continue_on_error
+            if continue_on_error is not None
+            else self._default_continue_on_error
+        )
+        self._none_remaining.clear()
+        # Start the Task to running.
+        task.start_soon()
         return task
 
     @overload
@@ -154,8 +167,7 @@ class TaskManager:
                     # Do other stuff in parallel to my_func
                     ...
         """
-        self._ensure_can_add()
-
+        # Handle the case where fork is called as a function and returns the decorator.
         if coro_func is None:
             if continue_on_error is None:
                 raise TypeError(
@@ -172,30 +184,9 @@ class TaskManager:
 
             return deco
 
-        try:
-            task = Task[T](coro_func(), name=coro_func.__name__)
-        except TypeError:
-            raise TypeError(
-                f"fork() expected a coroutine function, got {type(coro_func).__name__}"
-            ) from None
-        self._add_task(task, continue_on_error=continue_on_error)
-        return task
-
-    def _add_task(
-        self,
-        task: Task[Any],
-        *,
-        continue_on_error: bool | None = None,
-    ) -> None:
-        # Track the Task and store per-Task continue_on_error setting
-        task._add_done_callback(self._done_callback)
-        if continue_on_error is None:
-            continue_on_error = self._default_continue_on_error
-        self._remaining_tasks[task] = continue_on_error
-        self._none_remaining.clear()
-
-        # Schedule the Task to run soon
-        task.start_soon()
+        return self.start_soon(
+            coro_func(), name=coro_func.__name__, continue_on_error=continue_on_error
+        )
 
     def _done_callback(self, task: Task[Any]) -> None:
         """Callback run when a child Task finishes."""
@@ -217,7 +208,7 @@ class TaskManager:
 
         # If a child Task fails while we are in the middle of a TaskManager block,
         # cancel the parent Task to force the block to end.
-        if not self._finishing and self._parent_task is not None:
+        if not self._finishing:
             self._parent_task.cancel()
 
         # Cancel all child Tasks.
@@ -236,12 +227,11 @@ class TaskManager:
     ) -> None:
         self._finishing = True
 
-        if self._parent_task is not None and self._cancelled:
+        if self._cancelled:
             # The context block was cancelled due to a child Task failure.
             if isinstance(exc, CancelledError):
                 # Suppress CancelledError in this case to allow child Tasks to finish cancelling.
                 exc = None
-                assert self._parent_task is not None
                 self._parent_task._uncancel()
             else:
                 # The context block ignored the cancellation. Hard fail the test.
@@ -278,11 +268,8 @@ class TaskManager:
             # This is likely because we ignored a CancelledError since there is no other
             # way to fail this await AFAICT. Cancel children and let it pass up as there's
             # nothing we can do.
-            # TODO Make this force a test failure. Special case KeyboardInterrupt/SystemExit/BdbQuit
             self._cancel()
             raise
-
-        self._finished = True
 
         # Build BaseExceptionGroup if there were any errors. Ignore CancelledError.
         if exc is not None and not isinstance(exc, CancelledError):

--- a/src/cocotb/_task_manager.py
+++ b/src/cocotb/_task_manager.py
@@ -195,7 +195,7 @@ class TaskManager:
         self._none_remaining.clear()
 
         # Schedule the Task to run soon
-        task._ensure_started()
+        task.start_soon()
 
     def _done_callback(self, task: Task[Any]) -> None:
         """Callback run when a child Task finishes."""

--- a/src/cocotb/_task_manager.py
+++ b/src/cocotb/_task_manager.py
@@ -12,9 +12,8 @@ from bdb import BdbQuit
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, TypeVar, overload
 
-from cocotb._base_triggers import NullTrigger
 from cocotb.task import Task, current_task
-from cocotb.triggers import Event, Trigger
+from cocotb.triggers import Event, NullTrigger, Trigger
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -227,6 +226,13 @@ class TaskManager:
     ) -> None:
         self._finishing = True
 
+        # Propagate special exceptions immediately.
+        # The GeneratorExit case is there so if the block is cancelled due to a child Task failure,
+        # and the block squashes the CancelledError and does an await, a GeneratorExit is thrown at the await, which may end up here.
+        if isinstance(exc, (KeyboardInterrupt, SystemExit, BdbQuit, GeneratorExit)):
+            self._cancel()
+            return None  # re-raise exception
+
         if self._cancelled:
             # The context block was cancelled due to a child Task failure.
             if isinstance(exc, CancelledError):
@@ -234,22 +240,16 @@ class TaskManager:
                 exc = None
                 self._parent_task._uncancel()
             else:
-                # The context block ignored the cancellation. Hard fail the test.
-                # There is a special case in Task if a cancelled Task finishes without
-                # raising CancelledError, it fails the test. So we just await *something*
-                # here to hit that code path.
-                # TODO Make this force a test failure.
-                self._cancel()
+                # The context block ignored the cancellation and either threw some other exception or finished successfully.
+                # We await a token NullTrigger to allow the parent Task to kill the Task due to ignored CancelledError.
                 await NullTrigger()
+                # This will never run as a GeneratorExit will be thrown at the above await.
+                return None  # pragma: no cover
         elif exc is not None:
             if isinstance(exc, CancelledError):
-                # Something else cancelled the parent task. Propagate CancelledError.
+                # Something else cancelled the parent task. Propagate CancelledError immediately.
                 self._cancel()
                 return None  # re-raise CancelledError
-            elif isinstance(exc, (KeyboardInterrupt, SystemExit, BdbQuit)):
-                # Certain BaseExceptions should be immediately propagated like they are in Task.
-                self._cancel()
-                return None  # re-raise exception
             elif not self._context_continue_on_error:
                 # Block finished with an exception and we are not continuing on error.
                 self._cancel()

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 import pdb
 import sys
 from asyncio import CancelledError
-from collections.abc import Coroutine
+from collections.abc import Awaitable, Coroutine
 from typing import (
     Any,
     Callable,
     NoReturn,
+    TypeVar,
+    overload,
 )
 
 import cocotb
@@ -195,8 +197,29 @@ class TestManager:
             self._abort(e)
 
 
+TriggerT = TypeVar("TriggerT", bound=Trigger)
+
+
+@overload
 def start_soon(
-    coro: Task[ResultType] | Coroutine[Trigger, None, ResultType],
+    coro: Task[ResultType]
+    | Coroutine[Trigger, None, ResultType]
+    | Awaitable[ResultType],
+    *,
+    name: str | None = None,
+) -> Task[ResultType]: ...
+
+
+@overload
+def start_soon(
+    coro: TriggerT,
+    *,
+    name: str | None = None,
+) -> Task[TriggerT]: ...
+
+
+def start_soon(
+    coro: Awaitable[Any],
     *,
     name: str | None = None,
 ) -> Task[ResultType]:
@@ -217,18 +240,43 @@ def start_soon(
         The :class:`~cocotb.task.Task` that is scheduled to be run.
 
     .. versionadded:: 1.6
+
+    .. versionchanged:: 2.1
+        This function now accepts any :class:`~collections.abc.Awaitable` object, not just :term:`coroutines <coroutine>`.
+
+        .. warning::
+            If you are passing a bespoke :class:`~collections.abc.Awaitable` object to this function,
+            read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
     task = create_task(coro, name=name)
     task._ensure_started()
     return task
 
 
-@deprecated("Use ``cocotb.start_soon`` instead.")
+@overload
 async def start(
-    coro: Task[ResultType] | Coroutine[Trigger, None, ResultType],
+    coro: Task[ResultType]
+    | Coroutine[Trigger, None, ResultType]
+    | Awaitable[ResultType],
     *,
     name: str | None = None,
-) -> Task[ResultType]:
+) -> Task[ResultType]: ...
+
+
+@overload
+async def start(
+    coro: TriggerT,
+    *,
+    name: str | None = None,
+) -> Task[TriggerT]: ...
+
+
+@deprecated("Use ``cocotb.start_soon`` instead.")
+async def start(
+    coro: Awaitable[Any],
+    *,
+    name: str | None = None,
+) -> Task[Any]:
     """
     Schedule a :term:`coroutine` to be run concurrently, then yield control to allow pending tasks to execute.
 
@@ -265,17 +313,42 @@ async def start(
             task_started = Event()
             task = cocotb.start_soon(coro(task_started))
             await task_started.wait()
+
+    .. versionchanged:: 2.1
+        This function now accepts any :class:`~collections.abc.Awaitable` object, not just :term:`coroutines <coroutine>`.
+
+        .. warning::
+            If you are passing a bespoke :class:`~collections.abc.Awaitable` object to this function,
+            read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
     task = start_soon(coro, name=name)
     await NullTrigger()
     return task
 
 
+@overload
 def create_task(
-    coro: Task[ResultType] | Coroutine[Trigger, None, ResultType],
+    coro: Task[ResultType]
+    | Coroutine[Trigger, None, ResultType]
+    | Awaitable[ResultType],
     *,
     name: str | None = None,
-) -> Task[ResultType]:
+) -> Task[ResultType]: ...
+
+
+@overload
+def create_task(
+    coro: TriggerT,
+    *,
+    name: str | None = None,
+) -> Task[TriggerT]: ...
+
+
+def create_task(
+    coro: Awaitable[Any],
+    *,
+    name: str | None = None,
+) -> Task[Any]:
     """
     Construct a :term:`!coroutine` into a :class:`~cocotb.task.Task` without scheduling the task.
 
@@ -292,6 +365,13 @@ def create_task(
         Either the provided :class:`~cocotb.task.Task` or a new Task wrapping the coroutine.
 
     .. versionadded:: 1.6
+
+    .. versionchanged:: 2.1
+        This function now accepts any :class:`~collections.abc.Awaitable` object, not just :term:`coroutines <coroutine>`.
+
+        .. warning::
+            If you are passing a bespoke :class:`~collections.abc.Awaitable` object to this function,
+            read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
     if _current_test is None:
         raise RuntimeError("No test is currently running; cannot schedule new Task.")
@@ -303,7 +383,7 @@ def create_task(
             coro.set_name(name)
         return coro
 
-    task = Task[ResultType](coro, name=name)
+    task = Task(coro, name=name)
     _current_test.add_task(task)
 
     return task

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -251,7 +251,10 @@ def start_soon(
     task = create_task(coro, name=name)
     # This is _ensure_started() rather than start_soon() for backwards compatibility.
     # Calling cocotb.start_soon(task) on a task that already started should not fail.
-    task._ensure_started()
+    if task._unstarted():
+        task.start_soon()
+    elif task.done():
+        raise RuntimeError("Cannot schedule a Task that has already completed.")
     return task
 
 

--- a/src/cocotb/_test_manager.py
+++ b/src/cocotb/_test_manager.py
@@ -88,7 +88,7 @@ class TestManager:
 
         # start main task
         self._main_task._add_done_callback(self._test_done_callback)
-        self._main_task._ensure_started()
+        self._main_task.start_soon()
         self._tasks[self._main_task] = None
 
         # start timeout if specified
@@ -249,6 +249,8 @@ def start_soon(
             read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
     task = create_task(coro, name=name)
+    # This is _ensure_started() rather than start_soon() for backwards compatibility.
+    # Calling cocotb.start_soon(task) on a task that already started should not fail.
     task._ensure_started()
     return task
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -3,14 +3,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import collections.abc
 import inspect
 import logging
 import sys
 import traceback
 from asyncio import CancelledError, InvalidStateError
 from bdb import BdbQuit
-from collections.abc import Coroutine, Generator
+from collections.abc import Awaitable, Coroutine, Generator
 from enum import auto
 from functools import cached_property
 from types import CoroutineType, SimpleNamespace
@@ -20,6 +19,7 @@ from typing import (
     Generic,
     TypeVar,
     cast,
+    overload,
 )
 
 import cocotb
@@ -66,27 +66,61 @@ class Task(Generic[ResultType]):
     """Concurrently executing task.
 
     This class is not intended for users to directly instantiate.
-    Use :func:`cocotb.create_task` to create a Task object
-    or :func:`cocotb.start_soon` to create a Task and schedule it to run.
+    Use :func:`cocotb.create_task` to create a :class:`!Task` object
+    or :func:`cocotb.start_soon` to create a :class:`!Task` and schedule it to run.
+
+    Args:
+        inst: A coroutine to run as a :class:`!Task`, or any :class:`!Awaitable` to wrap in a coroutine and run as a :class:`!Task`.
+        name: Optional name. If not provided, a generic name is generated.
+
+    Raises:
+        TypeError: If *inst* is not Awaitable.
 
     .. versionchanged:: 1.8
-        Moved to the ``cocotb.task`` module.
+        Moved to the :mod:`cocotb.task` module.
 
     .. versionchanged:: 2.0
         The ``retval``, ``_finished``, and ``__bool__`` methods were removed.
         Use :meth:`result`, :meth:`done`, and :meth:`done` methods instead, respectively.
+
+    .. versionadded:: 2.1
+        Added support for giving any :class:`~collections.abc.Awaitable` to the constructor, not just coroutines.
+        This implicitly wraps the Awaitable in a coroutine that :keyword:`await`s it.
+
+        If you are passing a bespoke :class:`~collections.abc.Awaitable` object to this class,
+        read the :ref:`design note <awaitable-design-note>` for important information about how to use it correctly.
     """
 
     _id_count = 0  # used by the scheduler for debug
 
+    @overload
     def __init__(
         self, inst: Coroutine[Trigger, None, ResultType], *, name: str | None = None
-    ) -> None:
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self, inst: Awaitable[ResultType], *, name: str | None = None
+    ) -> None: ...
+
+    def __init__(self, inst: Awaitable[ResultType], *, name: str | None = None) -> None:
         self._native_coroutine: bool
+        self._coro: Coroutine[Trigger, Any, ResultType]
         if inspect.iscoroutine(inst):
             self._native_coroutine = True
-        elif isinstance(inst, collections.abc.Coroutine):
+            self._coro = inst
+        elif isinstance(inst, Coroutine):
             self._native_coroutine = False
+            self._coro = inst
+        elif isinstance(inst, Awaitable):
+            self._native_coroutine = True
+
+            async def waiter() -> ResultType:
+                return await inst
+
+            # TODO consider better naming for this coroutine,
+            # perhaps delegating to the Awaitable.
+            self._coro = waiter()
         elif inspect.iscoroutinefunction(inst):
             raise TypeError(
                 f"Coroutine function {inst} should be called prior to being scheduled."
@@ -97,9 +131,8 @@ class Task(Generic[ResultType]):
                 "You likely used the yield keyword instead of await."
             )
         else:
-            raise TypeError(f"{inst} isn't a valid coroutine!")
+            raise TypeError(f"Expected Awaitable, got {type(inst).__name__}")
 
-        self._coro = inst
         self._state: _TaskState = _TaskState.UNSTARTED
         self._outcome: ResultType | BaseException
         self._trigger: Trigger

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -273,28 +273,32 @@ class Task(Generic[ResultType]):
         """
         if self._state is not _TaskState.UNSTARTED:
             raise RuntimeError("Can only start_soon() an unstarted Task")
-        self._schedule_resume()
-
-    def _ensure_started(self) -> None:
-        state = self._state
-        if state is _TaskState.UNSTARTED:
-            if debug.debug:
-                self._log.debug("Starting %r", self)
-            self._schedule_resume()
-        elif state in (
-            _TaskState.FINISHED,
-            _TaskState.ERRORED,
-            _TaskState.CANCELLED,
-        ):
-            raise RuntimeError("Cannot start a finished Task")
-        # RUNNING, SCHEDULED, PENDING are already running
+        if debug.debug:
+            self._log.debug("Starting %r", self)
+        # Schedule the Task to run
+        self._state = _TaskState.SCHEDULED
+        self._exc = None
+        self._schedule_callback = cocotb._event_loop._inst.schedule(self._resume)
 
     def _start_next(self) -> None:
+        """Queues an unstarted Task to start running, but schedules it to run before other scheduled Tasks.
+
+        Currently private until someone needs it.
+        This is a potential footgun in the hands of a novice.
+
+        Raises:
+            RuntimeError: If the Task has already started.
+        """
         if self._state != _TaskState.UNSTARTED:
             raise RuntimeError(
                 "Cannot _start_next() on a Task that has already been started"
             )
-        cocotb._event_loop._inst.schedule_left(self._resume)
+        if debug.debug:
+            self._log.debug("Starting %r", self)
+        # Schedule the Task to run
+        self._state = _TaskState.SCHEDULED
+        self._exc = None
+        self._schedule_callback = cocotb._event_loop._inst.schedule_left(self._resume)
 
     def _set_outcome(
         self,
@@ -601,6 +605,10 @@ class Task(Generic[ResultType]):
         if self._must_cancel > 0:
             self._must_cancel -= 1
 
+    def _unstarted(self) -> bool:
+        """Return ``True`` if the Task has not started executing."""
+        return self._state is _TaskState.UNSTARTED
+
     def cancelled(self) -> bool:
         """Return ``True`` if the Task was cancelled."""
         return self._state is _TaskState.CANCELLED
@@ -663,8 +671,9 @@ class Task(Generic[ResultType]):
         self._done_callbacks.append(callback)
 
     def __await__(self) -> Generator[Trigger, None, ResultType]:
+        if self._unstarted():
+            self.start_soon()
         if not self.done():
-            self._ensure_started()
             yield self.complete
         return self.result()
 

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -263,6 +263,18 @@ class Task(Generic[ResultType]):
         else:
             raise RuntimeError("Task in unknown state")
 
+    def start_soon(self) -> None:
+        """Queues an unstarted Task to start running.
+
+        Raises:
+            RuntimeError: If the Task has already started.
+
+        .. versionadded:: 2.1
+        """
+        if self._state is not _TaskState.UNSTARTED:
+            raise RuntimeError("Can only start_soon() an unstarted Task")
+        self._schedule_resume()
+
     def _ensure_started(self) -> None:
         state = self._state
         if state is _TaskState.UNSTARTED:

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -351,6 +351,7 @@ class Task(Generic[ResultType]):
             if self._must_cancel:
                 if debug.debug:
                     self._log.debug("Task %r was cancelled but exited normally", self)
+                self._coro.close()
                 self._set_outcome(
                     RuntimeError(
                         "Task was cancelled, but exited normally. Did you forget to re-raise the CancelledError?"
@@ -397,6 +398,7 @@ class Task(Generic[ResultType]):
             if self._must_cancel:
                 if debug.debug:
                     self._log.debug("Task %r was cancelled but continued running", self)
+                self._coro.close()
                 self._set_outcome(
                     RuntimeError(
                         "Task was cancelled, but continued running. Did you forget to re-raise the CancelledError?"

--- a/src/cocotb/triggers.py
+++ b/src/cocotb/triggers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import warnings
 
 from cocotb._base_triggers import Event, Lock, NullTrigger, Trigger
-from cocotb._concurrent_waiters import gather, select
+from cocotb._concurrent_waiters import gather, select, wait
 from cocotb._extended_awaitables import (
     ClockCycles,
     Combine,
@@ -52,6 +52,7 @@ __all__ = (
     "current_gpi_trigger",
     "gather",
     "select",
+    "wait",
     "with_timeout",
 )
 

--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -8,30 +8,12 @@ Common utilities shared by many tests in this directory
 from __future__ import annotations
 
 import operator
-import re
-import traceback
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Callable
 
 from cocotb.simtime import TimeUnit
 from cocotb.utils import get_sim_steps, get_sim_time, get_time_from_sim_steps
-
-
-async def _check_traceback(running_coro, exc_type, pattern, *match_args):
-    try:
-        await running_coro
-    except exc_type:
-        tb_text = traceback.format_exc()
-    else:
-        assert False, "Exception was not raised"
-
-    assert re.match(pattern, tb_text, *match_args), (
-        "Traceback didn't match - got:\n\n"
-        f"{tb_text}\n"
-        "which did not match the pattern:\n\n"
-        f"{pattern}"
-    )
 
 
 class MyException(Exception): ...

--- a/tests/test_cases/test_cocotb/test_deprecated.py
+++ b/tests/test_cases/test_cocotb/test_deprecated.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import sys
 import warnings
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -16,7 +17,7 @@ from cocotb._base_triggers import Lock
 from cocotb.clock import Clock
 from cocotb.regression import TestFactory
 from cocotb.task import Join, current_task
-from cocotb.triggers import Edge, Event, First, Timer
+from cocotb.triggers import Edge, Event, First, Timer, Trigger
 from cocotb.utils import get_sim_steps, get_sim_time, get_time_from_sim_steps
 
 LANGUAGE = os.environ["TOPLEVEL_LANG"].lower().strip()
@@ -367,3 +368,18 @@ async def test_pass_test_in_expect_error(dut: object) -> None:
 async def test_pass_test_in_expect_fail(dut: object) -> None:
     with pytest.warns(DeprecationWarning):
         cocotb.pass_test("Finished test early")
+
+
+@cocotb.test
+async def test_cocotb_start_awaitable(_: object) -> None:
+    """Test that cocotb.start() works with any Awaitable, not just coroutines."""
+
+    class AwaitableThing:
+        def __await__(self) -> Generator[Trigger, None, int]:
+            yield Timer(1)
+            return 42
+
+    with pytest.warns(DeprecationWarning):
+        task = await cocotb.start(AwaitableThing())
+    result = await task
+    assert result == 42

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -7,13 +7,14 @@ Tests for concurrency primitives like First and Combine
 
 from __future__ import annotations
 
+import inspect
 import re
 from collections import deque
 from random import randint
 from typing import Any
 
 import pytest
-from common import MyException, _check_traceback, assert_takes
+from common import MyException, assert_takes
 
 import cocotb
 from cocotb.triggers import Combine, Event, First, Timer, Trigger, gather, select
@@ -59,10 +60,11 @@ async def test_select_unfired_triggers_killed_on_exception(_: object) -> None:
     with pytest.raises(ValueError):
         await select(fails(), *triggers)
 
-    # test all triggers were unprimed
+    # Sibling waiters were cancelled before they got a chance to run,
+    # so their triggers were never primed and never need unpriming.
     for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
+        assert t.primed == 0
+        assert t.unprimed == 0
 
 
 @cocotb.test
@@ -77,38 +79,47 @@ async def test_gather_unfired_triggers_killed_on_exception(_: object) -> None:
     with pytest.raises(ValueError):
         await gather(fails(), *triggers)
 
-    # test all triggers were unprimed
+    # Sibling waiters were cancelled before they got a chance to run,
+    # so their triggers were never primed and never need unpriming.
     for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
+        assert t.primed == 0
+        assert t.unprimed == 0
 
 
 @cocotb.test
 async def test_nested_unfired_triggers_killed_on_exception(_: object) -> None:
     """Test that un-fired trigger(s) in nested First after exception don't later cause a spurious wakeup."""
 
-    triggers = [MyTrigger() for _ in range(3)]
-
     async def fails() -> None:
         raise ValueError("I am a failure")
 
+    triggers = [MyTrigger() for _ in range(3)]
+    g = gather(*triggers)
     with pytest.raises(ValueError):
-        await select(fails(), gather(*triggers))
+        await select(fails(), g)
 
-    # test all triggers were unprimed
+    # Sibling waiters were cancelled before they got a chance to run,
+    # so their triggers were never primed and never need unpriming.
     for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
+        assert t.primed == 0
+        assert t.unprimed == 0
+
+    assert inspect.getcoroutinestate(g) == inspect.CORO_CLOSED
 
     triggers = [MyTrigger() for _ in range(3)]
-
+    g = gather(*triggers)
+    s = select(g)
     with pytest.raises(ValueError):
-        await select(fails(), select(gather(*triggers)))
+        await select(fails(), s)
 
-    # test all triggers were unprimed
+    # Sibling waiters were cancelled before they got a chance to run,
+    # so their triggers were never primed and never need unpriming.
     for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
+        assert t.primed == 0
+        assert t.unprimed == 0
+
+    assert inspect.getcoroutinestate(g) == inspect.CORO_CLOSED
+    assert inspect.getcoroutinestate(s) == inspect.CORO_CLOSED
 
 
 @cocotb.test()
@@ -172,9 +183,8 @@ async def test_exceptions_first(dut):
         with pytest.warns(DeprecationWarning):
             await First(cocotb.start_soon(raise_inner()))
 
-    await _check_traceback(
-        raise_soon(), ValueError, r".*in raise_soon.*in raise_inner", re.DOTALL
-    )
+    with pytest.raises(ValueError, match=r"It is soon now"):
+        await raise_soon()
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -1138,3 +1138,17 @@ async def test_957_2(dut: Any) -> None:
     # pending coroutine doesn't interfere with this test.
     cocotb.start_soon(wait_edge(dut))
     await Timer(10, "ns")
+
+
+@cocotb.test
+async def test_start_soon_awaitable(_: object) -> None:
+    """Test that cocotb.start_soon() works with any Awaitable, not just coroutines."""
+
+    class AwaitableThing:
+        def __await__(self) -> Generator[Trigger, None, int]:
+            yield Timer(1)
+            return 42
+
+    task = cocotb.start_soon(AwaitableThing())
+    result = await task
+    assert result == 42

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -1152,3 +1152,20 @@ async def test_start_soon_awaitable(_: object) -> None:
     task = cocotb.start_soon(AwaitableThing())
     result = await task
     assert result == 42
+
+
+@cocotb.test
+async def test_task_start_soon(_: object) -> None:
+    """Test functionality of Task.start_soon()."""
+
+    async def coro() -> None:
+        await Timer(2)
+
+    task = Task(coro())
+    task.start_soon()
+    await Timer(1)
+    assert not task.done()
+    with pytest.raises(RuntimeError):
+        task.start_soon()
+    await Timer(2)
+    assert task.done()

--- a/tests/test_cases/test_cocotb/test_task_manager.py
+++ b/tests/test_cases/test_cocotb/test_task_manager.py
@@ -678,12 +678,13 @@ async def test_external_cancel_in_nested_child_aexit(
 ) -> None:
     outer_task: Task[Any] | None = None
     inner_task: Task[Any] | None = None
+    inner_block_task: Task[Any] | None = None
 
     async def run_task_manager() -> None:
         async with TaskManager(
             default_continue_on_error=outer_continue_on_error
         ) as tm_outer:
-            nonlocal outer_task
+            nonlocal outer_task, inner_block_task
             outer_task = tm_outer.start_soon(coro(5, ret=9))
 
             @tm_outer.fork
@@ -693,6 +694,8 @@ async def test_external_cancel_in_nested_child_aexit(
                 ) as tm_inner:
                     nonlocal inner_task
                     inner_task = tm_inner.start_soon(coro(5, ret=9))
+
+            inner_block_task = inner_block
 
     task = cocotb.start_soon(run_task_manager())
 
@@ -712,6 +715,8 @@ async def test_external_cancel_in_nested_child_aexit(
     assert inner_task.result() == 9
     assert outer_task is not None
     assert outer_task.cancelled()
+    assert inner_block_task is not None
+    assert inner_block_task.cancelled()
 
 
 @cocotb.test
@@ -1116,7 +1121,7 @@ async def test_bad_args(_: object) -> None:
         with pytest.raises(TypeError):
             tm.fork(123)  # type: ignore
 
-        async def oops_async_generator() -> AsyncGenerator[None, None, None]:
+        async def oops_async_generator() -> AsyncGenerator[None]:
             yield None
 
         c = oops_async_generator()
@@ -1162,3 +1167,246 @@ async def test_context_block_continue_on_error(
         assert task1.cancelled()
         assert task2.cancelled()
         assert task3.cancelled()
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_cancel_inner_child_task_in_nested_block(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    cancelled = False
+    task_outer: Task[Any] | None = None
+    other: Task[Any] | None = None
+
+    async with TaskManager(
+        default_continue_on_error=outer_continue_on_error
+    ) as tm_outer:
+        task_outer = tm_outer.start_soon(coro(4, ret=9))
+
+        async with TaskManager(
+            default_continue_on_error=inner_continue_on_error
+        ) as tm_inner:
+
+            @tm_inner.fork
+            async def child() -> None:
+                try:
+                    await Timer(5)
+                finally:
+                    nonlocal cancelled
+                    cancelled = True
+
+            await Timer(1)
+            child.cancel()
+
+            @tm_inner.fork
+            async def other() -> None:
+                await Timer(1)
+
+    assert cancelled
+    assert other is not None
+    assert other.done()
+    assert task_outer.result() == 9
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_cancel_inner_child_task_in_nested_child_block(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    cancelled = False
+    task_outer: Task[Any] | None = None
+    other: Task[Any] | None = None
+
+    async with TaskManager(
+        default_continue_on_error=outer_continue_on_error
+    ) as tm_outer:
+        task_outer = tm_outer.start_soon(coro(4, ret=9))
+
+        @tm_outer.fork
+        async def inner_block() -> None:
+            async with TaskManager(
+                default_continue_on_error=inner_continue_on_error
+            ) as tm_inner:
+
+                @tm_inner.fork
+                async def child() -> None:
+                    try:
+                        await Timer(5)
+                    finally:
+                        nonlocal cancelled
+                        cancelled = True
+
+                await Timer(1)
+                child.cancel()
+
+                nonlocal other
+
+                @tm_inner.fork
+                async def other() -> None:
+                    await Timer(1)
+
+    assert cancelled
+    assert other is not None
+    assert other.done()
+    assert task_outer.result() == 9
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_external_cancel_in_nested_block_ignored_at_end_of_block(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    async def run_task_manager() -> None:
+        async with TaskManager(default_continue_on_error=outer_continue_on_error):
+            async with TaskManager(default_continue_on_error=inner_continue_on_error):
+                try:
+                    await Timer(2)
+                except CancelledError:
+                    pass
+
+    task = cocotb.start_soon(run_task_manager())
+
+    await Timer(1)
+
+    task.cancel()
+    await task.complete
+    assert not task.cancelled()
+    assert task.exception() is not None
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_external_cancel_in_nested_block_ignored_new_raise(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    async def run_task_manager() -> None:
+        async with TaskManager(default_continue_on_error=outer_continue_on_error):
+            async with TaskManager(default_continue_on_error=inner_continue_on_error):
+                try:
+                    await Timer(2)
+                except CancelledError:
+                    raise MyException()
+
+    task = cocotb.start_soon(run_task_manager())
+
+    await Timer(1)
+
+    task.cancel()
+    await task.complete
+    assert not task.cancelled()
+    assert task.exception() is not None
+
+
+@cocotb.test
+@cocotb.parametrize(outer_continue_on_error=[True, False])
+@cocotb.parametrize(inner_continue_on_error=[True, False])
+async def test_external_cancel_in_nested_block_ignored_and_await(
+    _: object, outer_continue_on_error: bool, inner_continue_on_error: bool
+) -> None:
+    async def run_task_manager() -> None:
+        async with TaskManager(default_continue_on_error=outer_continue_on_error):
+            async with TaskManager(default_continue_on_error=inner_continue_on_error):
+                try:
+                    await Timer(2)
+                except CancelledError:
+                    pass
+
+                await Timer(1)
+
+    task = cocotb.start_soon(run_task_manager())
+
+    await Timer(1)
+
+    task.cancel()
+    await task.complete
+    assert not task.cancelled()
+    assert task.exception() is not None
+
+
+@cocotb.test
+@cocotb.parametrize(continue_on_error=[True, False])
+async def test_two_children_fail_simultaneously(
+    _: object, continue_on_error: bool
+) -> None:
+    try:
+        async with TaskManager(default_continue_on_error=continue_on_error) as tm:
+            task1 = tm.start_soon(raises_after(1))
+            task2 = tm.start_soon(raises_after(1))
+
+    except BaseExceptionGroup as e:
+        my_exc, rest = e.split(MyException)
+        assert rest is None
+        assert my_exc is not None
+        if continue_on_error:
+            # We expect both tasks fail, since we keep going after the first failure.
+            assert len(my_exc.exceptions) == 2
+        else:
+            # One task will fail, and the other will be cancelled before it can run again to "fail."
+            assert len(my_exc.exceptions) == 1
+
+    if continue_on_error:
+        # We expect both tasks fail
+        assert task1.exception() is not None
+        assert task2.exception() is not None
+
+
+@cocotb.test
+async def test_second_child_fails_after_group_cancelled(_: object) -> None:
+    try:
+        async with TaskManager(default_continue_on_error=False) as tm:
+            task1 = tm.start_soon(raises_after(1))
+
+            @tm.fork
+            async def task2() -> None:
+                try:
+                    await Timer(5)
+                except CancelledError:
+                    raise MyException()
+
+    except BaseExceptionGroup as e:
+        my_exc, rest = e.split(MyException)
+        assert rest is None
+        assert my_exc is not None
+        assert len(my_exc.exceptions) == 2
+
+    assert task1.exception() is not None
+    assert task2.exception() is not None
+
+
+@cocotb.test
+async def test_cancel_child_during_wait_cannot_be_swallowed(_: object) -> None:
+    child: Task[int] | None = None
+
+    async def run_task_manager() -> None:
+        nonlocal child
+
+        try:
+            async with TaskManager() as tm:
+
+                @tm.fork
+                async def child() -> int:
+                    try:
+                        await Timer(5)
+                    except CancelledError:
+                        pass
+                    return 42
+        except BaseExceptionGroup as e:
+            my_exc, rest = e.split(RuntimeError)
+            assert rest is None
+            assert my_exc is not None
+            assert len(my_exc.exceptions) == 1
+
+    tm_task = cocotb.start_soon(run_task_manager())
+
+    # wait until block has exited and __aexit__ is waiting on the child
+    await Timer(1)
+
+    assert child is not None
+    child.cancel()
+
+    await tm_task.complete
+    assert isinstance(child.exception(), RuntimeError)

--- a/tests/test_cases/test_cocotb/test_waiters.py
+++ b/tests/test_cases/test_cocotb/test_waiters.py
@@ -10,29 +10,29 @@ from collections.abc import Generator
 import pytest
 
 import cocotb
-from cocotb.triggers import NullTrigger, Timer, Trigger, gather, select
+from cocotb.triggers import NullTrigger, Timer, Trigger, gather, select, wait
 
 
-async def coro(wait: int, ret: int = 0) -> int:
-    await Timer(wait)
+async def coro(delay: int, ret: int = 0) -> int:
+    await Timer(delay)
     return ret
 
 
 class AwaitableThing:
-    def __init__(self, wait: int, ret: int = 0) -> None:
-        self._wait = wait
+    def __init__(self, delay: int, ret: int = 0) -> None:
+        self._delay = delay
         self._ret = ret
 
     def __await__(self) -> Generator[Trigger, None, int]:
-        yield from coro(self._wait).__await__()
+        yield from coro(self._delay).__await__()
         return self._ret
 
 
 class MyException(Exception): ...
 
 
-async def raises_after(wait: int) -> None:
-    await Timer(wait)
+async def raises_after(delay: int) -> None:
+    await Timer(delay)
     raise MyException()
 
 
@@ -40,7 +40,7 @@ async def raises_after(wait: int) -> None:
 async def test_gather(_: object) -> None:
     timer1 = Timer(1)
     a1, b1, c1 = await gather(
-        coro(wait=3, ret=123),
+        coro(delay=3, ret=123),
         AwaitableThing(2, ret=9),
         timer1,
     )
@@ -50,21 +50,10 @@ async def test_gather(_: object) -> None:
 
     with pytest.raises(MyException):
         await gather(
-            raises_after(wait=3),
+            raises_after(delay=3),
             AwaitableThing(2, ret=9),
             Timer(1),
         )
-
-    timer2 = Timer(2)
-    a2, b2, c2 = await gather(
-        raises_after(wait=3),
-        AwaitableThing(1, ret=56),
-        timer2,
-        return_exceptions=True,
-    )
-    assert isinstance(a2, MyException)
-    assert b2 == 56
-    assert c2 == timer2
 
     assert await gather() == ()
 
@@ -73,54 +62,102 @@ async def test_gather(_: object) -> None:
 async def test_select(_: object) -> None:
     timer1 = Timer(1)
     idx, res1 = await select(
-        coro(wait=3, ret=123),
+        coro(delay=3, ret=123),
         AwaitableThing(2, ret=9),
         timer1,
     )
     assert idx == 2
     assert res1 == timer1
 
-    idx, res2 = await select(
-        raises_after(wait=3),
-        AwaitableThing(1, ret=31),
-        Timer(2),
-        return_exceptions=True,
-    )
-    assert idx == 1
-    assert res2 == 31
-    await Timer(5)  # ensure failing task was killed
-
     with pytest.raises(MyException):
         await select(
-            raises_after(wait=1),
+            raises_after(delay=1),
             AwaitableThing(2, ret=9),
             Timer(3),
         )
-
-    idx, res3 = await select(
-        raises_after(wait=1),
-        AwaitableThing(2, ret=12),
-        Timer(3),
-        return_exceptions=True,
-    )
-    assert idx == 0
-    assert isinstance(res3, MyException)
 
     with pytest.raises(ValueError):
         await select()
 
 
 @cocotb.test
+async def test_wait_empty(_: object) -> None:
+    """wait() with no awaitables raises ValueError for every return_when mode."""
+    with pytest.raises(ValueError):
+        await wait(return_when="FIRST_COMPLETED")  # type: ignore[call-overload]
+    with pytest.raises(ValueError):
+        await wait(return_when="FIRST_EXCEPTION")  # type: ignore[call-overload]
+    with pytest.raises(ValueError):
+        await wait(return_when="ALL_COMPLETED")  # type: ignore[call-overload]
+
+
+@cocotb.test
+async def test_wait_all_completed(_: object) -> None:
+    """wait() with ALL_COMPLETED returns after every awaitable is done, regardless of exceptions."""
+    timer2 = Timer(2)
+    idx, tasks = await wait(
+        raises_after(delay=3),
+        AwaitableThing(1, ret=56),
+        timer2,
+        return_when="ALL_COMPLETED",
+    )
+    assert idx is None
+    assert isinstance(tasks[0].exception(), MyException)
+    assert tasks[1].result() == 56
+    assert tasks[2].result() == timer2
+
+
+@cocotb.test
+async def test_wait_first_completed(_: object) -> None:
+    """wait() with FIRST_COMPLETED returns after the first awaitable completes."""
+    idx, tasks = await wait(
+        raises_after(delay=3),
+        AwaitableThing(1, ret=31),
+        Timer(2),
+        return_when="FIRST_COMPLETED",
+    )
+    assert idx == 1
+    assert tasks[1].result() == 31
+    await Timer(5)  # ensure remaining tasks were killed
+    assert tasks[0].cancelled()
+    assert tasks[2].cancelled()
+
+
+@cocotb.test
+async def test_wait_first_exception(_: object) -> None:
+    """wait() with FIRST_EXCEPTION returns at the first exception, or after all complete."""
+    idx, tasks = await wait(
+        raises_after(delay=1),
+        AwaitableThing(2, ret=12),
+        Timer(3),
+        return_when="FIRST_EXCEPTION",
+    )
+    assert idx == 0
+    assert isinstance(tasks[0].exception(), MyException)
+    assert tasks[1].cancelled()
+    assert tasks[2].cancelled()
+
+    idx2, tasks2 = await wait(
+        coro(delay=1, ret=7),
+        AwaitableThing(2, ret=8),
+        return_when="FIRST_EXCEPTION",
+    )
+    assert idx2 is None
+    assert tasks2[0].result() == 7
+    assert tasks2[1].result() == 8
+
+
+@cocotb.test
 async def test_gather_single(_: object) -> None:
     """gather with one awaitable still returns a single-element tuple."""
-    (result,) = await gather(coro(wait=1, ret=42))
+    (result,) = await gather(coro(delay=1, ret=42))
     assert result == 42
 
 
 @cocotb.test
 async def test_select_single(_: object) -> None:
     """select with one awaitable returns index 0 and its result."""
-    idx, res = await select(coro(wait=1, ret=42))
+    idx, res = await select(coro(delay=1, ret=42))
     assert idx == 0
     assert res == 42
 
@@ -148,8 +185,8 @@ async def test_gather_outer_cancel(_: object) -> None:
 
 
 @cocotb.test
-async def test_gather_outer_cancel_return_exceptions(_: object) -> None:
-    """return_exceptions=True must NOT swallow outer cancellation."""
+async def test_wait_outer_cancel_all_completed(_: object) -> None:
+    """Cancelling the task awaiting wait(ALL_COMPLETED) propagates CancelledError and cancels children."""
     child_completed = False
 
     async def child() -> None:
@@ -158,14 +195,14 @@ async def test_gather_outer_cancel_return_exceptions(_: object) -> None:
         child_completed = True
 
     async def waiter() -> None:
-        await gather(child(), Timer(20), return_exceptions=True)
+        await wait(child(), Timer(20), return_when="ALL_COMPLETED")
 
     task = cocotb.start_soon(waiter())
     await Timer(1)
     task.cancel()
     await Timer(1)
     assert task.cancelled(), (
-        "outer cancellation should propagate even with return_exceptions=True"
+        "outer cancellation should propagate even with ALL_COMPLETED"
     )
     assert not child_completed
 
@@ -193,8 +230,7 @@ async def test_select_outer_cancel(_: object) -> None:
 
 @cocotb.test
 async def test_gather_child_cancelled_default(_: object) -> None:
-    """When a child is cancelled and return_exceptions=False, gather re-raises CancelledError
-    and cancels the remaining children."""
+    """When a child is cancelled, gather re-raises CancelledError and cancels the remaining children."""
     sibling_completed = False
 
     async def sibling() -> None:
@@ -202,7 +238,7 @@ async def test_gather_child_cancelled_default(_: object) -> None:
         await Timer(10)
         sibling_completed = True
 
-    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
     async def waiter() -> None:
         await gather(victim_task, sibling())
@@ -217,29 +253,33 @@ async def test_gather_child_cancelled_default(_: object) -> None:
 
 
 @cocotb.test
-async def test_gather_child_cancelled_return_exceptions(_: object) -> None:
-    """When a child is cancelled and return_exceptions=True, gather returns CancelledError
-    in the tuple and other children continue."""
-    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+async def test_wait_child_cancelled_all_completed(_: object) -> None:
+    """With wait(ALL_COMPLETED) a cancelled child does not stop other children, and the
+    cancellation is observable as a cancelled waiter task."""
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
-    async def waiter() -> tuple[object, ...]:
-        return await gather(victim_task, coro(wait=10, ret=99), return_exceptions=True)
+    async def waiter() -> tuple[int | None, tuple[object, ...]]:
+        idx, tasks = await wait(
+            victim_task, coro(delay=10, ret=99), return_when="ALL_COMPLETED"
+        )
+        return idx, tuple(t.exception() if t.cancelled() else t.result() for t in tasks)
 
     task = cocotb.start_soon(waiter())
     await Timer(1)
     victim_task.cancel()
     await Timer(15)
     assert task.done()
-    a, b = task.result()
+    idx, results = task.result()
+    assert idx is None
+    a, b = results
     assert isinstance(a, CancelledError)
     assert b == 99
 
 
 @cocotb.test
 async def test_select_child_cancelled(_: object) -> None:
-    """When the winning child was cancelled, select raises CancelledError by default
-    and returns it when return_exception=True."""
-    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+    """When the winning child was cancelled, select raises CancelledError."""
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
     async def waiter_raises() -> None:
         await select(victim_task, Timer(30))
@@ -251,36 +291,44 @@ async def test_select_child_cancelled(_: object) -> None:
     assert t1.done()
     assert isinstance(t1.exception(), CancelledError)
 
-    victim_task2 = cocotb.start_soon(coro(wait=20, ret=0))
 
-    async def waiter_returns() -> tuple[int, object]:
-        return await select(victim_task2, Timer(30), return_exception=True)
+@cocotb.test
+async def test_wait_first_completed_child_cancelled(_: object) -> None:
+    """When the winning child was cancelled, wait(FIRST_COMPLETED) returns it as a cancelled waiter task."""
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
-    t2 = cocotb.start_soon(waiter_returns())
+    async def waiter() -> tuple[int | None, bool]:
+        idx, tasks = await wait(victim_task, Timer(30), return_when="FIRST_COMPLETED")
+        assert idx is not None
+        return idx, tasks[idx].cancelled()
+
+    t = cocotb.start_soon(waiter())
     await Timer(1)
-    victim_task2.cancel()
+    victim_task.cancel()
     await Timer(2)
-    assert t2.done()
-    idx, exc = t2.result()
+    assert t.done()
+    idx, was_cancelled = t.result()
     assert idx == 0
-    assert isinstance(exc, CancelledError)
+    assert was_cancelled
 
 
 @cocotb.test
-async def test_gather_preserves_cancel_message(_: object) -> None:
-    """When return_exceptions=True, the original CancelledError instance (with its message)
-    is returned, not a fresh one."""
-    victim_task = cocotb.start_soon(coro(wait=20, ret=0))
+async def test_wait_preserves_cancel_message(_: object) -> None:
+    """The original CancelledError instance (with its message) is preserved on the waiter task."""
+    victim_task = cocotb.start_soon(coro(delay=20, ret=0))
 
-    async def waiter() -> tuple[object, ...]:
-        return await gather(victim_task, coro(wait=5, ret=1), return_exceptions=True)
+    async def waiter() -> BaseException | None:
+        _, tasks = await wait(
+            victim_task, coro(delay=5, ret=1), return_when="ALL_COMPLETED"
+        )
+        return tasks[0].exception()
 
     task = cocotb.start_soon(waiter())
     await Timer(1)
     victim_task.cancel("specific reason")
     await Timer(10)
     assert task.done()
-    a, _ = task.result()
+    a = task.result()
     assert isinstance(a, CancelledError)
     assert a.args == ("specific reason",), (
         f"expected original CancelledError message preserved, got args={a.args!r}"
@@ -300,7 +348,7 @@ async def test_gather_does_not_cancel_passed_tasks(_: object) -> None:
     # raises_after fires first; gather cancels the waiter wrapping `task`,
     # but `task` itself must keep running.
     with pytest.raises(MyException):
-        await gather(task, raises_after(wait=1))
+        await gather(task, raises_after(delay=1))
     await NullTrigger()
     assert not task.cancelled()
     assert await task == 7


### PR DESCRIPTION
This is a reversal of one of the changes in #5623. Depends on #5625, #5653, #5654, and #5659.

The reason we wanted the previous behavior was to prevent coroutines from emitting ResourceWarnings when the children were cancelled before they were started. This is bad logic. We should have instead fixed the issue that caused the ResourceWarnings and killed children before they even started.

Reason being:
* Less code executed before the first await.
* No prime/unprime on GPITriggers which can have more wide-reaching performance impacts.
* Half as much scheduling/state tracking in Tasks.

We already fixed the ResourceWarnings issue in #5653, by passing Awaitables directly to Task, which importantly only wraps objects in waiters if they aren't Coroutines.

The ResourceWarnings were caused by wrapper coroutines awaiting on the passed in coroutine, but if the waiter was cancelled before it ever started, it had no way to cancel the passed in coroutine object, leading to the Warning.