### PR TITLE
Add tests for logic_array

### DIFF
--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -150,6 +150,12 @@ def test_logic_array_bytes_conversion():
         "0011000100110010"
     )
 
+    assert LogicArray.from_bytes(b"12", 16, byteorder="big") == LogicArray(
+        "0011000100110010"
+    )
+
+    with pytest.raises(ValueError):
+        LogicArray.from_bytes(b"12", 17, byteorder="big")
     with pytest.raises(ValueError):
         LogicArray.from_bytes(b"123", Range(6, "downto", 0), byteorder="big")
     with pytest.raises(ValueError):


### PR DESCRIPTION
@ktbarrett  If we allow range as an arg for class method `from_bytes()`. It should be obvious that range must be exactly equal.
Or do we allow larger widths with zeroed out MSBs

<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
