### PR TITLE
tests: Trim First and Combine tests to the wrapper behavior

### DIFF
--- a/tests/test_cases/test_cocotb/test_first_combine.py
+++ b/tests/test_cases/test_cocotb/test_first_combine.py
@@ -2,306 +2,26 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 """
-Tests for concurrency primitives like First and Combine
+Tests for the First and Combine scaffolding.
+
+First and Combine are implemented in terms of select and gather,
+whose behavior is tested in test_waiters.py.
+The tests here cover only what First and Combine add on top:
+argument checking, the deprecated Task arguments, what awaiting them returns,
+and nesting.
 """
 
 from __future__ import annotations
-
-import re
-from collections import deque
-from random import randint
-from typing import Any
 
 import pytest
 from common import MyException, assert_takes
 
 import cocotb
-from cocotb.triggers import Combine, Event, First, Timer, Trigger, gather, select
-
-
-class MyTrigger(Trigger):
-    def __init__(self) -> None:
-        super().__init__()
-        self.primed = 0
-        self.unprimed = 0
-
-    def _prime(self) -> None:
-        self.primed += 1
-
-    def _unprime(self) -> None:
-        self.unprimed += 1
+from cocotb.triggers import Combine, Event, First, Timer
 
 
 @cocotb.test
-async def test_select_unfired_triggers_killed(_: object) -> None:
-    """Test that un-fired trigger(s) in select don't later cause a spurious wakeup."""
-
-    triggers = [MyTrigger() for _ in range(3)]
-
-    timer = Timer(1, "ns")
-    _, res = await select(timer, *triggers)
-    assert res is timer
-
-    for t in triggers:
-        assert t.primed == 1
-        assert t.unprimed == 1
-
-
-@cocotb.test
-async def test_select_unfired_triggers_killed_on_exception(_: object) -> None:
-    """Test that un-fired trigger(s) in select after exception don't later cause a spurious wakeup."""
-
-    triggers = [MyTrigger() for _ in range(3)]
-
-    async def fails() -> None:
-        raise ValueError("I am a failure")
-
-    with pytest.raises(ValueError):
-        await select(fails(), *triggers)
-
-    # test all triggers that were primed were unprimed
-    for t in triggers:
-        assert t.primed == t.unprimed
-
-
-@cocotb.test
-async def test_gather_unfired_triggers_killed_on_exception(_: object) -> None:
-    """Test that un-fired trigger(s) in gather after exception don't later cause a spurious wakeup."""
-
-    triggers = [MyTrigger() for _ in range(3)]
-
-    async def fails() -> None:
-        raise ValueError("I am a failure")
-
-    with pytest.raises(ValueError):
-        await gather(fails(), *triggers)
-
-    # test all triggers were unprimed
-    for t in triggers:
-        assert t.primed == t.unprimed
-
-
-@cocotb.test
-async def test_nested_unfired_triggers_killed_on_exception(_: object) -> None:
-    """Test that un-fired trigger(s) in nested First after exception don't later cause a spurious wakeup."""
-
-    triggers = [MyTrigger() for _ in range(3)]
-
-    async def fails() -> None:
-        raise ValueError("I am a failure")
-
-    with pytest.raises(ValueError):
-        await select(fails(), gather(*triggers))
-
-    # test all triggers were unprimed
-    for t in triggers:
-        assert t.primed == t.unprimed
-
-    triggers = [MyTrigger() for _ in range(3)]
-
-    with pytest.raises(ValueError):
-        await select(fails(), select(gather(*triggers)))
-
-    # test all triggers were unprimed
-    for t in triggers:
-        assert t.primed == t.unprimed
-
-
-@cocotb.test()
-async def test_nested_first(dut):
-    """Test that nested First triggers behave as expected"""
-    events = [Event() for i in range(3)]
-    waiters = [e.wait() for e in events]
-
-    async def fire_events():
-        """fire the events in order"""
-        for e in events:
-            await Timer(1, "ns")
-            e.set()
-
-    async def wait_for_nested_first():
-        inner_first = First(waiters[0], waiters[1])
-        ret = await First(inner_first, waiters[2])
-
-        # should unpack completely, rather than just by one level
-        assert ret is not inner_first
-        assert ret is waiters[0]
-
-    fire_task = cocotb.start_soon(fire_events())
-    await wait_for_nested_first()
-    await fire_task
-
-
-@cocotb.test()
-async def test_first_does_not_kill(dut):
-    """Test that `First` does not kill coroutines that did not finish first"""
-    ran = False
-
-    async def coro():
-        nonlocal ran
-        await Timer(2, unit="ns")
-        ran = True
-
-    # Coroutine runs for 2ns, so we expect the timer to fire first
-    timer = Timer(1, unit="ns")
-    with pytest.warns(DeprecationWarning):
-        t = await First(timer, cocotb.start_soon(coro()))
-    assert t is timer
-    assert not ran
-
-    # the background routine is still running, but should finish after 1ns
-    await Timer(2, unit="ns")
-
-    assert ran
-
-
-@cocotb.test()
-async def test_exceptions_first(dut):
-    """Test exception propagation via cocotb.triggers.First"""
-
-    async def raise_inner():
-        await Timer(10, "ns")
-        raise ValueError("It is soon now")
-
-    async def raise_soon():
-        await Timer(1, "ns")
-        with pytest.warns(DeprecationWarning):
-            await First(cocotb.start_soon(raise_inner()))
-
-    with pytest.raises(ValueError):
-        await raise_soon()
-
-
-@cocotb.test()
-async def test_combine(dut):
-    """Test the Combine trigger."""
-    # gh-852
-
-    async def coro(delay):
-        await Timer(delay, "ns")
-
-    tasks = [cocotb.start_soon(coro(dly)) for dly in [10, 30, 20]]
-
-    with pytest.warns(DeprecationWarning):
-        await Combine(*tasks)
-
-
-@cocotb.test()
-async def test_fork_combine(dut):
-    """Test the Combine trigger with forked coroutines."""
-    # gh-852
-
-    async def coro(delay):
-        await Timer(delay, "ns")
-
-    tasks = [cocotb.start_soon(coro(dly)) for dly in [10, 30, 20]]
-
-    with pytest.warns(DeprecationWarning):
-        await Combine(*tasks)
-
-
-@cocotb.test()
-async def test_event_is_set(dut):
-    e = Event()
-
-    assert not e.is_set()
-    e.set()
-    assert e.is_set()
-    e.clear()
-    assert not e.is_set()
-
-
-@cocotb.test()
-async def test_combine_start_soon(_):
-    async def coro(delay):
-        await Timer(delay, "ns")
-
-    max_delay = 10
-
-    tasks = [cocotb.start_soon(coro(d)) for d in range(1, max_delay + 1)]
-
-    with assert_takes(max_delay, "ns"), pytest.warns(DeprecationWarning):
-        await Combine(*tasks)
-
-
-@cocotb.test()
-async def test_recursive_combine_and_start_soon(_):
-    """Test using `Combine` on forked coroutines that themselves use `Combine`."""
-
-    async def mergesort(n):
-        if len(n) == 1:
-            return n
-        part1 = n[: len(n) // 2]
-        part2 = n[len(n) // 2 :]
-        sort1 = cocotb.start_soon(mergesort(part1))
-        sort2 = cocotb.start_soon(mergesort(part2))
-        with pytest.warns(DeprecationWarning):
-            await Combine(sort1, sort2)
-        res1 = deque(sort1.result())
-        res2 = deque(sort2.result())
-        res = []
-        while res1 and res2:
-            if res1[0] < res2[0]:
-                res.append(res1.popleft())
-            else:
-                res.append(res2.popleft())
-        res.extend(res1)
-        res.extend(res2)
-        return res
-
-    t = [randint(0, 1000) for _ in range(100)]
-    res = await mergesort(t)
-    t.sort()
-    assert t == res
-
-
-@cocotb.test()
-async def test_recursive_combine(_):
-    """Test passing a `Combine` trigger directly to another `Combine` trigger."""
-
-    done = set()
-
-    async def waiter(N):
-        await Timer(N, "ns")
-        done.add(N)
-
-    with assert_takes(30, "ns"):
-        with pytest.warns(DeprecationWarning):
-            await Combine(
-                Combine(cocotb.start_soon(waiter(10)), cocotb.start_soon(waiter(20))),
-                cocotb.start_soon(waiter(30)),
-            )
-    assert done == {10, 20, 30}
-
-
-class MyEvent(Event):
-    pass
-
-
-@cocotb.test
-async def test_concurrency_trigger_repr(_):
-    e = Event()
-    assert re.match(r"<Event at \w+>", repr(e))
-
-    e = MyEvent()
-    assert re.match(r"<MyEvent at \w+>", repr(e))
-    w = e.wait()
-    assert re.match(r"<<MyEvent at \w+>\.wait\(\) at \w+>", repr(w))
-
-
-@cocotb.test()
-async def test_invalid_trigger_types(dut):
-    o = object()
-
-    with pytest.raises(TypeError):
-        await First(Timer(1), o)
-
-    with pytest.raises(TypeError):
-        await Combine(Timer(1), o)
-
-
-@cocotb.test
-async def test_Combine_empty(_) -> None:
+async def test_Combine_empty(_: object) -> None:
     """Test that a Combine with no triggers passes no time."""
     combine = Combine()
     with assert_takes(0, "ns"):
@@ -310,7 +30,7 @@ async def test_Combine_empty(_) -> None:
 
 
 @cocotb.test
-async def test_Combine_single(_) -> None:
+async def test_Combine_single(_: object) -> None:
     """Test Combine with a single trigger acts the same as awaiting the trigger directly."""
     combine = Combine(Timer(9, "ns"))
     with assert_takes(9, "ns"):
@@ -318,13 +38,29 @@ async def test_Combine_single(_) -> None:
     assert res is combine
 
 
+@cocotb.test
+async def test_Combine_repr(_: object) -> None:
+    """Test that Combine reprs its child triggers."""
+    timer = Timer(1, "ns")
+    assert repr(Combine(timer)) == f"Combine({timer!r})"
+
+
+@cocotb.test
+async def test_nested_combine(_: object) -> None:
+    """Test passing a Combine trigger directly to another Combine trigger."""
+    combine = Combine(Combine(Timer(10, "ns"), Timer(20, "ns")), Timer(30, "ns"))
+    with assert_takes(30, "ns"):
+        res = await combine
+    assert res is combine
+
+
 @cocotb.test(timeout_time=10, timeout_unit="ns")
-async def test_Combine_exception(dut) -> None:
+async def test_Combine_exception(_: object) -> None:
     """Test Combine with exception ends immediately and isn't blocked by unfired triggers."""
 
     e = Event()  # we never plan on setting this
 
-    async def raises_after_1ns():
+    async def raises_after_1ns() -> None:
         await Timer(1, "ns")
         raise MyException
 
@@ -337,14 +73,29 @@ async def test_Combine_exception(dut) -> None:
 
 
 @cocotb.test
-async def test_First_empty(_) -> None:
+async def test_Combine_task_deprecated(_: object) -> None:
+    """Test that passing Tasks to Combine is deprecated, but still waits for them all."""
+
+    async def coro(delay: int) -> None:
+        await Timer(delay, "ns")
+
+    tasks = [cocotb.start_soon(coro(delay)) for delay in (10, 30, 20)]
+
+    with pytest.warns(DeprecationWarning):
+        combine = Combine(*tasks)
+    with assert_takes(30, "ns"):
+        await combine
+
+
+@cocotb.test
+async def test_First_empty(_: object) -> None:
     """Test that a First with no triggers raises an error."""
     with pytest.raises(ValueError):
         await First()
 
 
 @cocotb.test
-async def test_First_single(_) -> None:
+async def test_First_single(_: object) -> None:
     """Test First with a single trigger acts the same as awaiting the trigger directly."""
     timer = Timer(13, "ns")
     with assert_takes(13, "ns"):
@@ -352,137 +103,48 @@ async def test_First_single(_) -> None:
     assert res is timer
 
 
-@cocotb.test(timeout_time=10, timeout_unit="ns")
-async def test_First_exception(_) -> None:
-    """Test First with exception ends immediately and isn't blocked by unfired triggers."""
+@cocotb.test
+async def test_nested_first(_: object) -> None:
+    """Test that a nested First unpacks completely, rather than just by one level."""
+    timer = Timer(1, "ns")
+    inner_first = First(timer, Timer(2, "ns"))
+    with assert_takes(1, "ns"):
+        res = await First(inner_first, Timer(3, "ns"))
+    assert res is not inner_first
+    assert res is timer
 
-    e = Event()  # we never plan on setting this
 
-    async def raises_after_1ns():
-        await Timer(1, "ns")
-        raise MyException
+@cocotb.test
+async def test_First_task_deprecated(_: object) -> None:
+    """Test that passing Tasks to First is deprecated, but still returns the first result."""
+
+    async def coro() -> None:
+        await Timer(2, "ns")
+
+    task = cocotb.start_soon(coro())
+    timer = Timer(1, "ns")
 
     with pytest.warns(DeprecationWarning):
-        first = First(cocotb.start_soon(raises_after_1ns()), Timer(10, "ns"), e.wait())
-    with assert_takes(1, "ns"), pytest.raises(MyException):
-        await first
+        first = First(timer, task)
+    with assert_takes(1, "ns"):
+        res = await first
+    assert res is timer
+
+    # the Task that did not finish first is not killed
+    assert not task.done()
+    await task
 
 
 @cocotb.test
-async def test_Combine_objects_shared_by_multiple(_: Any) -> None:
-    """Test waiting for the same objects in multiple concurrent Combines."""
-    count = 0
-    events = [Event() for _ in range(5)]
+async def test_invalid_trigger_types(_: object) -> None:
+    """Test that First and Combine type-check their arguments up front."""
+    o = object()
 
-    async def wait_for_all_events():
-        nonlocal count
-        await Combine(*(event.wait() for event in events))
-        count += 1
+    with pytest.raises(TypeError):
+        await First(Timer(1, "ns"), o)
 
-    waiters = [cocotb.start_soon(wait_for_all_events()) for _ in range(5)]
-    for e in events:
-        e.set()
-    with pytest.warns(DeprecationWarning):
-        await Combine(*waiters)
-    assert count == 5
-
-
-@cocotb.test
-async def test_Combine_task_cancelled(_: Any) -> None:
-    """Test that cancelling a Task waiting on a Combine cleans waiter tasks."""
-
-    triggers = [MyTrigger() for _ in range(5)]
-
-    async def waiter() -> None:
-        await Combine(*triggers)
-
-    task = cocotb.start_soon(waiter())
-    await Timer(1, "ns")
-    for t in triggers:
-        assert t.primed == 1
-    for t in triggers:
-        assert t.unprimed == 0
-    task.cancel()
-    await Timer(1, "ns")
-    for t in triggers:
-        assert t.primed == 1
-    for t in triggers:
-        assert t.unprimed == 1
-
-
-@cocotb.test
-async def test_First_task_cancelled(_: Any) -> None:
-    """Test that cancelling a Task waiting on a First cleans waiter tasks."""
-
-    triggers = [MyTrigger() for _ in range(5)]
-
-    async def waiter() -> None:
-        await First(*triggers)
-
-    task = cocotb.start_soon(waiter())
-    await Timer(1, "ns")
-    for t in triggers:
-        assert t.primed == 1
-    for t in triggers:
-        assert t.unprimed == 0
-    task.cancel()
-    await Timer(1, "ns")
-    for t in triggers:
-        assert t.primed == 1
-    for t in triggers:
-        assert t.unprimed == 1
-
-
-@cocotb.test
-async def test_Combine_task_being_waited_cancelled(_: Any) -> None:
-    """Test cancelling a Task being awaited by a Combine causes it to finish."""
-    e = Event()
-
-    async def wait_forever() -> None:
-        await e.wait()
-
-    tasks = [cocotb.start_soon(wait_forever()) for _ in range(5)]
-
-    async def wait_on_tasks() -> None:
-        with pytest.warns(DeprecationWarning):
-            await Combine(*tasks)
-
-    waiter_task = cocotb.start_soon(wait_on_tasks())
-    await Timer(1, "ns")
-
-    # cancel just one task
-    tasks[0].cancel()
-
-    # check all Tasks have been cancelled and the Combine is finished.
-    await Timer(1, "ns")
-    assert waiter_task.done()
-
-
-@cocotb.test
-async def test_First_task_being_waited_cancelled(_: Any) -> None:
-    """Test cancelling a Task being awaited by a First causes it to finish."""
-    e = Event()
-
-    async def wait_forever() -> None:
-        await e.wait()
-
-    tasks = [cocotb.start_soon(wait_forever()) for _ in range(5)]
-
-    async def wait_on_tasks() -> None:
-        with pytest.warns(DeprecationWarning):
-            await First(*tasks)
-
-    waiter_task = cocotb.start_soon(wait_on_tasks())
-    await Timer(1, "ns")
-
-    # cancel just one task
-    tasks[0].cancel()
-
-    # check other tasks have been cancelled and the Combine is finished.
-    await Timer(1, "ns")
-    assert waiter_task.done()
-    for t in tasks[1:]:
-        assert not t.done()
+    with pytest.raises(TypeError):
+        await Combine(Timer(1, "ns"), o)
 
 
 @cocotb.test(timeout_time=5, timeout_unit="ns")

--- a/tests/test_cases/test_cocotb/test_synchronization_primitives.py
+++ b/tests/test_cases/test_cocotb/test_synchronization_primitives.py
@@ -240,6 +240,22 @@ async def test_Event_multiple_task_share_trigger(_) -> None:
     await Timer(1, "ns")
 
 
+class MyEvent(Event):
+    pass
+
+
+@cocotb.test
+async def test_Event_repr(_: Any) -> None:
+    """Test that an Event and its wait() Trigger repr their own type."""
+    e = Event()
+    assert re.match(r"<Event at \w+>", repr(e))
+
+    e = MyEvent()
+    assert re.match(r"<MyEvent at \w+>", repr(e))
+    w = e.wait()
+    assert re.match(r"<<MyEvent at \w+>\.wait\(\) at \w+>", repr(w))
+
+
 @cocotb.test
 async def test_Event_wait_after_set(_: Any) -> None:
     """Test that getting the _Event Trigger, setting it, then awaiting the Trigger doesn't hang."""

--- a/tests/test_cases/test_cocotb/test_waiters.py
+++ b/tests/test_cases/test_cocotb/test_waiters.py
@@ -31,6 +31,19 @@ class AwaitableThing:
 class MyException(Exception): ...
 
 
+class MyTrigger(Trigger):
+    def __init__(self) -> None:
+        super().__init__()
+        self.primed = 0
+        self.unprimed = 0
+
+    def _prime(self) -> None:
+        self.primed += 1
+
+    def _unprime(self) -> None:
+        self.unprimed += 1
+
+
 async def raises_after(delay: int) -> None:
     await Timer(delay)
     raise MyException()
@@ -368,6 +381,114 @@ async def test_select_does_not_cancel_passed_tasks(_: object) -> None:
     await NullTrigger()
     assert not task.cancelled()
     assert await task == 7
+
+
+@cocotb.test
+async def test_select_unfired_triggers_killed(_: object) -> None:
+    """Test that un-fired trigger(s) in select don't later cause a spurious wakeup."""
+
+    triggers = [MyTrigger() for _ in range(3)]
+
+    timer = Timer(1, "ns")
+    _, res = await select(timer, *triggers)
+    assert res is timer
+
+    for t in triggers:
+        assert t.primed == 1
+        assert t.unprimed == 1
+
+
+@cocotb.test
+async def test_select_unfired_triggers_killed_on_exception(_: object) -> None:
+    """Test that un-fired trigger(s) in select after exception don't later cause a spurious wakeup."""
+
+    triggers = [MyTrigger() for _ in range(3)]
+
+    with pytest.raises(MyException):
+        await select(raises_after(delay=1), *triggers)
+
+    # test all triggers that were primed were unprimed
+    for t in triggers:
+        assert t.primed == t.unprimed
+
+
+@cocotb.test
+async def test_gather_unfired_triggers_killed_on_exception(_: object) -> None:
+    """Test that un-fired trigger(s) in gather after exception don't later cause a spurious wakeup."""
+
+    triggers = [MyTrigger() for _ in range(3)]
+
+    with pytest.raises(MyException):
+        await gather(raises_after(delay=1), *triggers)
+
+    # test all triggers were unprimed
+    for t in triggers:
+        assert t.primed == t.unprimed
+
+
+@cocotb.test
+async def test_nested_unfired_triggers_killed_on_exception(_: object) -> None:
+    """Test that un-fired trigger(s) nested in a select after exception don't later cause a spurious wakeup."""
+
+    triggers = [MyTrigger() for _ in range(3)]
+
+    with pytest.raises(MyException):
+        await select(raises_after(delay=1), gather(*triggers))
+
+    # test all triggers were unprimed
+    for t in triggers:
+        assert t.primed == t.unprimed
+
+    triggers = [MyTrigger() for _ in range(3)]
+
+    with pytest.raises(MyException):
+        await select(raises_after(delay=1), select(gather(*triggers)))
+
+    # test all triggers were unprimed
+    for t in triggers:
+        assert t.primed == t.unprimed
+
+
+@cocotb.test
+async def test_gather_outer_cancel_unprimes(_: object) -> None:
+    """Cancelling the task awaiting gather unprimes the child triggers."""
+
+    triggers = [MyTrigger() for _ in range(5)]
+
+    async def waiter() -> None:
+        await gather(*triggers)
+
+    task = cocotb.start_soon(waiter())
+    await Timer(1)
+    for t in triggers:
+        assert t.primed == 1
+        assert t.unprimed == 0
+    task.cancel()
+    await Timer(1)
+    for t in triggers:
+        assert t.primed == 1
+        assert t.unprimed == 1
+
+
+@cocotb.test
+async def test_select_outer_cancel_unprimes(_: object) -> None:
+    """Cancelling the task awaiting select unprimes the child triggers."""
+
+    triggers = [MyTrigger() for _ in range(5)]
+
+    async def waiter() -> None:
+        await select(*triggers)
+
+    task = cocotb.start_soon(waiter())
+    await Timer(1)
+    for t in triggers:
+        assert t.primed == 1
+        assert t.unprimed == 0
+    task.cancel()
+    await Timer(1)
+    for t in triggers:
+        assert t.primed == 1
+        assert t.unprimed == 1
 
 
 @cocotb.test


### PR DESCRIPTION
Fixes #5662.

First and Combine are implemented in terms of `select` and `gather`, so most of their tests duplicated the `select`/`gather` tests in `test_waiters.py`. `test_first_combine.py` now covers only what the wrappers add: argument checking, the deprecated Task arguments, what awaiting them returns, and nesting — plus a new test for `Combine.__repr__`, which had none.

Tests that exercised `select`/`gather` rather than First and Combine moved to `test_waiters.py`, including the trigger prime/unprime checks (rewritten against `select` and `gather`; the outer-cancel tests already there did not assert unpriming). The Event repr test moved to `test_synchronization_primitives.py` alongside the other Event tests; `test_event_is_set` is dropped since `test_internalevent` already covers `is_set`/`clear`.

I also dropped `test_Combine_objects_shared_by_multiple` — happy to restore it as an Event test if you want that scenario kept.

47/47 pass under Icarus for `test_first_combine`, `test_waiters`, and `test_synchronization_primitives`.
