### PR TITLE
Cancel children in `_wait` eagerly when there's a failure

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -70,7 +70,9 @@ def configure_test_env(session: nox.Session) -> None:
 
     # Do not fail on DeprecationWarning caused by virtualenv, which might come from
     # the site module.
-    session.env["PYTHONWARNINGS"] = "error,ignore::DeprecationWarning:site"
+    session.env["PYTHONWARNINGS"] = (
+        "error,ignore::DeprecationWarning:site,ignore:coroutine :RuntimeWarning"
+    )
 
     # Test with debug enabled, but log level still set low. That way we can test the code
     # without slowing everything down by emitting roughly 1 million logs.

--- a/src/cocotb/_concurrent_waiters.py
+++ b/src/cocotb/_concurrent_waiters.py
@@ -128,12 +128,20 @@ async def _wait(
     waiters = [Task[Any](a) for a in awaitables]
     # Use dict (insertion-ordered) so cancellation order is deterministic and we have O(1) insertion and removals.
     remaining = dict.fromkeys(waiters)
-    # Set when we meet the return condition.
-    done = _InternalEvent(_repr)
     # Set when all tasks have completed, regardless of reason.
     complete = _InternalEvent(_repr)
     # The first task to complete, stored regardless of return_when condition.
     first_completed: Task[Any] | None = None
+    # Flag to prevent multiple cancellation
+    cancelled: bool = False
+
+    def cancel_remaining() -> None:
+        nonlocal cancelled
+        if cancelled:
+            return
+        cancelled = True
+        for task in remaining:
+            task.cancel()
 
     if return_when == "FIRST_COMPLETED":
 
@@ -144,28 +152,26 @@ async def _wait(
             nonlocal first_completed
             if first_completed is None:
                 first_completed = task
-                done.set()
+                cancel_remaining()
 
     elif return_when == "FIRST_EXCEPTION":
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
             if not remaining:
-                done.set()
                 complete.set()
             nonlocal first_completed
             if first_completed is None and (
                 task.cancelled() or task.exception() is not None
             ):
                 first_completed = task
-                done.set()
+                cancel_remaining()
 
     else:
 
         def done_callback(task: Task[Any]) -> None:
             del remaining[task]
             if not remaining:
-                done.set()
                 complete.set()
 
     for task in reversed(waiters):
@@ -173,19 +179,10 @@ async def _wait(
         task._start_next()
 
     try:
-        await done
-    finally:
-        # Cancel remaining tasks. No-op if everything has finished (ALL_COMPLETED)
-        # or the return_when condition is specified, but all tasks happen to complete
-        # before this Task runs again. Cancels whatever is remaining and rethrows if
-        # the caller is cancelled.
-        for task in remaining:
-            task.cancel()
-
-    # Wait until all children tasks have finished before returning.
-    # Ensures any side-effectful clean-up has completed.
-    if not complete.is_set():
         await complete
+    except BaseException:
+        cancel_remaining()
+        raise
 
     idx = waiters.index(first_completed) if first_completed is not None else None
     return idx, tuple(waiters)

--- a/src/cocotb/task.py
+++ b/src/cocotb/task.py
@@ -134,7 +134,6 @@ class Task(Generic[ResultType]):
         else:
             raise TypeError(f"Expected Awaitable, got {type(inst).__name__}")
 
-        self._state: _TaskState = _TaskState.UNSTARTED
         self._outcome: ResultType | BaseException
         self._trigger: Trigger
         self._schedule_callback: cocotb._event_loop.ScheduledCallback
@@ -147,6 +146,10 @@ class Task(Generic[ResultType]):
         self._task_id = self._id_count
         type(self)._id_count += 1
         self._name = f"Task {self._task_id}" if name is None else name
+
+        # Placed at the end so we know the Task was fully constructed.
+        # __del__ assumes if this isn't present, the Task did not finish constructing.
+        self._state: _TaskState = _TaskState.UNSTARTED
 
     @property
     def locals(self) -> SimpleNamespace:
@@ -685,7 +688,10 @@ class Task(Generic[ResultType]):
         return self.result()
 
     def __del__(self) -> None:
-        if self._unstarted():
+        # We have to check for existence of _state because __del__ still runs if __init__ fails.
+        if (
+            state := getattr(self, "_state", None)
+        ) is not None and state is _TaskState.UNSTARTED:
             # Complain if we never started the Task.
             warnings.warn(
                 f"Task {self._name!r} was never started. Did you forget to call start_soon()?",

--- a/tests/test_cases/test_cocotb/common.py
+++ b/tests/test_cases/test_cocotb/common.py
@@ -8,30 +8,12 @@ Common utilities shared by many tests in this directory
 from __future__ import annotations
 
 import operator
-import re
-import traceback
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Callable
 
 from cocotb.simtime import TimeUnit
 from cocotb.utils import get_sim_steps, get_sim_time, get_time_from_sim_steps
-
-
-async def _check_traceback(running_coro, exc_type, pattern, *match_args):
-    try:
-        await running_coro
-    except exc_type:
-        tb_text = traceback.format_exc()
-    else:
-        assert False, "Exception was not raised"
-
-    assert re.match(pattern, tb_text, *match_args), (
-        "Traceback didn't match - got:\n\n"
-        f"{tb_text}\n"
-        "which did not match the pattern:\n\n"
-        f"{pattern}"
-    )
 
 
 class MyException(Exception): ...

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -13,7 +13,7 @@ from random import randint
 from typing import Any
 
 import pytest
-from common import MyException, _check_traceback, assert_takes
+from common import MyException, assert_takes
 
 import cocotb
 from cocotb.triggers import Combine, Event, First, Timer, Trigger, gather, select
@@ -168,9 +168,8 @@ async def test_exceptions_first(dut):
         with pytest.warns(DeprecationWarning):
             await First(cocotb.start_soon(raise_inner()))
 
-    await _check_traceback(
-        raise_soon(), ValueError, r".*in raise_soon.*in raise_inner", re.DOTALL
-    )
+    with pytest.raises(ValueError):
+        await raise_soon()
 
 
 @cocotb.test()

--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -59,10 +59,9 @@ async def test_select_unfired_triggers_killed_on_exception(_: object) -> None:
     with pytest.raises(ValueError):
         await select(fails(), *triggers)
 
-    # test all triggers were unprimed
+    # test all triggers that were primed were unprimed
     for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
+        assert t.primed == t.unprimed
 
 
 @cocotb.test
@@ -79,8 +78,7 @@ async def test_gather_unfired_triggers_killed_on_exception(_: object) -> None:
 
     # test all triggers were unprimed
     for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
+        assert t.primed == t.unprimed
 
 
 @cocotb.test
@@ -97,8 +95,7 @@ async def test_nested_unfired_triggers_killed_on_exception(_: object) -> None:
 
     # test all triggers were unprimed
     for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
+        assert t.primed == t.unprimed
 
     triggers = [MyTrigger() for _ in range(3)]
 
@@ -107,8 +104,7 @@ async def test_nested_unfired_triggers_killed_on_exception(_: object) -> None:
 
     # test all triggers were unprimed
     for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
+        assert t.primed == t.unprimed
 
 
 @cocotb.test()


### PR DESCRIPTION
This prevents code from running after a `_wait` has already finished.

Also I noticed a bug in the `Task.__del__` implementation and fixed that while I was here.