### PR TITLE
Prevent using setuptools 84+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "wheel", "setuptools-git-versioning>=3.0,<4"]
+requires = ["setuptools>=77,<84", "wheel", "setuptools-git-versioning>=3.0,<4"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
setuptools shuffled around where the build configuration lived, which apparently breaks MacOS builds. #5361 showed it wasn't cocotb_build_libs.py usage that broke, but some internal reference that is only a problem because of our mucking about in things that aren't our business.

The cocotb_build_libs.py will be deleted after this release, so there's no reason to worry about future setuptools compatibility.

Release run: https://github.com/cocotb/cocotb/actions/runs/31643061959