### PR TITLE
Improve `resolve()` semantics

### DIFF
--- a/src/cocotb/types/_logic.py
+++ b/src/cocotb/types/_logic.py
@@ -105,7 +105,7 @@ class Logic:
         value: value to construct into a :class:`!Logic`.
 
     Raises:
-        ValueError: If the value if of the correct type, but cannot be constructed into a :class:`!Logic`.
+        ValueError: If the value is of the correct type, but cannot be constructed into a :class:`!Logic`.
         TypeError: If the value is of a type that can't be constructed into a :class:`!Logic`.
     """
 

--- a/src/cocotb/types/_logic.py
+++ b/src/cocotb/types/_logic.py
@@ -9,7 +9,6 @@ from typing import ClassVar, Union
 
 from cocotb.types._resolve import (
     ResolverLiteral,
-    get_default_resolve_method,
     get_str_resolver,
 )
 
@@ -243,10 +242,10 @@ class Logic:
         return ("U", "X", "0", "1", "Z", "W", "L", "H", "-")[self._repr]
 
     def __bool__(self) -> bool:
-        return self.resolve(get_default_resolve_method())._repr == _1
+        return self.resolve("weak")._repr == _1
 
     def __int__(self) -> int:
-        return 1 if self.resolve(get_default_resolve_method())._repr == _1 else 0
+        return 1 if self.resolve("weak")._repr == _1 else 0
 
     def __index__(self) -> int:
         return int(self)
@@ -292,18 +291,7 @@ class Logic:
 
         .. versionadded:: 2.0
         """
-        resolver = get_default_resolve_method()
-
-        if resolver == "weak":
-            return (False, False, True, True, False, False, True, True, False)[
-                self._repr
-            ]
-        elif resolver == "error":
-            return (False, False, True, True, False, False, False, False, False)[
-                self._repr
-            ]
-        else:
-            return True
+        return (False, False, True, True, False, False, True, True, False)[self._repr]
 
     def __copy__(self) -> Logic:
         return self

--- a/src/cocotb/types/_logic.py
+++ b/src/cocotb/types/_logic.py
@@ -7,7 +7,11 @@ import sys
 from functools import cache
 from typing import ClassVar, Union
 
-from cocotb.types._resolve import RESOLVE_X, ResolverLiteral, get_str_resolver
+from cocotb.types._resolve import (
+    ResolverLiteral,
+    get_default_resolve_method,
+    get_str_resolver,
+)
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -238,31 +242,11 @@ class Logic:
     def __str__(self) -> str:
         return ("U", "X", "0", "1", "Z", "W", "L", "H", "-")[self._repr]
 
-    if RESOLVE_X is None:
+    def __bool__(self) -> bool:
+        return self.resolve(get_default_resolve_method())._repr == _1
 
-        def __bool__(self) -> bool:
-            if self._repr in (_0, _L):
-                return False
-            elif self._repr in (_1, _H):
-                return True
-            raise ValueError(f"Cannot convert {self!r} to bool")
-
-        def __int__(self) -> int:
-            if self._repr in (_0, _L):
-                return 0
-            elif self._repr in (_1, _H):
-                return 1
-            raise ValueError(f"Cannot convert {self!r} to int")
-
-    else:
-
-        def __bool__(self) -> bool:
-            return self._repr in (_1, _H)
-
-        def __int__(self) -> int:
-            s = str(self)
-            s = RESOLVE_X(s)  # type: ignore
-            return int(s, 2)
+    def __int__(self) -> int:
+        return 1 if self.resolve(get_default_resolve_method())._repr == _1 else 0
 
     def __index__(self) -> int:
         return int(self)
@@ -308,7 +292,18 @@ class Logic:
 
         .. versionadded:: 2.0
         """
-        return (False, False, True, True, False, False, True, True, False)[self._repr]
+        resolver = get_default_resolve_method()
+
+        if resolver == "weak":
+            return (False, False, True, True, False, False, True, True, False)[
+                self._repr
+            ]
+        elif resolver == "error":
+            return (False, False, True, True, False, False, False, False, False)[
+                self._repr
+            ]
+        else:
+            return True
 
     def __copy__(self) -> Logic:
         return self

--- a/src/cocotb/types/_logic_array.py
+++ b/src/cocotb/types/_logic_array.py
@@ -962,19 +962,10 @@ class LogicArray(AbstractMutableArray[Logic]):
     def __invert__(self) -> LogicArray:
         return LogicArray(~v for v in self)
 
-    if RESOLVE_X is None:
-
-        def __bool__(self) -> bool:
-            if len(self) == 0:
-                return False
-            return bool(int(self))
-
-    else:
-
-        def __bool__(self) -> bool:
-            if len(self) == 0:
-                return False
-            return any(bool(bit) for bit in self)
+    def __bool__(self) -> bool:
+        if len(self) == 0:
+            return False
+        return bool(self.to_unsigned())
 
     def resolve(self, resolver: ResolverLiteral) -> LogicArray:
         """Resolves non-0/1 values to 0/1.

