### PR TITLE
Prevent installing incompatible IPython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,7 +346,7 @@ test_common = [
     # Needed for RaisesExc and RaisesGroup testing.
     "pytest>=8.4",
     # Needed for IPython shell interactive testing.
-    "IPython",
+    "IPython<9.17",
     "pexpect",
     # Needed for leak testing.
     "psutil",

--- a/src/cocotb_tools/ipython_support.py
+++ b/src/cocotb_tools/ipython_support.py
@@ -18,6 +18,13 @@ from cocotb.utils import get_sim_time
 T = TypeVar("T")
 
 
+if IPython.version_info[:2] >= (9, 17):
+    raise ImportError(
+        "cocotb_tools.ipython_support requires IPython<9.17; "
+        f"found IPython {IPython.__version__}"
+    )
+
+
 class SimTimePrompt(Prompts):
     """custom prompt that shows the sim time after a trigger fires"""
 

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ dev = [
     { name = "clang-format" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.2" },
     { name = "gcovr", specifier = "==8.4" },
-    { name = "ipython" },
+    { name = "ipython", specifier = "<9.17" },
     { name = "mypy", specifier = ">=1.18,!=1.20.*" },
     { name = "nox" },
     { name = "nox-uv" },
@@ -726,7 +726,7 @@ dev = [
 ]
 dev-test = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.2" },
-    { name = "ipython" },
+    { name = "ipython", specifier = "<9.17" },
     { name = "pexpect" },
     { name = "psutil" },
     { name = "pytest", specifier = ">=8.4" },
@@ -780,14 +780,14 @@ release-build-wheel = [{ name = "cibuildwheel", marker = "python_full_version >=
 release-test = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "find-libpython" },
-    { name = "ipython" },
+    { name = "ipython", specifier = "<9.17" },
     { name = "pexpect" },
     { name = "psutil" },
     { name = "pytest", specifier = ">=6" },
     { name = "pytest", specifier = ">=8.4" },
 ]
 test-common = [
-    { name = "ipython" },
+    { name = "ipython", specifier = "<9.17" },
     { name = "pexpect" },
     { name = "psutil" },
     { name = "pytest", specifier = ">=8.4" },


### PR DESCRIPTION
IPython 9.17 changes something and broke ipython_support.py. I haven't figure out what the issue is yet, but before the release, lets just prevent that from being an issue.
