### PR TITLE
Warn when a Task is created but never started before it's GC'd

### DIFF
--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import sys
 import traceback
+import warnings
 from asyncio import CancelledError, InvalidStateError
 from bdb import BdbQuit
 from collections.abc import Awaitable, Coroutine, Generator
@@ -678,6 +679,17 @@ class Task(Generic[ResultType]):
         if not self.done():
             yield self.complete
         return self.result()
+
+    def __del__(self) -> None:
+        if self._unstarted():
+            # Complain if we never started the Task.
+            warnings.warn(
+                f"Task {self._name!r} was never started. Did you forget to call start_soon()?",
+                ResourceWarning,
+                source=self,
+            )
+            # But close the coroutine so we don't get another ResourceWarning about an un-awaited coroutine.
+            self._coro.close()
 
 
 _current_task: Task[Any] | None = None

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -12,6 +12,8 @@ Test for scheduler and coroutine behavior
 from __future__ import annotations
 
 import contextlib
+import gc
+import inspect
 import logging
 import os
 import random
@@ -1169,3 +1171,24 @@ async def test_start_soon_awaitable(_: object) -> None:
     task = cocotb.start_soon(AwaitableThing())
     result = await task
     assert result == 42
+
+
+@cocotb.test
+async def test_task_closes_coro_when_never_started(_: object) -> None:
+    """Test that Task closes coroutine when never started."""
+
+    async def coro() -> None:
+        await Timer(1)
+
+    c = coro()
+    task = Task(c)
+
+    assert inspect.getcoroutinestate(c) == inspect.CORO_CREATED
+
+    # Ensure ResourceWarning is raised
+    with pytest.warns(ResourceWarning, match="Task '.*' was never started."):
+        del task
+        gc.collect()
+
+    # Ensure child was closed
+    assert inspect.getcoroutinestate(c) == inspect.CORO_CLOSED


### PR DESCRIPTION
Depends on #5659.

Title says it all. `Task` always handled eventually calling `close()` on coroutines except in the case the Task was never started. This ensures `close()` is called to prevent coroutine's `ResouceWarning`, but also emits its own `ResourceWarning` for never starting a Task, which is a rarer and more specific kind of evil than never awaiting a coroutine.

- [x] Figure out how to test this since it's a GC thing