### PR TITLE
Set RuntimeError if cancelled task raises another exception type

### DIFF
--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -388,13 +388,27 @@ class Task(Generic[ResultType]):
                 remove_traceback_frames(e, ["_resume"]), _TaskState.CANCELLED
             )
         except BaseException as e:
-            if debug.debug:
-                self._log.debug(
-                    "Task %r errored with exception of type %r", self, type(e)
+            if self._must_cancel:
+                if debug.debug:
+                    self._log.debug(
+                        "Task %r was cancelled but raised a different exception of type %r",
+                        self,
+                        type(e),
+                    )
+                self._set_outcome(
+                    RuntimeError(
+                        f"Task was cancelled, but raised a different exception of type {type(e)!r} during cancellation"
+                    ),
+                    _TaskState.ERRORED,
                 )
-            self._set_outcome(
-                remove_traceback_frames(e, ["_resume"]), _TaskState.ERRORED
-            )
+            else:
+                if debug.debug:
+                    self._log.debug(
+                        "Task %r errored with exception of type %r", self, type(e)
+                    )
+                self._set_outcome(
+                    remove_traceback_frames(e, ["_resume"]), _TaskState.ERRORED
+                )
         else:
             if self._must_cancel:
                 if debug.debug:

--- a/tests/test_cases/test_cocotb/test_scheduler.py
+++ b/tests/test_cases/test_cocotb/test_scheduler.py
@@ -788,6 +788,24 @@ async def test_cancel_task_cancellation_error(_: object) -> None:
     await Timer(1, "ns")
 
 
+@cocotb.test
+async def test_raise_exception_during_cancellation(_: object) -> None:
+    async def raises_in_cleanup() -> None:
+        try:
+            await Timer(10)
+        except CancelledError:
+            raise MyException()
+
+    t = cocotb.start_soon(raises_in_cleanup())
+    await Timer(1)
+    t.cancel()
+
+    await t.complete
+    assert t.done()
+    assert not t.cancelled()
+    assert isinstance(t.exception(), RuntimeError)
+
+
 @cocotb.test()
 async def test_invalid_operations_task(_):
     async def coro():

--- a/tests/test_cases/test_cocotb/test_task_manager.py
+++ b/tests/test_cases/test_cocotb/test_task_manager.py
@@ -1380,9 +1380,12 @@ async def test_second_child_fails_after_group_cancelled(_: object) -> None:
 
     except BaseExceptionGroup as e:
         my_exc, rest = e.split(MyException)
-        assert rest is None
         assert my_exc is not None
-        assert len(my_exc.exceptions) == 2
+        assert len(my_exc.exceptions) == 1
+        runtime_errs, rest = rest.split(RuntimeError)
+        assert runtime_errs is not None
+        assert len(runtime_errs.exceptions) == 1
+        assert rest is None
 
     assert task1.exception() is not None
     assert task2.exception() is not None


### PR DESCRIPTION
Check if `Task` is cancelling when an `Exception` is raised.
Set outcome to `RuntimeError` to match what happens when cancellation is ignored.