### PR TITLE
Avoid dynamic loading by default in the GPI library

### DIFF
--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -246,9 +246,11 @@ static int gpi_load_users() {
     return 0;
 }
 
-void gpi_entry_point() {
-    LOG_TRACE("=> [ GPI Init ]");
+extern "C" {
+    void gpi_entry_point_callback();
+}
 
+void gpi_entry_point_callback() {
     /* Lets look at what other libs we were asked to load too */
     char *lib_env = getenv("GPI_EXTRA");
 
@@ -275,6 +277,12 @@ void gpi_entry_point() {
     if (gpi_load_users()) {
         return;
     }
+}
+
+void gpi_entry_point() {
+    LOG_TRACE("=> [ GPI Init ]");
+
+    gpi_entry_point_callback();
 
     gpi_print_registered_impl();
 


### PR DESCRIPTION
Thank you for all the generous work you have done. Especially in my case, I find the GPI a great compatibility layer between vpi/vhpi/fli and all the simulators out there.

I think the GPI library is so useful that people might use it outside the context of cocotb.

This is, at least in my case. I am attempting to make a Rust/RTL co-sim/co-execution library, where Rust code executes alongside simulated RTL(not necessarily for verification purposes). To achieve this, I am statically linking against the GPI library.

I still need to fully comprehend the workings of the GPI library. But one design choice I don't fully comprehend, especially in the context of my use case, is that the GPI assumes dynamically loaded libraries/functions through the environment variables of `GPI_USERS` and `GPI_IMPLS`.

I find it strange that, as a user of the GPI library, I have to rely on dynamically loaded functions via environment variables. It does not allow me to ship a single binary. And I especially find it strange that, as the developer of a piece of code, a user of my code may, by mere use of the GPI library, hijack the execution of my shipped binary by crafting the `GPI_USERS` and `GPI_EXTRA` environment variables.

I think it is the responsibility of the user of the GPI library to dynamically load extra libraries **if needed**, possibly through environment variables ( of e.g., `GPI_USERS` and `GPI_EXTRA`). But I don't think the GPI library should assume dynamically loaded libraries through environment variables, by default in all cases.

I think it is still important to allow a callback, though, after the GPI library initializes. Therefore, I propose this implementation of the `gpi_entry_point` function, which I implemented in my vendored version of the GPI library and included in this pull request.

```cpp
extern "C" {
  void gpi_entry_point_callback(); // A user of the GPI library may decide to call a function after the GPI library is initialized
}

void gpi_entry_point() {
    LOG_TRACE("=> [ GPI Init ]");

    gpi_entry_point_callback(); // A user of the GPI library may decide to dynamically load functions through the GPI_USERS and GPI_EXTRA environment variables.
    
    gpi_print_registered_impl();

    LOG_TRACE("[ GPI Init ] =>");
}
```

The body of `gpi_entry_point_callback` is put in the same file in this pull request, for illustration purposes. In actuality, I think it should be in a separate file and not even be compiled into `libgpi.so`. I just don't know where it should be put and compiled into :).

Hope this pull request can push a discussion forward for the user friendliness of the GPI library for also projects outside cocotb :).