### PR TITLE
docs: Add how-to guide on separating cocotb and simulator logs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -147,6 +147,7 @@ Then follow the :doc:`first_steps` tutorial to get a simple test running.
    upgrade-2.0
    update_indexing
    rotating_logger
+   separating_logs
    profiling
    coverage
 

--- a/docs/source/newsfragments/2835.doc.rst
+++ b/docs/source/newsfragments/2835.doc.rst
@@ -1,0 +1,1 @@
+Added a how-to guide on separating cocotb's log output from the simulator's own output, :ref:`separating-logs`.

--- a/docs/source/separating_logs.rst
+++ b/docs/source/separating_logs.rst
@@ -1,0 +1,78 @@
+.. _separating-logs:
+
+******************************************
+Separating cocotb and Simulator Log Output
+******************************************
+
+When a test runs, cocotb's own log messages and the simulator's output
+share a single stream.
+This is fine interactively,
+but it makes life hard when you want to keep the simulator transcript free of cocotb chatter or vice versa.
+
+This guide shows users how to configure cocotb's loggers to output to a file.
+
+Why the two are mixed
+=====================
+
+cocotb emits its messages through the Python :mod:`python:logging` module.
+:func:`cocotb.logging.default_config` configures the root logger to write to
+standard output,
+and every cocotb logger propagates its records up to that root logger.
+
+The simulator writes its own output, such as that produced by ``$display``,
+directly to standard output.
+It never passes through Python's :mod:`python:logging` machinery,
+so it cannot be redirected by configuring a logger.
+
+Redirecting cocotb's log
+========================
+
+Because every cocotb logger propagates to the root logger,
+you do not need to touch the individual cocotb loggers.
+Remove the handlers cocotb installed on the root logger,
+and register your own instead.
+cocotb's logs then flow through your handler to wherever that handler is configured to write to,
+while the simulator's output is left on standard output untouched.
+
+.. code-block:: python
+
+    import logging
+
+    from cocotb.logging import SimLogFormatter
+
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+        handler.close()
+
+    file_handler = logging.FileHandler("cocotb.log", mode="w")
+    file_handler.setFormatter(SimLogFormatter())
+    root_logger.addHandler(file_handler)
+
+Place this at module level in your test module so that it runs when cocotb imports the module.
+
+Using :class:`~cocotb.logging.SimLogFormatter` keeps the simulation timestamp
+and the familiar cocotb layout in the redirected output.
+A plain :class:`python:logging.Formatter` works too,
+but the simulation time is then lost unless the format string refers to it.
+
+To send cocotb's output somewhere other than a file,
+register a different :class:`python:logging.Handler`.
+For example, a :class:`python:logging.StreamHandler` on :data:`python:sys.stderr`
+keeps cocotb's messages on the console
+while still separating them from the simulator's output on standard output,
+which is convenient when redirecting one stream to a file from the shell.
+
+.. note::
+   A handful of start-up messages are still written to standard output.
+   These come from the ``gpi`` and ``pygpi`` loggers,
+   and from ``cocotb.initialize`` reporting the cocotb and simulator versions.
+   They are emitted before cocotb imports your test module,
+   so they are logged before the handler above is installed.
+   The exact count depends on the simulator,
+   so treat the remaining start-up lines as expected rather than fixed.
+
+.. seealso::
+
+   :ref:`rotating-logger` keeps the redirected output in rotating files,
+   and :ref:`logging-reference-section` documents the logging API.


### PR DESCRIPTION
cocotb's log output and the simulator's own output share standard output, because cocotb logs through the Python logging module onto the root logger's stdout handler while the simulator writes to stdout directly. The latter never passes through the logging machinery, so redirecting only the cocotb side requires attaching a handler to cocotb's own loggers and disabling propagation.

Documents that recipe, including the four top-level logger names cocotb uses (cocotb, gpi, pygpi, and test), why propagate must be set to False, and the fact that start-up messages emitted before the test module is imported still reach standard output.

Follow-on documentation action from #23.

Fixes #2835

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
