### PR TITLE
Updates verilator.cpp to exit with non-zero status code if assert was triggered

### DIFF
--- a/docs/source/newsfragments/5699.change.rst
+++ b/docs/source/newsfragments/5699.change.rst
@@ -1,0 +1,1 @@
+Verilator now exits with a non-zero status code if any ``$error`` or assertion fired during the simulation.

--- a/src/cocotb/share/lib/verilator/verilator.cpp
+++ b/src/cocotb/share/lib/verilator/verilator.cpp
@@ -218,5 +218,10 @@ int main(int argc, char **argv) {
     }
 #endif
 
+    // Fail the sim if any assertion/error fired during the run.
+    if (Verilated::threadContextp()->errorCount() > 0) {
+        return 1;
+    }
+
     return 0;
 }


### PR DESCRIPTION
Xcelium simulations will exit with status code 1 if any asserts were triggered. This occurs even in cases where the number of asserts fired does not exceed the value of `-asserterrormax`. To ensure consistency across both Xcelium and Verilator, this change updates `verilator.cpp` to exit with a non-zero status code if any asserts were raised even if the number of asserts raised was less than `+verilator+error+limit+`.