--- a/src/cocotb/types/_resolve.py
+++ b/src/cocotb/types/_resolve.py
@@ -15,6 +15,8 @@ if sys.version_info >= (3, 10):
 
 ResolverLiteral: TypeAlias = Literal["weak", "zeros", "ones", "random"]
 
+# global resolver, default to "weak" for backwards compatibility of is_resolvable/resolve.
+_resolve_method: ResolverLiteral = "weak"
 
 _randomResolveRng = Random()
 
@@ -38,14 +40,27 @@ _rnd_table = _random_resolve_table()
 _resolve_tables: dict[str, dict[int, int]] = {
     "error": {},
     "weak": str.maketrans("LH", "01"),
-    "zeros": str.maketrans("LHUXZ-", "010000"),
-    "ones": str.maketrans("LHUXZ-", "011111"),
+    "zeros": str.maketrans("LHUXZW-", "0100000"),
+    "ones": str.maketrans("LHUXZW-", "0111111"),
 }
 
 _VALID_RESOLVERS = ("error", "weak", "zeros", "ones", "random")
 _VALID_RESOLVERS_ERR_MSG = (
     "Valid values are 'error', 'weak', 'zeros', 'ones', or 'random'"
 )
+
+
+def get_default_resolve_method() -> ResolverLiteral:
+    """Returns the global default resolver method."""
+    return _resolve_method
+
+
+def set_default_resolve_method(resolver: ResolverLiteral) -> None:
+    if resolver not in _VALID_RESOLVERS:
+        raise ValueError(f"Invalid resolver: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}")
+    """Sets the global default resolver method."""
+    global _resolve_method
+    _resolve_method = resolver
 
 
 @cache
@@ -63,8 +78,10 @@ def get_str_resolver(resolver: ResolverLiteral) -> Callable[[str], str]:
         resolve_table = _resolve_tables[resolver]
 
         def resolve_func(value: str) -> str:
-            if "W" in value:
-                raise ValueError("Cannot resolve 'W'")
+            if resolver == "weak" and any(char in value for char in "WUXZ-"):
+                raise ValueError("Cannot resolve unknown values with 'weak' resolver")
+            if resolver == "error" and any(char in value for char in "LHWUXZ-"):
+                raise ValueError("Cannot resolve unknown values with 'error' resolver")
             return value.translate(resolve_table)
 
     return resolve_func
@@ -83,6 +100,7 @@ def _init() -> Callable[[str], str] | None:
 
     # get resolver
     try:
