### PR TITLE
Fix pytest plugin progress bar exceeding 100%

### DIFF
--- a/docs/source/newsfragments/5303.bugfix.rst
+++ b/docs/source/newsfragments/5303.bugfix.rst
@@ -1,0 +1,1 @@
+The pytest plugin's terminal progress bar no longer exceeds 100% when a :func:`pytest.mark.cocotb_runner`-marked test runs multiple :func:`pytest.mark.cocotb_test`-marked tests.

--- a/src/cocotb_tools/_pytest/_controller.py
+++ b/src/cocotb_tools/_pytest/_controller.py
@@ -88,6 +88,15 @@ class Controller:
             self._thread = Thread(target=self._handle_test_reports)
             os.environ["COCOTB_PYTEST_REPORTER_ADDRESS"] = str(self._listener.address)
 
+        # Number of cocotb tests skipped from being collected as separate pytest items
+        # (they are bound to their cocotb runner and reported later over IPC). Pytest's
+        # own ``session.testscollected`` only counts collected items (i.e. runners), so
+        # the built-in terminal progress bar overshoots 100% once individual cocotb test
+        # reports start coming in. We track the true count here and correct
+        # ``session.testscollected`` once collection has finished (see
+        # ``pytest_collection``).
+        self._extra_testscollected: int = 0
+
     @hookimpl(tryfirst=True)
     def pytest_configure(self, config: Config) -> None:
         """Configure environment for the main pytest parent process.
@@ -221,6 +230,30 @@ class Controller:
 
         return f"{runner_nodeid}::{report.nodeid}"
 
+    @hookimpl(wrapper=True)
+    def pytest_collection(self, session: Session) -> Generator[None, None, object]:
+        """Correct ``session.testscollected`` once collection has finished.
+
+        Pytest sets ``session.testscollected = len(items)`` at the very end of
+        :meth:`Session.perform_collect`, after all collection hooks (including
+        ``pytest_pycollect_makeitem``) have already run. Cocotb tests are deliberately
+        *not* added as separate items there (see ``_collect``), only their parent
+        cocotb runner is. Correcting the count during collection would therefore just
+        be overwritten. Doing it here, in a wrapper around ``pytest_collection``, runs
+        after that assignment and keeps the built-in terminal progress bar (which
+        divides reported test reports by ``session.testscollected``) from exceeding
+        100% once individual cocotb test reports start arriving over IPC.
+
+        Args:
+            session: Pytest session object.
+
+        Yields:
+            Control back to pytest to perform the actual collection.
+        """
+        result = yield
+        session.testscollected += self._extra_testscollected
+        return result
+
     @hookimpl(tryfirst=True)
     def pytest_sessionstart(self, session: Session) -> None:
         """Start thread to receive test reports from pytest sub-process (simulator)."""
@@ -298,7 +331,11 @@ class Controller:
                             # Add cocotb test keywords to cocotb runner
                             # This will allow to run cocotb runner by using keywords associated with cocotb test
                             runner.item.extra_keyword_matches.update(item.keywords)
-                            # Skip cocotb test here, it will be collected by pytest that is running from HDL simulator
+                            # Skip cocotb test here, it will be collected by pytest that is running from HDL simulator.
+                            # It still produces its own test report over IPC (see _handle_test_reports), so count
+                            # it towards session.testscollected (corrected in pytest_collection) to keep the
+                            # built-in terminal progress bar accurate.
+                            self._extra_testscollected += 1
                 else:
                     yield item  # some coroutine test function that is not part of cocotb
 

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,0 +1,8 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Shared pytest configuration for cocotb's own unit test suite."""
+
+from __future__ import annotations
+
+pytest_plugins = ["pytester"]

