### PR TITLE
Fixing cmake build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 
 # Prevent CMake from picking up GCC-style env flags when targeting MSVC
 if(WIN32)
@@ -23,7 +23,9 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Python COMPONENTS Interpreter Development REQUIRED)
+# Request Development.Module, not Development. The latter also requires
+# Development.Embed / libpython, which manylinux images intentionally omit.
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 
 if(WIN32)
     set(PYTHON_EXT_SUFFIX ".${Python_SOABI}.pyd")
@@ -265,9 +267,12 @@ add_cocotb_library(simulator
         ${SHARE_LIB_DIR}/pygpi/embed.cpp
         ${SHARE_LIB_DIR}/pygpi/logging.cpp
     DEFINES PYGPI_EXPORTS
-    LIBRARIES gpi ${Python_LIBRARIES}
+    LIBRARIES gpi
     RC_LIBRARIES ""
 )
+# Python::Module links the import library on Windows and leaves Python
+# symbols unresolved on Unix (libpython is preloaded at runtime).
+target_link_libraries(simulator PRIVATE Python::Module)
 
 if(SKBUILD_STATE STREQUAL "editable")
     set_target_properties(simulator PROPERTIES
@@ -285,10 +290,6 @@ set_target_properties(simulator PROPERTIES
     PREFIX ""
     SUFFIX ${PYTHON_EXT_SUFFIX}
 )
-
-if(WIN32)
-    target_link_directories(simulator PRIVATE ${Python_LIBRARY_DIRS})
-endif()
 
 function(add_vpi_library SIM_NAME SIM_DEFINE)
     set(options "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dirty_template = "{tag}.dev{ccount}+r{sha}.dirty"
 [tool.scikit-build]
 experimental = true
 cmake.source-dir = "."
-cmake.version = ">=3.15"
+cmake.version = ">=3.18"
 build-dir = "build/{wheel_tag}"
 cmake.args = []
 build.verbose = false
@@ -225,6 +225,9 @@ required-imports = ["from __future__ import annotations"]
 # - CPython on Windows x86_64
 # - CPython on macOS x86_64 and arm64
 build = "cp*-manylinux_x86_64 cp*-win_amd64 cp*-macosx_x86_64 cp*-macosx_arm64"
+# cibuildwheel 3.2+ builds CPython 3.14 free-threaded wheels by default.
+# Skip them until cocotb supports the free-threaded ABI.
+skip = "cp3??t-*"
 
 # Build with optimizations and debugging
 # -O2   Enables reasonable optimizations. -O3 is unnecessary with the virtual-call-heavy code in the GPI and may bloat binary size.


### PR DESCRIPTION
`CMakeLists.txt` -  require CMake 3.18, find Interpreter + Development.Module, and link Python::Module (Windows import library, Unix leaves Python symbols unresolved so find_libpython can preload at runtime). That matches the old setuptools extension.

`pyproject.toml` - skip = "cp3??t-*" so free-threaded wheels are not built until cocotb supports that ABI.