### PR TITLE
Add support for versioned git archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%D$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt export-subst


### PR DESCRIPTION
With this in, `setuptools-git-versioning` will create a archive from `git archive` with the generated version, so if a user uses `Download as ZIP` from the Github UI, the version with the commit tag and dev number will be included when the user builds from that archive.