+        set_default_resolve_method(cast("ResolverLiteral", resolver))
         return get_str_resolver(cast("ResolverLiteral", resolver))
     except ValueError:
         raise ValueError(

--- a/src/cocotb/types/_resolve.py
+++ b/src/cocotb/types/_resolve.py
@@ -37,9 +37,9 @@ _rnd_table = _random_resolve_table()
 
 _resolve_tables: dict[str, dict[int, int]] = {
     "error": {},
-    "weak": str.maketrans("LHW", "01X"),
-    "zeros": str.maketrans("LHUXZW-", "0100000"),
-    "ones": str.maketrans("LHUXZW-", "0111111"),
+    "weak": str.maketrans("LH", "01"),
+    "zeros": str.maketrans("LHUXZ-", "010000"),
+    "ones": str.maketrans("LHUXZ-", "011111"),
 }
 
 _VALID_RESOLVERS = ("error", "weak", "zeros", "ones", "random")
@@ -63,6 +63,8 @@ def get_str_resolver(resolver: ResolverLiteral) -> Callable[[str], str]:
         resolve_table = _resolve_tables[resolver]
 
         def resolve_func(value: str) -> str:
+            if "W" in value:
+                raise ValueError("Cannot resolve 'W'")
             return value.translate(resolve_table)
 
     return resolve_func

--- a/src/cocotb/types/_resolve.py
+++ b/src/cocotb/types/_resolve.py
@@ -15,9 +15,6 @@ if sys.version_info >= (3, 10):
 
 ResolverLiteral: TypeAlias = Literal["weak", "zeros", "ones", "random"]
 
-# global resolver, default to "weak" for backwards compatibility of is_resolvable/resolve.
-_resolve_method: ResolverLiteral = "weak"
-
 _randomResolveRng = Random()
 
 _01lookup = ("0", "1")
@@ -48,19 +45,6 @@ _VALID_RESOLVERS = ("error", "weak", "zeros", "ones", "random")
 _VALID_RESOLVERS_ERR_MSG = (
     "Valid values are 'error', 'weak', 'zeros', 'ones', or 'random'"
 )
-
-
-def get_default_resolve_method() -> ResolverLiteral:
-    """Returns the global default resolver method."""
-    return _resolve_method
-
-
-def set_default_resolve_method(resolver: ResolverLiteral) -> None:
-    if resolver not in _VALID_RESOLVERS:
-        raise ValueError(f"Invalid resolver: {resolver!r}. {_VALID_RESOLVERS_ERR_MSG}")
-    """Sets the global default resolver method."""
-    global _resolve_method
-    _resolve_method = resolver
 
 
 @cache
@@ -100,7 +84,6 @@ def _init() -> Callable[[str], str] | None:
 
     # get resolver
     try:
-        set_default_resolve_method(cast("ResolverLiteral", resolver))
         return get_str_resolver(cast("ResolverLiteral", resolver))
     except ValueError:
         raise ValueError(

--- a/tests/pytest/test_env.py
+++ b/tests/pytest/test_env.py
@@ -346,7 +346,9 @@ def test_env_cocotb_resolve_x_weak(monkeypatch: MonkeyPatch) -> None:
     assert resolve("1") == "1"
     assert resolve("L") == "0"
     assert resolve("H") == "1"
-    assert resolve("W") == "X"
+
+    with pytest.raises(ValueError, match="Cannot resolve 'W'"):
+        assert resolve("W")
 
 
 def test_env_cocotb_resolve_x_value_error(monkeypatch: MonkeyPatch) -> None:
@@ -383,7 +385,7 @@ def test_env_cocotb_resolve_x_logic_conversion(resolver: str, tmp_path: Path) ->
     Expected ints are computed in the parent via ``.resolve(resolver)``.
     """
     typed_resolver = cast("ResolverLiteral", resolver)
-    chars = "UX01ZWLH-"
+    chars = "UX01ZLH-"
     arrays = ["1010", "01LH", "X01Z", "UXWZ", "1HLH"]
     lines: list[str] = ["from cocotb.types import Logic, LogicArray"]
 

--- a/tests/pytest/test_env.py
+++ b/tests/pytest/test_env.py
@@ -7,15 +7,12 @@ environment variables in a consistent and unified way."""
 
 from __future__ import annotations
 
-import os
 import shlex
-import subprocess
-import sys
 from importlib import reload
 from logging import getLogger
 from pathlib import Path
 from re import escape
-from typing import Callable, cast
+from typing import Callable
 
 import pytest
 from pytest import MonkeyPatch, raises
@@ -26,8 +23,6 @@ import cocotb._profiling
 import cocotb.regression
 import cocotb.types._resolve
 from cocotb.handle import SimHandleBase
-from cocotb.types import Logic, LogicArray
-from cocotb.types._resolve import ResolverLiteral
 from cocotb_tools import _env
 
 
@@ -347,7 +342,7 @@ def test_env_cocotb_resolve_x_weak(monkeypatch: MonkeyPatch) -> None:
     assert resolve("L") == "0"
     assert resolve("H") == "1"
 
-    with pytest.raises(ValueError, match="Cannot resolve 'W'"):
+    with pytest.raises(ValueError):
         assert resolve("W")
 
 
@@ -373,65 +368,3 @@ def test_env_cocotb_resolve_x_invalid(monkeypatch: MonkeyPatch) -> None:
         ),
     ):
         cocotb.types._resolve._init()