--- a/tests/pytest/test_pytest_plugin_progress.py
+++ b/tests/pytest/test_pytest_plugin_progress.py
@@ -1,0 +1,101 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Regression tests for the cocotb pytest plugin's terminal progress reporting.
+
+These tests exercise :mod:`cocotb_tools._pytest.plugin`'s collection logic in
+isolation, using pytest's built-in ``pytester`` fixture instead of a real HDL
+simulator. They do not run any cocotb test for real (no ``dut`` fixture is
+available); they only check what pytest's collection machinery records, which
+is what drives the built-in terminal progress bar.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.pytester import Pytester
+
+PLUGIN = "cocotb_tools._pytest.plugin"
+
+# A single cocotb runner with three cocotb tests bound to it. Only the runner
+# becomes a real pytest item during a normal (non ``--collect-only``) run; the
+# three cocotb tests are instead reported later over IPC from the simulator
+# subprocess (see ``Controller._handle_test_reports``). Regardless, all four
+# still produce a test report and should count towards the pytest session's
+# collected-test total, or the built-in progress bar overshoots 100% (#5303).
+_TESTBENCH_SOURCE = """
+    import pytest
+
+    @pytest.mark.cocotb_runner
+    def test_my_runner():
+        pass
+
+    @pytest.mark.cocotb_test
+    async def test_thing_one(dut):
+        pass
+
+    @pytest.mark.cocotb_test
+    async def test_thing_two(dut):
+        pass
+
+    @pytest.mark.cocotb_test
+    async def test_thing_three(dut):
+        pass
+"""
+
+# Printed from a conftest-level ``pytest_runtestloop`` wrapper, which only
+# runs once every ``pytest_collection`` hook (including the plugin's own
+# correction, applied via a hook wrapper around ``pytest_collection``) has
+# fully unwound. This is the value that pytest's terminal reporter actually
+# uses to compute progress percentages.
+_OBSERVER_CONFTEST = """
+    import pytest
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_runtestloop(session):
+        print("OBSERVED_TESTSCOLLECTED", session.testscollected)
+        return (yield)
+"""
+
+
+def test_progress_count_includes_bound_cocotb_tests(pytester: Pytester) -> None:
+    """``session.testscollected`` must count cocotb tests bound to a runner.
+
+    Regression test for `#5303
+    <https://github.com/cocotb/cocotb/issues/5303>`__: the pytest plugin
+    deliberately skips collecting ``@pytest.mark.cocotb_test`` items as their
+    own pytest items when they are bound to a ``@pytest.mark.cocotb_runner``
+    (they are instead reported over IPC by the runner's simulator subprocess).
+    Without correction, pytest's own ``session.testscollected`` therefore only
+    counts the runner, so the built-in terminal progress bar exceeds 100% once
+    the individual cocotb test reports start arriving.
+    """
+    pytester.makepyfile(test_testbench=_TESTBENCH_SOURCE)
+    pytester.makeconftest(_OBSERVER_CONFTEST)
+
+    result = pytester.runpytest("-p", PLUGIN, "--strict-markers", "-s")
+
+    result.assert_outcomes(passed=1)  # only the runner is a real pytest item
+    # 1 runner + 3 cocotb tests bound to it.
+    result.stdout.fnmatch_lines(["OBSERVED_TESTSCOLLECTED 4"])
+
+
+def test_progress_count_matches_plain_collection(pytester: Pytester) -> None:
+    """A module with no cocotb markers is unaffected by the plugin's correction."""
+    pytester.makepyfile(
+        test_plain="""
+        def test_a():
+            pass
+
+        def test_b():
+            pass
+        """
+    )
+    pytester.makeconftest(_OBSERVER_CONFTEST)
+
+    result = pytester.runpytest("-p", PLUGIN, "--strict-markers", "-s")
+
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines(["OBSERVED_TESTSCOLLECTED 2"])


### PR DESCRIPTION
   Correct session.testscollected to include cocotb tests bound to a
   runner, since they're skipped as separate pytest items but still
   report over IPC.

   Fixes #5303

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
