### PR TITLE
Enable --coverage-per-instance under the Verilator harness (#5684)

### DIFF
--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -70,6 +70,7 @@ void wrap_up() {
     // VM_COVERAGE is a define which is set if Verilator is
     // instructed to collect coverage (when compiling the simulation)
 #if VM_COVERAGE
+    Verilated::threadContextp()->coveragep()->forcePerInstance(true);  // --coverage-per-instance; Verilator only sets this in its own main()
     VerilatedCov::write();  // Uses +verilator+coverage+file+<filename>,
                             // defaults to coverage.dat
 #endif


### PR DESCRIPTION
Building a Verilator model with --coverage-per-instance has no effect when run under cocotb: coverage points from replicated instances collapse to a single *-wildcarded hierarchy in coverage.dat (e.g. dut.u_a and dut.u_b both become dut.u_*).

The reason is that Verilator only emits the forcePerInstance(true) runtime call into its own generated main() (V3EmitCMain.cpp), gated on the option. cocotb replaces main() with its own harness (share/lib/verilator/verilator.cpp), which calls VerilatedCov::write() but never sets the flag, so the per-instance counters that --coverage-per-instance compiles into the model are collapsed again at write time.

- Compatibility: VerilatedCovContext::forcePerInstance() has existed since Verilator v4.202, well below cocotb's minimum supported version (5.036+), so this compiles on all supported Verilator versions. --coverage-per-instance itself is new in v5.050.
- Behaviour change: the call is unconditional, so --coverage-only builds now also emit per-instance (un-collapsed) records rather than the collapsed * form.