-
-
-@pytest.mark.parametrize("resolver", ["weak", "zeros", "ones", "random", "error"])
-def test_env_cocotb_resolve_x_logic_conversion(resolver: str, tmp_path: Path) -> None:
-    """Test that :envvar:`COCOTB_RESOLVE_X` affects ``int()``/``bool()`` of
-    :class:`~cocotb.types.Logic` and :class:`~cocotb.types.LogicArray`.
-
-    The resolving ``__int__``/``__bool__`` methods are bound at import time
-    based on the env var, so this runs in a subprocess with the variable set.
-    Expected ints are computed in the parent via ``.resolve(resolver)``.
-    """
-    typed_resolver = cast("ResolverLiteral", resolver)
-    chars = "UX01ZLH-"
-    arrays = ["1010", "01LH", "X01Z", "UXWZ", "1HLH"]
-    lines: list[str] = ["from cocotb.types import Logic, LogicArray"]
-
-    def append_int_check(
-        expr: str, expected: int | None, length: int, random_input: bool
-    ) -> None:
-        if resolver == "random" and random_input:
-            lines.append(f"assert 0 <= int({expr}) < (1 << {length}), {expr!r}")
-        elif expected is None:
-            lines.extend(
-                [
-                    f"try: int({expr})",
-                    "except ValueError: pass",
-                    f"else: raise AssertionError({expr!r})",
-                ]
-            )
-        else:
-            lines.append(f"assert int({expr}) == {expected}, {expr!r}")
-
-    for c in chars:
-        # Logic.__int__ under a resolver does `int(resolver(str(self)), 2)`.
-        # The resolved Logic's str is "0"/"1" iff that int call succeeds.
-        resolved = str(Logic(c).resolve(typed_resolver))
-        expected: int | None = int(resolved) if resolved in ("0", "1") else None
-        append_int_check(f"Logic({c!r})", expected, 1, c not in "01LH")
-        # Under any resolver, only 1/H are truthy; others return False (no raise).
-        lines.append(f"assert bool(Logic({c!r})) is {c in '1H'}, {c!r}")
-
-    for s in arrays:
-        # LogicArray._get_int pre-translates L,H -> 0,1 in both branches, so
-        # int(LogicArray(s).resolve(resolver)) predicts subprocess behavior.
-        try:
-            expected = int(LogicArray(s).resolve(typed_resolver))
-        except ValueError:
-            expected = None
-        random_input = any(c not in "01LH" for c in s)
-        append_int_check(f"LogicArray({s!r})", expected, len(s), random_input)
-        lines.append(
-            f"assert bool(LogicArray({s!r})) is {any(c in '1H' for c in s)}, {s!r}"
-        )
-    lines.append("assert bool(LogicArray('')) is False")
-
-    script = tmp_path / "check.py"
-    script.write_text("\n".join(lines) + "\n")
-    subprocess.run(
-        [sys.executable, str(script)],
-        env={**os.environ, "COCOTB_RESOLVE_X": resolver},
-        check=True,
-    )

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -162,13 +162,13 @@ def test_logic_invert():
 
 
 def test_resolve():
-    for inp, exp in zip("UX01ZWLH-", "UX01ZX01-"):
+    for inp, exp in zip("UX01ZLH-", "UX01Z01-"):
         assert Logic(inp).resolve("weak") == Logic(exp)
 
-    for inp, exp in zip("UX01ZWLH-", "000100010"):
+    for inp, exp in zip("UX01ZLH-", "00010010"):
         assert Logic(inp).resolve("zeros") == Logic(exp)
 
-    for inp, exp in zip("UX01ZWLH-", "110111011"):
+    for inp, exp in zip("UX01ZLH-", "11011011"):
         assert Logic(inp).resolve("ones") == Logic(exp)
 
     assert Logic("U").resolve("random") in (Logic("0"), Logic("1"))

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -8,6 +8,7 @@ import copy
 import pytest
 
 from cocotb.types import Bit, Logic
+from cocotb.types._resolve import set_default_resolve_method
 
 
 def test_logic_conversions():
@@ -67,6 +68,7 @@ def test_logic_equality():
 
 
 def test_logic_bool_conversions():
+    set_default_resolve_method("weak")
     assert bool(Logic("1")) is True
     assert bool(Logic("H")) is True
     assert bool(Logic("0")) is False
@@ -162,13 +164,17 @@ def test_logic_invert():
 
 
 def test_resolve():
-    for inp, exp in zip("UX01ZLH-", "UX01Z01-"):
+    for inp in ("UXZW-", "0101"):
+        with pytest.raises(ValueError):
+            Logic(inp).resolve("weak")
+
+    for inp, exp in zip("01LH", "0101"):
         assert Logic(inp).resolve("weak") == Logic(exp)
 
-    for inp, exp in zip("UX01ZLH-", "00010010"):
+    for inp, exp in zip("UX01ZWLH-", "000100010"):
         assert Logic(inp).resolve("zeros") == Logic(exp)
 
-    for inp, exp in zip("UX01ZLH-", "11011011"):
+    for inp, exp in zip("UX01ZWLH-", "110111011"):
         assert Logic(inp).resolve("ones") == Logic(exp)
 
     assert Logic("U").resolve("random") in (Logic("0"), Logic("1"))
@@ -187,6 +193,7 @@ def test_logic_is_resolvable() -> None:
     assert Logic(1).is_resolvable
     assert Logic("L").is_resolvable
     assert Logic("H").is_resolvable
+    set_default_resolve_method("weak")
     assert not Logic("U").is_resolvable
     assert not Logic("X").is_resolvable
     assert not Logic("Z").is_resolvable

--- a/tests/pytest/test_logic.py
+++ b/tests/pytest/test_logic.py
@@ -8,7 +8,6 @@ import copy
 import pytest
 
 from cocotb.types import Bit, Logic
-from cocotb.types._resolve import set_default_resolve_method
 
 
 def test_logic_conversions():
@@ -68,7 +67,6 @@ def test_logic_equality():
 
 
 def test_logic_bool_conversions():
-    set_default_resolve_method("weak")
     assert bool(Logic("1")) is True
     assert bool(Logic("H")) is True
     assert bool(Logic("0")) is False
@@ -193,7 +191,6 @@ def test_logic_is_resolvable() -> None:
     assert Logic(1).is_resolvable
     assert Logic("L").is_resolvable
     assert Logic("H").is_resolvable
-    set_default_resolve_method("weak")
     assert not Logic("U").is_resolvable
     assert not Logic("X").is_resolvable
     assert not Logic("Z").is_resolvable

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -8,7 +8,6 @@ import copy
 import pytest
 
 from cocotb.types import Logic, LogicArray, Range
-from cocotb.types._resolve import set_default_resolve_method
 
 
 def test_logic_array_str_construction():
@@ -171,7 +170,6 @@ def test_logic_array_bytes_conversion():
 
 def test_logic_array_properties():
     assert LogicArray("01").is_resolvable
-    set_default_resolve_method("weak")
     assert not LogicArray("1X1").is_resolvable
 
 

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -481,9 +481,9 @@ def test_bool_cast():
 
 
 def test_resolve():
-    assert LogicArray("UX01ZWLH-").resolve("weak") == LogicArray("UX01ZX01-")
-    assert LogicArray("UX01ZWLH-").resolve("zeros") == LogicArray("000100010")
-    assert LogicArray("UX01ZWLH-").resolve("ones") == LogicArray("110111011")
+    assert LogicArray("UX01ZLH-").resolve("weak") == LogicArray("UX01Z01-")
+    assert LogicArray("UX01ZLH-").resolve("zeros") == LogicArray("00010010")
+    assert LogicArray("UX01ZLH-").resolve("ones") == LogicArray("11011011")
     assert LogicArray("01LH").resolve("random") == LogicArray("0101")
     array = LogicArray("UXZW-").resolve("random")
     assert all(elem in (Logic("0"), Logic("1")) for elem in array)

--- a/tests/pytest/test_logic_array.py
+++ b/tests/pytest/test_logic_array.py
@@ -8,6 +8,7 @@ import copy
 import pytest
 
 from cocotb.types import Logic, LogicArray, Range
+from cocotb.types._resolve import set_default_resolve_method
 
 
 def test_logic_array_str_construction():
@@ -170,6 +171,7 @@ def test_logic_array_bytes_conversion():
 
 def test_logic_array_properties():
     assert LogicArray("01").is_resolvable
+    set_default_resolve_method("weak")
     assert not LogicArray("1X1").is_resolvable
 
 
@@ -481,12 +483,15 @@ def test_bool_cast():
 
 
 def test_resolve():
-    assert LogicArray("UX01ZLH-").resolve("weak") == LogicArray("UX01Z01-")
-    assert LogicArray("UX01ZLH-").resolve("zeros") == LogicArray("00010010")
-    assert LogicArray("UX01ZLH-").resolve("ones") == LogicArray("11011011")
+    assert LogicArray("01LH").resolve("weak") == LogicArray("0101")
+    assert LogicArray("UX01ZWLH-").resolve("zeros") == LogicArray("000100010")
+    assert LogicArray("UX01ZWLH-").resolve("ones") == LogicArray("110111011")
     assert LogicArray("01LH").resolve("random") == LogicArray("0101")
     array = LogicArray("UXZW-").resolve("random")
     assert all(elem in (Logic("0"), Logic("1")) for elem in array)
+
+    with pytest.raises(ValueError):
+        LogicArray("01X").resolve("weak")
 
 
 def test_copy() -> None:


### PR DESCRIPTION
Aids #5611 
- throw an error on `W` as it is not a resolvable state
- `resolve()` returns LogicArray strictly only having 0 or 1s, In future we need to return BitArray so #5611 should not be closed yet
- `is_resolvable()` should know what resolve method will be used to `resolve()`
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
